### PR TITLE
This resolved 527 by changing the load_node function such that it acc…

### DIFF
--- a/aiida/backends/djsite/db/subtests/nodes.py
+++ b/aiida/backends/djsite/db/subtests/nodes.py
@@ -283,22 +283,22 @@ class TestNodeBasicDjango(AiidaTestCase):
         """
         """
         from aiida.orm import load_node
-        from aiida.common.exceptions import NotExistent
+        from aiida.common.exceptions import NotExistent, InputValidationError
 
         a = Node()
         a.store()
         self.assertEquals(a.pk, load_node(pk=a.pk).pk)
         self.assertEquals(a.pk, load_node(uuid=a.uuid).pk)
 
-        with self.assertRaises(ValueError):
+        with self.assertRaises(InputValidationError):
             load_node(node_id=a.pk, pk=a.pk)
-        with self.assertRaises(ValueError):
+        with self.assertRaises(InputValidationError):
             load_node(pk=a.pk, uuid=a.uuid)
-        with self.assertRaises(ValueError):
+        with self.assertRaises(TypeError):
             load_node(pk=a.uuid)
-        with self.assertRaises(NotExistent):
+        with self.assertRaises(TypeError):
             load_node(uuid=a.pk)
-        with self.assertRaises(ValueError):
+        with self.assertRaises(InputValidationError):
             load_node()
 
 

--- a/aiida/backends/sqlalchemy/tests/nodes.py
+++ b/aiida/backends/sqlalchemy/tests/nodes.py
@@ -163,7 +163,7 @@ class TestNodeBasicSQLA(AiidaTestCase):
         Test for load_node() function.
         """
         from aiida.orm import load_node
-        from aiida.common.exceptions import NotExistent
+        from aiida.common.exceptions import NotExistent, InputValidationError
         import aiida.backends.sqlalchemy
         from aiida.backends.sqlalchemy import get_scoped_session
 
@@ -179,35 +179,35 @@ class TestNodeBasicSQLA(AiidaTestCase):
 
         try:
             session.begin_nested()
-            with self.assertRaises(ValueError):
+            with self.assertRaises(InputValidationError):
                 load_node(node_id=a.pk, pk=a.pk)
         finally:
             session.rollback()
 
         try:
             session.begin_nested()
-            with self.assertRaises(ValueError):
+            with self.assertRaises(InputValidationError):
                 load_node(pk=a.pk, uuid=a.uuid)
         finally:
             session.rollback()
 
         try:
             session.begin_nested()
-            with self.assertRaises(ValueError):
+            with self.assertRaises(TypeError):
                 load_node(pk=a.uuid)
         finally:
             session.rollback()
 
         try:
             session.begin_nested()
-            with self.assertRaises(ValueError):
+            with self.assertRaises(TypeError):
                 load_node(uuid=a.pk)
         finally:
             session.rollback()
 
         try:
             session.begin_nested()
-            with self.assertRaises(ValueError):
+            with self.assertRaises(InputValidationError):
                 load_node()
         finally:
             session.rollback()

--- a/aiida/backends/tests/dataclasses.py
+++ b/aiida/backends/tests/dataclasses.py
@@ -1660,6 +1660,7 @@ class TestStructureDataReload(AiidaTestCase):
         for i in range(3):
             self.assertAlmostEqual(b.sites[1].position[i], 1.)
 
+
     def test_copy(self):
         """
         Start from a StructureData object, copy it and see if it is preserved

--- a/aiida/backends/tests/query.py
+++ b/aiida/backends/tests/query.py
@@ -167,7 +167,7 @@ class TestQueryBuilder(AiidaTestCase):
         from aiida.orm.querybuilder import QueryBuilder
         from aiida.orm import Node
         from datetime import datetime
-
+        from aiida.common.exceptions import MultipleObjectsError, NotExistent
         n0 = Node()
         n0.label = 'hello'
         n0.description=''
@@ -222,13 +222,17 @@ class TestQueryBuilder(AiidaTestCase):
 
         qb2 = QueryBuilder(**qh)
 
+
         resdict = qb2.dict()
-
         self.assertEqual(len(resdict), 1)
+        self.assertTrue(isinstance(resdict[0]['n1']['ctime'], datetime))
 
-        resdict = resdict[0]
-        self.assertTrue(isinstance(resdict['n1']['ctime'], datetime))
-        self.assertEqual(resdict['n2']['label'], 'bar')
+
+        res_one = qb2.one()
+        self.assertTrue('bar' in res_one)
+
+
+
 
         qh = {
             'path': [
@@ -254,6 +258,11 @@ class TestQueryBuilder(AiidaTestCase):
         query1 = qb.get_query()
         qb.add_filter('n2', {'label': 'nonexistentlabel'})
         self.assertEqual(qb.count(), 0)
+
+        with self.assertRaises(NotExistent):
+            qb.one()
+        with self.assertRaises(MultipleObjectsError):
+            QueryBuilder().append(Node).one()
 
         query2 = qb.get_query()
         query3 = qb.get_query()
@@ -368,7 +377,7 @@ class TestQueryBuilder(AiidaTestCase):
         # here I am giving a nonsensical projection:
         with self.assertRaises(InputValidationError):
             QueryBuilder().append(StructureData, project=True)
-        
+
         # here I am giving a nonsensical projection for the edge:
         with self.assertRaises(InputValidationError):
             QueryBuilder().append(Calculation).append(StructureData, edge_tag='t').add_projection('t', True)
@@ -461,7 +470,7 @@ class TestAttributes(AiidaTestCase):
         res_uuids.add(n1.uuid)
 
         # I want all the nodes where whatever is smaller than 1. or there is no such value:
-        
+
         qb = QueryBuilder()
         qb.append(Node, filters={
                     'or':[
@@ -487,7 +496,7 @@ class QueryBuilderDateTimeAttribute(AiidaTestCase):
         n._set_attr('now', now)
         n.store()
 
-        qb = QueryBuilder().append(Node, 
+        qb = QueryBuilder().append(Node,
             filters={'attributes.now': {"and":[
                 {">":now-timedelta(seconds=1)},
                 {"<":now+timedelta(seconds=1)},
@@ -562,7 +571,7 @@ class QueryBuilderLimitOffsetsTest(AiidaTestCase):
         qb.limit(3)
         res = list(zip(*qb.all())[0])
         self.assertEqual(res, range(4,1, -1))
-        
+
 
 class QueryBuilderJoinsTests(AiidaTestCase):
     def test_joins1(self):

--- a/aiida/orm/querybuilder.py
+++ b/aiida/orm/querybuilder.py
@@ -2266,6 +2266,21 @@ class QueryBuilder(object):
         return returnval
 
 
+    def one(self):
+        """
+        Executes the query asking for exactly one results. Will raise an exception if this is not the case
+        :raises: MultipleObjectsError if more then one row can be returned
+        :raises: NotExistent if no result was found
+        """
+        from aiida.common.exceptions import MultipleObjectsError, NotExistent
+        self.limit(2)
+        res = self.all()
+        if len(res) > 1:
+            raise MultipleObjectsError("More than one result was found")
+        elif len(res) == 0:
+            raise NotExistent("No result was found")
+        return res[0]
+
 
     def count(self):
         """
@@ -2391,6 +2406,7 @@ class QueryBuilder(object):
 
         """
         return list(self.iterdict(batch_size=batch_size))
+
 
 
     def get_results_dict(self):

--- a/aiida/orm/utils.py
+++ b/aiida/orm/utils.py
@@ -50,56 +50,93 @@ def WorkflowFactory(module):
     return BaseFactory(module, Workflow, "aiida.workflows")
 
 
-def load_node(node_id=None, pk=None, uuid=None, parent_class=None):
+def load_node(node_id=None, pk=None, uuid=None, parent_class=None, query_with_dashes=True):
     """
     Return an AiiDA node given PK or UUID.
 
     :param node_id: PK (integer) or UUID (string) or a node
     :param pk: PK of a node
-    :param uuid: UUID of a node
+    :param uuid: UUID of a node, or the beginning of the uuid
     :param parent_class: if specified, checks whether the node loaded is a
         subclass of parent_class
+    :param bool query_with_dashes: Specific if uuid is passed, allows to put the uuid in the correct form.
+        Default=True
     :return: an AiiDA node
-    :raise ValueError: if none or more than one of parameters is supplied
-        or type of node_id is neither string nor integer.
-    :raise NotExistent: if the parent_class is specified
-        and no matching Node is found.
+    :raise InputValidationError: if none or more than one of parameters is supplied
+    :raise TypeError: I the wrong types are provided
+    :raise NotExistent: if no matching Node is found.
+    :raise MultipleObjectsError: If more than one Node was fouuund
     """
-    from aiida.common.exceptions import NotExistent
+    from aiida.common.exceptions import NotExistent, MultipleObjectsError, NotExistent, InputValidationError
     # This must be done inside here, because at import time the profile
     # must have been already loaded. If you put it at the module level,
     # the implementation is frozen to the default one at import time.
     from aiida.orm.implementation import Node
+    from aiida.orm.querybuilder import QueryBuilder
 
-    if int(node_id is None) + int(pk is None) + int(uuid is None) == 3:
-        raise ValueError("one of the parameters 'node_id', 'pk' and 'uuid' "
+
+    # First checking if the inputs are valid:
+    inputs_provided = [val is not None for val in (node_id, pk, uuid)].count(True)
+    if inputs_provided == 0:
+        raise InputValidationError("one of the parameters 'node_id', 'pk' and 'uuid' "
                          "has to be supplied")
-    if int(node_id is None) + int(pk is None) + int(uuid is None) < 2:
-        raise ValueError("only one of parameters 'node_id', 'pk' and 'uuid' "
+    elif inputs_provided > 1:
+        raise InputValidationError("only one of parameters 'node_id', 'pk' and 'uuid' "
                          "has to be supplied")
-    loaded_node = None
+
+    class_ = parent_class or Node
+    if not issubclass(class_,  Node):
+        raise TypeError("{} is not a subclass of {}".format(class_, Node))
+    # The logic is as follows: If pk is specified I will look for the pk
+    # if UUID is specified for the uuid.
+    # node_id can either be string -> uuid or an integer -> pk
+    # Checking first if node_id specified
     if node_id is not None:
-        if isinstance(node_id, str) or isinstance(node_id, unicode):
-            loaded_node = Node.get_subclass_from_uuid(node_id)
+        if isinstance(node_id, (str, unicode)):
+            uuid = node_id
         elif isinstance(node_id, int):
-            loaded_node = Node.get_subclass_from_pk(node_id)
+            pk = node_id
         else:
-            raise ValueError("'node_id' has to be either string, unicode or "
-                             "integer, {} given".format(type(node_id)))
-    if loaded_node is None:
-        if pk is not None:
-            loaded_node = Node.get_subclass_from_pk(pk)
-        else:
-            loaded_node = Node.get_subclass_from_uuid(uuid)
+            raise TypeError("'node_id' has to be either string, unicode or "
+                                 "integer, {} given".format(type(node_id)))
 
-    if parent_class is not None:
-        if not issubclass(parent_class, Node):
-            raise ValueError("parent_class must be a subclass of Node")
-        if not isinstance(loaded_node, parent_class):
-            raise NotExistent('No node found as '
-                              'subclass of {}'.format(parent_class))
+            #I am checking whether uuid, if supplied,  is a string
+    if uuid is not None:
+        if not isinstance(uuid,(str, unicode)):
+            raise TypeError("'uuid' has to be string or unicode")
+        # or whether the pk, if provided, is an integer
+    elif pk is not None:
+        if not isinstance(pk, int):
+            raise TypeError("'pk' has to be an integer")
+    else:
+        # I really shouldn't get here
+        assert True,  "Neither pk  nor uuid was provided"
 
-    return loaded_node
+    qb = QueryBuilder()
+    qb.append(class_, tag='node', project='*')
+
+    if pk:
+        qb.add_filter('node',  {'id':pk})
+    elif uuid:
+        # Put back dashes in the right place
+        start_uuid = uuid.replace('-', '')
+        if query_with_dashes:
+            # Essential that this is ordered from largest to smallest!
+            for dash_pos in [20,16,12,8]:
+                if len(start_uuid) > dash_pos:
+                    start_uuid = "{}-{}".format(
+                        start_uuid[:dash_pos], start_uuid[dash_pos:]
+                        )
+
+        qb.add_filter('node',{'uuid': {'like': "{}%".format(start_uuid)}})
+    try:
+        return qb.one()[0]
+    except MultipleObjectsError:
+        raise MultipleObjectsError("More than one found with UUID starting by '{}'".format(
+                start_uuid))
+    except NotExistent:
+        raise NotExistent("No node found with UUID starting by '{}'".format(
+                start_uuid))
 
 
 def load_workflow(wf_id=None, pk=None, uuid=None):


### PR DESCRIPTION
…epts the beginning of a uuid.

Used this opportunity to clean up the the way load_node works.
It raises now TypeError and InputValidationError instead of ValueError and uses the querybuilder instead of subclass_from_pk.