### PR TITLE
Accept BaseTypes as attributes/extras

### DIFF
--- a/aiida/backends/djsite/db/models.py
+++ b/aiida/backends/djsite/db/models.py
@@ -25,7 +25,7 @@ from aiida.common.exceptions import (
 from aiida.backends.settings import AIIDANODES_UUID_VERSION
 from aiida.backends.djsite.settings.settings import AUTH_USER_MODEL
 import aiida.backends.djsite.db.migrations as migrations
-
+from aiida.backends.utils import AIIDA_ATTRIBUTE_SEP
 
 # This variable identifies the schema version of this file.
 # Every time you change the schema below in *ANY* way, REMEMBER TO CHANGE
@@ -649,7 +649,7 @@ class DbMultipleValueAttributeBaseClass(m.Model):
     dval = m.DateTimeField(default=None, null=True)
 
     # separator for subfields
-    _sep = "."
+    _sep = AIIDA_ATTRIBUTE_SEP
 
     class Meta:
         abstract = True
@@ -692,16 +692,8 @@ class DbMultipleValueAttributeBaseClass(m.Model):
         :return: None if the key is valid
         :raise ValidationError: if the key is not valid
         """
-        from aiida.common.exceptions import ValidationError
-
-        if not isinstance(key, basestring):
-            raise ValidationError("The key must be a string.")
-        if not key:
-            raise ValidationError("The key cannot be an empty string.")
-        if cls._sep in key:
-            raise ValidationError("The separator symbol '{}' cannot be present "
-                                  "in the key of a {}.".format(
-                cls._sep, cls.__name__))
+        from aiida.backends.utils import validate_attribute_key
+        return validate_attribute_key(key)
 
     @classmethod
     def set_value(cls, key, value, with_transaction=True,

--- a/aiida/backends/sqlalchemy/models/node.py
+++ b/aiida/backends/sqlalchemy/models/node.py
@@ -210,23 +210,28 @@ class DbNode(Base):
     def set_attr(self, key, value):
         DbNode._set_attr(self.attributes, key, value)
         flag_modified(self, "attributes")
+        self.save()
 
     def set_extra(self, key, value):
         DbNode._set_attr(self.extras, key, value)
         flag_modified(self, "extras")
+        self.save()
 
     def reset_extras(self, new_extras):
         self.extras.clear()
         self.extras.update(new_extras)
         flag_modified(self, "extras")
+        self.save()
 
     def del_attr(self, key):
         DbNode._del_attr(self.attributes, key)
         flag_modified(self, "attributes")
+        self.save()
 
     def del_extra(self, key):
         DbNode._del_attr(self.extras, key)
         flag_modified(self, "extras")
+        self.save()
 
     @staticmethod
     def _set_attr(d, key, value):

--- a/aiida/backends/tests/dataclasses.py
+++ b/aiida/backends/tests/dataclasses.py
@@ -2562,7 +2562,7 @@ class TestKpointsData(AiidaTestCase):
         mesh, offset = k.get_kpoints_mesh()
         self.assertEqual(mesh, list(input_mesh))
         self.assertEqual(offset,
-                         (0., 0., 0.))  # must be a tuple of three 0 by default
+                         [0., 0., 0.])  # must be a tuple of three 0 by default
 
         # a too long list should fail
         with self.assertRaises(ValueError):

--- a/aiida/backends/tests/dataclasses.py
+++ b/aiida/backends/tests/dataclasses.py
@@ -2560,7 +2560,7 @@ class TestKpointsData(AiidaTestCase):
         input_mesh = [4, 4, 4]
         k.set_kpoints_mesh(input_mesh)
         mesh, offset = k.get_kpoints_mesh()
-        self.assertEqual(mesh, tuple(input_mesh))
+        self.assertEqual(mesh, list(input_mesh))
         self.assertEqual(offset,
                          (0., 0., 0.))  # must be a tuple of three 0 by default
 
@@ -2572,13 +2572,13 @@ class TestKpointsData(AiidaTestCase):
         input_offset = [0.5, 0.5, 0.5]
         k.set_kpoints_mesh(input_mesh, input_offset)
         mesh, offset = k.get_kpoints_mesh()
-        self.assertEqual(mesh, tuple(input_mesh))
-        self.assertEqual(offset, tuple(input_offset))
+        self.assertEqual(mesh, list(input_mesh))
+        self.assertEqual(offset, list(input_offset))
 
         # verify the same but after storing
         k.store()
-        self.assertEqual(mesh, tuple(input_mesh))
-        self.assertEqual(offset, tuple(input_offset))
+        self.assertEqual(mesh, list(input_mesh))
+        self.assertEqual(offset, list(input_offset))
 
         # cannot modify it after storage
         with self.assertRaises(ModificationNotAllowed):

--- a/aiida/backends/tests/nodes.py
+++ b/aiida/backends/tests/nodes.py
@@ -761,6 +761,19 @@ class TestNodeBasic(AiidaTestCase):
         self.assertEquals(self.boolval, a.get_attr('bool'))
         self.assertEquals(a_string, a.get_extra('bool'))
 
+        self.assertEquals(a.get_extras(), {'bool': a_string})
+
+    def test_get_extras_with_default(self):
+        a = Node()
+        a.store()
+        a.set_extra('a', 'b')
+        
+        self.assertEquals(a.get_extra('a'), 'b')
+        with self.assertRaises(AttributeError):
+            a.get_extra('c')
+
+        self.assertEquals(a.get_extra('c', 'def'), 'def')
+
     def test_attr_and_extras_multikey(self):
         """
         Multiple nodes with the same key. This should not be a problem
@@ -965,19 +978,33 @@ class TestNodeBasic(AiidaTestCase):
         Test that setting a basetype as an attribute works transparently
         """
         from aiida.orm.data.parameter import ParameterData
-        from aiida.orm.data.base import Str
-        
+        from aiida.orm.data.base import Str, List
+
+        # This one is unstored
+        l1 = List()
+        l1._set_list(['b', [1,2]])
+
+        # This one is stored
+        l2 = List()
+        l2._set_list(['f', True, {'gg': None}])
+        l2.store()
+
         # Manages to store, and value is converted to its base type
-        p = ParameterData(dict={'b': Str("sometext")})
+        p = ParameterData(dict={'b': Str("sometext"), 'c': l1})
         p.store()
         self.assertEqual(p.get_attr('b'), "sometext")
         self.assertIsInstance(p.get_attr('b'),basestring)
+        self.assertEqual(p.get_attr('c'), ['b', [1,2]])
+        self.assertIsInstance(p.get_attr('c'), (list, tuple))
         
         # Check also before storing
         n = Node()
         n._set_attr('a', Str("sometext2"))
+        n._set_attr('b', l2)
         self.assertEqual(n.get_attr('a'), "sometext2")
-        self.assertIsInstance(n.get_attr('a'),basestring)     
+        self.assertIsInstance(n.get_attr('a'),basestring)
+        self.assertEqual(n.get_attr('b'), ['f', True, {'gg': None}])
+        self.assertIsInstance(n.get_attr('b'), (list, tuple))
         
         # Check also deep in a dictionary/list
         n = Node()
@@ -992,16 +1019,30 @@ class TestNodeBasic(AiidaTestCase):
         """
         Test that setting a basetype as an attribute works transparently
         """
-        from aiida.orm.data.parameter import ParameterData
-        from aiida.orm.data.base import Str
-                
+        from aiida.orm.data.base import Str, List
+
+        # This one is unstored
+        l1 = List()
+        l1._set_list(['b', [1,2]])
+
+        # This one is stored
+        l2 = List()
+        l2._set_list(['f', True, {'gg': None}])
+        l2.store()
+
         # Check also before storing
         n = Node()
         n.store()
         n.set_extra('a', Str("sometext2"))
+        n.set_extra('c', l1)
+        n.set_extra('d', l2)
         self.assertEqual(n.get_extra('a'), "sometext2")
-        self.assertIsInstance(n.get_extra('a'),basestring)     
-        
+        self.assertIsInstance(n.get_extra('a'),basestring)
+        self.assertEqual(n.get_extra('c'), ['b', [1, 2]])
+        self.assertIsInstance(n.get_extra('c'), (list, tuple))
+        self.assertEqual(n.get_extra('d'), ['f', True, {'gg': None}])
+        self.assertIsInstance(n.get_extra('d'), (list, tuple))
+
         # Check also deep in a dictionary/list
         n = Node()
         n.store()

--- a/aiida/backends/tests/nodes.py
+++ b/aiida/backends/tests/nodes.py
@@ -960,6 +960,55 @@ class TestNodeBasic(AiidaTestCase):
         extras_to_set.update(new_extras)
         self.assertEquals({k: v for k, v in a.iterextras()}, extras_to_set)
 
+    def test_basetype_as_attr(self):
+        """
+        Test that setting a basetype as an attribute works transparently
+        """
+        from aiida.orm.data.parameter import ParameterData
+        from aiida.orm.data.base import Str
+        
+        # Manages to store, and value is converted to its base type
+        p = ParameterData(dict={'b': Str("sometext")})
+        p.store()
+        self.assertEqual(p.get_attr('b'), "sometext")
+        self.assertIsInstance(p.get_attr('b'),basestring)
+        
+        # Check also before storing
+        n = Node()
+        n._set_attr('a', Str("sometext2"))
+        self.assertEqual(n.get_attr('a'), "sometext2")
+        self.assertIsInstance(n.get_attr('a'),basestring)     
+        
+        # Check also deep in a dictionary/list
+        n = Node()
+        n._set_attr('a', {'b': [Str("sometext3")]})
+        self.assertEqual(n.get_attr('a')['b'][0], "sometext3")
+        self.assertIsInstance(n.get_attr('a')['b'][0],basestring)     
+        n.store()
+        self.assertEqual(n.get_attr('a')['b'][0], "sometext3")
+        self.assertIsInstance(n.get_attr('a')['b'][0],basestring)     
+
+    def test_basetype_as_extra(self):
+        """
+        Test that setting a basetype as an attribute works transparently
+        """
+        from aiida.orm.data.parameter import ParameterData
+        from aiida.orm.data.base import Str
+                
+        # Check also before storing
+        n = Node()
+        n.store()
+        n.set_extra('a', Str("sometext2"))
+        self.assertEqual(n.get_extra('a'), "sometext2")
+        self.assertIsInstance(n.get_extra('a'),basestring)     
+        
+        # Check also deep in a dictionary/list
+        n = Node()
+        n.store()
+        n.set_extra('a', {'b': [Str("sometext3")]})
+        self.assertEqual(n.get_extra('a')['b'][0], "sometext3")
+        self.assertIsInstance(n.get_extra('a')['b'][0],basestring)     
+
     def test_versioning_lowlevel(self):
         """
         Checks the versioning.

--- a/aiida/backends/utils.py
+++ b/aiida/backends/utils.py
@@ -17,8 +17,26 @@ from aiida.common.exceptions import (
         InvalidOperation
     )
 
+AIIDA_ATTRIBUTE_SEP = '.'
 
+def validate_attribute_key(key):
+    """
+    Validate the key string to check if it is valid (e.g., if it does not
+    contain the separator symbol.).
 
+    :return: None if the key is valid
+    :raise ValidationError: if the key is not valid
+    """
+    from aiida.common.exceptions import ValidationError
+
+    if not isinstance(key, basestring):
+        raise ValidationError("The key must be a string.")
+    if not key:
+        raise ValidationError("The key cannot be an empty string.")
+    if AIIDA_ATTRIBUTE_SEP in key:
+        raise ValidationError("The separator symbol '{}' cannot be present "
+                              "in the key of attributes, extras, etc.".format(
+            AIIDA_ATTRIBUTE_SEP))
 
 
 def QueryFactory():
@@ -305,4 +323,5 @@ def _get_column(colname, alias):
                     '\n'.join(alias._sa_class_manager.mapper.c.keys())
                 )
         )
+
 

--- a/aiida/common/utils.py
+++ b/aiida/common/utils.py
@@ -37,6 +37,34 @@ class classproperty(object):
         return self.getter(owner)
 
 
+class abstractclassmethod(classmethod):
+    """
+    A decorator indicating abstract classmethods.
+
+    Backported from python3.
+    """
+    __isabstractmethod__ = True
+
+    def __init__(self, callable):
+        callable.__isabstractmethod__ = True
+        super(abstractclassmethod, self).__init__(callable)
+
+
+class abstractstaticmethod(staticmethod):
+    """
+    A decorator indicating abstract staticmethods.
+
+    Similar to abstractmethod.
+    Backported from python3.
+    """
+
+    __isabstractmethod__ = True
+
+    def __init__(self, callable):
+        callable.__isabstractmethod__ = True
+        super(abstractstaticmethod, self).__init__(callable)
+
+
 def get_configured_user_email():
     """
     Return the email (that is used as the username) configured during the

--- a/aiida/orm/implementation/django/node.py
+++ b/aiida/orm/implementation/django/node.py
@@ -308,15 +308,20 @@ class Node(AbstractNode):
             raise ModificationNotAllowed(
                 "Node with uuid={} was already stored".format(self.uuid))
 
-    def _set_attr(self, key, value):
-        from aiida.backends.djsite.db.models import DbAttribute
-        DbAttribute.validate_key(key)
+    def _set_db_attr(self, key, value):
+        """
+        Set the value directly in the DB, without checking if it is stored, or
+        using the cache.
 
-        if self._to_be_stored:
-            self._attrs_cache[key] = copy.deepcopy(value)
-        else:
-            DbAttribute.set_value_for_node(self.dbnode, key, value)
-            self._increment_version_number_db()
+        DO NOT USE DIRECTLY.
+
+        :param str key: key name
+        :param value: its value
+        """
+        from aiida.backends.djsite.db.models import DbAttribute
+
+        DbAttribute.set_value_for_node(self.dbnode, key, value)
+        self._increment_version_number_db()
 
     def _del_attr(self, key):
         from aiida.backends.djsite.db.models import DbAttribute

--- a/aiida/orm/implementation/django/node.py
+++ b/aiida/orm/implementation/django/node.py
@@ -19,7 +19,6 @@ from aiida.backends.djsite.utils import get_automatic_user
 from aiida.common.exceptions import (InternalError, ModificationNotAllowed,
                                      NotExistent, UniquenessError)
 from aiida.common.folders import RepositoryFolder
-from aiida.common.lang import override
 from aiida.common.links import LinkType
 from aiida.common.utils import get_new_uuid
 from aiida.orm.implementation.general.node import AbstractNode, _NO_DEFAULT
@@ -57,12 +56,6 @@ class Node(AbstractNode):
             raise NotExistent("pk= {} is not an instance of {}".format(
                 pk, cls.__name__))
         return node
-
-    def __int__(self):
-        if self._to_be_stored:
-            return None
-        else:
-            return self._dbnode.pk
 
     def __init__(self, **kwargs):
         from aiida.backends.djsite.db.models import DbNode
@@ -246,67 +239,28 @@ class Node(AbstractNode):
                                   "name (raw message was {})"
                                   "".format(e.message))
 
-    def get_inputs(self, node_type=None, also_labels=False, only_in_db=False,
-                   link_type=None):
+    def _get_db_input_links(self, link_type):
         from aiida.backends.djsite.db.models import DbLink
 
         link_filter = {'output': self.dbnode}
         if link_type is not None:
             link_filter['type'] = link_type.value
-        inputs_list = [(i.label, i.input.get_aiida_class()) for i in
-                       DbLink.objects.filter(**link_filter).distinct()]
+        return [(i.label, i.input.get_aiida_class()) for i in
+                DbLink.objects.filter(**link_filter).distinct()]
 
-        if not only_in_db:
-            # Needed for the check
-            input_list_keys = [i[0] for i in inputs_list]
 
-            for label, v in self._inputlinks_cache.iteritems():
-                src = v[0]
-                if label in input_list_keys:
-                    raise InternalError("There exist a link with the same name "
-                                        "'{}' both in the DB and in the internal "
-                                        "cache for node pk= {}!".format(label, self.pk))
-                inputs_list.append((label, src))
-
-        if node_type is None:
-            filtered_list = inputs_list
-        else:
-            filtered_list = [i for i in inputs_list if isinstance(i[1], node_type)]
-
-        if also_labels:
-            return list(filtered_list)
-        else:
-            return [i[1] for i in filtered_list]
-
-    @override
-    def get_outputs(self, type=None, also_labels=False, link_type=None):
+    def _get_db_output_links(self, link_type):
         from aiida.backends.djsite.db.models import DbLink
 
         link_filter = {'input': self.dbnode}
         if link_type is not None:
             link_filter['type'] = link_type.value
-        outputs_list = ((i.label, i.output.get_aiida_class()) for i in
-                        DbLink.objects.filter(**link_filter).distinct())
+        return ((i.label, i.output.get_aiida_class()) for i in
+                DbLink.objects.filter(**link_filter).distinct())
 
-        if type is None:
-            if also_labels:
-                return list(outputs_list)
-            else:
-                return [i[1] for i in outputs_list]
-        else:
-            filtered_list = (i for i in outputs_list if isinstance(i[1], type))
-            if also_labels:
-                return list(filtered_list)
-            else:
-                return [i[1] for i in filtered_list]
-
-    def set_computer(self, computer):
+    def _set_db_computer(self, computer):
         from aiida.backends.djsite.db.models import DbComputer
-        if self._to_be_stored:
-            self.dbnode.dbcomputer = DbComputer.get_dbcomputer(computer)
-        else:
-            raise ModificationNotAllowed(
-                "Node with uuid={} was already stored".format(self.uuid))
+        self.dbnode.dbcomputer = DbComputer.get_dbcomputer(computer)
 
     def _set_db_attr(self, key, value):
         """
@@ -323,149 +277,65 @@ class Node(AbstractNode):
         DbAttribute.set_value_for_node(self.dbnode, key, value)
         self._increment_version_number_db()
 
-    def _del_attr(self, key):
+    def _del_db_attr(self, key):
         from aiida.backends.djsite.db.models import DbAttribute
-        if self._to_be_stored:
-            try:
-                del self._attrs_cache[key]
-            except KeyError:
-                raise AttributeError(
-                    "DbAttribute {} does not exist".format(key))
-        else:
-            if not DbAttribute.has_key(self.dbnode, key):
-                raise AttributeError("DbAttribute {} does not exist".format(
-                    key))
-            DbAttribute.del_value_for_node(self.dbnode, key)
-            self._increment_version_number_db()
-
-    def get_attr(self, key, default=_NO_DEFAULT):
-        from aiida.backends.djsite.db.models import DbAttribute
-        try:
-            if self._to_be_stored:
-                try:
-                    return self._attrs_cache[key]
-                except KeyError:
-                    raise AttributeError(
-                        "DbAttribute '{}' does not exist".format(key))
-            else:
-                return DbAttribute.get_value_for_node(
-                    dbnode=self.dbnode, key=key)
-        except AttributeError:
-            if default is _NO_DEFAULT:
-                raise
-            return default
-
-    def set_extra(self, key, value, exclusive=False):
-        from aiida.backends.djsite.db.models import DbExtra
-        DbExtra.validate_key(key)
-
-        if self._to_be_stored:
-            raise ModificationNotAllowed(
-                "The extras of a node can be set only after "
-                "storing the node")
-        DbExtra.set_value_for_node(self.dbnode, key, value,
-                                   stop_if_existing=exclusive)
+        if not DbAttribute.has_key(self.dbnode, key):
+            raise AttributeError("DbAttribute {} does not exist".format(
+                key))
+        DbAttribute.del_value_for_node(self.dbnode, key)
         self._increment_version_number_db()
 
-    def set_extra_exclusive(self, key, value):
-        from aiida.backends.djsite.db.models import DbExtra
-        DbExtra.validate_key(key)
+    def _get_db_attr(self, key):
+        from aiida.backends.djsite.db.models import DbAttribute
+        return DbAttribute.get_value_for_node(
+            dbnode=self.dbnode, key=key)
 
-        if self._to_be_stored:
-            raise ModificationNotAllowed(
-                "The extras of a node can be set only after "
-                "storing the node")
+    def _set_db_extra(self, key, value, exclusive=False):
+        from aiida.backends.djsite.db.models import DbExtra
+
         DbExtra.set_value_for_node(self.dbnode, key, value,
-                                   stop_if_existing=True)
+                                   stop_if_existing=exclusive)
         self._increment_version_number_db()
 
     def reset_extras(self, new_extras):
         raise NotImplementedError("Reset of extras has not been implemented"
                                   "for Django backend.")
 
-    def get_extra(self, key, *args):
+    def _get_db_extra(self, key, *args):
         from aiida.backends.djsite.db.models import DbExtra
-        if len(args) > 1:
-            raise ValueError("After the key name you can pass at most one"
-                             "value, that is the default value to be used "
-                             "if no extra is found.")
+        return DbExtra.get_value_for_node(dbnode=self.dbnode,
+                                          key=key)
 
-        try:
-            if self._to_be_stored:
-                raise AttributeError("DbExtra '{}' does not exist yet, the "
-                                     "node is not stored".format(key))
-            else:
-                return DbExtra.get_value_for_node(dbnode=self.dbnode,
-                                                  key=key)
-        except AttributeError as e:
-            try:
-                return args[0]
-            except IndexError:
-                raise e
-
-    def get_extras(self):
-        return dict(self.iterextras())
-
-    def del_extra(self, key):
+    def _del_db_extra(self, key):
         from aiida.backends.djsite.db.models import DbExtra
-        if self._to_be_stored:
-            raise ModificationNotAllowed(
-                "The extras of a node can be set and deleted "
-                "only after storing the node")
         if not DbExtra.has_key(self.dbnode, key):
             raise AttributeError("DbExtra {} does not exist".format(
                 key))
         return DbExtra.del_value_for_node(self.dbnode, key)
         self._increment_version_number_db()
 
-    def extras(self):
+    def _db_iterextras(self):
         from aiida.backends.djsite.db.models import DbExtra
-        if self._to_be_stored:
-            return
-        else:
-            extraslist = DbExtra.list_all_node_elements(self.dbnode)
-            for e in extraslist:
-                yield e.key
+        extraslist = DbExtra.list_all_node_elements(self.dbnode)
+        for e in extraslist:
+            yield (e.key, e.getvalue())
 
-    def iterextras(self):
-        from aiida.backends.djsite.db.models import DbExtra
-        if self._to_be_stored:
-            # If it is not stored yet, there are no extras that can be
-            # added (in particular, we do not even have an ID to use!)
-            # Return without value, meaning that this is an empty generator
-            return
-        else:
-            extraslist = DbExtra.list_all_node_elements(self.dbnode)
-            for e in extraslist:
-                yield (e.key, e.getvalue())
-
-    def iterattrs(self):
+    def _db_iterattrs(self):
         from aiida.backends.djsite.db.models import DbAttribute
-        # TODO: check what happens if someone stores the object while
-        #        the iterator is being used!
-        if self._to_be_stored:
-            for k, v in self._attrs_cache.iteritems():
-                yield (k, v)
-        else:
-            all_attrs = DbAttribute.get_all_values_for_node(self.dbnode)
-            for attr in all_attrs:
-                yield (attr, all_attrs[attr])
 
-    def get_attrs(self):
-        return dict(self.iterattrs())
+        all_attrs = DbAttribute.get_all_values_for_node(self.dbnode)
+        for attr in all_attrs:
+            yield (attr, all_attrs[attr])
 
-    def attrs(self):
-        from aiida.backends.djsite.db.models import DbAttribute
-        # Note: I "duplicate" the code from iterattrs, rather than
+    def _db_attrs(self):
+        # Note: I "duplicate" the code from iterattrs and reimplement it
+        # here, rather than
         # calling iterattrs from here, because iterattrs is slow on each call
         # since it has to call .getvalue(). To improve!
-        if self._to_be_stored:
-            for k in self._attrs_cache.iterkeys():
-                yield k
-        else:
-            attrlist = DbAttribute.list_all_node_elements(self.dbnode)
-            for attr in attrlist:
-                yield attr.key
+        from aiida.backends.djsite.db.models import DbAttribute
+        attrlist = DbAttribute.list_all_node_elements(self.dbnode)
+        for attr in attrlist:
+            yield attr.key
 
     def add_comment(self, content, user=None):
         from aiida.backends.djsite.db.models import DbComment
@@ -584,10 +454,6 @@ class Node(AbstractNode):
         return unicode(self.dbnode.uuid)
 
     @property
-    def pk(self):
-        return self.dbnode.pk
-
-    @property
     def id(self):
         return self.dbnode.id
 
@@ -641,39 +507,6 @@ class Node(AbstractNode):
 
         return self
 
-    def _store_input_nodes(self):
-        """
-        Find all input nodes, and store them, checking that they do not
-        have unstored inputs in turn.
-
-        :note: this function stores all nodes without transactions; always
-          call it from within a transaction!
-        """
-        if not self._to_be_stored:
-            raise ModificationNotAllowed(
-                "_store_input_nodes can be called only if the node is "
-                "unstored (node {} is stored, instead)".format(self.pk))
-
-        for label in self._inputlinks_cache:
-            parent = self._inputlinks_cache[label][0]
-            if not parent.is_stored:
-                parent.store(with_transaction=False)
-
-    def _check_are_parents_stored(self):
-        """
-        Check if all parents are already stored, otherwise raise.
-
-        :raise ModificationNotAllowed: if one of the input nodes in not already
-          stored.
-        """
-        # Preliminary check to verify that inputs are stored already
-        for label in self._inputlinks_cache:
-            if not self._inputlinks_cache[label][0].is_stored:
-                raise ModificationNotAllowed(
-                    "Cannot store the input link '{}' because the "
-                    "source node is not stored. Either store it first, "
-                    "or call _store_input_links with the store_parents "
-                    "parameter set to True".format(label))
 
     def _store_cached_input_links(self, with_transaction=True):
         """

--- a/aiida/orm/implementation/django/node.py
+++ b/aiida/orm/implementation/django/node.py
@@ -297,7 +297,7 @@ class Node(AbstractNode):
                                    stop_if_existing=exclusive)
         self._increment_version_number_db()
 
-    def reset_extras(self, new_extras):
+    def _reset_db_extras(self, new_extras):
         raise NotImplementedError("Reset of extras has not been implemented"
                                   "for Django backend.")
 

--- a/aiida/orm/implementation/general/code.py
+++ b/aiida/orm/implementation/general/code.py
@@ -13,6 +13,7 @@ from aiida.orm.implementation import Node
 from aiida.common.exceptions import (ValidationError, MissingPluginError)
 from aiida.common.links import LinkType
 from aiida.orm.mixins import SealableWithUpdatableAttributes
+from aiida.common.utils import abstractclassmethod
 
 
 
@@ -128,8 +129,7 @@ class AbstractCode(SealableWithUpdatableAttributes, Node):
         else:
             return qb.first()[0]
 
-    @classmethod
-    @abstractmethod
+    @abstractclassmethod
     def get(cls, pk=None, label=None, machinename=None):
         """
         Get a Computer object with given identifier string, that can either be
@@ -165,8 +165,7 @@ class AbstractCode(SealableWithUpdatableAttributes, Node):
             raise InputValidationError("Pass either pk or code label (and machinename)")
 
 
-    @classmethod
-    @abstractmethod
+    @abstractclassmethod
     def get_from_string(cls, code_string):
         """
         Get a Computer object with given identifier string in the format
@@ -202,8 +201,7 @@ class AbstractCode(SealableWithUpdatableAttributes, Node):
             return cls.get_code_helper(label, machinename)
 
 
-    @classmethod
-    @abstractmethod
+    @abstractclassmethod
     def list_for_plugin(cls, plugin, labels=True):
         """
         Return a list of valid code strings for a given plugin.

--- a/aiida/orm/implementation/general/computer.py
+++ b/aiida/orm/implementation/general/computer.py
@@ -20,7 +20,7 @@ from aiida.common.exceptions import (
     MissingPluginError, ValidationError)
 
 from aiida.common.utils import classproperty
-
+from aiida.common.utils import abstractclassmethod, abstractstaticmethod
 
 
 class AbstractComputer(object):
@@ -179,8 +179,7 @@ class AbstractComputer(object):
     def set(self, **kwargs):
         pass
 
-    @staticmethod
-    @abstractmethod
+    @abstractstaticmethod
     def get_db_columns():
         """
         This method returns a list with the column names and types of the
@@ -190,8 +189,7 @@ class AbstractComputer(object):
         """
         pass
 
-    @classmethod
-    @abstractmethod
+    @abstractclassmethod
     def list_names(cls):
         """
         Return a list with all the names of the computers in the DB.
@@ -210,8 +208,7 @@ class AbstractComputer(object):
     def to_be_stored(self):
         pass
 
-    @classmethod
-    @abstractmethod
+    @abstractclassmethod
     def get(cls, computer):
         """
         Return a computer from its name (or from another Computer or DbComputer instance)

--- a/aiida/orm/implementation/general/group.py
+++ b/aiida/orm/implementation/general/group.py
@@ -11,7 +11,7 @@
 from abc import ABCMeta, abstractmethod, abstractproperty
 
 from aiida.common.exceptions import UniquenessError, NotExistent, MultipleObjectsError
-
+from aiida.common.utils import abstractclassmethod, abstractstaticmethod
 
 
 def get_group_type_mapping():
@@ -124,8 +124,7 @@ class AbstractGroup(object):
         """
         pass
 
-    @staticmethod
-    @abstractmethod
+    @abstractstaticmethod
     def get_db_columns():
         """
         This method returns a list with the column names and types of the table
@@ -215,8 +214,7 @@ class AbstractGroup(object):
         """
         pass
 
-    @classmethod
-    @abstractmethod
+    @abstractclassmethod
     def query(cls, name=None, type_string="", pk=None, uuid=None, nodes=None,
               user=None, node_attributes=None, past_days=None, **kwargs):
         """

--- a/aiida/orm/implementation/general/node.py
+++ b/aiida/orm/implementation/general/node.py
@@ -8,6 +8,7 @@
 # For further information please visit http://www.aiida.net               #
 ###########################################################################
 from abc import ABCMeta, abstractmethod, abstractproperty
+from aiida.common.utils import abstractclassmethod
 
 import os
 import logging
@@ -118,8 +119,7 @@ class AbstractNode(object):
         """
         return self._logger
 
-    @classmethod
-    @abstractmethod
+    @abstractclassmethod
     def get_subclass_from_uuid(cls, uuid):
         """
         Get a node object from the uuid, with the proper subclass of Node.
@@ -132,8 +132,7 @@ class AbstractNode(object):
         """
         pass
 
-    @classmethod
-    @abstractmethod
+    @abstractclassmethod
     def get_subclass_from_pk(cls, pk):
         """
         Get a node object from the pk, with the proper subclass of Node.
@@ -222,8 +221,7 @@ class AbstractNode(object):
         """
         return {}
 
-    @classmethod
-    @abstractmethod
+    @abstractclassmethod
     def query(cls, *args, **kwargs):
         """
         Map to the aiidaobjects manager of the DbNode, that returns

--- a/aiida/orm/implementation/general/node.py
+++ b/aiida/orm/implementation/general/node.py
@@ -20,7 +20,7 @@ from aiida.common.utils import combomethod
 
 from aiida.common.links import LinkType
 from aiida.common.old_pluginloader import get_query_type_string
-
+from aiida.backends.utils import validate_attribute_key
 
 
 _NO_DEFAULT = tuple()
@@ -676,7 +676,6 @@ class AbstractNode(object):
         #      check for the type
         pass
 
-    @abstractmethod
     def _set_attr(self, key, value):
         """
         Set a new attribute to the Node (in the DbAttribute table).
@@ -689,6 +688,25 @@ class AbstractNode(object):
 
         :raise ValidationError: if the key is not valid (e.g. it contains the
             separator symbol).
+        """
+        validate_attribute_key(key)
+
+        if self._to_be_stored:
+            import copy
+            self._attrs_cache[key] = copy.deepcopy(value)
+        else:
+            self._set_db_attr(key, value)
+
+    @abstractmethod
+    def _set_db_attr(self, key, value):
+        """
+        Set the value directly in the DB, without checking if it is stored, or
+        using the cache.
+
+        DO NOT USE DIRECTLY.
+
+        :param str key: key name
+        :param value: its value
         """
         pass
 

--- a/aiida/orm/implementation/general/node.py
+++ b/aiida/orm/implementation/general/node.py
@@ -1233,6 +1233,10 @@ class AbstractNode(object):
 
     @property
     def pk(self):
+        """
+        :return: the principal key (the ID) as an integer, or None if the
+           node was not stored yet
+        """
         return self.id
 
     @property

--- a/aiida/orm/implementation/general/node.py
+++ b/aiida/orm/implementation/general/node.py
@@ -961,12 +961,30 @@ class AbstractNode(object):
             raise AttributeError("set_extras takes a dictionary as argument")
 
 
-    @abstractmethod
     def reset_extras(self, new_extras):
         """
         Deletes existing extras and creates new ones.
         :param new_extras: dictionary with new extras
         :return: nothing, an exceptions is raised in several circumnstances
+        """
+        if not isinstance(new_extras, dict):
+            raise TypeError("The new extras have to be a dictionary")
+
+        if self._to_be_stored:
+            raise ModificationNotAllowed(
+                "The extras of a node can be set only after "
+                "storing the node")
+
+        self._reset_db_extras(clean_value(new_extras))
+
+    @abstractmethod
+    def _reset_db_extras(self, new_extras):
+        """
+        Resets the extras (replacing existing ones) directly in the DB
+
+        DO NOT USE DIRECTLY!
+
+        :param new_extras: dictionary with new extras
         """
         pass
 

--- a/aiida/orm/implementation/general/node.py
+++ b/aiida/orm/implementation/general/node.py
@@ -10,20 +10,59 @@
 from abc import ABCMeta, abstractmethod, abstractproperty
 from aiida.common.utils import abstractclassmethod
 
-import os
-import logging
 import collections
+import logging
+import os
+import types
+
 from aiida.common.exceptions import (InternalError, ModificationNotAllowed,
                                      UniquenessError)
 from aiida.common.folders import SandboxFolder
 from aiida.common.utils import combomethod
 
 from aiida.common.links import LinkType
+from aiida.common.lang import override
 from aiida.common.old_pluginloader import get_query_type_string
 from aiida.backends.utils import validate_attribute_key
 
-
 _NO_DEFAULT = tuple()
+
+
+def clean_value(value):
+    """
+    Get value from input and (recursively) replace, if needed, all occurrences
+    of BaseType AiiDA data nodes with their value, and List with a standard list.
+
+    It also makes a deep copy of everything.
+
+    Note however that there is no logic to avoid infinite loops when the
+    user passes some perverse recursive dictionary or list.
+    In any case, however, this would not be storable by AiiDA...
+
+    :param value: A value to be set as an attribute or an extra
+    :return: a "cleaned" value, potentially identical to value, but with
+        values replaced where needed.
+    """
+    # Must be imported in here to avoid recursive imports
+    from aiida.orm.data import base as basedatatypes
+
+    if isinstance(value, basedatatypes.BaseType):
+        return value.value
+    elif isinstance(value, dict):
+        # Check dictionary before iterables
+        return {k: clean_value(v) for k, v in value.iteritems()}
+    elif (isinstance(value, collections.Iterable) and
+            not isinstance(value, types.StringTypes)):
+        # list, tuple, ... but not a string
+        # This should also properly take care of dealing with the
+        # basedatatypes.List object
+        return [clean_value(v) for v in value]
+    else:
+        # If I don't know what to do I just return the value
+        # itself - it's not super robust, but relies on duck typing
+        # (e.g. if there is something that behaves like an integer
+        # but is not an integer, I still accept it)
+        return value
 
 
 class AbstractNode(object):
@@ -160,16 +199,11 @@ class AbstractNode(object):
         """
         return self.dbnode.mtime
 
-    @abstractmethod
     def __int__(self):
-        """
-        Convert the class to an integer. This is needed to allow querying
-        with Django. Be careful, though, not to pass it to a wrong field!
-        This only returns the local DB principal key (pk) value.
-
-        :return: the integer pk of the node or None if not stored.
-        """
-        pass
+        if self._to_be_stored:
+            return None
+        else:
+            return self.id
 
     @abstractmethod
     def __init__(self, **kwargs):
@@ -594,6 +628,9 @@ class AbstractNode(object):
 
         :return: a dictionary {linkname:object}
         """
+        if link_type is not None and not isinstance(link_type, LinkType):
+            raise TypeError("link_type should be a LinkType object")
+
         all_outputs = self.get_outputs(also_labels=True, link_type=link_type)
 
         all_linknames = [i[0] for i in all_outputs]
@@ -615,7 +652,6 @@ class AbstractNode(object):
 
         return new_outputs
 
-    @abstractmethod
     def get_inputs(self, node_type=None, also_labels=False, only_in_db=False,
                    link_type=None):
         """
@@ -633,9 +669,45 @@ class AbstractNode(object):
         :param link_type: Only get inputs of this link type, if None then
                 returns all inputs of all link types.
         """
+        if link_type is not None and not isinstance(link_type, LinkType):
+            raise TypeError("link_type should be a LinkType object")
+
+        inputs_list = self._get_db_input_links(link_type=link_type)
+
+        if not only_in_db:
+            # Needed for the check
+            input_list_keys = [i[0] for i in inputs_list]
+
+            for label, v in self._inputlinks_cache.iteritems():
+                src = v[0]
+                if label in input_list_keys:
+                    raise InternalError("There exist a link with the same name "
+                                        "'{}' both in the DB and in the internal "
+                                        "cache for node pk= {}!".format(label, self.pk))
+                inputs_list.append((label, src))
+
+        if node_type is None:
+            filtered_list = inputs_list
+        else:
+            filtered_list = [i for i in inputs_list if isinstance(i[1], node_type)]
+
+        if also_labels:
+            return list(filtered_list)
+        else:
+            return [i[1] for i in filtered_list]
+
+    @abstractclassmethod
+    def _get_db_input_links(self, link_type):
+        """
+        Return a list of tuples (label, aiida_class) for each input link,
+        possibly filtering only by those of a given type.
+
+        :param link_type: if not None, a link type to filter results
+        :return:  a list of tuples (label, aiida_class)
+        """
         pass
 
-    @abstractmethod
+    @override
     def get_outputs(self, type=None, also_labels=False, link_type=None):
         """
         Return a list of nodes that exit (directly) from this node
@@ -647,6 +719,29 @@ class AbstractNode(object):
                 following format: ('label', Node), with 'label' the link label,
                 and Node a Node instance or subclass
         :param link_type: Only return outputs connected by links of this type.
+        """
+        outputs_list = self._get_db_output_links(link_type=link_type)
+
+        if type is None:
+            if also_labels:
+                return list(outputs_list)
+            else:
+                return [i[1] for i in outputs_list]
+        else:
+            filtered_list = (i for i in outputs_list if isinstance(i[1], type))
+            if also_labels:
+                return list(filtered_list)
+            else:
+                return [i[1] for i in filtered_list]
+
+    @abstractmethod
+    def _get_db_output_links(self, link_type):
+        """
+        Return a list of tuples (label, aiida_class) for each output link,
+        possibly filtering only by those of a given type.
+
+        :param link_type: if not None, a link type to filter results
+        :return:  a list of tuples (label, aiida_class)
         """
         pass
 
@@ -662,7 +757,6 @@ class AbstractNode(object):
         else:
             return Computer(dbcomputer=self.dbnode.dbcomputer)
 
-    @abstractmethod
     def set_computer(self, computer):
         """
         Set the computer to be used by the node.
@@ -672,8 +766,21 @@ class AbstractNode(object):
 
         :param computer: the computer object
         """
-        # TODO: probably this method should be in the base class, and
-        #      check for the type
+        if self._to_be_stored:
+            self._set_db_computer(computer)
+        else:
+            raise ModificationNotAllowed(
+                "Node with uuid={} was already stored".format(self.uuid))
+
+    @abstractmethod
+    def _set_db_computer(self, computer):
+        """
+        Set the computer directly inside the dbnode member, in the DB.
+
+        DO NOT USE DIRECTLY.
+
+        :param computer: the computer object
+        """
         pass
 
     def _set_attr(self, key, value):
@@ -693,9 +800,9 @@ class AbstractNode(object):
 
         if self._to_be_stored:
             import copy
-            self._attrs_cache[key] = copy.deepcopy(value)
+            self._attrs_cache[key] = clean_value(value)
         else:
-            self._set_db_attr(key, value)
+            self._set_db_attr(key, clean_value(value))
 
     @abstractmethod
     def _set_db_attr(self, key, value):
@@ -710,7 +817,6 @@ class AbstractNode(object):
         """
         pass
 
-    @abstractmethod
     def _del_attr(self, key):
         """
         Delete an attribute.
@@ -718,6 +824,24 @@ class AbstractNode(object):
         :param key: attribute to delete.
         :raise AttributeError: if key does not exist.
         :raise ModificationNotAllowed: if the Node was already stored.
+        """
+        if self._to_be_stored:
+            try:
+                del self._attrs_cache[key]
+            except KeyError:
+                raise AttributeError(
+                    "DbAttribute {} does not exist".format(key))
+        else:
+            self._del_db_attr(key)
+
+    @abstractmethod
+    def _del_db_attr(self, key):
+        """
+        Delete an attribute directly from the DB
+
+        DO NOT USE DIRECTLY.
+
+        :param key: The key of the attribute to delete
         """
         pass
 
@@ -732,7 +856,6 @@ class AbstractNode(object):
         for attr_name in list(self.attrs()):
             self._del_attr(attr_name)
 
-    @abstractmethod
     def get_attr(self, key, default=_NO_DEFAULT):
         """
         Get the attribute.
@@ -744,12 +867,36 @@ class AbstractNode(object):
 
         :raise AttributeError: If no attribute is found and there is no default
         """
-        pass
+        try:
+            if self._to_be_stored:
+                try:
+                    return self._attrs_cache[key]
+                except KeyError:
+                    raise AttributeError(
+                        "DbAttribute '{}' does not exist".format(key))
+            else:
+                return self._get_db_attr(key)
+        except AttributeError:
+            if default is _NO_DEFAULT:
+                raise
+            return default
 
     @abstractmethod
+    def _get_db_attr(self, key):
+        """
+        Return the attribute value, directly from the DB.
+
+        DO NOT USE DIRECTLY.
+
+        :param key: the attribute key
+        :return: the attribute value
+        :raise AttributeError: if the attribute does not exist.
+        """
+        pass
+
     def set_extra(self, key, value, exclusive=False):
         """
-        Immediately sets an extra of a calculation, in the DB!
+        Sets an extra of a calculation.
         No .store() to be called. Can be used *only* after saving.
 
         :param key: key name
@@ -760,6 +907,41 @@ class AbstractNode(object):
             node and avoid to run multiple times the same computation on it).
 
         :raise UniquenessError: if extra already exists and exclusive is True.
+        """
+        validate_attribute_key(key)
+
+        if self._to_be_stored:
+            raise ModificationNotAllowed(
+                "The extras of a node can be set only after "
+                "storing the node")
+        self._set_db_extra(key, clean_value(value), exclusive)
+
+
+    def set_extra_exclusive(self, key, value):
+        """
+        Set an extra in exclusive mode (stops if the attribute
+        is already there).
+        Deprecated, use set_extra() with exclusive=False
+
+        :param key: key name
+        :param value: key value
+        """
+        self.set_extra(key, value, exclusive=True)
+
+
+    @abstractmethod
+    def _set_db_extra(self, key, value, exclusive):
+        """
+        Store extra directly in the DB, without checks.
+
+        DO NOT USE DIRECTLY.
+
+        :param key: key name
+        :param value: key value
+        :param exclusive: (default=False).
+            If exclusive is True, it raises a UniquenessError if an Extra with
+            the same name already exists in the DB (useful e.g. to "lock" a
+            node and avoid to run multiple times the same computation on it).
         """
         pass
 
@@ -788,7 +970,6 @@ class AbstractNode(object):
         """
         pass
 
-    @abstractmethod
     def get_extra(self, key, *args):
         """
         Get the value of a extras, reading directly from the DB!
@@ -802,9 +983,36 @@ class AbstractNode(object):
 
         :raise ValueError: If more than two arguments are passed to get_extra
         """
-        pass
+        if len(args) > 1:
+            raise ValueError("After the key name you can pass at most one"
+                             "value, that is the default value to be used "
+                             "if no extra is found.")
+
+        try:
+            if self._to_be_stored:
+                raise AttributeError("DbExtra '{}' does not exist yet, the "
+                                     "node is not stored".format(key))
+            else:
+                return self._get_db_extra(key)
+        except AttributeError as e:
+            try:
+                return args[0]
+            except IndexError:
+                raise e
 
     @abstractmethod
+    def _get_db_extra(self, key):
+        """
+        Get an extra, directly from the DB.
+
+        DO NOT USE DIRECTLY.
+
+        :param str key: key name
+        :return: the key value
+        :raise AttributeError: if the key does not exist
+        """
+        pass
+
     def get_extras(self):
         """
         Get the value of extras, reading directly from the DB!
@@ -813,10 +1021,9 @@ class AbstractNode(object):
 
         :return: the dictionary of extras ({} if no extras)
         """
+        return dict(self.iterextras())
 
-        pass
 
-    @abstractmethod
     def del_extra(self, key):
         """
         Delete a extra, acting directly on the DB!
@@ -828,58 +1035,100 @@ class AbstractNode(object):
         :raise: AttributeError: if key starts with underscore
         :raise: ModificationNotAllowed: if the node is not stored yet
         """
-        pass
+        if self._to_be_stored:
+            raise ModificationNotAllowed(
+                "The extras of a node can be set and deleted "
+                "only after storing the node")
+        self._del_db_extra(key)
 
     @abstractmethod
+    def _del_db_extra(self, key):
+        """
+        Delete an extra, directly on the DB.
+
+        DO NOT USE DIRECTLY.
+
+        :param str key: key name
+        """
+        pass
+
     def extras(self):
         """
         Get the keys of the extras.
 
         :return: a list of strings
         """
-        pass
+        for k, v in self.iterextras():
+            yield k
 
-    @abstractmethod
     def iterextras(self):
         """
         Iterator over the extras, returning tuples (key, value)
 
         :todo: verify that I am not creating a list internally
         """
-        pass
+        if self._to_be_stored:
+            # If it is not stored yet, there are no extras that can be
+            # added (in particular, we do not even have an ID to use!)
+            # Return without value, meaning that this is an empty generator
+            return
+            yield # Needed after return to convert it to a generator
+        for _ in self._db_iterextras():
+            yield _
 
-    @abstractmethod
+
     def iterattrs(self):
         """
         Iterator over the attributes, returning tuples (key, value)
+        """
+        # TODO: check what happens if someone stores the object while
+        #        the iterator is being used!
+        if self._to_be_stored:
+            for k, v in self._attrs_cache.iteritems():
+                yield (k, v)
+        else:
+            for k, v in self._db_iterattrs():
+                yield k, v
 
-        :todo: optimize! At the moment, the call is very slow because it is
-            also calling attr.getvalue() for each attribute, that has to
-            perform complicated queries to rebuild the object.
+    def attrs(self):
+        """
+        Returns the keys of the attributes as a generator.
 
-        :param bool also_updatable: if False, does not iterate over
-            attributes that are updatable
+        :return: a generator of a strings
+        """
+        # Note: this calls a different function _db_attrs
+        # because often it's faster not to retrieve the values from the DB
+        if self._to_be_stored:
+            for k in self._attrs_cache.iterkeys():
+                yield k
+        else:
+            for k in self._db_attrs():
+                yield k
+
+    @abstractmethod
+    def _db_attrs(self):
+        """
+        Returns the keys of the attributes as a generator,
+        directly from the DB.
+
+        DO NOT USE DIRECTLY.
         """
         pass
 
     @abstractmethod
+    def _db_iterattrs(self):
+        """
+        Iterator over the attributes (directly in the DB!)
+
+        DO NOT USE DIRECTLY.
+        """
+        pass
+
     def get_attrs(self):
         """
         Return a dictionary with all attributes of this node.
         """
-        pass
-
-    @abstractmethod
-    def attrs(self):
-        """
-        Returns the keys of the attributes.
-
-        :return: a list of strings
-        """
-        # Note: I "duplicate" the code from iterattrs, rather than
-        # calling iterattrs from here, because iterattrs is slow on each call
-        # since it has to call .getvalue(). To improve!
-        pass
+        return dict(self.iterattrs())
 
     @abstractmethod
     def add_comment(self, content, user=None):
@@ -965,13 +1214,8 @@ class AbstractNode(object):
         pass
 
     @property
-    @abstractmethod
     def pk(self):
-        """
-        :return: the principal key (the ID) as an integer, or None if the
-           node was not stored yet
-        """
-        pass
+        return self.id
 
     @property
     @abstractmethod
@@ -1125,7 +1369,7 @@ class AbstractNode(object):
         """
         pass
 
-    @abstractmethod
+
     def _store_input_nodes(self):
         """
         Find all input nodes, and store them, checking that they do not
@@ -1134,9 +1378,16 @@ class AbstractNode(object):
         :note: this function stores all nodes without transactions; always
           call it from within a transaction!
         """
-        pass
+        if not self._to_be_stored:
+            raise ModificationNotAllowed(
+                "_store_input_nodes can be called only if the node is "
+                "unstored (node {} is stored, instead)".format(self.pk))
 
-    @abstractmethod
+        for label in self._inputlinks_cache:
+            parent = self._inputlinks_cache[label][0]
+            if not parent.is_stored:
+                parent.store(with_transaction=False)
+
     def _check_are_parents_stored(self):
         """
         Check if all parents are already stored, otherwise raise.
@@ -1145,7 +1396,13 @@ class AbstractNode(object):
           stored.
         """
         # Preliminary check to verify that inputs are stored already
-        pass
+        for label in self._inputlinks_cache:
+            if not self._inputlinks_cache[label][0].is_stored:
+                raise ModificationNotAllowed(
+                    "Cannot store the input link '{}' because the "
+                    "source node is not stored. Either store it first, "
+                    "or call _store_input_links with the store_parents "
+                    "parameter set to True".format(label))
 
     @abstractmethod
     def _store_cached_input_links(self, with_transaction=True):

--- a/aiida/orm/implementation/general/user.py
+++ b/aiida/orm/implementation/general/user.py
@@ -10,7 +10,7 @@
 import logging
 from abc import abstractmethod, abstractproperty, ABCMeta
 from aiida.common.hashing import is_password_usable
-
+from aiida.common.utils import abstractclassmethod
 
 
 class AbstractUser(object):
@@ -151,8 +151,7 @@ class AbstractUser(object):
     def get_all_users(cls):
         return cls.search_for_users()
 
-    @classmethod
-    @abstractmethod
+    @abstractclassmethod
     def search_for_users(cls, **kwargs):
         """
         Search for a user the passed keys.

--- a/aiida/orm/implementation/general/workflow.py
+++ b/aiida/orm/implementation/general/workflow.py
@@ -27,7 +27,7 @@ from aiida.backends.utils import get_automatic_user
 
 from aiida.utils import timezone
 from aiida.utils.logger import get_dblogger_extra
-
+from aiida.common.utils import abstractclassmethod
 
 logger = aiidalogger.getChild('Workflow')
 
@@ -278,8 +278,7 @@ class AbstractWorkflow(object):
             raise ValueError("The path in get_abs_path must be relative")
         return self.current_folder.get_subfolder(section, reset_limit=True).get_abs_path(path, check_existence=True)
 
-    @classmethod
-    @abstractmethod
+    @abstractclassmethod
     def query(cls, *args, **kwargs):
         """
         Map to the aiidaobjects manager of the DbWorkflow, that returns
@@ -886,8 +885,7 @@ class AbstractWorkflow(object):
         """
         pass
 
-    @classmethod
-    @abstractmethod
+    @abstractclassmethod
     def get_subclass_from_dbnode(cls, wf_db):
         """
         Loads the workflow object and reaoads the python script in memory with the importlib library, the
@@ -897,8 +895,7 @@ class AbstractWorkflow(object):
         """
         pass
 
-    @classmethod
-    @abstractmethod
+    @abstractclassmethod
     def get_subclass_from_pk(cls, pk):
         """
         Calls the ``get_subclass_from_dbnode`` selecting the DbWorkflowNode from
@@ -908,8 +905,7 @@ class AbstractWorkflow(object):
         """
         pass
 
-    @classmethod
-    @abstractmethod
+    @abstractclassmethod
     def get_subclass_from_uuid(cls, uuid):
         """
         Calls the ``get_subclass_from_dbnode`` selecting the DbWorkflowNode from

--- a/aiida/orm/implementation/sqlalchemy/node.py
+++ b/aiida/orm/implementation/sqlalchemy/node.py
@@ -334,18 +334,24 @@ class Node(AbstractNode):
             raise ModificationNotAllowed(
                 "Node with uuid={} was already stored".format(self.uuid))
 
-    def _set_attr(self, key, value):
-        if self._to_be_stored:
-            self._attrs_cache[key] = copy.deepcopy(value)
-        else:
-            try:
-                self.dbnode.set_attr(key, value)
-                self._increment_version_number_db()
-            except:
-                from aiida.backends.sqlalchemy import get_scoped_session
-                session = get_scoped_session()
-                session.rollback()
-                raise
+    def _set_db_attr(self, key, value):
+        """
+        Set the value directly in the DB, without checking if it is stored, or
+        using the cache.
+
+        DO NOT USE DIRECTLY.
+
+        :param str key: key name
+        :param value: its value
+        """
+        try:
+            self.dbnode.set_attr(key, value)
+            self._increment_version_number_db()
+        except:
+            from aiida.backends.sqlalchemy import get_scoped_session
+            session = get_scoped_session()
+            session.rollback()
+            raise
 
     def _del_attr(self, key):
         if self._to_be_stored:

--- a/aiida/orm/implementation/sqlalchemy/node.py
+++ b/aiida/orm/implementation/sqlalchemy/node.py
@@ -333,16 +333,7 @@ class Node(AbstractNode):
             session.rollback()
             raise
 
-    def reset_extras(self, new_extras):
-
-        if type(new_extras) is not dict:
-            raise ValueError("The new extras have to be a dictionary")
-
-        if self._to_be_stored:
-            raise ModificationNotAllowed(
-                "The extras of a node can be set only after "
-                "storing the node")
-
+    def _reset_db_extras(self, new_extras):
         try:
             self.dbnode.reset_extras(new_extras)
             self._increment_version_number_db()

--- a/aiida/orm/utils.py
+++ b/aiida/orm/utils.py
@@ -9,7 +9,7 @@
 ###########################################################################
 from abc import ABCMeta, abstractmethod
 from aiida.common.pluginloader import BaseFactory
-
+from aiida.common.utils import abstractclassmethod
 
 
 def CalculationFactory(module, from_abstract=False):
@@ -164,8 +164,7 @@ class BackendDelegateWithDefault(object):
 
     _DEFAULT = None
 
-    @classmethod
-    @abstractmethod
+    @abstractclassmethod
     def create_default(cls):
         raise NotImplementedError("The subclass should implement this")
 


### PR DESCRIPTION
These are transparently converted to their value now, even if deep into a dict/list.
This fixes #518 
Also, I did important restructuring of the AbstractNode (even if it could be further improved) to avoid copy-pasted code and have the logic for Node caching only written once.