### PR TITLE
Reverting several commits made for issue #641 regarding input links

### DIFF
--- a/aiida/backends/tests/nodes.py
+++ b/aiida/backends/tests/nodes.py
@@ -1657,18 +1657,20 @@ class TestSubNodesAndLinks(AiidaTestCase):
 
         # Caching the links
         n2.add_link_from(n1, label='l1')
-        n3.add_link_from(n1, label='l1')
         n3.add_link_from(n2, label='l2')
-
-        # Add link with same label and link_type, regardless of src node
-        with self.assertRaises(UniquenessError):
-            n3.add_link_from(n4, label='l1')
-
-        # Twice the link to the same node but different label is fine
         n3.add_link_from(n1, label='l3')
 
-        # Same should be allowed in _replace_link_from
-        n3._replace_link_from(n2, label='l4')
+        # Twice the same link name
+        with self.assertRaises(UniquenessError):
+            n3.add_link_from(n4, label='l2')
+
+        # Twice the link to the same node
+        with self.assertRaises(UniquenessError):
+            n3.add_link_from(n2, label='l4')
+
+        # Same error also in _replace_link_from
+        with self.assertRaises(UniquenessError):
+            n3._replace_link_from(n2, label='l4')
 
         n2.store_all()
         n3.store_all()
@@ -1676,21 +1678,17 @@ class TestSubNodesAndLinks(AiidaTestCase):
         n2_in_links = [(l, n.uuid) for l, n in n2.get_inputs_dict().iteritems()]
         self.assertEquals(sorted(n2_in_links), sorted([('l1', n1.uuid),
                                                        ]))
-
         n3_in_links = [(l, n.uuid) for l, n in n3.get_inputs_dict().iteritems()]
-        self.assertEquals(sorted(n3_in_links), sorted([('l1', n1.uuid),
-                                                       ('l4', n2.uuid),
-                                                       ('l3', n1.uuid)
+        self.assertEquals(sorted(n3_in_links), sorted([('l2', n2.uuid),
+                                                       ('l3', n1.uuid),
                                                        ]))
 
         n1_out_links = [(l, n.pk) for l, n in n1.get_outputs(also_labels=True)]
         self.assertEquals(sorted(n1_out_links), sorted([('l1', n2.pk),
-                                                        ('l1', n3.pk),
-                                                        ('l3', n3.pk)
+                                                        ('l3', n3.pk),
                                                         ]))
         n2_out_links = [(l, n.pk) for l, n in n2.get_outputs(also_labels=True)]
-        self.assertEquals(sorted(n2_out_links), sorted([('l4', n3.pk)
-                                                        ]))
+        self.assertEquals(sorted(n2_out_links), sorted([('l2', n3.pk)]))
 
     def test_valid_links(self):
         import tempfile

--- a/aiida/backends/tests/work/workChain.py
+++ b/aiida/backends/tests/work/workChain.py
@@ -172,24 +172,6 @@ class TestWorkchain(AiidaTestCase):
         with self.assertRaises(ValueError):
             Wf.spec()
 
-    def test_identical_input_node_different_label(self):
-        # We allow the creation of multiple INPUT links from the same node
-        # as long as the label is different
-        class Wf(WorkChain):
-            @classmethod
-            def define(cls, spec):
-                super(Wf, cls).define(spec)
-                spec.input('a', valid_type=Int)
-                spec.input('b', valid_type=Int)
-                spec.outline(cls.check_inputs)
-
-            def check_inputs(self):
-                assert 'a' in self.inputs
-                assert 'b' in self.inputs
-
-        A = Int(1)
-        run(Wf, a=A, b=A)
-
     def test_context(self):
         A = Str("a")
         B = Str("b")

--- a/aiida/orm/implementation/django/node.py
+++ b/aiida/orm/implementation/django/node.py
@@ -165,11 +165,11 @@ class Node(AbstractNode):
         except UniquenessError:
             # I have to replace the link; I do it within a transaction
             with transaction.atomic():
-                self._remove_dblink_from(label, link_type)
+                self._remove_dblink_from(label)
                 self._add_dblink_from(src, label, link_type)
 
-    def _remove_dblink_from(self, label, link_type):
-        DbLink.objects.filter(output=self.dbnode, label=label, type=link_type).delete()
+    def _remove_dblink_from(self, label):
+        DbLink.objects.filter(output=self.dbnode, label=label).delete()
 
     def _add_dblink_from(self, src, label=None, link_type=LinkType.UNSPECIFIED):
         from aiida.backends.djsite.db.models import DbPath
@@ -488,9 +488,9 @@ class Node(AbstractNode):
                 "Node with pk= {} was already stored".format(self.pk))
 
         # For each parent, check that all its inputs are stored
-        for link in self._inputlinks_cache.itervalues():
+        for label in self._inputlinks_cache:
             try:
-                parent_node = link.src
+                parent_node = self._inputlinks_cache[label][0]
                 parent_node._check_are_parents_stored()
             except ModificationNotAllowed:
                 raise ModificationNotAllowed(
@@ -546,9 +546,10 @@ class Node(AbstractNode):
             self._check_are_parents_stored()
             # I have to store only those links where the source is already
             # stored
-            links_to_store = list(self._inputlinks_cache.itervalues())
+            links_to_store = list(self._inputlinks_cache.keys())
 
-            for src, label, link_type in links_to_store:
+            for label in links_to_store:
+                src, link_type = self._inputlinks_cache[label]
                 self._add_dblink_from(src, label, link_type)
             # If everything went smoothly, clear the entries from the cache.
             # I do it here because I delete them all at once if no error

--- a/aiida/orm/implementation/general/calculation/job/__init__.py
+++ b/aiida/orm/implementation/general/calculation/job/__init__.py
@@ -531,6 +531,22 @@ class AbstractJobCalculation(object):
                                                                       label,
                                                                       link_type)
 
+    def _remove_link_from(self, label):
+        """
+        Remove a link. Only possible if the calculation is in state NEW.
+
+        :param str label: Name of the link to remove.
+        """
+        valid_states = [calc_states.NEW]
+
+        if self.get_state() not in valid_states:
+            raise ModificationNotAllowed(
+                "Can remove an input link to a calculation only if it is in one "
+                "of the following states:\n   {}\n it is instead {}".format(
+                    valid_states, self.get_state()))
+
+        return super(AbstractJobCalculation, self)._remove_link_from(label)
+
     @abstractmethod
     def _set_state(self, state):
         """

--- a/aiida/orm/implementation/sqlalchemy/node.py
+++ b/aiida/orm/implementation/sqlalchemy/node.py
@@ -180,17 +180,17 @@ class Node(AbstractNode):
         except UniquenessError:
             # I have to replace the link; I do it within a transaction
             try:
-                self._remove_dblink_from(label, link_type)
+                self._remove_dblink_from(label)
                 self._add_dblink_from(src, label, link_type)
                 session.commit()
             except:
                 session.rollback()
                 raise
 
-    def _remove_dblink_from(self, label, link_type):
+    def _remove_dblink_from(self, label):
         from aiida.backends.sqlalchemy import get_scoped_session
         session = get_scoped_session()
-        link = DbLink.query.filter_by(label=label, type=link_type).first()
+        link = DbLink.query.filter_by(label=label).first()
         if link is not None:
             session.delete(link)
 
@@ -524,9 +524,9 @@ class Node(AbstractNode):
                 "Node with pk= {} was already stored".format(self.id))
 
         # For each parent, check that all its inputs are stored
-        for link in self._inputlinks_cache.itervalues():
+        for link in self._inputlinks_cache:
             try:
-                parent_node = link.src
+                parent_node = self._inputlinks_cache[link][0]
                 parent_node._check_are_parents_stored()
             except ModificationNotAllowed:
                 raise ModificationNotAllowed("Parent node (UUID={}) has "
@@ -579,9 +579,10 @@ class Node(AbstractNode):
         self._check_are_parents_stored()
         # I have to store only those links where the source is already
         # stored
-        links_to_store = list(self._inputlinks_cache.itervalues())
+        links_to_store = list(self._inputlinks_cache.keys())
 
-        for src, label, link_type in links_to_store:
+        for label in links_to_store:
+            src, link_type = self._inputlinks_cache[label]
             self._add_dblink_from(src, label, link_type)
         # If everything went smoothly, clear the entries from the cache.
         # I do it here because I delete them all at once if no error

--- a/docs/source/developer_guide/internals.rst
+++ b/docs/source/developer_guide/internals.rst
@@ -99,9 +99,11 @@ Link management methods
 
 - :py:meth:`~aiida.orm.implementation.general.node.AbstractNode._replace_link_from` replaces or creates an input link.
 
+- :py:meth:`~aiida.orm.implementation.general.node.AbstractNode._remove_link_from` removes an input link that is stored in the database.
+
 - :py:meth:`~aiida.orm.implementation.general.node.AbstractNode._replace_dblink_from` is similar to :py:meth:`~aiida.orm.implementation.general.node.AbstractNode._replace_link_from` but works directly on the database.
 
-- :py:meth:`~aiida.orm.implementation.general.node.AbstractNode._remove_dblink_from` works directly on the database.
+- :py:meth:`~aiida.orm.implementation.general.node.AbstractNode._remove_dblink_from` is similar to :py:meth:`~aiida.orm.implementation.general.node.AbstractNode._remove_link_from` but works directly on the database.
 
 - :py:meth:`~aiida.orm.implementation.general.node.AbstractNode._add_dblink_from` adds a link to the current node from the given 'src' node. It acts directly on the database.
 


### PR DESCRIPTION
The changes made all passed the tests but after more extensive testing
it was found that the changes break the legacy workflows. The changes
allowed the existence of multiple links of the same type with the same
label, as long as the source node was different. The legacy workflow
and calculation plugins bank on the link label for a given link type
to be unique but this was no longer the case. The link system will
need a big overhaul soon anyway, so it will be better to leave the
current state unchanged and do the change in a separate release.

This reverts the following commits:

 * 627a7648e453b34c7865e373237113a5fe532826
 * 11741dd4dc6c95e2a82347be3187ab19b001f9d5
 * 777f80d2e09647447580f13c8af58b201dcd073d
 * aeac53b5b390d0093cad82053e30129c328df483