### PR TITLE
Adding indices for daemon queries and node UUID queries.

### DIFF
--- a/aiida/backends/djsite/db/migrations/0004_add_daemon_and_uuid_indices.py
+++ b/aiida/backends/djsite/db/migrations/0004_add_daemon_and_uuid_indices.py
@@ -1,0 +1,43 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+import django_extensions.db.fields
+from django.db import migrations
+
+from aiida.backends.djsite.db.migrations import update_schema_version
+
+__copyright__ = u"Copyright (c), This file is part of the AiiDA platform. For further information please visit http://www.aiida.net/. All rights reserved."
+__license__ = "MIT license, see LICENSE.txt file."
+__authors__ = "The AiiDA team."
+__version__ = "0.7.1"
+
+SCHEMA_VERSION = "1.0.4"
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ('db', '0003_add_link_type'),
+    ]
+
+    operations = [
+        # Create the index that speeds up the daemon queries
+        # We use the RunSQL command because Django interface
+        # doesn't seem to support partial indexes
+        migrations.RunSQL("""
+        CREATE INDEX tval_idx_for_daemon
+        ON db_dbattribute (tval)
+        WHERE ("db_dbattribute"."tval"
+        IN ('COMPUTED', 'WITHSCHEDULER', 'TOSUBMIT'))"""),
+
+        # Create an index on UUIDs to speed up loading of nodes
+        # using this field
+        migrations.AlterField(
+            model_name='dbnode',
+            name='uuid',
+            field=django_extensions.db.fields.UUIDField(db_index=True,
+                                                        editable=False,
+                                                        blank=True),
+            preserve_default=True,
+        ),
+        update_schema_version(SCHEMA_VERSION)
+    ]

--- a/aiida/backends/djsite/db/migrations/__init__.py
+++ b/aiida/backends/djsite/db/migrations/__init__.py
@@ -5,7 +5,7 @@ __license__ = "MIT license, see LICENSE.txt file."
 __version__ = "0.7.1"
 __authors__ = "The AiiDA team."
 
-LATEST_MIGRATION = '0003_add_link_type'
+LATEST_MIGRATION = '0004_add_daemon_and_uuid_indices'
 
 
 def _update_schema_version(version, apps, schema_editor):

--- a/aiida/backends/djsite/db/models.py
+++ b/aiida/backends/djsite/db/models.py
@@ -143,7 +143,7 @@ class DbNode(m.Model):
        modify them, but can be changed (e.g., the append_text of a code, that
        can be redefined if the code has to be recompiled).
     """
-    uuid = UUIDField(auto=True, version=AIIDANODES_UUID_VERSION)
+    uuid = UUIDField(auto=True, version=AIIDANODES_UUID_VERSION, db_index=True)
     # in the form data.upffile., data.structure., calculation., code.quantumespresso.pw., ...
     # Note that there is always a final dot, to allow to do queries of the
     # type (type__startswith="calculation.") and avoid problems with classes


### PR DESCRIPTION
This is a partial fix for #390.
It speeds by orders of magnitude daemon queries.
It also speeds up node loading using the UUIDs.