### PR TITLE
Fix #641 - this issue was already closed but had a bug

### DIFF
--- a/aiida/backends/tests/nodes.py
+++ b/aiida/backends/tests/nodes.py
@@ -1670,10 +1670,6 @@ class TestSubNodesAndLinks(AiidaTestCase):
         # Same should be allowed in _replace_link_from
         n3._replace_link_from(n2, label='l4')
 
-        # However, replacing with existing link of identical label and link_type
-        with self.assertRaises(UniquenessError):
-            n3._replace_link_from(n1, label='l4')
-
         n2.store_all()
         n3.store_all()
 

--- a/aiida/orm/implementation/general/node.py
+++ b/aiida/orm/implementation/general/node.py
@@ -518,15 +518,6 @@ class AbstractNode(object):
             except KeyError:
                 pass
         else:
-            # At least one node is not stored: set in the internal cache
-
-            # The combination label/link_type should still be unique just
-            # as is checked for in the 'add_link_from' method.
-            for link_info in self._inputlinks_cache.itervalues():
-                if label == link_info.label and link_type == link_info.link_type:
-                    raise UniquenessError('A link with the label {} and type {} already'
-                        'exists'.format(label, link_type))
-
             # Remove any potential pre-existing links with the same source node and type
             existing_link_key = None
             for key, link_info in self._inputlinks_cache.iteritems():


### PR DESCRIPTION
Fix bug introduced in aeac53b5b390d0093cad82053e30129c328df483

In the reference commit, the internal structure of the _inputlinks_cache
of the Node class was changed by replacing the key of the dictionary
from being just the link label, to a tuple of the link label and source
node uuid. There used to be a uniqueness constraint therefore just on the
label, which was a problem and the original aim of the fix of the referenced
commit. However, in the _replace_link_from a check for uniqueness on the
link label + link type pair, was kept in place. However, when replacing
this check is not necessary and actually breaks the restart functionality
of the legacy workflows. Therefore, this commit removes that uniqueness
check