### PR TITLE
Add support for the ASE-Espresso QE ASE-interface

### DIFF
--- a/aiida/orm/calculation/job/aseplugins/ase.py
+++ b/aiida/orm/calculation/job/aseplugins/ase.py
@@ -379,6 +379,8 @@ def get_calculator_impstr(calculator_name):
     """
     if calculator_name.lower() == "gpaw" or calculator_name is None:
         return "from gpaw import GPAW as custom_calculator"
+    elif calculator_name.lower() == "espresso":
+        return "from espresso import espresso as custom_calculator"
     else:
         possibilities = {"abinit":"abinit.Abinit",
                          "aims":"aims.Aims",


### PR DESCRIPTION
This interface (https://github.com/vossjo/ase-espresso/) is currently stand-alone and not integrated with ASE, so it needs to be imported from its own package.