### PR TITLE
Fix #563 - exception when calling verdi calculation logshow for WorkCalculation

### DIFF
--- a/aiida/cmdline/commands/calculation.py
+++ b/aiida/cmdline/commands/calculation.py
@@ -289,12 +289,13 @@ class Calculation(VerdiCommandWithSubcommands):
             print_node_info(calc)
 
     def calculation_logshow(self, *args):
-        from aiida.common.exceptions import NotExistent
-        from aiida.backends.utils import get_log_messages
-        from aiida.common.datastructures import calc_states
-
         if not is_dbenv_loaded():
             load_dbenv()
+
+        from aiida.backends.utils import get_log_messages
+        from aiida.common.exceptions import NotExistent
+        from aiida.common.datastructures import calc_states
+        from aiida.orm.calculation.work import WorkCalculation
 
         for calc_pk in args:
             try:
@@ -304,6 +305,11 @@ class Calculation(VerdiCommandWithSubcommands):
                 continue
             except NotExistent:
                 print "*** {}: Not a valid calculation".format(calc_pk)
+                continue
+
+            if isinstance(calc, WorkCalculation):
+                print "*** {}: Is a WorkCalculation node. Use 'verdi work report' " \
+                    "instead to show the log messages".format(calc_pk)
                 continue
 
             log_messages = get_log_messages(calc)


### PR DESCRIPTION
Since WorkCalculations are a subclass of Calculation nodes, they can also
be passed to 'verdi calculation show', which, if they have log messages
associated with them, will display the message to use 'verdi calculation logshow'
to show these messages. However, this verdi command fetches more than just
log messages but also retrieves attributes unique to JobCalculations, and
so an exception is thrown.

The equivalent verdi command for WorkCalculations is 'verdi work report'.
Ideally 'logshow' should just dispatch the request to the report command
but since the latter is implemented using the click library, but the former
is not, this is not easily accomplishable. Therefore, in the meantime, we
simply print a message that tells the user to use 'verdi work report' instead.