### PR TITLE
add test trying to load all preinstalled plugins.

### DIFF
--- a/aiida/backends/tests/__init__.py
+++ b/aiida/backends/tests/__init__.py
@@ -57,6 +57,7 @@ db_test_list = {
         'work.workChain': ['aiida.backends.tests.work.workChain'],
         'work.workfunction': ['aiida.backends.tests.work.workfunction'],
         'work.legacy.job_process': ['aiida.backends.tests.work.legacy.job_process'],
+        'pluginloader': ['aiida.backends.tests.test_plugin_loader'],
     }
 }
 
@@ -67,7 +68,7 @@ def get_db_test_names():
             retlist.append(name)
 
 
-    # Explode the list so that if I have a.b.c, 
+    # Explode the list so that if I have a.b.c,
     # I can run it also just with 'a' or with 'a.b'
     final_list = [_ for _ in retlist]
     for k in retlist:
@@ -83,7 +84,7 @@ def get_db_test_names():
 
 def get_db_test_list():
     """
-    This function returns the db_test_list for the current backend, 
+    This function returns the db_test_list for the current backend,
     merged with the 'common' tests.
 
     :note: This function should be called only after setting the
@@ -113,7 +114,7 @@ def get_db_test_list():
         for t in tests:
             retdict[k].append(t)
 
-    # Explode the dictionary so that if I have a.b.c, 
+    # Explode the dictionary so that if I have a.b.c,
     # I can run it also just with 'a' or with 'a.b'
     final_retdict = defaultdict(list)
     for k, v in retdict.iteritems():

--- a/aiida/backends/tests/test_plugin_loader.py
+++ b/aiida/backends/tests/test_plugin_loader.py
@@ -17,18 +17,27 @@ class TestExistingPlugins(AiidaTestCase):
         from aiida.orm.calculation.job import JobCalculation
         calcs = pl.existing_plugins(JobCalculation, 'aiida.orm.calculation.job', suffix='Calculation')
         self.assertIsInstance(calcs, list)
+        from aiida.orm import CalculationFactory
+        for i in calcs:
+            self.assertIsInstance(CalculationFactory(i), JobCalculation)
 
     def test_existing_parsers(self):
         """Test listing all preinstalled parsers"""
         from aiida.parsers import Parser
         pars = pl.existing_plugins(Parser, 'aiida.parsers.plugins')
         self.assertIsInstance(pars, list)
+        from aiida.parsers import ParserFactory
+        for i in pars:
+            self.assertIsInstance(ParserFactory(i), Parser)
 
     def test_existing_data(self):
         """Test listing all preinstalled data formats"""
         from aiida.orm.data import Data
         data = pl.existing_plugins(Data, 'aiida.orm.data')
         self.assertIsInstance(data, list)
+        from aiida.orm import DataFactory
+        for i in data:
+            self.assertIsInstance(DataFactory(i), Data)
 
     def test_existing_schedulers(self):
         """Test listing all preinstalled schedulers"""
@@ -47,6 +56,9 @@ class TestExistingPlugins(AiidaTestCase):
         from aiida.orm import Workflow
         work = pl.existing_plugins(Workflow, 'aiida.workflows')
         self.assertIsInstance(work, list)
+        from aiida.orm import WorkflowFactory
+        for i in work:
+            self.assertIsInstance(WorkflowFactory(i), Workflow)
 
     def test_existing_tcod_plugins(self):
         """Test listing all preinstalled tcod exporter plugins"""

--- a/aiida/backends/tests/test_plugin_loader.py
+++ b/aiida/backends/tests/test_plugin_loader.py
@@ -19,7 +19,7 @@ class TestExistingPlugins(AiidaTestCase):
         self.assertIsInstance(calcs, list)
         from aiida.orm import CalculationFactory
         for i in calcs:
-            self.assertIsInstance(CalculationFactory(i), JobCalculation)
+            self.assertTrue(issubclass(CalculationFactory(i), JobCalculation))
 
     def test_existing_parsers(self):
         """Test listing all preinstalled parsers"""
@@ -28,7 +28,7 @@ class TestExistingPlugins(AiidaTestCase):
         self.assertIsInstance(pars, list)
         from aiida.parsers import ParserFactory
         for i in pars:
-            self.assertIsInstance(ParserFactory(i), Parser)
+            self.assertTrue(issubclass(ParserFactory(i), Parser))
 
     def test_existing_data(self):
         """Test listing all preinstalled data formats"""
@@ -37,7 +37,7 @@ class TestExistingPlugins(AiidaTestCase):
         self.assertIsInstance(data, list)
         from aiida.orm import DataFactory
         for i in data:
-            self.assertIsInstance(DataFactory(i), Data)
+            self.assertTrue(issubclass(DataFactory(i), Data))
 
     def test_existing_schedulers(self):
         """Test listing all preinstalled schedulers"""
@@ -58,7 +58,7 @@ class TestExistingPlugins(AiidaTestCase):
         self.assertIsInstance(work, list)
         from aiida.orm import WorkflowFactory
         for i in work:
-            self.assertIsInstance(WorkflowFactory(i), Workflow)
+            self.assertTrue(issubclass(WorkflowFactory(i), Workflow))
 
     def test_existing_tcod_plugins(self):
         """Test listing all preinstalled tcod exporter plugins"""

--- a/aiida/backends/tests/test_plugin_loader.py
+++ b/aiida/backends/tests/test_plugin_loader.py
@@ -22,7 +22,7 @@ class TestExistingPlugins(AiidaTestCase):
         """Test listing all preinstalled parsers"""
         from aiida.parsers import Parser
         pars = pl.existing_plugins(Parser, 'aiida.parsers.plugins')
-        self.assertIsInstance(calcs, list)
+        self.assertIsInstance(pars, list)
 
     def test_existing_data(self):
         """Test listing all preinstalled data formats"""

--- a/aiida/backends/tests/test_plugin_loader.py
+++ b/aiida/backends/tests/test_plugin_loader.py
@@ -1,9 +1,10 @@
 # -*- coding: utf-8 -*-
+from aiida.backends.testbase import AiidaTestCase
 from aiida.common import pluginloader as pl
 import unittest
 
 
-class TestExistingPlugins(unittest.TestCase):
+class TestExistingPlugins(AiidaTestCase):
     """
     Test pluginloader's existing_plugins function.
 
@@ -11,11 +12,6 @@ class TestExistingPlugins(unittest.TestCase):
     * will fail when pluginloader gets broken.
     * will fail if pluginloader returns something else than a list
     """
-    def setUp(self):
-        from aiida import load_dbenv, is_dbenv_loaded
-        if not is_dbenv_loaded():
-            load_dbenv()
-
     def test_existing_calculations(self):
         """Test listing all preinstalled calculations """
         from aiida.orm.calculation.job import JobCalculation

--- a/aiida/common/pluginloader.py
+++ b/aiida/common/pluginloader.py
@@ -77,7 +77,7 @@ def get_class_typestring(type_string):
 
 
 def _existing_plugins_with_module(base_class, plugins_module_path,
-                                  pkgname, basename, max_depth, suffix=None, verbose=False):
+                                  pkgname, basename, max_depth, suffix=None):
     """
         Recursive function to return the existing plugins within a given module.
 
@@ -180,7 +180,7 @@ def _find_module(base_class, pkgname, this_basename, suffix=None):
     return retlist
 
 
-def existing_plugins(base_class, plugins_module_name, max_depth=5, suffix=None, verbose=False):
+def existing_plugins(base_class, plugins_module_name, max_depth=5, suffix=None):
     """
     Return a list of strings of valid plugins.
 
@@ -207,7 +207,7 @@ def existing_plugins(base_class, plugins_module_name, max_depth=5, suffix=None, 
                                          pluginmod.__path__[0],
                                          plugins_module_name,
                                          "",
-                                         max_depth, suffix, verbose=verbose)
+                                         max_depth, suffix)
 
 
 def load_plugin(base_class, plugins_module, plugin_type):

--- a/aiida/common/test_plugin_loader.py
+++ b/aiida/common/test_plugin_loader.py
@@ -1,0 +1,59 @@
+# -*- coding: utf-8 -*-
+from aiida.common import pluginloader as pl
+import unittest
+
+
+class TestExistingPlugins(unittest.TestCase):
+    """
+    Test pluginloader's existing_plugins function.
+
+    * will fail when any of the plugins distributede with aiida fail to load.
+    * will fail when pluginloader gets broken.
+    * will fail if pluginloader returns something else than a list
+    """
+    def setUp(self):
+        from aiida import load_dbenv, is_dbenv_loaded
+        if not is_dbenv_loaded():
+            load_dbenv()
+
+    def test_existing_calculations(self):
+        """Test listing all preinstalled calculations """
+        from aiida.orm.calculation.job import JobCalculation
+        calcs = pl.existing_plugins(JobCalculation, 'aiida.orm.calculation.job', suffix='Calculation')
+        self.assertIsInstance(calcs, list)
+
+    def test_existing_parsers(self):
+        """Test listing all preinstalled parsers"""
+        from aiida.parsers import Parser
+        pars = pl.existing_plugins(Parser, 'aiida.parsers.plugins')
+        self.assertIsInstance(calcs, list)
+
+    def test_existing_data(self):
+        """Test listing all preinstalled data formats"""
+        from aiida.orm.data import Data
+        data = pl.existing_plugins(Data, 'aiida.orm.data')
+        self.assertIsInstance(data, list)
+
+    def test_existing_schedulers(self):
+        """Test listing all preinstalled schedulers"""
+        from aiida.scheduler import Scheduler
+        sche = pl.existing_plugins(Scheduler, 'aiida.scheduler.plugins')
+        self.assertIsInstance(sche, list)
+
+    def test_existing_transports(self):
+        """Test listing all preinstalled transports"""
+        from aiida.transport import Transport
+        tran = pl.existing_plugins(Transport, 'aiida.transport.plugins')
+        self.assertIsInstance(tran, list)
+
+    def test_existing_workflows(self):
+        """Test listing all preinstalled workflows"""
+        from aiida.orm import Workflow
+        work = pl.existing_plugins(Workflow, 'aiida.workflows')
+        self.assertIsInstance(work, list)
+
+    def test_existing_tcod_plugins(self):
+        """Test listing all preinstalled tcod exporter plugins"""
+        from aiida.tools.dbexporters.tcod_plugins import BaseTcodtranslator
+        tcpl = pl.existing_plugins(BaseTcodtranslator, 'aiida.tools.dbexporters.tcod_plugins')
+        self.assertIsInstance(tcpl, list)

--- a/aiida/parsers/plugins/ase/__init__.py
+++ b/aiida/parsers/plugins/ase/__init__.py
@@ -11,18 +11,17 @@ from aiida.orm.data.array import ArrayData
 from aiida.orm.data.parameter import ParameterData
 from aiida.orm.data.structure import StructureData
 import json
-import ase, ase.io
 
 
 class AseParser(Parser):
     """
     This class is the implementation of the Parser class for Ase calculators.
     """
-    
+
     _outarray_name = 'output_array'
     _outdict_name = 'output_parameters'
     _outstruc_name = 'output_structure'
-    
+
     def __init__(self,calculation):
         """
         Initialize the instance of AseParser
@@ -31,7 +30,7 @@ class AseParser(Parser):
         if not isinstance(calculation,AseCalculation):
             raise OutputParsingError("Input calculation must be a AseCalculation")
         self._calc = calculation
-            
+
     def parse_from_calc(self):
         """
         Parses the datafolder, stores results.
@@ -41,73 +40,76 @@ class AseParser(Parser):
         from aiida.common.exceptions import InvalidOperation
         from aiida.common import aiidalogger
         from aiida.djsite.utils import get_dblogger_extra
+
+        import ase, ase.io
+
         parserlogger = aiidalogger.getChild('aseparser')
         logger_extra = get_dblogger_extra(self._calc)
-        
+
         # suppose at the start that the job is successful
         successful = True
-        
+
         # check that calculation is in the right state
         state = self._calc.get_state()
         if state != calc_states.PARSING:
             raise InvalidOperation("Calculation not in {} state"
                                    .format(calc_states.PARSING) )
-        
+
         # select the folder object
         out_folder = self._calc.get_retrieved_node()
-        
+
         # check what is inside the folder
         list_of_files = out_folder.get_folder_list()
-        
+
         # at least the stdout should exist
         if not self._calc._OUTPUT_FILE_NAME in list_of_files:
             successful = False
             parserlogger.error("Standard output not found",extra=logger_extra)
             return successful,()
-        
+
         # output structure
         has_out_atoms = True if self._calc._output_aseatoms in list_of_files else False
         if has_out_atoms:
             out_atoms = ase.io.read( out_folder.get_abs_path( self._calc._output_aseatoms ) )
             out_structure = StructureData().set_ase(out_atoms)
-        
+
         # load the results dictionary
         json_outfile = out_folder.get_abs_path( self._calc._OUTPUT_FILE_NAME )
         with open(json_outfile,'r') as f:
-            json_params = json.load(f) 
-        
+            json_params = json.load(f)
+
         # extract arrays from json_params
         dictionary_array = {}
         for k,v in list(json_params.iteritems()):
             if isinstance(v, (list,tuple)):
                 dictionary_array[k] = json_params.pop(k)
-        
+
         # look at warnings
         warnings = []
         with open(out_folder.get_abs_path( self._calc._SCHED_ERROR_FILE )) as f:
             errors = f.read()
         if errors:
             warnings = [errors]
-        json_params['warnings'] = warnings    
-        
+        json_params['warnings'] = warnings
+
         # save the outputs
         new_nodes_list= []
-        
+
         # save the arrays
         if dictionary_array:
             array_data = ArrayData()
             for k,v in dictionary_array.iteritems():
                 array_data.set_array(k,numpy.array(v))
             new_nodes_list.append( (self._outarray_name, array_data) )
-        
+
         # save the parameters
         if json_params:
             parameter_data = ParameterData( dict=json_params )
             new_nodes_list.append( (self._outdict_name, parameter_data) )
-        
+
         if has_out_atoms:
             structure_data = StructureData()
-            new_nodes_list.append( (self._outstruc_name, structure_data) ) 
-       
+            new_nodes_list.append( (self._outstruc_name, structure_data) )
+
         return successful,new_nodes_list
-        
+


### PR DESCRIPTION
adds a test to aiida.common, running pluginloader.existing_plugins on all types of plugins.
This test will fail when one of the plugins errors on import, preventing commits from breaking (old) plugins.