### PR TITLE
Fix 497 slow state queries

### DIFF
--- a/aiida/backends/djsite/querybuilder_django/dummy_model.py
+++ b/aiida/backends/djsite/querybuilder_django/dummy_model.py
@@ -393,9 +393,7 @@ class DbNode(Base):
             DbCalcState.state.label('state'),
             func.row_number().over(partition_by=DbCalcState.dbnode_id,
                                                  order_by=custom_sort_order).label('the_row_number')
-        ])
-
-        q1 = q1.cte()
+        ]).alias()
 
         subq = select([
             q1.c.dbnode_id.label('dbnode_id'),

--- a/aiida/backends/djsite/querybuilder_django/dummy_model.py
+++ b/aiida/backends/djsite/querybuilder_django/dummy_model.py
@@ -387,24 +387,43 @@ class DbNode(Base):
                                  whens=whens,
                                  else_=100) # else: high value to put it at the bottom
 
-        q1 = select([
+        # Add numerical state to string, to allow to sort them
+        states_with_num = select([
             DbCalcState.id.label('id'),
             DbCalcState.dbnode_id.label('dbnode_id'),
-            DbCalcState.state.label('state'),
-            func.row_number().over(partition_by=DbCalcState.dbnode_id,
-                                                 order_by=custom_sort_order).label('the_row_number')
-        ]).alias()
+            DbCalcState.state.label('state_string'),
+            custom_sort_order.label('num_state')
+        ]).select_from(DbCalcState).alias()
 
+        # Get the most 'recent' state (using the state ordering, and the min function) for
+        # each calc
+        calc_state_num = select([
+            states_with_num.c.dbnode_id.label('dbnode_id'),
+            func.min(states_with_num.c.num_state).label('recent_state')
+        ]).group_by(states_with_num.c.dbnode_id).alias()
+
+        # Join the most-recent-state table with the DbCalcState table
+        all_states_q = select([
+            DbCalcState.dbnode_id.label('dbnode_id'),
+            DbCalcState.state.label('state_string'),
+            calc_state_num.c.recent_state.label('recent_state'),
+            custom_sort_order.label('num_state'),
+        ]).select_from(#DbCalcState).alias().join(
+            join(DbCalcState, calc_state_num, DbCalcState.dbnode_id == calc_state_num.c.dbnode_id)).alias()
+
+        # Get the association between each calc and only its corresponding most-recent-state row
         subq = select([
-            q1.c.dbnode_id.label('dbnode_id'),
-            q1.c.state.label('state')
-        ]).select_from(q1).where(q1.c.the_row_number==1).alias()
+            all_states_q.c.dbnode_id.label('dbnode_id'),
+            all_states_q.c.state_string.label('state')
+        ]).select_from(all_states_q).where(all_states_q.c.num_state == all_states_q.c.recent_state).alias()
 
+        # Final filtering for the actual query
         return select([subq.c.state]).\
             where(
                     subq.c.dbnode_id == cls.id,
                 ).\
             label('laststate')
+
 
 
 

--- a/aiida/backends/sqlalchemy/models/node.py
+++ b/aiida/backends/sqlalchemy/models/node.py
@@ -296,9 +296,7 @@ class DbNode(Base):
             DbCalcState.state.label('state'),
             func.row_number().over(partition_by=DbCalcState.dbnode_id,
                                                  order_by=custom_sort_order).label('the_row_number')
-        ])
-
-        q1 = q1.cte()
+        ]).alias()
 
         subq = select([
             q1.c.dbnode_id.label('dbnode_id'),

--- a/aiida/backends/sqlalchemy/models/node.py
+++ b/aiida/backends/sqlalchemy/models/node.py
@@ -290,19 +290,37 @@ class DbNode(Base):
                                  whens=whens,
                                  else_=100) # else: high value to put it at the bottom
 
-        q1 = select([
+        # Add numerical state to string, to allow to sort them
+        states_with_num = select([
             DbCalcState.id.label('id'),
             DbCalcState.dbnode_id.label('dbnode_id'),
-            DbCalcState.state.label('state'),
-            func.row_number().over(partition_by=DbCalcState.dbnode_id,
-                                                 order_by=custom_sort_order).label('the_row_number')
-        ]).alias()
+            DbCalcState.state.label('state_string'),
+            custom_sort_order.label('num_state')
+        ]).select_from(DbCalcState).alias()
 
+        # Get the most 'recent' state (using the state ordering, and the min function) for
+        # each calc
+        calc_state_num = select([
+            states_with_num.c.dbnode_id.label('dbnode_id'),
+            func.min(states_with_num.c.num_state).label('recent_state')
+        ]).group_by(states_with_num.c.dbnode_id).alias()
+
+        # Join the most-recent-state table with the DbCalcState table
+        all_states_q = select([
+            DbCalcState.dbnode_id.label('dbnode_id'),
+            DbCalcState.state.label('state_string'),
+            calc_state_num.c.recent_state.label('recent_state'),
+            custom_sort_order.label('num_state'),
+        ]).select_from(#DbCalcState).alias().join(
+            join(DbCalcState, calc_state_num, DbCalcState.dbnode_id == calc_state_num.c.dbnode_id)).alias()
+
+        # Get the association between each calc and only its corresponding most-recent-state row
         subq = select([
-            q1.c.dbnode_id.label('dbnode_id'),
-            q1.c.state.label('state')
-        ]).select_from(q1).where(q1.c.the_row_number==1).alias()
+            all_states_q.c.dbnode_id.label('dbnode_id'),
+            all_states_q.c.state_string.label('state')
+        ]).select_from(all_states_q).where(all_states_q.c.num_state == all_states_q.c.recent_state).alias()
 
+        # Final filtering for the actual query
         return select([subq.c.state]).\
             where(
                     subq.c.dbnode_id == cls.id,


### PR DESCRIPTION
This rewrites the query for states in the state hybrid property to use less syntax constructs that are hard to optimise for the query optimiser.
Should be roughly as fast (maybe just ~30% slower) than the one on 0.7.0, but much faster (orders of magnitude, see #497) than the previous commits.
This fixes #497 