### PR TITLE
Fix #641 node link uniqueness constraints

### DIFF
--- a/aiida/backends/tests/work/workChain.py
+++ b/aiida/backends/tests/work/workChain.py
@@ -172,6 +172,24 @@ class TestWorkchain(AiidaTestCase):
         with self.assertRaises(ValueError):
             Wf.spec()
 
+    def test_identical_input_node_different_label(self):
+        # We allow the creation of multiple INPUT links from the same node
+        # as long as the label is different
+        class Wf(WorkChain):
+            @classmethod
+            def define(cls, spec):
+                super(Wf, cls).define(spec)
+                spec.input('a', valid_type=Int)
+                spec.input('b', valid_type=Int)
+                spec.outline(cls.check_inputs)
+
+            def check_inputs(self):
+                assert 'a' in self.inputs
+                assert 'b' in self.inputs
+
+        A = Int(1)
+        run(Wf, a=A, b=A)
+
     def test_context(self):
         A = Str("a")
         B = Str("b")

--- a/aiida/orm/implementation/general/calculation/job/__init__.py
+++ b/aiida/orm/implementation/general/calculation/job/__init__.py
@@ -531,22 +531,6 @@ class AbstractJobCalculation(object):
                                                                       label,
                                                                       link_type)
 
-    def _remove_link_from(self, label):
-        """
-        Remove a link. Only possible if the calculation is in state NEW.
-
-        :param str label: Name of the link to remove.
-        """
-        valid_states = [calc_states.NEW]
-
-        if self.get_state() not in valid_states:
-            raise ModificationNotAllowed(
-                "Can remove an input link to a calculation only if it is in one "
-                "of the following states:\n   {}\n it is instead {}".format(
-                    valid_states, self.get_state()))
-
-        return super(AbstractJobCalculation, self)._remove_link_from(label)
-
     @abstractmethod
     def _set_state(self, state):
         """

--- a/aiida/orm/implementation/general/node.py
+++ b/aiida/orm/implementation/general/node.py
@@ -27,6 +27,9 @@ from aiida.backends.utils import validate_attribute_key
 
 _NO_DEFAULT = tuple()
 
+LinkKey = collections.namedtuple('LinkKey', ['src_uuid', 'label'])
+LinkInfo = collections.namedtuple('LinkInfo', ['src', 'label', 'link_type'])
+
 
 def clean_value(value):
     """
@@ -451,22 +454,16 @@ class AbstractNode(object):
         """
         assert src is not None, "You must provide a valid Node to link"
 
-        # Check that the label does not already exist
+        # Check if the link for the same label/node/type combination already
+        # exists in the link cache, in which case we don't have to do anything
+        if LinkInfo(src, label, link_type) in self._inputlinks_cache.itervalues():
+            return
 
-        # This can happen also if both nodes are stored, e.g. if one first
-        # stores the output node and then the input node. Therefore I check
-        # it here.
-        if label in self._inputlinks_cache:
-            raise UniquenessError("Input link with name '{}' already present "
-                                  "in the internal cache".format(label))
-
-        # See if I am pointing to already saved nodes and I am already
-        # linking to a given node
-        if src.uuid in [_[0].uuid for _ in self._inputlinks_cache.values()]:
-            raise UniquenessError(
-                "A link from node with UUID={} and "
-                "the current node (UUID={}) already exists!".format(
-                    src.uuid, self.uuid))
+        # The combination label/link_type should be unique
+        for link_info in self._inputlinks_cache.itervalues():
+            if label == link_info.label and link_type == link_info.link_type:
+                raise UniquenessError('A link with the label {} and type {} already'
+                    'exists'.format(label, link_type))
 
         # Check if the source allows output links from this node
         # (will raise ValueError if this is not the case)
@@ -495,7 +492,7 @@ class AbstractNode(object):
             raise UniquenessError("Input link with name '{}' already present "
                                   "in the internal cache".format(label))
 
-        self._inputlinks_cache[label] = (src, link_type)
+        self._inputlinks_cache[LinkKey(src.uuid, label)] = LinkInfo(src, label, link_type)
 
     def _replace_link_from(self, src, label, link_type=LinkType.UNSPECIFIED):
         """
@@ -508,6 +505,8 @@ class AbstractNode(object):
         :param src: the source object
         :param str label: the name of the label to set the link from src.
         """
+        link_key = LinkKey(src.uuid, label)
+
         # If both are stored, write directly on the DB
         if self.is_stored and src.is_stored:
             self._replace_dblink_from(src, label, link_type)
@@ -515,48 +514,33 @@ class AbstractNode(object):
             # (this could happen if I first store the output node, then
             # the input node.
             try:
-                del self._inputlinks_cache[label]
+                del self._inputlinks_cache[link_key]
             except KeyError:
                 pass
-        else:  # at least one is not stored: set in the internal cache
-            # See if I am pointing to already saved nodes and I am already
-            # linking to a given node
-            # It is similar to the 'add' method, but if I am replacing the
-            # same node, I will not complain (k!=label)
-            if src.uuid in [v[0].uuid for k, v in
-                            self._inputlinks_cache.iteritems() if k != label]:
-                raise UniquenessError(
-                    "A link from node with UUID={} and "
-                    "the current node (UUID={}) already exists!".format(
-                        src.uuid, self.uuid))
+        else:
+            # At least one node is not stored: set in the internal cache
+
+            # The combination label/link_type should still be unique just
+            # as is checked for in the 'add_link_from' method.
+            for link_info in self._inputlinks_cache.itervalues():
+                if label == link_info.label and link_type == link_info.link_type:
+                    raise UniquenessError('A link with the label {} and type {} already'
+                        'exists'.format(label, link_type))
+
+            # Remove any potential pre-existing links with the same source node and type
+            existing_link_key = None
+            for key, link_info in self._inputlinks_cache.iteritems():
+                if link_info.src == src and link_info.link_type == link_type:
+                    existing_link_key = key
+
+            if existing_link_key:
+                del self._inputlinks_cache[existing_link_key]
+
             # I insert the link directly in the cache rather than calling
             # _add_cachelink_from because this latter performs an undesired check
-            self._inputlinks_cache[label] = (src, link_type)
+            self._inputlinks_cache[link_key] = LinkInfo(src, label, link_type)
 
-           # self._add_cachelink_from(src, label, link_type)
-
-    def _remove_link_from(self, label):
-        """
-        Remove from the DB the input link with the given label.
-
-        :note: In subclasses, change only this. Moreover, remember to call
-            the super() method in order to properly use the caching logic!
-
-        :note: No error is raised if the link does not exist.
-
-        :param str label: the name of the label to set the link from src.
-        :param link_type: The type of link, must be one of the enum values form
-          :class:`~aiida.common.links.LinkType`
-        """
-        # Try to remove from the local cache, no problem if none is present
-        try:
-            del self._inputlinks_cache[label]
-        except KeyError:
-            pass
-
-        # If both are stored, remove also from the DB
-        if self.is_stored:
-            self._remove_dblink_from(label)
+            # self._add_cachelink_from(src, label, link_type)
 
     @abstractmethod
     def _replace_dblink_from(self, src, label, link_type):
@@ -575,7 +559,7 @@ class AbstractNode(object):
         pass
 
     @abstractmethod
-    def _remove_dblink_from(self, label):
+    def _remove_dblink_from(self, label, link_type):
         """
         Remove from the DB the input link with the given label.
 
@@ -690,13 +674,12 @@ class AbstractNode(object):
             # Needed for the check
             input_list_keys = [i[0] for i in inputs_list]
 
-            for label, v in self._inputlinks_cache.iteritems():
-                src = v[0]
-                if label in input_list_keys:
+            for link_info in self._inputlinks_cache.itervalues():
+                if link_info.label in input_list_keys:
                     raise InternalError("There exist a link with the same name "
                                         "'{}' both in the DB and in the internal "
-                                        "cache for node pk= {}!".format(label, self.pk))
-                inputs_list.append((label, src))
+                                        "cache for node pk= {}!".format(link_info.label, self.pk))
+                inputs_list.append((link_info.label, link_info.src))
 
         if node_type is None:
             filtered_list = inputs_list
@@ -1417,8 +1400,8 @@ class AbstractNode(object):
                 "_store_input_nodes can be called only if the node is "
                 "unstored (node {} is stored, instead)".format(self.pk))
 
-        for label in self._inputlinks_cache:
-            parent = self._inputlinks_cache[label][0]
+        for link_info in self._inputlinks_cache.itervalues():
+            parent = link_info.src
             if not parent.is_stored:
                 parent.store(with_transaction=False)
 
@@ -1430,13 +1413,13 @@ class AbstractNode(object):
           stored.
         """
         # Preliminary check to verify that inputs are stored already
-        for label in self._inputlinks_cache:
-            if not self._inputlinks_cache[label][0].is_stored:
+        for link_info in self._inputlinks_cache.itervalues():
+            if not link_info.src.is_stored:
                 raise ModificationNotAllowed(
                     "Cannot store the input link '{}' because the "
                     "source node is not stored. Either store it first, "
                     "or call _store_input_links with the store_parents "
-                    "parameter set to True".format(label))
+                    "parameter set to True".format(link_info.label))
 
     @abstractmethod
     def _store_cached_input_links(self, with_transaction=True):

--- a/docs/source/developer_guide/internals.rst
+++ b/docs/source/developer_guide/internals.rst
@@ -99,11 +99,9 @@ Link management methods
 
 - :py:meth:`~aiida.orm.implementation.general.node.AbstractNode._replace_link_from` replaces or creates an input link.
 
-- :py:meth:`~aiida.orm.implementation.general.node.AbstractNode._remove_link_from` removes an input link that is stored in the database.
-
 - :py:meth:`~aiida.orm.implementation.general.node.AbstractNode._replace_dblink_from` is similar to :py:meth:`~aiida.orm.implementation.general.node.AbstractNode._replace_link_from` but works directly on the database.
 
-- :py:meth:`~aiida.orm.implementation.general.node.AbstractNode._remove_dblink_from` is similar to :py:meth:`~aiida.orm.implementation.general.node.AbstractNode._remove_link_from` but works directly on the database.
+- :py:meth:`~aiida.orm.implementation.general.node.AbstractNode._remove_dblink_from` works directly on the database.
 
 - :py:meth:`~aiida.orm.implementation.general.node.AbstractNode._add_dblink_from` adds a link to the current node from the given 'src' node. It acts directly on the database.
 


### PR DESCRIPTION
This fixes issue #641.

This issue was uncovered by @greschd who was trying to add multiple input links from the same data node to a work calculation node, with different labels. In our current conception, this should be perfectly legal, but it hit the `UniquenessError` constraint in the `Node._add_link_from` method.

In trying to fix this, I found a lot more inconsistencies. For example the `_inputlinks_cache` which was used to store the links while nodes were unstored, used the link label as the key of its dictionary. This indirectly put a uniqueness constraint on the link label, independent of the source node and or link type, which is in contradiction of the current concept of possible links. For example, a node with an `INPUT` and `CREATE` link to two different data nodes with an identical label `parameters` should be perfectly legal, but is impossible with the old structure of the `_inputlinks_cache` dictionary.