### PR TITLE
Fix #354 verdi restapi

### DIFF
--- a/aiida/backends/djsite/settings/settings.py
+++ b/aiida/backends/djsite/settings/settings.py
@@ -36,6 +36,9 @@ if settings.AIIDADB_PROFILE is None:
 
 profile_conf = get_profile_config(settings.AIIDADB_PROFILE, conf_dict=confs)
 
+print settings.AIIDADB_PROFILE
+print profile_conf
+
 # put all database specific portions of settings here
 DBENGINE = profile_conf.get('AIIDADB_ENGINE', '')
 DBNAME = profile_conf.get('AIIDADB_NAME', '')

--- a/aiida/backends/djsite/settings/settings.py
+++ b/aiida/backends/djsite/settings/settings.py
@@ -36,9 +36,6 @@ if settings.AIIDADB_PROFILE is None:
 
 profile_conf = get_profile_config(settings.AIIDADB_PROFILE, conf_dict=confs)
 
-print settings.AIIDADB_PROFILE
-print profile_conf
-
 # put all database specific portions of settings here
 DBENGINE = profile_conf.get('AIIDADB_ENGINE', '')
 DBNAME = profile_conf.get('AIIDADB_NAME', '')

--- a/aiida/cmdline/commands/graph.py
+++ b/aiida/cmdline/commands/graph.py
@@ -26,7 +26,7 @@ class Graph(VerdiCommandWithSubcommands):
 
     def __init__(self):
         """
-        A dictionary with valid subcommandsa as keys and corresponding functions as values
+        A dictionary with valid subcommands as keys and corresponding functions as values
         """
         self.valid_subcommands = {
             'generate': (self.graph_generate, self.complete_none)
@@ -70,10 +70,9 @@ class Graph(VerdiCommandWithSubcommands):
             print >> sys.stderr, e.message
             sys.exit(1)
 
-        # From this point on I inherit Giovanni's script grap-generator.py.
-        # This script starts from the root_pk and goes both input-ward and output-ward via a breadth-first algorithm
+        # The algorithm starts from the root_pk and goes both input-ward and output-ward via a breadth-first algorithm
         # until the connected part of the graph that contains the root_pk is fully explored.
-        # TODO this command deserves to be radically improved, with options and further subcommands
+        # TODO this command deserves to be improved, with options and further subcommands
 
 
         def kpoints_desc(node):

--- a/aiida/cmdline/commands/graph.py
+++ b/aiida/cmdline/commands/graph.py
@@ -28,6 +28,11 @@ class Graph(VerdiCommandWithSubcommands):
         """
         A dictionary with valid subcommands as keys and corresponding functions as values
         """
+
+        # Usual boilerplate to set the environment
+        if not is_dbenv_loaded():
+            load_dbenv()
+
         self.valid_subcommands = {
             'generate': (self.graph_generate, self.complete_none)
             # TODO: add a command to find connections between two points
@@ -39,9 +44,6 @@ class Graph(VerdiCommandWithSubcommands):
         :param args: root_pk
         :return: Generate a .dot file that can be rendered by graphviz utility dot
         """
-        # Usual boilerplate to load certain classes and functions
-        if not is_dbenv_loaded():
-            load_dbenv()
         from aiida.orm import load_node
         from aiida.orm.calculation import Calculation
         from aiida.orm.calculation.job import JobCalculation

--- a/aiida/cmdline/commands/restapi.py
+++ b/aiida/cmdline/commands/restapi.py
@@ -7,6 +7,7 @@ profiles can be selected at hook-up (-p flag).
 """
 
 import os
+
 import aiida
 from aiida.cmdline.baseclass import VerdiCommand
 from aiida.restapi.api import app
@@ -28,6 +29,7 @@ class Restapi(VerdiCommand):
     default_port = "5000"
     default_config_dir = os.path.join(os.path.split(os.path.abspath(
         aiida.restapi.__file__))[0], 'common')
+    parse_aiida_profile = False
 
     def run(self, *args):
         """
@@ -40,11 +42,11 @@ class Restapi(VerdiCommand):
             prog_name=self.get_full_command_name(),
             default_host=self.default_host,
             default_port=self.default_port,
-            default_config=self.default_config_dir)
+            default_config=self.default_config_dir,
+            parse_aiida_profile=self.parse_aiida_profile)
 
         # Invoke the runner
         flaskrun(app, *args, **kwargs)
-
 
     def complete(self, subargs_idx, subargs):
         """

--- a/aiida/cmdline/commands/restapi.py
+++ b/aiida/cmdline/commands/restapi.py
@@ -1,21 +1,50 @@
 # -*- coding: utf-8 -*-
 """
 This allows to hook-up the AiIDA built-in RESTful API.
-Main advantage of doing this by means of a verdi command is that different profiles can be selected at hook-up (-p flag).
+Main advantage of doing this by means of a verdi command is that different
+profiles can be selected at hook-up (-p flag).
 
 """
 
-from aiida.restapi.api import app, hookup
+import os
+import aiida
 from aiida.cmdline.baseclass import VerdiCommand
+from aiida.restapi.api import app
+from aiida.restapi.common.flaskrun import flaskrun
+
 
 class Restapi(VerdiCommand):
     """
-    Hook up the default RESTful API of AiiDA.
-    No special logic required
+    verdi command used to hook up the AiIDA REST API.
+    Example Usage:
+
+    verdi -p <profile_name> restapi --host 127.0.0.5 --port 6789
+    --config-dir <location of the onfig.py file>
+
     """
 
+    # Defaults defined at class level
+    default_host = "127.0.0.1"
+    default_port = "5000"
+    default_config_dir = os.path.join(os.path.split(os.path.abspath(
+        aiida.restapi.__file__))[0], 'common')
+
     def run(self, *args):
-        hookup(app)
+        """
+        Hook up the default RESTful API of AiiDA.
+        args include port, host, config_file
+        """
+
+        # Construct dparameter dictionary
+        kwargs = dict(
+            prog_name=self.get_full_command_name(),
+            default_host=self.default_host,
+            default_port=self.default_port,
+            default_config=self.default_config_dir)
+
+        # Invoke the runner
+        flaskrun(app, *args, **kwargs)
+
 
     def complete(self, subargs_idx, subargs):
         """

--- a/aiida/cmdline/commands/restapi.py
+++ b/aiida/cmdline/commands/restapi.py
@@ -1,0 +1,24 @@
+# -*- coding: utf-8 -*-
+"""
+This allows to hook-up the AiIDA built-in RESTful API.
+Main advantage of doing this by means of a verdi command is that different profiles can be selected at hook-up (-p flag).
+
+"""
+
+from aiida.restapi.api import app, hookup
+from aiida.cmdline.baseclass import VerdiCommand
+
+class Restapi(VerdiCommand):
+    """
+    Hook up the default RESTful API of AiiDA.
+    No special logic required
+    """
+
+    def run(self, *args):
+        hookup(app)
+
+    def complete(self, subargs_idx, subargs):
+        """
+        No particular completion features required
+        """
+        return ""

--- a/aiida/cmdline/verdilib.py
+++ b/aiida/cmdline/verdilib.py
@@ -43,6 +43,7 @@ from aiida.cmdline.commands.workflow import Workflow
 from aiida.cmdline.commands.work import Work
 from aiida.cmdline.commands.comment import Comment
 from aiida.cmdline.commands.shell import Shell
+from aiida.cmdline.commands.restapi import Restapi
 from aiida.cmdline import execname
 
 __copyright__ = u"Copyright (c), This file is part of the AiiDA platform. For further information please visit http://www.aiida.net/. All rights reserved."

--- a/aiida/restapi/api.py
+++ b/aiida/restapi/api.py
@@ -153,9 +153,8 @@ api.add_resource(Group,
                  '/groups/<int:pk>/',
                  strict_slashes=False)
 
-
-# Standard boilerplate to run the app
-if __name__ == '__main__':
+#TODO transfer all this logic to flaskrun (and change this name, call it hookup)
+def hookup(app):
 
     #Config the app
     app.config.update(**conf.APP_CONFIG)
@@ -170,3 +169,8 @@ if __name__ == '__main__':
     # Default address is 127.0.01:5000
     #Warm up the engine - brum brum - and staaarrrt!!
     flaskrun(app)
+
+# Standard boilerplate to run the app
+if __name__ == '__main__':
+    hookup(app)
+

--- a/aiida/restapi/api.py
+++ b/aiida/restapi/api.py
@@ -160,7 +160,9 @@ if __name__ == '__main__':
     # Default address is 127.0.01:5000, default config directory is
     # <aiida_path>/aiida/restapi/common
 
-    #Start the app by sliding the argvs to flaskrun
+    #Start the app by sliding the argvs to flaskrun, choose to take as an
+    # argument also whether to parse the aiida profile or not (in verdi
+    # restapi this would not be the case)
     import sys
-    flaskrun(app, *sys.argv[1:])
+    flaskrun(app, *sys.argv[1:], parse_aiida_profile=True)
 

--- a/aiida/restapi/api.py
+++ b/aiida/restapi/api.py
@@ -8,15 +8,13 @@ Author: Snehal P. Waychal and Fernando Gargiulo @ Theos, EPFL
 
 from flask import Flask, jsonify
 from flask_restful import Api
-from flask_cors import CORS, cross_origin
+from flask_cors import CORS
 from aiida.restapi.common.exceptions import RestInputValidationError,\
     RestValidationError
 from aiida.restapi.resources import Calculation, Computer, Code, Data, Group, \
     Node, User
 import aiida.restapi.common.config as conf
 from aiida.restapi.common.flaskrun import flaskrun
-from flask.ext.sqlalchemy import SQLAlchemy
-
 
 ## Initiate an app with its api
 app = Flask(__name__)
@@ -153,24 +151,16 @@ api.add_resource(Group,
                  '/groups/<int:pk>/',
                  strict_slashes=False)
 
-#TODO transfer all this logic to flaskrun (and change this name, call it hookup)
-def hookup(app):
-
-    #Config the app
-    app.config.update(**conf.APP_CONFIG)
-
-    #Config the serializer used by the app
-    if conf.SERIALIZER_CONFIG:
-        from aiida.restapi.common.utils import CustomJSONEncoder
-        app.json_encoder = CustomJSONEncoder
-
-    #I run the app via a wrapper that accepts arguments such as host and port
-    #e.g. python api.py --host=127.0.0.2 --port=6000
-    # Default address is 127.0.01:5000
-    #Warm up the engine - brum brum - and staaarrrt!!
-    flaskrun(app)
 
 # Standard boilerplate to run the app
 if __name__ == '__main__':
-    hookup(app)
+
+    #I run the app via a wrapper that accepts arguments such as host and port
+    #e.g. python api.py --host=127.0.0.2 --port=6000 --config-dir=~/.restapi
+    # Default address is 127.0.01:5000, default config directory is
+    # <aiida_path>/aiida/restapi/common
+
+    #Start the app by sliding the argvs to flaskrun
+    import sys
+    flaskrun(app, *sys.argv[1:])
 

--- a/aiida/restapi/common/flaskrun.py
+++ b/aiida/restapi/common/flaskrun.py
@@ -1,49 +1,109 @@
-## This snippet has been writtten by Armin Ronacher, who explicitely defined
-# it to be of public domain and freely usable as the user likes.
+## This snippet has been originally writtten by Armin Ronacher, who explicitely
+# defined it to be of public domain and freely usable as the user likes.
 
-import optparse
+import argparse
+import imp
+import os
+import aiida  # Mainly needed to locate the correct aiida path
+from aiida.backends.utils import load_dbenv, is_dbenv_loaded
 
-def flaskrun(app, default_host="127.0.0.1",
-                  default_port="5000"):
+def flaskrun(app, *args, **kwargs):
+
     """
     Takes a flask.Flask instance and runs it. Parses
     command-line flags to configure the app.
+
+    app: app to be run
+    *args: required by argparse
+
+    List of valid parameters
+    prog_name: name of the command before arguments are parsed. Useful when
+    api is embedded in a command, such as verdi restapi
+    default_host: self-explainatory
+    default_port: self-explainatory
+    default_config_dir = directory containing the config.py file used to
+    configure the RESTapi
+
+    All other passed parameters are ignored.
+
     """
 
+    # Unpack parameters and assign defaults if needed
+    prog_name = kwargs['prog_name'] if 'prog_name' in kwargs else ""
+
+    default_host = kwargs['default_host'] if 'default_host' in kwargs else \
+        "127.0.0.1"
+
+    default_port = kwargs['default_port'] if 'default_port' in kwargs else \
+        "5000"
+
+    default_config_dir = kwargs['default_config_dir'] if\
+        'default_config_dir' in kwargs\
+        else  os.path.join(os.path.split(os.path.abspath(
+        aiida.restapi.__file__))[0], 'common')
+
     # Set up the command-line options
-    parser = optparse.OptionParser()
-    parser.add_option("-H", "--host",
-                      help="Hostname of the Flask app " + \
-                           "[default %s]" % default_host,
-                      default=default_host)
-    parser.add_option("-P", "--port",
-                      help="Port for the Flask app " + \
-                           "[default %s]" % default_port,
-                      default=default_port)
+    parser = argparse.ArgumentParser(prog=prog_name,
+                                     description='Hook up the AiiDA '
+                                                 'RESTful API')
+
+    parser.add_argument("-H", "--host",
+                        help="Hostname of the Flask app " + \
+                             "[default %s]" % default_host,
+                        dest='host',
+                        default=default_host)
+    parser.add_argument("-P", "--port",
+                        help="Port for the Flask app " + \
+                             "[default %s]" % default_port,
+                        dest='port',
+                        default=default_port)
+    parser.add_argument("-c", "--config-dir",
+                        help="Directory with config.py for Flask app " + \
+                             "[default {}]".format(default_config_dir),
+                        dest='config_dir',
+                        default=default_config_dir)
 
     # Two options useful for debugging purposes, but
     # a bit dangerous so not exposed in the help message.
-    parser.add_option("-d", "--debug",
-                      action="store_true", dest="debug",
-                      help=optparse.SUPPRESS_HELP)
-    parser.add_option("-p", "--profile",
-                      action="store_true", dest="profile",
-                      help=optparse.SUPPRESS_HELP)
+    parser.add_argument("-d", "--debug",
+                        action="store_true", dest="debug",
+                        help=argparse.SUPPRESS)
+    parser.add_argument("-w", "--wsgi-profile",
+                        action="store_true", dest="profile",
+                        help=argparse.SUPPRESS)
 
-    options, _ = parser.parse_args()
+    parsed_args = parser.parse_args(args)
 
     # If the user selects the profiling option, then we need
     # to do a little extra setup
-    if options.profile:
+    if parsed_args.profile:
         from werkzeug.contrib.profiler import ProfilerMiddleware
 
         app.config['PROFILE'] = True
         app.wsgi_app = ProfilerMiddleware(app.wsgi_app,
-                       restrictions=[30])
-        options.debug = True
+                                          restrictions=[30])
 
+    # Import the right configuration file
+    confs = imp.load_source(os.path.join(parsed_args.config_dir, 'config'),
+                            os.path.join(parsed_args.config_dir,
+                                         'config.py')
+                            )
+
+    # Set the AiiDA environment, if not already done
+    if not is_dbenv_loaded():
+        load_dbenv()
+
+    # Config the app
+    app.config.update(**confs.APP_CONFIG)
+
+    # Config the serializer used by the app
+    if confs.SERIALIZER_CONFIG:
+        from aiida.restapi.common.utils import CustomJSONEncoder
+        app.json_encoder = CustomJSONEncoder
+
+    # Hook up the app
     app.run(
-        debug=options.debug,
-        host=options.host,
-        port=int(options.port)
+        debug=parsed_args.debug,
+        host=parsed_args.host,
+        port=int(parsed_args.port)
     )

--- a/aiida/restapi/resources.py
+++ b/aiida/restapi/resources.py
@@ -5,16 +5,13 @@ from urllib import unquote
 from flask import request
 from flask_restful import Resource
 
-from aiida.backends.utils import load_dbenv, is_dbenv_loaded
-if not is_dbenv_loaded():
-    load_dbenv()
-
 ## TODO add the caching support. I cache total count, results, and possibly
 # set_query
 class BaseResource(Resource):
     ## Each derived class will instantiate a different type of translator.
     # This is the only difference in the classes.
     def __init__(self):
+
         self.trans = None
 
     def get(self, **kwargs):

--- a/aiida/restapi/translator/base.py
+++ b/aiida/restapi/translator/base.py
@@ -71,7 +71,7 @@ class BaseTranslator(object):
         # Load correspondent orm class
         orm_class = get_object_from_string(class_string)
 
-        # Construct the json object to return it
+        # Construct the json object to be returned
         basic_schema = orm_class.get_db_columns()
 
         if cls._default_projections == ['**']:
@@ -84,7 +84,7 @@ class BaseTranslator(object):
         # (orm class/db table ==> RESTapi resource)
         def table2resource(table_name):
             # TODO Consider ways to make this function backend independent (one
-            # idea would be to gro from table name to aiida class name which is
+            # idea would be to go from table name to aiida class name which is
             # univoque)
             if BACKEND == BACKEND_DJANGO:
                 (spam, resource_name) = issingular(table_name[2:].lower())


### PR DESCRIPTION
Added command verdi restapi used to hook up the REST api:

```bash
verdi -p myprofile restapi --port 6000 --host 127.0.0.5 --config-dir ~/aiida/aiida/restapi/common
* Running on http://127.0.0.5:6000/ (Press CTRL+C to quit)
```

The original way to fire up the api is still available (Note that both ways use the flaskrun wrapper to avoid code duplication). Also in this case you have an additional '-p' option to set the aiida profile 

```bash
cd <aiida_folder>/aiida/restapi
./api.py --port 6000 --host 127.0.0.5 --config-dir ~/aiida/aiida/restapi/common --aiida-profile myprofile
* Running on http://127.0.0.5:6000/ (Press CTRL+C to quit)
```

Default ports, host, and directory of config_file are the same as before 

Tests work identically as before.