### PR TITLE
Never store timezone values, always use system timezone

### DIFF
--- a/aiida/backends/djsite/settings/settings.py
+++ b/aiida/backends/djsite/settings/settings.py
@@ -9,6 +9,7 @@ from aiida.common.exceptions import ConfigurationError
 from aiida.common.setup import (get_config, get_secret_key, get_property,
                                 get_profile_config, parse_repository_uri)
 from aiida.backends import settings
+from aiida.utils.timezone import get_current_timezone
 
 # Assumes that parent directory of aiida is root for
 # things like templates/, SQL/ etc.  If not, change what follows...
@@ -111,15 +112,8 @@ ADMINS = (
 
 MANAGERS = ADMINS
 
-# Local time zone for this installation. Choices can be found here:
-# http://en.wikipedia.org/wiki/List_of_tz_zones_by_name
-# although not all choices may be available on all operating systems.
-# In a Windows environment this must be set to your system time zone.
-try:
-    TIME_ZONE = profile_conf['TIMEZONE']
-except KeyError:
-    raise ConfigurationError("You did not set your timezone during the "
-                             "verdi install phase.")
+# Local time zone for this installation. Always choose the system timezone
+TIME_ZONE = get_current_timezone().zone
 
 # Language code for this installation. All choices can be found here:
 # http://www.i18nguy.com/unicode/language-identifiers.html

--- a/aiida/common/setup.py
+++ b/aiida/common/setup.py
@@ -271,77 +271,6 @@ def get_secret_key():
     return secret_key.strip()
 
 
-def ask_for_timezone(existing_timezone):
-    """
-    Interactively ask for the current timezone.
-
-    :param existing_timezone: the string for the already configured timezone,
-      or None if there is no previous configuration.
-    :return: a string with the timezone as chosen by the user.
-    """
-    import time
-    import pytz
-    import datetime
-
-    if existing_timezone is not None:
-        print "Configured timezone: {}".format(existing_timezone)
-        answer = raw_input("Do you want to change it? [y/N] ")
-        if answer.lower() != 'y':
-            # No configuration to do, return the existing value
-            return existing_timezone
-
-    # If we are here, either there was no configuration, or the user asked to
-    # change it.
-
-    # Try to get a set of valid timezones, as suggested in
-    # one of the answers of http://stackoverflow.com/questions/7669938
-
-    # Get some information on the local TZ and the local offset, doing the
-    # right thing it we are in DST. (time.daylight just tells whether the
-    # local timezone has DST, not the current state
-    if time.daylight and time.localtime().tm_isdst > 0:
-        local_offset = time.altzone
-        localtz = time.tzname[1]
-    else:
-        local_offset = time.timezone
-        localtz = time.tzname[0]
-
-    # convert to a datetime.timedelta object
-    local_offset = datetime.timedelta(seconds=-local_offset)
-
-    valid_zones = []
-    # Iterate over all valid TZ
-    for name in pytz.all_timezones:
-        # get the TZ obejct
-        timezone = pytz.timezone(name)
-        # skip if a TZ has no info
-        if not hasattr(timezone, '_tzinfos'):
-            continue
-        # Append to the list if the offset and the localtz match
-        for (utcoffset, daylight, tzname), _ in timezone._tzinfos.iteritems():
-            if utcoffset == local_offset and tzname == localtz:
-                valid_zones.append(name)
-
-    print "# These seem to be valid timezones for the current environment:"
-    for z in sorted(valid_zones):
-        print "* {}".format(z)
-
-    print "# Type here a valid timezone (one of the above, or if the detection "
-    print "# did not work, any other valid timezone string)"
-
-    valid_zone = False
-    while not valid_zone:
-        answer = raw_input("Insert your timezone: ")
-        if answer in pytz.all_timezones:
-            valid_zone = True
-        else:
-            print "* ERROR! Invalid timezone inserted."
-            print "*        Valid timezones can be obtainedin a python shell with"
-            print "*        the 'import pytz; print pytz.all_timezones' command"
-
-    return answer
-
-
 def create_base_dirs(config_dir=None):
     """
     Create dirs for AiiDA, and install default daemon files.
@@ -526,7 +455,6 @@ key_explanation = {
     "AIIDADB_PORT": "Database port",
     "AIIDADB_REPOSITORY_URI": "AiiDA repository directory",
     "AIIDADB_USER": "AiiDA Database user",
-    "TIMEZONE": "Timezone",
     DEFAULT_USER_CONFIG_FIELD: "Default user email"
 }
 
@@ -599,10 +527,6 @@ def create_config_noninteractive(profile='default', force_overwrite=False, dry_r
         raise ValueError(
             '{} is not a valid backend choice.'.format(
                 backend_v))
-
-    # setting timezone
-    from tzlocal import get_localzone
-    new_profile['TIMEZONE'] = get_localzone().zone
 
     # Setting email
     from validate_email import validate_email
@@ -729,11 +653,6 @@ def create_configuration(profile='default'):
                                .format(', '.join(backend_possibilities)))
                 this_new_confs['AIIDADB_BACKEND'] = backend_ans
                 aiida_backend = backend_ans
-
-        # Setting the timezone
-        timezone = ask_for_timezone(
-            existing_timezone=this_existing_confs.get('TIMEZONE', None))
-        this_new_confs['TIMEZONE'] = timezone
 
         # Setting the email
         valid_email = False

--- a/aiida/settings.py
+++ b/aiida/settings.py
@@ -16,7 +16,6 @@ __authors__ = "The AiiDA team."
 __version__ = "0.7.1"
 
 
-TIME_ZONE = "Europe/Paris"
 USE_TZ = True
 
 try:

--- a/aiida/utils/timezone.py
+++ b/aiida/utils/timezone.py
@@ -17,15 +17,9 @@ __version__ = "0.7.1"
 
 utc = pytz.utc
 
-
-def get_default_timezone():
-    return pytz.timezone(settings.TIME_ZONE)
-
-#get_current_timezone = get_default_timezone
 def get_current_timezone():
     from tzlocal import get_localzone
     return get_localzone()
-
 
 
 def now():

--- a/aiida/utils/timezone.py
+++ b/aiida/utils/timezone.py
@@ -21,7 +21,11 @@ utc = pytz.utc
 def get_default_timezone():
     return pytz.timezone(settings.TIME_ZONE)
 
-get_current_timezone = get_default_timezone
+#get_current_timezone = get_default_timezone
+def get_current_timezone():
+    from tzlocal import get_localzone
+    return get_localzone()
+
 
 
 def now():


### PR DESCRIPTION
This way, local times seen by the user will always be what they expect based on their system settings.
 * remove hard-coded value from aiida.settings (fixes #445)
 * remove timezone key from profiles
 * stop asking for timezone in profile setup
 * have django use the current time zone too