### PR TITLE
Fix bug in Outputs when argument is instance of Process

### DIFF
--- a/aiida/work/workchain.py
+++ b/aiida/work/workchain.py
@@ -363,7 +363,7 @@ def Outputs(running_info):
         rinfo = RunningInfo(RunningType.PROCESS, running_info.pid)
         return ToContext.Action(
             rinfo, get_object_string(_get_proc_outputs_from_registry))
-    elif running_info.type == RunningType.LEGACY_CALC:
+    elif running_info.type == RunningType.PROCESS or running_info.type == RunningType.LEGACY_CALC:
         return ToContext.Action(
             running_info, get_object_string(_get_proc_outputs_from_registry))
     elif running_info.type is RunningType.LEGACY_WORKFLOW:


### PR DESCRIPTION
The case of RunningInfo.type == PROCESS was not being
handled, making the usage of Outputs on a Process, broken