### PR TITLE
fix #321: set default in safe cases (only profile, named default)

### DIFF
--- a/aiida/common/setup.py
+++ b/aiida/common/setup.py
@@ -638,8 +638,9 @@ def create_config_noninteractive(profile='default', force_overwrite=False, dry_r
     # finalizing
     write = not dry_run
     new_profile = update_profile(profile, new_profile, write=write)
-    old_profiles = [p for p in get_profiles_list() if p != profile]
-    if not old_profiles:
+    if write:
+        old_profiles = [p for p in get_profiles_list() if p != profile]
+        if not old_profiles:
         set_default_profile('verdi', profile)
         set_default_profile('daemon', profile)
     return new_profile

--- a/aiida/common/setup.py
+++ b/aiida/common/setup.py
@@ -641,8 +641,8 @@ def create_config_noninteractive(profile='default', force_overwrite=False, dry_r
     if write:
         old_profiles = [p for p in get_profiles_list() if p != profile]
         if not old_profiles:
-        set_default_profile('verdi', profile)
-        set_default_profile('daemon', profile)
+            set_default_profile('verdi', profile)
+            set_default_profile('daemon', profile)
     return new_profile
 
 def create_configuration(profile='default'):

--- a/aiida/common/setup.py
+++ b/aiida/common/setup.py
@@ -637,9 +637,9 @@ def create_config_noninteractive(profile='default', force_overwrite=False, dry_r
 
     # finalizing
     write = not dry_run
+    old_profiles = get_profiles_list()
     new_profile = update_profile(profile, new_profile, write=write)
     if write:
-        old_profiles = [p for p in get_profiles_list() if p != profile]
         if not old_profiles:
             set_default_profile('verdi', profile)
             set_default_profile('daemon', profile)

--- a/aiida/common/setup.py
+++ b/aiida/common/setup.py
@@ -639,7 +639,7 @@ def create_config_noninteractive(profile='default', force_overwrite=False, dry_r
     write = not dry_run
     new_profile = update_profile(profile, new_profile, write=write)
     old_profiles = [p for p in get_profiles_list() if p != profile]
-    if profile=='default' or not old_profiles:
+    if not old_profiles:
         set_default_profile('verdi', profile)
         set_default_profile('daemon', profile)
     return new_profile

--- a/aiida/common/setup.py
+++ b/aiida/common/setup.py
@@ -638,6 +638,10 @@ def create_config_noninteractive(profile='default', force_overwrite=False, dry_r
     # finalizing
     write = not dry_run
     new_profile = update_profile(profile, new_profile, write=write)
+    old_profiles = [p for p in get_profiles_list() if p != profile]
+    if profile=='default' or not old_profiles:
+        set_default_profile('verdi', profile)
+        set_default_profile('daemon', profile)
     return new_profile
 
 def create_configuration(profile='default'):


### PR DESCRIPTION
If the noninteractively created profile is either named 'default' or the only existing profile it is set to default for both verdi and daemon