### PR TITLE
Raise AttributeError in calculation.__getattr__ for '_use_methods'

### DIFF
--- a/aiida/orm/implementation/general/calculation/__init__.py
+++ b/aiida/orm/implementation/general/calculation/__init__.py
@@ -149,6 +149,8 @@ class AbstractCalculation(SealableWithUpdatableAttributes):
         None will then automatically raise the standard AttributeError
         exception.
         """
+        if name == '_use_methods':
+            raise AttributeError("'{0}' object has no attribute '{1}'".format(type(self), name))
 
         class UseMethod(object):
             """


### PR DESCRIPTION
Raising an explicit ``AttributeError`` in ``AbstractCalculation.__getattr__`` when it is called with ``name='_use_methods'``. The previous behavior is that it creates an infinite recursion.

In encountered this by having an incorrect ``super()`` call in ``_use_methods`` (``super(ClassName, None)`` instead of ``super(ClassName, cls)``). 

In correct code both cases should never occur, but the explicit error is easier to debug.