### PR TITLE
Storing files from Calcinfo's 'local_copy_list' in the TCOD CIF

### DIFF
--- a/aiida/tools/dbexporters/tcod.py
+++ b/aiida/tools/dbexporters/tcod.py
@@ -471,6 +471,10 @@ def _collect_files(base, path=''):
     from aiida.common.folders import Folder
     from aiida.common.utils import md5_file,sha1_file
     import os
+
+    def get_filename(file_dict):
+        return file_dict['name']
+
     if os.path.isdir(os.path.join(base,path)):
         folder = Folder(os.path.join(base,path))
         files_now = []
@@ -482,10 +486,10 @@ def _collect_files(base, path=''):
                     'name': path,
                     'type': 'folder',
                 })
-        for f in sorted(folder.get_content_list()):
+        for f in folder.get_content_list():
             files = _collect_files(base,path=os.path.join(path,f))
             files_now.extend(files)
-        return files_now
+        return sorted(files_now,key=get_filename)
     elif path == '.aiida/calcinfo.json':
         files = []
         with open(os.path.join(base,path)) as f:

--- a/aiida/tools/dbexporters/tcod.py
+++ b/aiida/tools/dbexporters/tcod.py
@@ -503,7 +503,7 @@ def _collect_files(base, path=''):
             for local_copy in calcinfo['local_copy_list']:
                 with open(local_copy[0]) as f:
                     files.append({
-                        'name': local_copy[1],
+                        'name': os.path.normpath(local_copy[1]),
                         'contents': f.read(),
                         'md5': md5_file(local_copy[0]),
                         'sha1': sha1_file(local_copy[0]),

--- a/aiida/tools/dbexporters/tcod.py
+++ b/aiida/tools/dbexporters/tcod.py
@@ -486,6 +486,30 @@ def _collect_files(base, path=''):
             files = _collect_files(base,path=os.path.join(path,f))
             files_now.extend(files)
         return files_now
+    elif path == '.aiida/calcinfo.json':
+        files = []
+        with open(os.path.join(base,path)) as f:
+            files.append({
+                'name': path,
+                'contents': f.read(),
+                'md5': md5_file(os.path.join(base,path)),
+                'sha1': sha1_file(os.path.join(base,path)),
+                'type': 'file',
+                })
+        import json
+        with open(os.path.join(base,path)) as f:
+            calcinfo = json.load(f)
+        if 'local_copy_list' in calcinfo:
+            for local_copy in calcinfo['local_copy_list']:
+                with open(local_copy[0]) as f:
+                    files.append({
+                        'name': local_copy[1],
+                        'contents': f.read(),
+                        'md5': md5_file(local_copy[0]),
+                        'sha1': sha1_file(local_copy[0]),
+                        'type': 'file',
+                        })
+        return files
     else:
         with open(os.path.join(base,path)) as f:
             return [{


### PR DESCRIPTION
Files from Calcinfo's field ``local_copy_list`` were not stored in TCOD CIF, resulting in preservation of only a partial calculation tree (to be precise, pseudos for QE were not stored). This deficiency is circumvented in this pull request by parsing ``.aiida/calcinfo.json`` and taking the ``local_copy_list``.

It would be great to have this pull request merged for v0.8.0 release (I assume it's not released yet).