### PR TITLE
Report all higher loglevels in 'verdi work report'

### DIFF
--- a/aiida/backends/tests/verdi_commands.py
+++ b/aiida/backends/tests/verdi_commands.py
@@ -224,7 +224,10 @@ class TestVerdiWorkCommands(AiidaTestCase):
         """
         from aiida.cmdline.commands.work import report
 
-        result = CliRunner().invoke(report, [str(self.workchain_pid)])
+        result = CliRunner().invoke(
+            report, [str(self.workchain_pid)],
+            catch_exceptions=False
+        )
         self.assertTrue(self.test_string in result.output)
 
     def test_report_debug(self):
@@ -233,5 +236,8 @@ class TestVerdiWorkCommands(AiidaTestCase):
         """
         from aiida.cmdline.commands.work import report
 
-        result = CliRunner().invoke(report, [str(self.workchain_pid), '--levelname', 'DEBUG'])
+        result = CliRunner().invoke(
+            report, [str(self.workchain_pid), '--levelname', 'DEBUG'],
+            catch_exceptions=False
+        )
         self.assertTrue(self.test_string in result.output)

--- a/aiida/backends/tests/verdi_commands.py
+++ b/aiida/backends/tests/verdi_commands.py
@@ -241,3 +241,15 @@ class TestVerdiWorkCommands(AiidaTestCase):
             catch_exceptions=False
         )
         self.assertTrue(self.test_string in result.output)
+
+    def test_report_error(self):
+        """
+        Test that 'verdi work report' does not contain the report message when called with levelname ERROR.
+        """
+        from aiida.cmdline.commands.work import report
+
+        result = CliRunner().invoke(
+            report, [str(self.workchain_pid), '--levelname', 'ERROR'],
+            catch_exceptions=False
+        )
+        self.assertTrue(self.test_string not in result.output)

--- a/aiida/backends/tests/verdi_commands.py
+++ b/aiida/backends/tests/verdi_commands.py
@@ -220,22 +220,18 @@ class TestVerdiWorkCommands(AiidaTestCase):
 
     def test_report(self):
         """
-        Do some code listing test to ensure the correct behaviour of
-        verdi code list
+        Test that 'verdi work report' contains the report message.
         """
         from aiida.cmdline.commands.work import report
 
-        # Run a verdi code list -c, capture the output and check the result
         result = CliRunner().invoke(report, [str(self.workchain_pid)])
         self.assertTrue(self.test_string in result.output)
 
     def test_report_debug(self):
         """
-        Do some code listing test to ensure the correct behaviour of
-        verdi code list
+        Test that 'verdi work report' contains the report message when called with levelname DEBUG.
         """
         from aiida.cmdline.commands.work import report
 
-        # Run a verdi code list -c, capture the output and check the result
         result = CliRunner().invoke(report, [str(self.workchain_pid), '--levelname', 'DEBUG'])
         self.assertTrue(self.test_string in result.output)

--- a/aiida/cmdline/commands/work.py
+++ b/aiida/cmdline/commands/work.py
@@ -17,7 +17,7 @@ CONTEXT_SETTINGS = dict(help_option_names=['-h', '--help'])
 
 LOG_LEVELS = [
     levelname for levelname in [
-        logging.getLevelName(i) for i in range(51)
+        logging.getLevelName(i) for i in range(logging.CRITICAL + 1)
     ]
     if not levelname.startswith('Level')
 ]

--- a/aiida/cmdline/commands/work.py
+++ b/aiida/cmdline/commands/work.py
@@ -16,8 +16,10 @@ from aiida.cmdline.baseclass import VerdiCommandWithSubcommands
 CONTEXT_SETTINGS = dict(help_option_names=['-h', '--help'])
 
 LOG_LEVEL_MAPPING = {
-    levelname: value for levelname, value in logging._levelNames.items()
-    if isinstance(value, int)
+    levelname: i for levelname, i in [
+        (logging.getLevelName(i), i) for i in range(logging.CRITICAL + 1)
+    ]
+    if not levelname.startswith('Level')
 }
 LOG_LEVELS = LOG_LEVEL_MAPPING.keys()
 

--- a/aiida/cmdline/commands/work.py
+++ b/aiida/cmdline/commands/work.py
@@ -124,8 +124,10 @@ def report(pk, levelname, order_by, indent_size):
                 all_levelnames = LOG_LEVELS[i:]
                 break
 
-        filters['levelname__in'] = all_levelnames
-        entries = backend.log.find(filter_by=filters)
+        entries = []
+        for ln in all_levelnames:
+            filters['levelname'] = ln
+            entries.extend(backend.log.find(filter_by=filters))
 
         if entries is None or len(entries) == 0:
             return []

--- a/aiida/cmdline/commands/work.py
+++ b/aiida/cmdline/commands/work.py
@@ -16,10 +16,8 @@ from aiida.cmdline.baseclass import VerdiCommandWithSubcommands
 CONTEXT_SETTINGS = dict(help_option_names=['-h', '--help'])
 
 LOG_LEVEL_MAPPING = {
-    levelname: i for levelname, i in [
-        (logging.getLevelName(i), i) for i in range(logging.CRITICAL + 1)
-    ]
-    if not levelname.startswith('Level')
+    levelname: value for levelname, value in logging._levelNames.items()
+    if isinstance(value, int)
 }
 LOG_LEVELS = LOG_LEVEL_MAPPING.keys()
 

--- a/aiida/orm/implementation/sqlalchemy/log.py
+++ b/aiida/orm/implementation/sqlalchemy/log.py
@@ -101,7 +101,7 @@ class SqlaLogEntry(LogEntry):
         """
         Get the primary key of the entry
         """
-        return self._model.pk
+        return self._model.objpk
 
     @property
     def time(self):


### PR DESCRIPTION
Fixes #644.

Valid log level names (``LOG_LEVELS``) are computed by using ``logging.getLogLevelName`` and discarding those which are just the default ``Level N``.

The logs are queried for each loglevel separately. This is not ideal in terms of efficiency, but it's used to easily work on both Django and SQLA.

Also fixes ``LogEntry.id`` for SQLA, which was broken before.