### PR TITLE
Replace deprecated commit_on_success with atomic for Django transactions

### DIFF
--- a/aiida/orm/implementation/django/calculation/inline.py
+++ b/aiida/orm/implementation/django/calculation/inline.py
@@ -79,7 +79,7 @@ def make_inline(func):
         for k, v in retval.iteritems():
             v.add_link_from(c, label=k, link_type=LinkType.RETURN)
 
-        with transaction.commit_on_success():
+        with transaction.atomic():
             # I call store_all for the Inline calculation;
             # this will store also the inputs, if needed.
             c.store_all(with_transaction=False)

--- a/aiida/orm/implementation/django/calculation/job/__init__.py
+++ b/aiida/orm/implementation/django/calculation/job/__init__.py
@@ -60,7 +60,7 @@ class JobCalculation(AbstractJobCalculation, Calculation):
                                              "to {}".format(old_state, state))
 
         try:
-            with transaction.commit_on_success():
+            with transaction.atomic():
                 new_state = DbCalcState(dbnode=self.dbnode, state=state).save()
         except IntegrityError:
             raise ModificationNotAllowed(

--- a/aiida/orm/implementation/django/code.py
+++ b/aiida/orm/implementation/django/code.py
@@ -193,6 +193,6 @@ def delete_code(code):
             len(existing_outputs)))
     else:
         repo_folder = code._repository_folder
-        with transaction.commit_on_success():
+        with transaction.atomic():
             code.dbnode.delete()
             repo_folder.erase()

--- a/aiida/orm/implementation/django/group.py
+++ b/aiida/orm/implementation/django/group.py
@@ -117,13 +117,13 @@ class Group(AbstractGroup):
 
     def store(self):
         if not self.is_stored:
-            with transaction.atomic():
-                try:
+            try:
+                with transaction.atomic():
                     self.dbgroup.save()
-                except IntegrityError:
-                    raise UniquenessError("A group with the same name (and of the "
-                                          "same type) already "
-                                          "exists, unable to store")
+            except IntegrityError:
+                raise UniquenessError("A group with the same name (and of the "
+                                      "same type) already "
+                                      "exists, unable to store")
 
         # To allow to do directly g = Group(...).store()
         return self

--- a/aiida/orm/implementation/django/group.py
+++ b/aiida/orm/implementation/django/group.py
@@ -117,14 +117,13 @@ class Group(AbstractGroup):
 
     def store(self):
         if not self.is_stored:
-            sid = transaction.savepoint()
-            try:
-                self.dbgroup.save()
-            except IntegrityError:
-                transaction.savepoint_rollback(sid)
-                raise UniquenessError("A group with the same name (and of the "
-                                      "same type) already "
-                                      "exists, unable to store")
+            with transaction.atomic():
+                try:
+                    self.dbgroup.save()
+                except IntegrityError:
+                    raise UniquenessError("A group with the same name (and of the "
+                                          "same type) already "
+                                          "exists, unable to store")
 
         # To allow to do directly g = Group(...).store()
         return self

--- a/aiida/orm/implementation/django/node.py
+++ b/aiida/orm/implementation/django/node.py
@@ -150,14 +150,14 @@ class Node(AbstractNode):
     def _update_db_label_field(self, field_value):
         self.dbnode.label = field_value
         if not self._to_be_stored:
-            with transaction.commit_on_success():
+            with transaction.atomic():
                 self._dbnode.save()
                 self._increment_version_number_db()
 
     def _update_db_description_field(self, field_value):
         self.dbnode.description = field_value
         if not self._to_be_stored:
-            with transaction.commit_on_success():
+            with transaction.atomic():
                 self._dbnode.save()
                 self._increment_version_number_db()
 
@@ -166,7 +166,7 @@ class Node(AbstractNode):
             self._add_dblink_from(src, label, link_type)
         except UniquenessError:
             # I have to replace the link; I do it within a transaction
-            with transaction.commit_on_success():
+            with transaction.atomic():
                 self._remove_dblink_from(label)
                 self._add_dblink_from(src, label, link_type)
 
@@ -603,7 +603,7 @@ class Node(AbstractNode):
         from aiida.common.utils import EmptyContextManager
 
         if with_transaction:
-            context_man = transaction.commit_on_success()
+            context_man = transaction.atomic()
         else:
             context_man = EmptyContextManager()
 
@@ -690,7 +690,7 @@ class Node(AbstractNode):
         from aiida.common.utils import EmptyContextManager
 
         if with_transaction:
-            context_man = transaction.commit_on_success()
+            context_man = transaction.atomic()
         else:
             context_man = EmptyContextManager()
 
@@ -741,7 +741,7 @@ class Node(AbstractNode):
         import aiida.orm.autogroup
 
         if with_transaction:
-            context_man = transaction.commit_on_success()
+            context_man = transaction.atomic()
         else:
             context_man = EmptyContextManager()
 

--- a/aiida/orm/implementation/django/workflow.py
+++ b/aiida/orm/implementation/django/workflow.py
@@ -163,7 +163,7 @@ class Workflow(AbstractWorkflow):
 
         self.dbworkflowinstance.label = field_value
         if not self._to_be_stored:
-            with transaction.commit_on_success():
+            with transaction.atomic():
                 self._dbworkflowinstance.save()
                 self._increment_version_number_db()
 
@@ -190,7 +190,7 @@ class Workflow(AbstractWorkflow):
 
         self.dbworkflowinstance.description = field_value
         if not self._to_be_stored:
-            with transaction.commit_on_success():
+            with transaction.atomic():
                 self._dbworkflowinstance.save()
                 self._increment_version_number_db()
 

--- a/aiida/orm/importexport.py
+++ b/aiida/orm/importexport.py
@@ -448,7 +448,7 @@ def import_data_dj(in_path,ignore_unknown_nodes=False,
         # IMPORT DATA #
         ###############
         # DO ALL WITH A TRANSACTION
-        with transaction.commit_on_success():
+        with transaction.atomic():
             foreign_ids_reverse_mappings = {}
             new_entries = {}
             existing_entries = {}
@@ -938,7 +938,7 @@ def import_data_sqla(in_path, ignore_unknown_nodes=False, silent=False):
         # IMPORT DATA #
         ###############
         # DO ALL WITH A TRANSACTION
-        # with transaction.commit_on_success():
+        # with transaction.atomic():
         # if True
         import aiida.backends.sqlalchemy
         try:


### PR DESCRIPTION
The new atomic() transaction contextmanager has the added benefit that
savepoints and rollbacks are taken care of automatically and do not
have to be managed manually