### PR TITLE
Fix for #536 - passing an integer pk to verdi code show

### DIFF
--- a/aiida/cmdline/commands/code.py
+++ b/aiida/cmdline/commands/code.py
@@ -808,20 +808,30 @@ class Code(VerdiCommandWithSubcommands):
         Get a Computer object with given identifier, that can either be
         the numeric ID (pk), or the label (if unique).
 
-        .. note:: If an string that can be converted to an integer is given,
-            the numeric ID is verified first (therefore, is a code A with a
-            label equal to the ID of another code B is present, code A cannot
-            be referenced by label).
+        .. note:: Since all command line arguments get converted to string types, we
+            cannot assess the intended type (an integer pk or a string label) from the
+            type of the variable code_id. If the code_id can be converted into an integer
+            we will assume the value corresponds to a pk. This means, however, that if there
+            would be another code, with a label directly equivalent to the string value of that
+            pk, that this code can not be referenced by its label, as the other code, corresponding
+            to the integer pk, will get matched first.
         """
-        from aiida.common.exceptions import NotExistent, MultipleObjectsError
-
+        from aiida.common.exceptions import NotExistent, MultipleObjectsError, InputValidationError
         from aiida.orm import Code as AiidaOrmCode
 
         try:
-            return AiidaOrmCode.get_from_string(code_id)
-        except (NotExistent, MultipleObjectsError) as e:
-            print >> sys.stderr, e.message
-            sys.exit(1)
+            pk = int(code_id)
+            try:
+                return AiidaOrmCode.get(pk=pk)
+            except (NotExistent, MultipleObjectsError, InputValidationError) as e:
+                print >> sys.stderr, e.message
+                sys.exit(1)
+        except ValueError:
+            try:
+                return AiidaOrmCode.get_from_string(code_id)
+            except (NotExistent, MultipleObjectsError) as e:
+                print >> sys.stderr, e.message
+                sys.exit(1)
 
     def code_show(self, *args):
         """

--- a/aiida/orm/implementation/general/code.py
+++ b/aiida/orm/implementation/general/code.py
@@ -142,6 +142,7 @@ class AbstractCode(SealableWithUpdatableAttributes, Node):
         :raise NotExistent: if no code identified by the given string is found
         :raise MultipleObjectsError: if the string cannot identify uniquely
             a code
+        :raise InputValidationError: if neither a pk nor a label was passed in
         """
         from aiida.common.exceptions import (NotExistent, MultipleObjectsError,
                                              InputValidationError)
@@ -182,23 +183,22 @@ class AbstractCode(SealableWithUpdatableAttributes, Node):
         :raise NotExistent: if no code identified by the given string is found
         :raise MultipleObjectsError: if the string cannot identify uniquely
             a code
+        :raise InputValidationError: if code_string is not of string type
 
         """
+        from aiida.common.exceptions import NotExistent, MultipleObjectsError, InputValidationError
 
-        from aiida.common.exceptions import InputValidationError
-
-        # check if code_string is a integer
         try:
-            int(code_string)
-            raise InputValidationError("Pass code string in the format of label@machinename")
-
-        except ValueError:
-
-            # split with the leftmost '@' symbol (i.e. code names cannot
-            # contain '@' symbols, computer names can)
             label, sep, machinename = code_string.partition('@')
+        except AttributeError as exception:
+            raise InputValidationError("the provided code_string is not of valid string type")
 
+        try:
             return cls.get_code_helper(label, machinename)
+        except NotExistent:
+            raise NotExistent("{} could not be resolved to a valid code label".format(code_string))
+        except MultipleObjectsError:
+            raise MultipleObjectsError("{} could not be uniquely resolved".format(code_string))
 
 
     @abstractclassmethod


### PR DESCRIPTION
The verdi code show command was failing when an integer pk was
passed as the AbstractCode get_from_string method was raising
an InputValidationError when a string was passed that could be
converted to an integer.

Since there already exists a general purpose get method Code.get()
that deals properly with the option of a pk or a label, the explicit
get_from_string should only be with strings and proper type should be
ensured by the caller.

The caller in this case is get_code in cmdline/commands/code.py
which now correctly calls get() or get_from_string() based on the
provided input