### PR TITLE
CIFs produced by TcodExporter now conform to cif_tcod.dic v0.010

### DIFF
--- a/aiida/backends/tests/tcodexporter.py
+++ b/aiida/backends/tests/tcodexporter.py
@@ -234,7 +234,7 @@ class TestTcodDbExporter(AiidaTestCase):
         self.assertEquals(values['_tcod_computation_environment'],
                           ['PATH=/dev/null\nUSER=unknown'])
         self.assertEquals(values['_tcod_computation_command'],
-                          ['cd 0; ./_aiidasubmit.sh'])
+                          ['cd 1; ./_aiidasubmit.sh'])
 
     def test_pw_translation(self):
         from aiida.tools.dbexporters.tcod \

--- a/aiida/tools/dbexporters/tcod.py
+++ b/aiida/tools/dbexporters/tcod.py
@@ -426,10 +426,10 @@ def _collect_calculation_data(calc):
         files_out = _collect_files(os.path.join(retrieved_abspath, 'path'))
         this_calc['env'] = calc.get_environment_variables()
         stdout_name = '{}.out'.format(aiida_executable_name)
-        while stdout_name in list(files_in,files_out):
+        while stdout_name in [files_in,files_out]:
             stdout_name = '_{}'.format(stdout_name)
         stderr_name = '{}.err'.format(aiida_executable_name)
-        while stderr_name in list(files_in,files_out):
+        while stderr_name in [files_in,files_out]:
             stderr_name = '_{}'.format(stderr_name)
         files_out.append({
             'name'    : stdout_name,

--- a/aiida/tools/dbexporters/tcod.py
+++ b/aiida/tools/dbexporters/tcod.py
@@ -630,8 +630,7 @@ def _collect_tags(node, calc,parameters=None,
 
     export_files = []
 
-    sn = 0
-    fn = 0
+    sn = 1
     for step in calc_data:
         tags['_tcod_computation_step'].append(sn)
         tags['_tcod_computation_command'].append(

--- a/aiida/tools/dbexporters/tcod.py
+++ b/aiida/tools/dbexporters/tcod.py
@@ -67,7 +67,7 @@ tcod_loops = {
 conforming_dictionaries = [
     {
         'name': 'cif_tcod.dic',
-        'version': '0.009',
+        'version': '0.010',
         'url': 'http://www.crystallography.net/tcod/cif/dictionaries/cif_tcod.dic'
     },
     {

--- a/aiida/tools/dbexporters/tcod.py
+++ b/aiida/tools/dbexporters/tcod.py
@@ -406,6 +406,7 @@ def _collect_calculation_data(calc):
     from aiida.orm.calculation import Calculation
     from aiida.orm.calculation.job import JobCalculation
     from aiida.orm.calculation.inline import InlineCalculation
+    import hashlib
     import os
     calcs_now = []
     for d in calc.get_inputs(node_type=Data):
@@ -449,7 +450,6 @@ def _collect_calculation_data(calc):
         this_calc['stderr'] = stderr_name
     else:
         # Calculation is InlineCalculation
-        import hashlib
         python_script = _inline_to_standalone_script(calc)
         files_in.append({
             'name'    : inline_executable_name,

--- a/aiida/tools/dbexporters/tcod.py
+++ b/aiida/tools/dbexporters/tcod.py
@@ -437,14 +437,16 @@ def _collect_calculation_data(calc):
             'contents': calc.get_scheduler_output(),
             'md5'     : hashlib.md5(calc.get_scheduler_output()).hexdigest(),
             'sha1'    : hashlib.sha1(calc.get_scheduler_output()).hexdigest(),
-            'type'    : 'output',
+            'role'    : 'stdout',
+            'type'    : 'file',
             })
         files_out.append({
             'name'    : stderr_name,
             'contents': calc.get_scheduler_error(),
             'md5'     : hashlib.md5(calc.get_scheduler_error()).hexdigest(),
             'sha1'    : hashlib.sha1(calc.get_scheduler_error()).hexdigest(),
-            'type'    : 'output',
+            'role'    : 'stderr',
+            'type'    : 'file',
             })
         this_calc['stdout'] = stdout_name
         this_calc['stderr'] = stderr_name
@@ -477,7 +479,8 @@ def _collect_calculation_data(calc):
     for f in files_out:
         if os.path.basename(f['name']) != calc._SCHED_OUTPUT_FILE and \
            os.path.basename(f['name']) != calc._SCHED_ERROR_FILE:
-            f['role'] = 'output'
+            if 'role' not in f.keys():
+                f['role'] = 'output'
             this_calc['files'].append(f)
 
     calcs_now.append(this_calc)


### PR DESCRIPTION
Changing TcodExporter to produce CIF files, conforming to the newest (as of 2017-04-26) version of [cif_tcod.dic](http://www.crystallography.net/tcod/cif/dictionaries/cif_tcod.dic).