### PR TITLE
Fix #674 - Add link types when traversing graph in tcod exporter

### DIFF
--- a/aiida/tools/dbexporters/tcod.py
+++ b/aiida/tools/dbexporters/tcod.py
@@ -333,9 +333,10 @@ def _get_calculation(node):
     """
     from aiida.common.exceptions import MultipleObjectsError
     from aiida.orm.calculation import Calculation
-    if len(node.get_inputs(node_type=Calculation)) == 1:
-        return node.get_inputs(node_type=Calculation)[0]
-    elif len(node.get_inputs(node_type=Calculation)) == 0:
+    from aiida.common.links import LinkType
+    if len(node.get_inputs(node_type=Calculation, link_type=LinkType.CREATE)) == 1:
+        return node.get_inputs(node_type=Calculation, link_type=LinkType.CREATE)[0]
+    elif len(node.get_inputs(node_type=Calculation, link_type=LinkType.CREATE)) == 0:
         return None
     else:
         raise MultipleObjectsError("Node {} seems to have more than one "
@@ -402,15 +403,17 @@ def _collect_calculation_data(calc):
     Recursively collects calculations from the tree, starting at given
     calculation.
     """
+    from aiida.common.links import LinkType
     from aiida.orm.data import Data
     from aiida.orm.calculation import Calculation
     from aiida.orm.calculation.job import JobCalculation
+    from aiida.orm.calculation.work import WorkCalculation
     from aiida.orm.calculation.inline import InlineCalculation
     import hashlib
     import os
     calcs_now = []
-    for d in calc.get_inputs(node_type=Data):
-        for c in d.get_inputs(node_type=Calculation):
+    for d in calc.get_inputs(node_type=Data, link_type=LinkType.INPUT):
+        for c in d.get_inputs(node_type=Calculation, link_type=LinkType.CREATE):
             calcs = _collect_calculation_data(c)
             calcs_now.extend(calcs)
 
@@ -450,7 +453,7 @@ def _collect_calculation_data(calc):
             })
         this_calc['stdout'] = stdout_name
         this_calc['stderr'] = stderr_name
-    else:
+    elif isinstance(calc, InlineCalculation):
         # Calculation is InlineCalculation
         python_script = _inline_to_standalone_script(calc)
         files_in.append({
@@ -468,6 +471,12 @@ def _collect_calculation_data(calc):
             'sha1'    : hashlib.sha1(shell_script).hexdigest(),
             'type'    : 'file',
             })
+    elif isinstance(calc, WorkCalculation):
+        # We do not know how to recreate a WorkCalculation so we pass
+        pass
+    else:
+        raise ValueError('calculation is of an unexpected type {}'.format(type(calc)))
+
 
     for f in files_in:
         if os.path.basename(f['name']) == aiida_executable_name:
@@ -630,6 +639,7 @@ def _collect_tags(node, calc,parameters=None,
     Retrieve metadata from attached calculation and pseudopotentials
     and prepare it to be saved in TCOD CIF.
     """
+    from aiida.common.links import LinkType
     import os, json
     import aiida
     tags = { '_audit_creation_method': "AiiDA version {}".format(aiida.__version__) }
@@ -790,7 +800,7 @@ def _collect_tags(node, calc,parameters=None,
 
     if calc is not None:
         from aiida.orm.data.array.kpoints import KpointsData
-        kpoints_list = calc.get_inputs(KpointsData)
+        kpoints_list = calc.get_inputs(KpointsData, link_type=LinkType.INPUT)
         # TODO: stop if more than one KpointsData is used?
         if len(kpoints_list) == 1:
             kpoints = kpoints_list[0]
@@ -817,7 +827,6 @@ def _collect_tags(node, calc,parameters=None,
                 plugins.append(cls)
 
     from aiida.common.exceptions import MultipleObjectsError
-
     if len(plugins) > 1:
         raise MultipleObjectsError("more than one plugin found for "
                                    "{}".calc._plugin_type_string)
@@ -952,6 +961,7 @@ def export_cifnode(what, parameters=None, trajectory_index=None,
         Default 1024.
     :return: a :py:class:`aiida.orm.data.cif.CifData` node.
     """
+    from aiida.common.links import LinkType
     from aiida.common.exceptions import MultipleObjectsError
     from aiida.orm.calculation.inline import make_inline
     CifData        = DataFactory('cif')
@@ -966,7 +976,7 @@ def export_cifnode(what, parameters=None, trajectory_index=None,
             raise ValueError("Supplied parameters are not an "
                              "instance of ParameterData")
     elif calc is not None:
-        params = calc.get_outputs(type=ParameterData)
+        params = calc.get_outputs(type=ParameterData, link_type=LinkType.CREATE)
         if len(params) == 1:
             parameters = params[0]
         elif len(params) > 0:


### PR DESCRIPTION
The original tcod exporter was written before the introduction
of RETURN links and so multiple paths to the same node were
impossible. We add specific link types in the get_inputs calls
such that only one result will be returned