### PR TITLE
Fix #666 - Temporarily disable logging to suppress console output during tests

### DIFF
--- a/aiida/backends/tests/daemon.py
+++ b/aiida/backends/tests/daemon.py
@@ -18,6 +18,17 @@ from aiida.workflows.test import WFTestSimpleWithSubWF
 
 
 class TestDaemonBasic(AiidaTestCase):
+
+    def setUp(self):
+        super(TestDaemonBasic, self).setUp()
+        import logging
+        logging.disable(logging.CRITICAL)
+
+    def tearDown(self):
+        super(TestDaemonBasic, self).tearDown()
+        import logging
+        logging.disable(logging.NOTSET)
+
     def test_workflow_fast_kill(self):
         from aiida.cmdline.commands.workflow import Workflow as WfCmd
 

--- a/aiida/backends/tests/work/workChain.py
+++ b/aiida/backends/tests/work/workChain.py
@@ -322,6 +322,17 @@ class TestWorkchain(AiidaTestCase):
 
 
 class TestWorkchainWithOldWorkflows(AiidaTestCase):
+
+    def setUp(self):
+        super(TestWorkchainWithOldWorkflows, self).setUp()
+        import logging
+        logging.disable(logging.CRITICAL)
+
+    def tearDown(self):
+        super(TestWorkchainWithOldWorkflows, self).tearDown()
+        import logging
+        logging.disable(logging.NOTSET)
+
     def test_call_old_wf(self):
         wf = WorkflowDemo()
         wf.start()


### PR DESCRIPTION
In several tests where the printing of log messages to stdout is not
critical for correct operation of the code, having it printed to
screen pollutes the test output. For these tests, the loggin is
temporarily disabled to prevent the output.