### PR TITLE
Replacing old pyspglib with new spglib

### DIFF
--- a/aiida/backends/tests/dataclasses.py
+++ b/aiida/backends/tests/dataclasses.py
@@ -121,7 +121,7 @@ class TestCifData(AiidaTestCase):
     Tests for CifData class.
     """
     from aiida.orm.data.cif import has_pycifrw
-    from aiida.orm.data.structure import has_ase, has_pymatgen, has_pyspglib, \
+    from aiida.orm.data.structure import has_ase, has_pymatgen, has_spglib, \
         get_pymatgen_version
     from distutils.version import StrictVersion
 
@@ -556,7 +556,7 @@ _publ_section_title                     'Test CIF'
 
     @unittest.skipIf(not has_ase(), "Unable to import ase")
     @unittest.skipIf(not has_pycifrw(), "Unable to import PyCifRW")
-    @unittest.skipIf(not has_pyspglib(), "Unable to import pyspglib")
+    @unittest.skipIf(not has_spglib(), "Unable to import spglib")
     def test_refine(self):
         """
         Test case for refinement (space group determination) for a
@@ -621,7 +621,7 @@ _publ_section_title                     'Test CIF'
 
     @unittest.skipIf(not has_ase(), "Unable to import ase")
     @unittest.skipIf(not has_pycifrw(), "Unable to import PyCifRW")
-    @unittest.skipIf(not has_pyspglib(), "Unable to import pyspglib")
+    @unittest.skipIf(not has_spglib(), "Unable to import spglib")
     def test_parse_formula(self):
         from aiida.orm.data.cif import parse_formula
 
@@ -1018,7 +1018,7 @@ class TestStructureData(AiidaTestCase):
     """
     Tests the creation of StructureData objects (cell and pbc).
     """
-    from aiida.orm.data.structure import has_ase, has_pyspglib
+    from aiida.orm.data.structure import has_ase, has_spglib
 
     def test_cell_ok_and_atoms(self):
         """
@@ -1292,7 +1292,7 @@ class TestStructureData(AiidaTestCase):
         self.assertEquals(a.get_symbols_set(), set(['Ba', 'Ti', 'O', 'H']))
 
     @unittest.skipIf(not has_ase(), "Unable to import ase")
-    @unittest.skipIf(not has_pyspglib(), "Unable to import pyspglib")
+    @unittest.skipIf(not has_spglib(), "Unable to import spglib")
     def test_kind_8(self):
         """
         Test the ase_refine_cell() function

--- a/aiida/backends/tests/tcodexporter.py
+++ b/aiida/backends/tests/tcodexporter.py
@@ -39,7 +39,7 @@ class TestTcodDbExporter(AiidaTestCase):
     """
     Tests for TcodDbExporter class.
     """
-    from aiida.orm.data.structure import has_ase, has_pyspglib
+    from aiida.orm.data.structure import has_ase, has_spglib
     from aiida.orm.data.cif import has_pycifrw
 
     def test_contents_encoding_1(self):
@@ -134,7 +134,7 @@ class TestTcodDbExporter(AiidaTestCase):
              {'name': 'save/2/', 'type': 'folder'}])
 
     @unittest.skipIf(not has_ase(), "Unable to import ase")
-    @unittest.skipIf(not has_pyspglib(), "Unable to import pyspglib")
+    @unittest.skipIf(not has_spglib(), "Unable to import spglib")
     @unittest.skipIf(not has_pycifrw(), "Unable to import PyCifRW")
     def test_cif_structure_roundtrip(self):
         from aiida.tools.dbexporters.tcod import export_cif, export_values
@@ -474,7 +474,7 @@ class TestTcodDbExporter(AiidaTestCase):
         })
 
     @unittest.skipIf(not has_ase(), "Unable to import ase")
-    @unittest.skipIf(not has_pyspglib(), "Unable to import pyspglib")
+    @unittest.skipIf(not has_spglib(), "Unable to import spglib")
     @unittest.skipIf(not has_pycifrw(), "Unable to import PyCifRW")
     def test_inline_export(self):
         from aiida.orm.data.cif import CifData
@@ -508,7 +508,7 @@ class TestTcodDbExporter(AiidaTestCase):
         self.assertNotEqual(script.find(function), script.rfind(function))
 
     @unittest.skipIf(not has_ase(), "Unable to import ase")
-    @unittest.skipIf(not has_pyspglib(), "Unable to import pyspglib")
+    @unittest.skipIf(not has_spglib(), "Unable to import spglib")
     @unittest.skipIf(not has_pycifrw(), "Unable to import PyCifRW")
     def test_symmetry_reduction(self):
         from aiida.orm.data.structure import StructureData
@@ -562,7 +562,7 @@ class TestTcodDbExporter(AiidaTestCase):
         self.assertEqual(options, {})
 
     @unittest.skipIf(not has_ase(), "Unable to import ase")
-    @unittest.skipIf(not has_pyspglib(), "Unable to import pyspglib")
+    @unittest.skipIf(not has_spglib(), "Unable to import spglib")
     @unittest.skipIf(not has_pycifrw(), "Unable to import PyCifRW")
     def test_export_trajectory(self):
         from aiida.orm.data.structure import StructureData

--- a/aiida/orm/data/structure.py
+++ b/aiida/orm/data/structure.py
@@ -121,12 +121,12 @@ def get_pymatgen_version():
     return pymatgen.__version__
 
 
-def has_pyspglib():
+def has_spglib():
     """
-    :return: True if the pyspglib module can be imported, False otherwise.
+    :return: True if the spglib module can be imported, False otherwise.
     """
     try:
-        import pyspglib
+        import spglib
     except ImportError:
         return False
     return True
@@ -652,11 +652,11 @@ def ase_refine_cell(aseatoms, **kwargs):
     refine unit cell.
 
     :param aseatoms: an ase.atoms.Atoms instance
-    :param symprec: symmetry precision, used by pyspglib
+    :param symprec: symmetry precision, used by spglib
     :return newase: refined cell with reduced set of atoms
     :return symmetry: a dictionary describing the symmetry space group
     """
-    from pyspglib.spglib import refine_cell, get_symmetry_dataset
+    from spglib import refine_cell, get_symmetry_dataset
     from ase.atoms import Atoms
     cell, positions, numbers = refine_cell(aseatoms, **kwargs)
 

--- a/docs/source/developer_guide/tcod_exporter.rst
+++ b/docs/source/developer_guide/tcod_exporter.rst
@@ -37,7 +37,7 @@ defined in column *Type*. Each step is described in more detail below:
     ASE atoms object.
 * Detection of the symmetry and reduction to the unit cell
     Detection of the symmetry and reduction to the unit cell is performed
-    using `pyspglib.spglib.refine_cell() function`_.
+    using `spglib.refine_cell() function`_.
 * Niggli reduction of the unit cell
     Reduction of the unit cell to Niggli cell is a *nice to have* feature,
     as it would allow to represent structure as an unambiguously selected
@@ -62,5 +62,5 @@ defined in column *Type*. Each step is described in more detail below:
     :ref:`cif_cod_deposit script from cod-tools package <codtools_cifcoddeposit>`.
 
 .. _Theoretical Crystallography Open Database: http://www.crystallography.net/tcod/
-.. _pyspglib.spglib.refine_cell() function: http://spglib.sourceforge.net/api.html#spg-refine-cell
+.. _spglib.refine_cell() function: https://atztogo.github.io/spglib/python-spglib.html#refine-cell
 .. _TCOD CIF dictionaries: http://www.crystallography.net/tcod/cif/dictionaries/

--- a/setup_requirements.py
+++ b/setup_requirements.py
@@ -96,7 +96,7 @@ extras_require = {
     # Requirements for non-core funciontalities that rely on external atomic
     # manipulation/processing software
     'atomic_tools': [
-        'pyspglib',
+        'spglib>=1.9',
         # support for symmetry detection in aiida.orm.data.structure. Has no
         # easily accessible version number
         'pymatgen==4.5.3',  # support for NWChem I/O


### PR DESCRIPTION
Fix of #290 - we now completely removed the (old) pyspglib dependency and we only use the (new) spglib module.

NOTE: the refine_cell behaviour changed in version 1.8.x:
https://atztogo.github.io/spglib/python-spglib.html#refine-cell
so depending on which version one was using before with pyspglib, the behavior of e.g. `refine_ase()` could be different. Tests, however, pass with the same results, and I think that probably with pyspglib we were already using v. 1.8.x (in my old venv, it was 1.8.3.1).
