### PR TITLE
Fixes #535, click shows help text now

### DIFF
--- a/aiida/cmdline/commands/__init__.py
+++ b/aiida/cmdline/commands/__init__.py
@@ -7,5 +7,19 @@
 # For further information on the license, see the LICENSE.txt file        #
 # For further information please visit http://www.aiida.net               #
 ###########################################################################
+import click
 
 
+@click.group()
+def verdi():
+    pass
+
+
+@verdi.group()
+def work():
+    pass
+
+
+@verdi.group()
+def user():
+    pass

--- a/aiida/cmdline/commands/user.py
+++ b/aiida/cmdline/commands/user.py
@@ -10,10 +10,9 @@
 """
 This allows to setup and configure a user from command line.
 """
-import click
 import sys
+import click
 from aiida.cmdline.commands import user, verdi
-
 from aiida.cmdline.baseclass import VerdiCommandWithSubcommands
 from aiida.backends.utils import load_dbenv, is_dbenv_loaded
 
@@ -33,11 +32,11 @@ class User(VerdiCommandWithSubcommands):
         A dictionary with valid commands and functions to be called.
         """
         self.valid_subcommands = {
-            'configure': (self._cli, self.complete_emails),
-            'list': (self._cli, self.complete_none),
+            'configure': (self.cli, self.complete_emails),
+            'list': (self.cli, self.complete_none),
         }
 
-    def _cli(self, *args):
+    def cli(self, *args):
         verdi()
 
     def complete_emails(self, subargs_idx, subargs):

--- a/aiida/cmdline/commands/user.py
+++ b/aiida/cmdline/commands/user.py
@@ -10,14 +10,13 @@
 """
 This allows to setup and configure a user from command line.
 """
+import click
 import sys
+from aiida.cmdline.commands import user, verdi
 
 from aiida.cmdline.baseclass import VerdiCommandWithSubcommands
 from aiida.backends.utils import load_dbenv, is_dbenv_loaded
-from aiida.common.exceptions import NotExistent
 
-
-import click
 CONTEXT_SETTINGS = dict(help_option_names=['-h', '--help'])
 
 
@@ -34,9 +33,12 @@ class User(VerdiCommandWithSubcommands):
         A dictionary with valid commands and functions to be called.
         """
         self.valid_subcommands = {
-            'configure': (self.user_configure, self.complete_emails),
-            'list': (self.user_list, self.complete_none),
+            'configure': (self._cli, self.complete_emails),
+            'list': (self._cli, self.complete_none),
         }
+
+    def _cli(self, *args):
+        verdi()
 
     def complete_emails(self, subargs_idx, subargs):
         load_dbenv()
@@ -46,214 +48,197 @@ class User(VerdiCommandWithSubcommands):
         emails = models.DbUser.objects.all().values_list('email', flat=True)
         return "\n".join(emails)
 
-    def user_configure(self, *args):
-        ctx = self._user_configure_cmd.make_context('configure', list(args))
-        with ctx:
-            ctx.obj = self
-            self._user_configure_cmd.invoke(ctx)
 
-    @click.command('configure', context_settings=CONTEXT_SETTINGS)
-    @click.argument('email', type=str)
-    @click.option('--first-name', prompt='First Name', type=str)
-    @click.option('--last-name', prompt='Last Name', type=str)
-    @click.option('--institution', prompt='Institution', type=str)
-    @click.option('--no-password', is_flag=True)
-    @click.pass_obj
-    def _user_configure_cmd(self, email, first_name, last_name, institution, no_password):
-        from aiida.backends.utils import is_dbenv_loaded
-        if not is_dbenv_loaded():
-            load_dbenv()
+@user.command(context_settings=CONTEXT_SETTINGS)
+@click.argument('email', type=str)
+@click.option('--first-name', prompt='First Name', type=str)
+@click.option('--last-name', prompt='Last Name', type=str)
+@click.option('--institution', prompt='Institution', type=str)
+@click.option('--no-password', is_flag=True)
+@click.pass_obj
+def configure(email, first_name, last_name, institution, no_password):
+    from aiida.backends.utils import is_dbenv_loaded
+    if not is_dbenv_loaded():
+        load_dbenv()
 
-        import readline
-        import getpass
+    import readline
+    import getpass
 
-        from aiida.orm.implementation import User
+    from aiida.orm.implementation import User
 
-        #if len(args) != 1:
-        #    print >> sys.stderr, ("You have to pass (only) one parameter after "
-        #                          "'user configure', the email of")
-        #    print >> sys.stderr, "the user to be configured."
-        #    sys.exit(1)
+    # if len(args) != 1:
+    #    print >> sys.stderr, ("You have to pass (only) one parameter after "
+    #                          "'user configure', the email of")
+    #    print >> sys.stderr, "the user to be configured."
+    #    sys.exit(1)
 
-        #email = args[0]
+    # email = args[0]
 
-        user_list = User.search_for_users(email=email)
-        if user_list is not None and len(user_list) >= 1:
-            user = user_list[0]
-            print ""
-            print ("An AiiDA user for email '{}' is already present "
-                   "in the DB:".format(email))
-            #print "First name:   {}".format(user.first_name)
-            #print "Last name:    {}".format(user.last_name)
-            #print "Institution:  {}".format(user.institution)
-            configure_user = False
-            reply = click.confirm("Do you want to reconfigure it?")
-            #if not reply:
-            #    pass
-            #elif reply.lower() == 'n':
-            #    pass
-            if reply:
-                configure_user = True
-            #else:
-            #    print "Invalid answer, assuming answer was 'NO'"
-        else:
+    user_list = User.search_for_users(email=email)
+    if user_list is not None and len(user_list) >= 1:
+        user = user_list[0]
+        print ""
+        print ("An AiiDA user for email '{}' is already present "
+               "in the DB:".format(email))
+        # print "First name:   {}".format(user.first_name)
+        # print "Last name:    {}".format(user.last_name)
+        # print "Institution:  {}".format(user.institution)
+        configure_user = False
+        reply = click.confirm("Do you want to reconfigure it?")
+        # if not reply:
+        #    pass
+        # elif reply.lower() == 'n':
+        #    pass
+        if reply:
             configure_user = True
-            user = User(email=email)
-            print "Configuring a new user with email '{}'".format(email)
+            # else:
+            #    print "Invalid answer, assuming answer was 'NO'"
+    else:
+        configure_user = True
+        user = User(email=email)
+        print "Configuring a new user with email '{}'".format(email)
 
-        if configure_user:
-            try:
-                kwargs = {}
-                # for field in models.DbUser.REQUIRED_FIELDS:
-                for field in User.REQUIRED_FIELDS:
-                    verbose_name = field.capitalize()
-                    readline.set_startup_hook(lambda: readline.insert_text(
-                        getattr(user, field)))
-                    if field=='first_name' and first_name:
-                        kwargs[field] = first_name
-                    elif field=='last_name' and last_name:
-                        kwargs[field] = last_name
-                    elif field=='institution' and institution:
-                        kwargs[field] = institution
-                    else:
-                        kwargs[field] = raw_input('{}: '.format(verbose_name))
-            finally:
-                readline.set_startup_hook(lambda: readline.insert_text(""))
-
-            for k, v in kwargs.iteritems():
-                setattr(user, k, v)
-
-            change_password = False
-            if no_password:
-                user.password = None
-            else:
-                if user.has_usable_password():
-                    reply = raw_input("Do you want to replace the user password? [y/N] ")
-                    reply = reply.strip()
-                    if not reply:
-                        pass
-                    elif reply.lower() == 'n':
-                        pass
-                    elif reply.lower() == 'y':
-                        change_password = True
-                    else:
-                        print "Invalid answer, assuming answer was 'NO'"
-                else:
-                    reply = raw_input("The user has no password, do you want to set one? [y/N] ")
-                    reply = reply.strip()
-                    if not reply:
-                        pass
-                    elif reply.lower() == 'n':
-                        pass
-                    elif reply.lower() == 'y':
-                        change_password = True
-                    else:
-                        print "Invalid answer, assuming answer was 'NO'"
-
-                if change_password:
-                    match = False
-                    while not match:
-                        new_password = getpass.getpass("Insert the new password: ")
-                        new_password_check = getpass.getpass(
-                            "Insert the new password (again): ")
-                        if new_password == new_password_check:
-                            match = True
-                        else:
-                            print "ERROR, the two passwords do not match."
-                    ## Set the password here
-                    user.password = new_password
-                else:
-                    user.password = None
-
-            user.force_save()
-            print ">> User {} {} saved. <<".format(user.first_name,
-                                                   user.last_name)
-            if not user.has_usable_password():
-                print "** NOTE: no password set for this user, "
-                print "         so he/she will not be able to login"
-                print "         via the REST API and the Web Interface."
-
-    def user_list(self, *args):
-
-        if not is_dbenv_loaded():
-            load_dbenv()
-
-        from aiida.orm.implementation import User
-        from aiida.common.utils import get_configured_user_email
-
-        from aiida.common.exceptions import ConfigurationError
-
+    if configure_user:
         try:
-            current_user = get_configured_user_email()
-        except ConfigurationError:
-            current_user = None
+            kwargs = {}
+            # for field in models.DbUser.REQUIRED_FIELDS:
+            for field in User.REQUIRED_FIELDS:
+                verbose_name = field.capitalize()
+                readline.set_startup_hook(lambda: readline.insert_text(
+                    getattr(user, field)))
+                if field == 'first_name' and first_name:
+                    kwargs[field] = first_name
+                elif field == 'last_name' and last_name:
+                    kwargs[field] = last_name
+                elif field == 'institution' and institution:
+                    kwargs[field] = institution
+                else:
+                    kwargs[field] = raw_input('{}: '.format(verbose_name))
+        finally:
+            readline.set_startup_hook(lambda: readline.insert_text(""))
 
-        use_colors = False
-        if args:
-            try:
-                if len(args) != 1:
-                    raise ValueError
-                if args[0] != "--color":
-                    raise ValueError
-                use_colors = True
-            except ValueError:
-                print >> sys.stderr, ("You can pass only one further argument, "
-                                      "--color, to show the results with colors")
-                sys.exit(1)
+        for k, v in kwargs.iteritems():
+            setattr(user, k, v)
 
-        if current_user is not None:
-            # print >> sys.stderr, "### The '>' symbol indicates the current default user ###"
-            pass
+        change_password = False
+        if no_password:
+            user.password = None
         else:
-            print >> sys.stderr, "### No default user configured yet, run 'verdi install'! ###"
-
-        for user in User.get_all_users():
-            name_pieces = []
-            if user.first_name:
-                name_pieces.append(user.first_name)
-            if user.last_name:
-                name_pieces.append(user.last_name)
-            full_name = " ".join(name_pieces)
-            if full_name:
-                full_name = " {}".format(full_name)
-
-            institution_str = " ({})".format(
-                user.institution) if user.institution else ""
-
-            color_id = 39  # Default foreground color
-            permissions_list = []
-            if user.is_staff:
-                permissions_list.append("STAFF")
-            if user.is_superuser:
-                permissions_list.append("SUPERUSER")
-            if not user.has_usable_password():
-                permissions_list.append("NO_PWD")
-                color_id = 90  # Dark gray
+            if user.has_usable_password():
+                reply = raw_input("Do you want to replace the user password? [y/N] ")
+                reply = reply.strip()
+                if not reply:
+                    pass
+                elif reply.lower() == 'n':
+                    pass
+                elif reply.lower() == 'y':
+                    change_password = True
+                else:
+                    print "Invalid answer, assuming answer was 'NO'"
             else:
-                color_id = 34  # Blue
-            permissions_str = ",".join(permissions_list)
-            if permissions_str:
-                permissions_str = " [{}]".format(permissions_str)
+                reply = raw_input("The user has no password, do you want to set one? [y/N] ")
+                reply = reply.strip()
+                if not reply:
+                    pass
+                elif reply.lower() == 'n':
+                    pass
+                elif reply.lower() == 'y':
+                    change_password = True
+                else:
+                    print "Invalid answer, assuming answer was 'NO'"
 
-            if user.email == current_user:
-                symbol = ">"
-                color_id = 31
+            if change_password:
+                match = False
+                while not match:
+                    new_password = getpass.getpass("Insert the new password: ")
+                    new_password_check = getpass.getpass(
+                        "Insert the new password (again): ")
+                    if new_password == new_password_check:
+                        match = True
+                    else:
+                        print "ERROR, the two passwords do not match."
+                ## Set the password here
+                user.password = new_password
             else:
-                symbol = "*"
+                user.password = None
 
-            if use_colors:
-                start_color = "\x1b[{}m".format(color_id)
-                end_color = "\x1b[0m"
-                bold_sequence = "\x1b[1;{}m".format(color_id)
-                nobold_sequence = "\x1b[0;{}m".format(color_id)
-            else:
-                start_color = ""
-                end_color = ""
-                bold_sequence = ""
-                nobold_sequence = ""
+        user.force_save()
+        print ">> User {} {} saved. <<".format(user.first_name,
+                                               user.last_name)
+        if not user.has_usable_password():
+            print "** NOTE: no password set for this user, "
+            print "         so he/she will not be able to login"
+            print "         via the REST API and the Web Interface."
 
-            print "{}{} {}{}{}:{}{}{}{}".format(
-                start_color, symbol,
-                bold_sequence, user.email, nobold_sequence,
-                full_name, institution_str, permissions_str, end_color)
 
+@user.command()
+@click.option('--color', is_flag=True, help='Show results with colors', default=False)
+def list(color):
+    if not is_dbenv_loaded():
+        load_dbenv()
+
+    from aiida.orm.implementation import User
+    from aiida.common.utils import get_configured_user_email
+
+    from aiida.common.exceptions import ConfigurationError
+
+    try:
+        current_user = get_configured_user_email()
+    except ConfigurationError:
+        current_user = None
+
+    if current_user is not None:
+        # print >> sys.stderr, "### The '>' symbol indicates the current default user ###"
+        pass
+    else:
+        print >> sys.stderr, "### No default user configured yet, run 'verdi install'! ###"
+
+    for user in User.get_all_users():
+        name_pieces = []
+        if user.first_name:
+            name_pieces.append(user.first_name)
+        if user.last_name:
+            name_pieces.append(user.last_name)
+        full_name = " ".join(name_pieces)
+        if full_name:
+            full_name = " {}".format(full_name)
+
+        institution_str = " ({})".format(
+            user.institution) if user.institution else ""
+
+        color_id = 39  # Default foreground color
+        permissions_list = []
+        if user.is_staff:
+            permissions_list.append("STAFF")
+        if user.is_superuser:
+            permissions_list.append("SUPERUSER")
+        if not user.has_usable_password():
+            permissions_list.append("NO_PWD")
+            color_id = 90  # Dark gray
+        else:
+            color_id = 34  # Blue
+        permissions_str = ",".join(permissions_list)
+        if permissions_str:
+            permissions_str = " [{}]".format(permissions_str)
+
+        if user.email == current_user:
+            symbol = ">"
+            color_id = 31
+        else:
+            symbol = "*"
+
+        if color:
+            start_color = "\x1b[{}m".format(color_id)
+            end_color = "\x1b[0m"
+            bold_sequence = "\x1b[1;{}m".format(color_id)
+            nobold_sequence = "\x1b[0;{}m".format(color_id)
+        else:
+            start_color = ""
+            end_color = ""
+            bold_sequence = ""
+            nobold_sequence = ""
+
+        print "{}{} {}{}{}:{}{}{}{}".format(
+            start_color, symbol,
+            bold_sequence, user.email, nobold_sequence,
+            full_name, institution_str, permissions_str, end_color)

--- a/aiida/cmdline/commands/work.py
+++ b/aiida/cmdline/commands/work.py
@@ -8,12 +8,28 @@
 # For further information please visit http://www.aiida.net               #
 ###########################################################################
 import click
-from aiida.cmdline.commands import work, verdi
-
-from aiida.cmdline.baseclass import VerdiCommandWithSubcommands
 from tabulate import tabulate
+from aiida.cmdline.commands import work, verdi
+from aiida.cmdline.baseclass import VerdiCommandWithSubcommands
 
 CONTEXT_SETTINGS = dict(help_option_names=['-h', '--help'])
+
+
+class Work(VerdiCommandWithSubcommands):
+    """
+    Manage the AiiDA worflow manager
+    """
+
+    def __init__(self):
+        self.valid_subcommands = {
+            'list': (self.cli, self.complete_none),
+            'report': (self.cli, self.complete_none),
+            'tree': (self.cli, self.complete_none),
+            'checkpoint': (self.cli, self.complete_none),
+        }
+
+    def cli(self, *args):
+        verdi()
 
 
 @work.command(context_settings=CONTEXT_SETTINGS)
@@ -244,20 +260,3 @@ def _build_query(order_by=None, limit=None, past_days=None):
         qb.limit(limit)
 
     return qb.iterdict()
-
-
-class Work(VerdiCommandWithSubcommands):
-    """
-    Manage the AiiDA worflow2 manager
-    """
-
-    def __init__(self):
-        self.valid_subcommands = {
-            'list': (self.cli, self.complete_none),
-            'report': (self.cli, self.complete_none),
-            'tree': (self.cli, self.complete_none),
-            'checkpoint': (self.cli, self.complete_none),
-        }
-
-    def cli(self, *args):
-        verdi()

--- a/aiida/cmdline/commands/work.py
+++ b/aiida/cmdline/commands/work.py
@@ -7,59 +7,23 @@
 # For further information on the license, see the LICENSE.txt file        #
 # For further information please visit http://www.aiida.net               #
 ###########################################################################
-import sys
 import click
+from aiida.cmdline.commands import work, verdi
 
 from aiida.cmdline.baseclass import VerdiCommandWithSubcommands
 from tabulate import tabulate
 
-
-
 CONTEXT_SETTINGS = dict(help_option_names=['-h', '--help'])
 
 
-class Work(VerdiCommandWithSubcommands):
-    """
-    Manage the AiiDA worflow2 manager
-    """
-
-    def __init__(self):
-        self.valid_subcommands = {
-            self.list.__name__: (self.list, self.complete_none),
-            self.report.__name__: (self.report, self.complete_none),
-            self.tree.__name__: (self.tree, self.complete_none),
-            self.checkpoint.__name__: (self.checkpoint, self.complete_none),
-        }
-
-    def list(self, *args):
-        ctx = do_list.make_context('list', list(args))
-        with ctx:
-            do_list.invoke(ctx)
-
-    def report(self, *args):
-        ctx = do_report.make_context('report', sys.argv[3:])
-        with ctx:
-            do_report.invoke(ctx)
-
-    def tree(self, *args):
-        ctx = do_tree.make_context('tree', list(args))
-        with ctx:
-            do_tree.invoke(ctx)
-
-    def checkpoint(self, *args):
-        ctx = do_checkpoint.make_context('checkpoint', list(args))
-        with ctx:
-            do_checkpoint.invoke(ctx)
-
-
-@click.command('list', context_settings=CONTEXT_SETTINGS)
+@work.command(context_settings=CONTEXT_SETTINGS)
 @click.option('-p', '--past-days', type=int, default=1,
               help="add a filter to show only workflows created in the past N"
                    " days")
 @click.option('-a', '--all', 'all_nodes', is_flag=True, help='Return all nodes. Overrides the -l flag')
 @click.option('-l', '--limit', type=int, default=None,
               help="Limit to this many results")
-def do_list(past_days, all_nodes, limit):
+def list(past_days, all_nodes, limit):
     """
     Return a list of running workflows on screen
     """
@@ -98,20 +62,21 @@ def do_list(past_days, all_nodes, limit):
     print(tabulate(table, headers=["PID", "Creation time", "ProcessLabel", "Sealed"]))
 
 
-@click.command('report', context_settings=CONTEXT_SETTINGS)
+# @work.command('report', context_settings=CONTEXT_SETTINGS)
+@work.command()
 @click.argument('pk', nargs=1, type=int)
 @click.option('-i', '--indent-size', type=int, default=2)
 @click.option('-l', '--levelname',
-    type=click.Choice(['DEBUG', 'INFO', 'REPORT', 'WARNING', 'ERROR', 'CRITICAL']),
-    default=None,
-    help='Filter the results by name of the log level'
-)
+              type=click.Choice(['DEBUG', 'INFO', 'REPORT', 'WARNING', 'ERROR', 'CRITICAL']),
+              default=None,
+              help='Filter the results by name of the log level'
+              )
 @click.option('-o', '--order-by',
-    type=click.Choice(['id', 'time', 'levelname']),
-    default='time',
-    help='Order the results by column'
-)
-def do_report(pk, levelname, order_by, indent_size):
+              type=click.Choice(['id', 'time', 'levelname']),
+              default='time',
+              help='Order the results by column'
+              )
+def report(pk, levelname, order_by, indent_size):
     """
     Return a list of recorded log messages for the WorkChain with pk=PK
     """
@@ -128,7 +93,7 @@ def do_report(pk, levelname, order_by, indent_size):
     def get_report_messages(pk, depth, levelname):
         backend = construct()
         filters = {
-            'objpk' : pk,
+            'objpk': pk,
         }
 
         if levelname:
@@ -162,12 +127,12 @@ def do_report(pk, levelname, order_by, indent_size):
         # This will return a single flat list of tuples, where the first element
         # corresponds to the WorkChain pk and the second element is an integer
         # that represents its level of nesting within the chain
-        return [(pk, level)] + list(itertools.chain(*[get_subtree(subpk, level=level+1) for subpk in result]))
+        return [(pk, level)] + list(itertools.chain(*[get_subtree(subpk, level=level + 1) for subpk in result]))
 
     def print_subtree(tree, prepend=""):
         print "{}{}".format(prepend, tree[0])
         for subtree in tree[1]:
-            print_subtree(subtree, prepend = prepend+"  ")
+            print_subtree(subtree, prepend=prepend + "  ")
 
     workchain_tree = get_subtree(pk)
 
@@ -190,12 +155,13 @@ def do_report(pk, levelname, order_by, indent_size):
             time=entry.time,
             width_id=width_id,
             width_levelname=width_levelname,
-            indent=' '*(depth * indent_size)
+            indent=' ' * (depth * indent_size)
         )
 
     return
 
-@click.command('tree', context_settings=CONTEXT_SETTINGS)
+
+@work.command('tree', context_settings=CONTEXT_SETTINGS)
 @click.option('--node-label', default='_process_label', type=str)
 @click.option('--depth', '-d', type=int, default=1)
 @click.argument('pks', nargs=-1, type=int)
@@ -215,7 +181,7 @@ def do_tree(node_label, depth, pks):
         print(t.get_ascii(show_internal=True))
 
 
-@click.command('checkpoint', context_settings=CONTEXT_SETTINGS)
+@work.command('checkpoint', context_settings=CONTEXT_SETTINGS)
 @click.argument('pks', nargs=-1, type=int)
 def do_checkpoint(pks):
     from aiida.backends.utils import load_dbenv, is_dbenv_loaded
@@ -278,3 +244,20 @@ def _build_query(order_by=None, limit=None, past_days=None):
         qb.limit(limit)
 
     return qb.iterdict()
+
+
+class Work(VerdiCommandWithSubcommands):
+    """
+    Manage the AiiDA worflow2 manager
+    """
+
+    def __init__(self):
+        self.valid_subcommands = {
+            'list': (self.cli, self.complete_none),
+            'report': (self.cli, self.complete_none),
+            'tree': (self.cli, self.complete_none),
+            'checkpoint': (self.cli, self.complete_none),
+        }
+
+    def cli(self, *args):
+        verdi()

--- a/aiida/cmdline/commands/workflow.py
+++ b/aiida/cmdline/commands/workflow.py
@@ -14,7 +14,7 @@ from aiida.cmdline.baseclass import VerdiCommandWithSubcommands
 
 class Workflow(VerdiCommandWithSubcommands):
     """
-    Manage the AiiDA worflow manager
+    Manage the AiiDA legacy worflow manager
 
     Valid subcommands are:
     * list: list the running workflows running and their state. Pass a -h


### PR DESCRIPTION
Previously click error handling was being bypassed to plumb work commands
into the aiida command line system.  This meant that bare exceptions were
being shown instead of error messages showing the missing parameters, etc.

To fix we emulated the hierarchy of commands verdi->work|user->... natively
in click when calling either work or user.  This restored native click error
messages.