### PR TITLE
Fix bug introduced in #647

### DIFF
--- a/aiida/backends/tests/work/legacy/job_process.py
+++ b/aiida/backends/tests/work/legacy/job_process.py
@@ -55,3 +55,25 @@ class TestJobProcess(AiidaTestCase):
 
         job_instance.stop()
         job_instance.run_until_complete()
+
+    def test_job_process_set_none(self):
+    	"""
+    	Verify that calculation label and description get set when passed through inputs
+    	"""
+        label = 'test_label'
+        description = 'test_description'
+        inputs = {
+            '_options': {
+                    'computer': self.computer,
+                    'resources': {
+                        'num_machines': 1,
+                        'num_mpiprocs_per_machine': 1
+                    },
+                    'max_wallclock_seconds': 10,
+                },
+            '_label': None,
+            '_description': None
+        }
+
+        job_class = TemplatereplacerCalculation.process()
+        job_instance = job_class.new_instance(inputs)

--- a/aiida/backends/tests/work/legacy/job_process.py
+++ b/aiida/backends/tests/work/legacy/job_process.py
@@ -46,22 +46,15 @@ class TestJobProcess(AiidaTestCase):
             '_label': label,
             '_description': description
         }
-
-        job_class = TemplatereplacerCalculation.process()
-        job_instance = job_class.new_instance(inputs)
+        job_instance = self._run_inputs(inputs)
 
         self.assertEquals(job_instance.calc.label, label)
         self.assertEquals(job_instance.calc.description, description)
 
-        job_instance.stop()
-        job_instance.run_until_complete()
-
     def test_job_process_set_none(self):
     	"""
-    	Verify that calculation label and description get set when passed through inputs
+    	Verify that calculation label and description can be set to ``None``.
     	"""
-        label = 'test_label'
-        description = 'test_description'
         inputs = {
             '_options': {
                     'computer': self.computer,
@@ -75,6 +68,13 @@ class TestJobProcess(AiidaTestCase):
             '_description': None
         }
 
+        self._run_inputs(inputs)
+
+    def _run_inputs(self, inputs):
         job_class = TemplatereplacerCalculation.process()
         job_instance = job_class.new_instance(inputs)
+
+        job_instance.stop()
         job_instance.run_until_complete()
+
+        return job_instance

--- a/aiida/backends/tests/work/legacy/job_process.py
+++ b/aiida/backends/tests/work/legacy/job_process.py
@@ -77,3 +77,4 @@ class TestJobProcess(AiidaTestCase):
 
         job_class = TemplatereplacerCalculation.process()
         job_instance = job_class.new_instance(inputs)
+        job_instance.run_until_complete()

--- a/aiida/backends/tests/work/process.py
+++ b/aiida/backends/tests/work/process.py
@@ -128,6 +128,11 @@ class TestProcess(AiidaTestCase):
         with self.assertRaises(ValueError):
             DummyProcess.new_instance(inputs={'_label': 5})
 
+    def test_inputs_template(self):
+        inputs = DummyProcess.get_inputs_template()
+        dp = DummyProcess.new_instance(inputs=inputs)
+        dp.run_until_complete()
+
     def test_calculation_input(self):
         @workfunction
         def simple_wf():
@@ -176,6 +181,3 @@ class TestFunctionProcess(AiidaTestCase):
         FP = FunctionProcess.build(wf_fixed_args)
         outs = FP.run(**inputs)
         self.assertEqual(outs, inputs)
-
-
-

--- a/aiida/work/legacy/job_process.py
+++ b/aiida/work/legacy/job_process.py
@@ -153,7 +153,9 @@ class JobProcess(Process):
             self._calc.add_link_from(parent_calc, "CALL", LinkType.CALL)
 
         if self.raw_inputs:
-            if '_description' in self.raw_inputs:
-                self._calc.description = self.raw_inputs._description
-            if '_label' in self.raw_inputs:
-                self._calc.label = self.raw_inputs._label
+            description = self.raw_inputs.get('_description', None)
+            if description is not None:
+                self._calc.description = description
+            label = self.raw_inputs.get('_label', None)
+            if label is not None:
+                self._calc.label = label

--- a/aiida/work/legacy/job_process.py
+++ b/aiida/work/legacy/job_process.py
@@ -152,10 +152,4 @@ class JobProcess(Process):
         if parent_calc:
             self._calc.add_link_from(parent_calc, "CALL", LinkType.CALL)
 
-        if self.raw_inputs:
-            description = self.raw_inputs.get('_description', None)
-            if description is not None:
-                self._calc.description = description
-            label = self.raw_inputs.get('_label', None)
-            if label is not None:
-                self._calc.label = label
+        self._add_description_and_label()

--- a/aiida/work/process.py
+++ b/aiida/work/process.py
@@ -44,7 +44,7 @@ class DictSchema(object):
         """
         Call this to validate the value against the schema.
 
-        :param value: a regular dictionary or a ParameterData instance 
+        :param value: a regular dictionary or a ParameterData instance
         :return: tuple (success, msg).  success is True if the value is valid
             and False otherwise, in which case msg will contain information about
             the validation failure.
@@ -339,8 +339,8 @@ class Process(plum.process.Process):
         # deal with things like input groups
         to_link = {}
         for name, input in self.inputs.iteritems():
-            # Ignore all inputs starting with a leading underscore
-            if name.startswith('_'):
+            # Ignore all inputs starting with a leading underscore, and None inputs
+            if name.startswith('_') or input is None:
                 continue
 
             if self.spec().has_input(name):
@@ -374,11 +374,16 @@ class Process(plum.process.Process):
             self.calc.add_link_from(parent_calc, "CALL",
                                     link_type=LinkType.CALL)
 
+        self._add_description_and_label()
+
+    def _add_description_and_label(self):
         if self.raw_inputs:
-            if '_description' in self.raw_inputs:
-                self.calc.description = self.raw_inputs._description
-            if '_label' in self.raw_inputs:
-                self.calc.label = self.raw_inputs._label
+            description = self.raw_inputs.get('_description', None)
+            if description is not None:
+                self._calc.description = description
+            label = self.raw_inputs.get('_label', None)
+            if label is not None:
+                self._calc.label = label
 
     def _can_fast_forward(self, inputs):
         return False


### PR DESCRIPTION
In PR #647, inputs which have ``_label=None`` can no longer be executed because the trigger an ``IntegrityError`` (label cannot be ``None``). This is a common case, especially when using the ``get_inputs_template`` function, which has ``_label=None`` as default.

This PR solves this by only setting the label if it is not ``None``, and adds a regression test.

**EDIT:** The same issue was also present in the ``Process`` class. This is now also fixed, and the code for adding description and labels is de-duplicated by factoring it out to a method in ``Process``, which the legacy ``JobProcess`` also uses.