### PR TITLE
Explicitly raise from thrown error

### DIFF
--- a/aiida/backends/djsite/db/models.py
+++ b/aiida/backends/djsite/db/models.py
@@ -7,6 +7,8 @@
 # For further information on the license, see the LICENSE.txt file        #
 # For further information please visit http://www.aiida.net               #
 ###########################################################################
+from future.utils import raise_from
+
 from django.db import models as m
 from django_extensions.db.fields import UUIDField
 from django.contrib.auth.models import (
@@ -1834,8 +1836,8 @@ class DbWorkflowData(m.Model):
                 self.json_value = json.dumps(arg)
                 self.value_type = wf_data_value_types.JSON
                 self.save()
-        except:
-            raise ValueError("Cannot set the parameter {}".format(self.name))
+        except Exception as exc:
+            raise_from(ValueError("Cannot set the parameter {}".format(self.name)), exc)
 
     def get_value(self):
         import json

--- a/aiida/backends/djsite/db/models.py
+++ b/aiida/backends/djsite/db/models.py
@@ -7,8 +7,9 @@
 # For further information on the license, see the LICENSE.txt file        #
 # For further information please visit http://www.aiida.net               #
 ###########################################################################
-from future.utils import raise_from
+import sys
 
+from six import reraise
 from django.db import models as m
 from django_extensions.db.fields import UUIDField
 from django.contrib.auth.models import (
@@ -1837,7 +1838,7 @@ class DbWorkflowData(m.Model):
                 self.value_type = wf_data_value_types.JSON
                 self.save()
         except Exception as exc:
-            raise_from(ValueError("Cannot set the parameter {}".format(self.name)), exc)
+            reraise(ValueError, "Cannot set the parameter {}".format(self.name), sys.exc_info()[2])
 
     def get_value(self):
         import json

--- a/setup_requirements.py
+++ b/setup_requirements.py
@@ -18,10 +18,11 @@ install_requires = [
     'django_extensions==1.5',
     'tzlocal==1.3',
     'pytz==2014.10',
-    # We need for the time being to stay with an old version 
+    'future==0.16',
+    # We need for the time being to stay with an old version
     # of celery, including the versions of the AMQP libraries below,
     # because the support for a SQLA broker has been dropped in later
-    # versions... Actually, this might be source or problems with 
+    # versions... Actually, this might be source or problems with
     # SQLA for us... probably switch to using rabbitmq?
     # Note that however this requires a new server process.
     'celery==3.1.25',

--- a/setup_requirements.py
+++ b/setup_requirements.py
@@ -18,7 +18,7 @@ install_requires = [
     'django_extensions==1.5',
     'tzlocal==1.3',
     'pytz==2014.10',
-    'future==0.16',
+    'six==1.10',
     # We need for the time being to stay with an old version
     # of celery, including the versions of the AMQP libraries below,
     # because the support for a SQLA broker has been dropped in later


### PR DESCRIPTION
Previously the explicit ``ValueError`` was swallowed by the generic try - except clause. I use the ``six`` module to chain the traceback.