### PR TITLE
Fix #550 - Extraneous suggested value for scheduler type

### DIFF
--- a/aiida/scheduler/plugins/pbsbaseclasses.py
+++ b/aiida/scheduler/plugins/pbsbaseclasses.py
@@ -11,9 +11,8 @@
 Base classes for PBSPro and PBS/Torque plugins.
 """
 from __future__ import division
-import aiida.scheduler
 from aiida.common.utils import escape_for_bash
-from aiida.scheduler import SchedulerError, SchedulerParsingError
+from aiida.scheduler import Scheduler, SchedulerError, SchedulerParsingError
 from aiida.scheduler.datastructures import (
     JobInfo, job_states, MachineInfo, NodeNumberJobResource)
 
@@ -104,7 +103,7 @@ class PbsJobResource(NodeNumberJobResource):
                                  * self.num_mpiprocs_per_machine)
         
                 
-class PbsBaseClass(aiida.scheduler.Scheduler):
+class PbsBaseClass(object):
     """
     Base class with support for the PBSPro scheduler
     (http://www.pbsworks.com/) and for PBS and Torque
@@ -113,7 +112,7 @@ class PbsBaseClass(aiida.scheduler.Scheduler):
     Only a few properties need to be redefined, see examples of the pbspro and
     torque plugins
     """
-    _logger = aiida.scheduler.Scheduler._logger.getChild('pbsbaseclass')
+    _logger = Scheduler._logger.getChild('pbsbaseclass')
 
     # Query only by list of jobs and not by user
     _features = {

--- a/aiida/scheduler/plugins/pbspro.py
+++ b/aiida/scheduler/plugins/pbspro.py
@@ -12,7 +12,7 @@ Plugin for PBSPro.
 This has been tested on PBSPro v. 12.
 """
 from __future__ import division
-import aiida.scheduler
+from aiida.scheduler import Scheduler
 from .pbsbaseclasses import PbsBaseClass
 
 # This maps PbsPro status letters to our own status list
@@ -33,14 +33,14 @@ from .pbsbaseclasses import PbsBaseClass
 
 
 
-class PbsproScheduler(PbsBaseClass):
+class PbsproScheduler(PbsBaseClass, Scheduler):
     """
     Subclass to support the PBSPro scheduler
     (http://www.pbsworks.com/).
 
     I redefine only what needs to change from the base class
     """
-    _logger = aiida.scheduler.Scheduler._logger.getChild('pbspro')
+    _logger = Scheduler._logger.getChild('pbspro')
 
     ## I don't need to change this from the base class
     #_job_resource_class = PbsJobResource

--- a/aiida/scheduler/plugins/torque.py
+++ b/aiida/scheduler/plugins/torque.py
@@ -12,7 +12,7 @@ Plugin for PBS/Torque.
 This has been tested on Torque v.2.4.16 (from Ubuntu).
 """
 from __future__ import division
-import aiida.scheduler
+from aiida.scheduler import Scheduler
 from .pbsbaseclasses import PbsBaseClass
 
 ## These are instead the states from PBS/Torque v.2.4.16 (from Ubuntu)
@@ -28,13 +28,13 @@ from .pbsbaseclasses import PbsBaseClass
 
 
 
-class TorqueScheduler(PbsBaseClass):
+class TorqueScheduler(PbsBaseClass, Scheduler):
     """
     Subclass to support the Torque scheduler..
 
     I redefine only what needs to change from the base class
     """
-    _logger = aiida.scheduler.Scheduler._logger.getChild('torque')
+    _logger = Scheduler._logger.getChild('torque')
 
     ## I don't need to change this from the base class
     #_job_resource_class = PbsJobResource


### PR DESCRIPTION
Remove Scheduler inheritance from PbsBaseClass

By removing the Scheduler inheritance from the PbsBaseClass scheduler
it will no longer be seen by the pluginloader as a concrete scheduler
class. Instead we let the sub classes inherit directly from the
Scheduler base class and use the PbsBaseClass as a mixin.