### PR TITLE
Add pip caching to travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,8 @@ language: python
 python:
     - "2.7"
 
+cache: pip
+
 services:
     - postgresql
     - docker
@@ -29,7 +31,7 @@ addons:
 ## Build matrix to test both backends, and the docs
 ## I still let it create the test backend for django also when building the docs
 ## because otherwise the code would complain. Also, I need latex.
-env: 
+env:
     - TEST_AIIDA_BACKEND=django COMPILE_DOCS=false
     - TEST_AIIDA_BACKEND=sqlalchemy COMPILE_DOCS=false
     - TEST_AIIDA_BACKEND=django COMPILE_DOCS=true
@@ -58,7 +60,7 @@ before_script:
 
     # Here I setup the actual AiiDA profile, non-interactively
     - verdi -p $TEST_AIIDA_BACKEND setup --non-interactive --backend=$TEST_AIIDA_BACKEND --email="aiida@localhost" --db_host="localhost" --db_port=5432 --db_name="$TEST_AIIDA_BACKEND" --db_user=postgres --db_pass='' --repo="/tmp/test_repository_${TEST_AIIDA_BACKEND}/" --first-name=AiiDA --last-name=test --institution="AiiDA Team" --no-password
-  
+
     # Here I setup the test AiiDA profile, non-interactively
     - verdi -p test_$TEST_AIIDA_BACKEND setup --non-interactive --backend=$TEST_AIIDA_BACKEND --email="aiida@localhost" --db_host="localhost" --db_port=5432 --db_name="test_$TEST_AIIDA_BACKEND" --db_user=postgres --db_pass='' --repo="/tmp/test_repository_test_${TEST_AIIDA_BACKEND}/" --first-name=AiiDA --last-name=test --institution="AiiDA Team" --no-password
 


### PR DESCRIPTION
This speeds up the travis builds by keeping ``.cache/pip`` between runs. See documentation here: https://docs.travis-ci.com/user/caching/

I did some simple timing, and it seems the benefit is about 60-90 seconds.