### PR TITLE
Query manage

### DIFF
--- a/aiida/backends/djsite/queries.py
+++ b/aiida/backends/djsite/queries.py
@@ -3,8 +3,6 @@ from aiida.backends.general.abstractqueries import AbstractQueryManager
 
 class QueryManagerDjango(AbstractQueryManager):
 
-
-
     def query_jobcalculations_by_computer_user_state(
             self, state, computer=None, user=None,
             only_computer_user_pairs=False,
@@ -45,6 +43,8 @@ class QueryManagerDjango(AbstractQueryManager):
             raise InputValidationError("querying for calculation state='{}', but it "
                                 "is not a valid calculation state".format(state))
 
+
+
         kwargs = {}
         if computer is not None:
             # I convert it from various type of inputs
@@ -53,6 +53,9 @@ class QueryManagerDjango(AbstractQueryManager):
             kwargs['dbcomputer'] = Computer.get(computer).dbcomputer
         if user is not None:
             kwargs['user'] = user
+        if only_enabled:
+            kwargs['dbcomputer__enabled'] = True
+
 
         queryresults = JobCalculation.query(
             dbattributes__key='state',
@@ -62,5 +65,7 @@ class QueryManagerDjango(AbstractQueryManager):
         if only_computer_user_pairs:
             return queryresults.values_list(
                 'dbcomputer__id', 'user__id')
+        elif limit is not None:
+            return queryresults[:limit]
         else:
             return queryresults

--- a/aiida/backends/djsite/queries.py
+++ b/aiida/backends/djsite/queries.py
@@ -8,7 +8,7 @@ class QueryManagerDjango(AbstractQueryManager):
             only_computer_user_pairs=False,
             only_enabled=True, limit=None):
         # Here I am overriding the implementation using the QueryBuilder:
-        
+
         """
         Filter all calculations with a given state.
 
@@ -34,10 +34,11 @@ class QueryManagerDjango(AbstractQueryManager):
         """
         # I assume that calc_states are strings. If this changes in the future,
         # update the filter below from dbattributes__tval to the correct field.
-        from aiida.orm import Computer
+        from aiida.orm import Computer,User
         from aiida.common.exceptions import InputValidationError
         from aiida.orm.implementation.django.calculation.job import JobCalculation
         from aiida.common.datastructures import calc_states
+        from aiida.backends.djsite.db.models import DbUser
 
         if state not in calc_states:
             raise InputValidationError("querying for calculation state='{}', but it "
@@ -63,8 +64,13 @@ class QueryManagerDjango(AbstractQueryManager):
             **kwargs)
 
         if only_computer_user_pairs:
-            return queryresults.values_list(
+            computer_users_ids = queryresults.values_list(
                 'dbcomputer__id', 'user__id')
+            computer_users = []
+            for computer_id,  user_id in computer_users_ids: #return cls(dbcomputer=DbComputer.get_dbcomputer(computer))DbNode.objects.get(pk=pk).get_aiida_class()
+                computer_users.append((Computer.get(computer_id), DbUser.objects.get(pk=user_id).get_aiida_class()))
+            return computer_users
+
         elif limit is not None:
             return queryresults[:limit]
         else:

--- a/aiida/backends/djsite/queries.py
+++ b/aiida/backends/djsite/queries.py
@@ -1,0 +1,66 @@
+from aiida.backends.general.abstractqueries import AbstractQueryManager
+
+
+class QueryManagerDjango(AbstractQueryManager):
+
+
+
+    def query_jobcalculations_by_computer_user_state(
+            self, state, computer=None, user=None,
+            only_computer_user_pairs=False,
+            only_enabled=True, limit=None):
+        # Here I am overriding the implementation using the QueryBuilder:
+        
+        """
+        Filter all calculations with a given state.
+
+        Issue a warning if the state is not in the list of valid states.
+
+        :param string state: The state to be used to filter (should be a string among
+                those defined in aiida.common.datastructures.calc_states)
+        :param computer: a Django DbComputer entry, or a Computer object, of a
+                computer in the DbComputer table.
+                A string for the hostname is also valid.
+        :param user: a Django entry (or its pk) of a user in the DbUser table;
+                if present, the results are restricted to calculations of that
+                specific user
+        :param bool only_computer_user_pairs: if False (default) return a queryset
+                where each element is a suitable instance of Node (it should
+                be an instance of Calculation, if everything goes right!)
+                If True, return only a list of tuples, where each tuple is
+                in the format
+                ('dbcomputer__id', 'user__id')
+                [where the IDs are the IDs of the respective tables]
+
+        :return: a list of calculation objects matching the filters.
+        """
+        # I assume that calc_states are strings. If this changes in the future,
+        # update the filter below from dbattributes__tval to the correct field.
+        from aiida.orm import Computer
+        from aiida.common.exceptions import InputValidationError
+        from aiida.orm.implementation.django.calculation.job import JobCalculation
+        from aiida.common.datastructures import calc_states
+
+        if state not in calc_states:
+            raise InputValidationError("querying for calculation state='{}', but it "
+                                "is not a valid calculation state".format(state))
+
+        kwargs = {}
+        if computer is not None:
+            # I convert it from various type of inputs
+            # (string, DbComputer, Computer)
+            # to a DbComputer type
+            kwargs['dbcomputer'] = Computer.get(computer).dbcomputer
+        if user is not None:
+            kwargs['user'] = user
+
+        queryresults = JobCalculation.query(
+            dbattributes__key='state',
+            dbattributes__tval=state,
+            **kwargs)
+
+        if only_computer_user_pairs:
+            return queryresults.values_list(
+                'dbcomputer__id', 'user__id')
+        else:
+            return queryresults

--- a/aiida/backends/djsite/queries.py
+++ b/aiida/backends/djsite/queries.py
@@ -65,7 +65,7 @@ class QueryManagerDjango(AbstractQueryManager):
 
         if only_computer_user_pairs:
             computer_users_ids = queryresults.values_list(
-                'dbcomputer__id', 'user__id')
+                'dbcomputer__id', 'user__id').distinct()
             computer_users = []
             for computer_id,  user_id in computer_users_ids: #return cls(dbcomputer=DbComputer.get_dbcomputer(computer))DbNode.objects.get(pk=pk).get_aiida_class()
                 computer_users.append((Computer.get(computer_id), DbUser.objects.get(pk=user_id).get_aiida_class()))

--- a/aiida/backends/general/abstractqueries.py
+++ b/aiida/backends/general/abstractqueries.py
@@ -1,0 +1,99 @@
+from abc import ABCMeta, abstractmethod
+
+
+class AbstractQueryManager(object):
+    __metaclass__ = ABCMeta
+
+
+    def __init__(self,  *args, **kwargs):
+        pass
+    # This is an example of a query that could be overriden by a better implementation,
+    # for performance reasons:
+    def query_jobcalculations_by_computer_user_state(
+            self, state, computer=None, user=None,
+            only_computer_user_pairs=False,
+            only_enabled=True, limit=None
+    ):
+        """
+        Filter all calculations with a given state.
+
+        Issue a warning if the state is not in the list of valid states.
+
+        :param string state: The state to be used to filter (should be a string among
+                those defined in aiida.common.datastructures.calc_states)
+        :param computer: a Django DbComputer entry, or a Computer object, of a
+                computer in the DbComputer table.
+                A string for the hostname is also valid.
+        :param user: a Django entry (or its pk) of a user in the DbUser table;
+                if present, the results are restricted to calculations of that
+                specific user
+        :param bool only_computer_user_pairs: if False (default) return a queryset
+                where each element is a suitable instance of Node (it should
+                be an instance of Calculation, if everything goes right!)
+                If True, return only a list of tuples, where each tuple is
+                in the format
+                ('dbcomputer__id', 'user__id')
+                [where the IDs are the IDs of the respective tables]
+        :param int limit: Limit the number of rows returned
+
+        :return: a list of calculation objects matching the filters.
+        """
+        # I assume that calc_states are strings. If this changes in the future,
+        # update the filter below from dbattributes__tval to the correct field.
+        from aiida.orm.computer import Computer
+        from aiida.orm.calculation.job import JobCalculation
+        from aiida.orm.user import User
+        from aiida.orm.querybuilder import QueryBuilder
+        from aiida.common.exceptions import InputValidationError
+        from aiida.common.datastructures import calc_states
+
+        if state not in calc_states:
+            raise InputValidationError("querying for calculation state='{}', but it "
+                                "is not a valid calculation state".format(state))
+
+        calcfilter = {'state': {'==': state}}
+        computerfilter = {"enabled": {'==': True}}
+        userfilter = {}
+
+        if computer is None:
+            pass
+        elif isinstance(computer, int):
+            computerfilter.update({'id': {'==': computer}})
+        elif isinstance(computer, Computer):
+            computerfilter.update({'id': {'==': computer.pk}})
+        else:
+            try:
+                computerfilter.update({'id': {'==': computer.id}})
+            except AttributeError as e:
+                raise Exception(
+                    "{} is not a valid computer\n{}".format(computer, e)
+                )
+        if user is None:
+            pass
+        elif isinstance(user, int):
+            userfilter.update({'id': {'==': user}})
+        else:
+            try:
+                userfilter.update({'id': {'==': int(user.id)}})
+                # Is that safe?
+            except:
+                raise Exception("{} is not a valid user".format(user))
+
+        qb = QueryBuilder()
+        qb.append(type="computer", tag='computer', filters=computerfilter)
+        qb.append(JobCalculation, filters=calcfilter, tag='calc', has_computer='computer')
+        qb.append(type="user", tag='user', filters=userfilter,
+                  creator_of="calc")
+
+        if only_computer_user_pairs:
+            qb.add_projection("computer", "*")
+            qb.add_projection("user", "*")
+            returnresult = qb.distinct().all()
+        else:
+            qb.add_projection("calc", "*")
+            if limit is not None:
+                qb.limit(limit)
+            returnresult = qb.all()
+            returnresult = zip(*returnresult)[0]
+        return returnresult
+

--- a/aiida/backends/sqlalchemy/queries.py
+++ b/aiida/backends/sqlalchemy/queries.py
@@ -1,0 +1,6 @@
+from aiida.backends.general.abstractqueries import AbstractQueryManager
+
+
+class QueryManagerSQLA(AbstractQueryManager):
+    pass
+

--- a/aiida/backends/utils.py
+++ b/aiida/backends/utils.py
@@ -16,6 +16,18 @@ __authors__ = "The AiiDA team."
 __version__ = "0.7.1"
 
 
+
+def QueryFactory():
+    if settings.BACKEND == BACKEND_SQLA:
+        from aiida.backends.sqlalchemy.queries import QueryManagerSQLA as QueryManager
+    elif settings.BACKEND == BACKEND_DJANGO:
+        from aiida.backends.djsite.queries import QueryManagerDjango as QueryManager
+    else:
+        raise ConfigurationError("Invalid settings.BACKEND: {}".format(
+            settings.BACKEND))
+    return QueryManager
+
+
 def is_dbenv_loaded():
     """
     Return True of the dbenv was already loaded (with a call to load_dbenv),

--- a/aiida/daemon/execmanager.py
+++ b/aiida/daemon/execmanager.py
@@ -237,15 +237,6 @@ def update_jobs():
             only_computer_user_pairs=True,
             only_enabled=True
         )
-    #~ print computers_users_to_check
-
-    #~ computers_users_to_check = list(
-        #~ JobCalculation._get_all_with_state(
-            #~ state=calc_states.WITHSCHEDULER,
-            #~ only_computer_user_pairs=True,
-            #~ only_enabled=True
-        #~ )
-    #~ )
 
     for computer, aiidauser in computers_users_to_check:
 
@@ -283,17 +274,9 @@ def submit_jobs():
             only_computer_user_pairs=True,
             only_enabled=True
         )
-    #~ print computers_users_to_check
-    #~ computers_users_to_check = list(JobCalculation._get_all_with_state(
-            #~ state=calc_states.TOSUBMIT,
-            #~ only_computer_user_pairs=True,
-            #~ only_enabled=True
-        #~ )
-    #~ )
-    #~ print computers_users_to_check
+
     for computer, aiidauser in computers_users_to_check:
-        #~ user = User.search_for_users(id=dbuser_id)
-        #~ computer = Computer.get(dbcomputer_id)
+
         execlogger.debug("({},{}) pair to submit".format(
             aiidauser.email, computer.name))
 
@@ -362,7 +345,6 @@ def submit_jobs_with_authinfo(authinfo):
                      "and machine {}".format(
         authinfo.aiidauser.email, authinfo.dbcomputer.name))
 
-    # This returns an iterator over aiida JobCalculation objects
     qmanager = QueryFactory()()
     # I create a unique set of pairs (computer, aiidauser)
     calcs_to_inquire = qmanager.query_jobcalculations_by_computer_user_state(
@@ -370,12 +352,6 @@ def submit_jobs_with_authinfo(authinfo):
         computer=authinfo.dbcomputer,
         user=authinfo.aiidauser)
 
-#~ 
-#~ 
-    #~ calcs_to_inquire = list(JobCalculation._get_all_with_state(
-        #~ state=calc_states.TOSUBMIT,
-        #~ computer=authinfo.dbcomputer,
-        #~ user=authinfo.aiidauser))
 
     # I avoid to open an ssh connection if there are
     # no calcs with state WITHSCHEDULER
@@ -696,16 +672,11 @@ def retrieve_computed_for_authinfo(authinfo):
 
     qmanager = QueryFactory()()
     # I create a unique set of pairs (computer, aiidauser)
-    calcs_to_inquire = qmanager.query_jobcalculations_by_computer_user_state(
+    calcs_to_retrieve = qmanager.query_jobcalculations_by_computer_user_state(
             state=calc_states.COMPUTED,
         computer=authinfo.dbcomputer,
         user=authinfo.aiidauser)
 
-    #~ calcs_to_retrieve = list(JobCalculation._get_all_with_state(
-        #~ state=calc_states.COMPUTED,
-        #~ computer=authinfo.dbcomputer,
-        #~ user=authinfo.aiidauser)
-    #~ )
 
     retrieved = []
 

--- a/aiida/daemon/execmanager.py
+++ b/aiida/daemon/execmanager.py
@@ -33,7 +33,8 @@ def update_running_calcs_status(authinfo):
     from aiida.orm import JobCalculation, Computer
     from aiida.scheduler.datastructures import JobInfo
     from aiida.utils.logger import get_dblogger_extra
-
+    from aiida.backends.utils import QueryFactory
+    
     if not authinfo.enabled:
         return
 
@@ -41,12 +42,18 @@ def update_running_calcs_status(authinfo):
                      "and machine {}".format(
         authinfo.aiidauser.email, authinfo.dbcomputer.name))
 
-    # This returns an iterator over aiida JobCalculation objects
-    calcs_to_inquire = list(JobCalculation._get_all_with_state(
+    qmanager = QueryFactory()()
+    calcs_to_inquire = qmanager.query_jobcalculations_by_computer_user_state(
         state=calc_states.WITHSCHEDULER,
         computer=authinfo.dbcomputer,
-        user=authinfo.aiidauser)
+        user=authinfo.aiidauser
     )
+
+    #~ calcs_to_inquire = list(JobCalculation._get_all_with_state(
+        #~ state=calc_states.WITHSCHEDULER,
+        #~ computer=authinfo.dbcomputer,
+        #~ user=authinfo.aiidauser)
+    #~ )
 
     # NOTE: no further check is done that machine and
     # aiidauser are correct for each calc in calcs
@@ -179,15 +186,23 @@ def update_running_calcs_status(authinfo):
 
 def retrieve_jobs():
     from aiida.orm import JobCalculation, Computer
-    from aiida.backends.utils import get_authinfo
+    from aiida.backends.utils import get_authinfo, QueryFactory
 
+    qmanager = QueryFactory()()
     # I create a unique set of pairs (computer, aiidauser)
-    computers_users_to_check = list(
-        JobCalculation._get_all_with_state(
+    computers_users_to_check = qmanager.query_jobcalculations_by_computer_user_state(
             state=calc_states.COMPUTED,
             only_computer_user_pairs=True,
-            only_enabled=True)
-    )
+            only_enabled=True
+        )
+
+    # I create a unique set of pairs (computer, aiidauser)
+    #~ computers_users_to_check = list(
+        #~ JobCalculation._get_all_with_state(
+            #~ state=calc_states.COMPUTED,
+            #~ only_computer_user_pairs=True,
+            #~ only_enabled=True)
+    #~ )
 
     for computer, aiidauser in computers_users_to_check:
         execlogger.debug("({},{}) pair to check".format(
@@ -213,17 +228,24 @@ def update_jobs():
     calls an update for each set of pairs (machine, aiidauser)
     """
     from aiida.orm import JobCalculation, Computer, User
-    from aiida.backends.utils import get_authinfo
+    from aiida.backends.utils import get_authinfo, QueryFactory
 
-
+    qmanager = QueryFactory()()
     # I create a unique set of pairs (computer, aiidauser)
-    computers_users_to_check = list(
-        JobCalculation._get_all_with_state(
+    computers_users_to_check = qmanager.query_jobcalculations_by_computer_user_state(
             state=calc_states.WITHSCHEDULER,
             only_computer_user_pairs=True,
             only_enabled=True
         )
-    )
+    #~ print computers_users_to_check
+
+    #~ computers_users_to_check = list(
+        #~ JobCalculation._get_all_with_state(
+            #~ state=calc_states.WITHSCHEDULER,
+            #~ only_computer_user_pairs=True,
+            #~ only_enabled=True
+        #~ )
+    #~ )
 
     for computer, aiidauser in computers_users_to_check:
 
@@ -251,15 +273,24 @@ def submit_jobs():
     """
     from aiida.orm import JobCalculation, Computer, User
     from aiida.utils.logger import get_dblogger_extra
-    from aiida.backends.utils import get_authinfo
+    from aiida.backends.utils import get_authinfo, QueryFactory
 
-    computers_users_to_check = list(JobCalculation._get_all_with_state(
+
+    qmanager = QueryFactory()()
+    # I create a unique set of pairs (computer, aiidauser)
+    computers_users_to_check = qmanager.query_jobcalculations_by_computer_user_state(
             state=calc_states.TOSUBMIT,
             only_computer_user_pairs=True,
             only_enabled=True
         )
-    )
-
+    #~ print computers_users_to_check
+    #~ computers_users_to_check = list(JobCalculation._get_all_with_state(
+            #~ state=calc_states.TOSUBMIT,
+            #~ only_computer_user_pairs=True,
+            #~ only_enabled=True
+        #~ )
+    #~ )
+    #~ print computers_users_to_check
     for computer, aiidauser in computers_users_to_check:
         #~ user = User.search_for_users(id=dbuser_id)
         #~ computer = Computer.get(dbcomputer_id)
@@ -273,9 +304,13 @@ def submit_jobs():
                 # TODO!!
                 # Put each calculation in the SUBMISSIONFAILED state because
                 # I do not have AuthInfo to submit them
-                calcs_to_inquire = JobCalculation._get_all_with_state(
-                    state=calc_states.TOSUBMIT,
-                    computer=computer, user=aiidauser)
+                calcs_to_inquire = qmanager.query_jobcalculations_by_computer_user_state(
+                        state=calc_states.TOSUBMIT,
+                        computer=computer, user=aiidauser
+                    )
+                #~ calcs_to_inquire = JobCalculation._get_all_with_state(
+                    #~ state=calc_states.TOSUBMIT,
+                    #~ computer=computer, user=aiidauser)
                 for calc in calcs_to_inquire:
                     try:
                         calc._set_state(calc_states.SUBMISSIONFAILED)
@@ -316,6 +351,10 @@ def submit_jobs_with_authinfo(authinfo):
     from aiida.orm import JobCalculation
     from aiida.utils.logger import get_dblogger_extra
 
+    from aiida.backends.utils import QueryFactory
+
+
+
     if not authinfo.enabled:
         return
 
@@ -324,10 +363,19 @@ def submit_jobs_with_authinfo(authinfo):
         authinfo.aiidauser.email, authinfo.dbcomputer.name))
 
     # This returns an iterator over aiida JobCalculation objects
-    calcs_to_inquire = list(JobCalculation._get_all_with_state(
-        state=calc_states.TOSUBMIT,
+    qmanager = QueryFactory()()
+    # I create a unique set of pairs (computer, aiidauser)
+    calcs_to_inquire = qmanager.query_jobcalculations_by_computer_user_state(
+            state=calc_states.TOSUBMIT,
         computer=authinfo.dbcomputer,
-        user=authinfo.aiidauser))
+        user=authinfo.aiidauser)
+
+#~ 
+#~ 
+    #~ calcs_to_inquire = list(JobCalculation._get_all_with_state(
+        #~ state=calc_states.TOSUBMIT,
+        #~ computer=authinfo.dbcomputer,
+        #~ user=authinfo.aiidauser))
 
     # I avoid to open an ssh connection if there are
     # no calcs with state WITHSCHEDULER
@@ -639,16 +687,26 @@ def retrieve_computed_for_authinfo(authinfo):
     from aiida.utils.logger import get_dblogger_extra
     from aiida.orm import DataFactory
 
+    from aiida.backends.utils import QueryFactory
+
     import os
 
     if not authinfo.enabled:
         return
 
-    calcs_to_retrieve = list(JobCalculation._get_all_with_state(
-        state=calc_states.COMPUTED,
+    qmanager = QueryFactory()()
+    # I create a unique set of pairs (computer, aiidauser)
+    calcs_to_inquire = qmanager.query_jobcalculations_by_computer_user_state(
+            state=calc_states.COMPUTED,
         computer=authinfo.dbcomputer,
         user=authinfo.aiidauser)
-    )
+
+    #~ calcs_to_retrieve = list(JobCalculation._get_all_with_state(
+        #~ state=calc_states.COMPUTED,
+        #~ computer=authinfo.dbcomputer,
+        #~ user=authinfo.aiidauser)
+    #~ )
+
     retrieved = []
 
     # I avoid to open an ssh connection if there are no


### PR DESCRIPTION
Working on  a fix for #308. This was achieved by a new QueryManager that uses backend specific queries. This avoids the need to use an aldjemy-created session in the DjangoBackend. Remains to be seen whether this issue will appear with SQLAlchemy