### PR TITLE
WIP: allow for the possibility of entry points to be overriden

### DIFF
--- a/aiida/common/exceptions.py
+++ b/aiida/common/exceptions.py
@@ -81,6 +81,13 @@ class MissingPluginError(AiidaException):
     pass
 
 
+class MultiplePluginError(AiidaException):
+    """
+    Raised when the user tries to load an entry point that cannot be uniquely resolved
+    """
+    pass
+
+
 class InvalidOperation(AiidaException):
     """
     The allowed operation is not valid (e.g., when trying to add a non-internal attribute


### PR DESCRIPTION
There is a use case where a registered entry point needs to be
overriden by a different class from another plugin repository.
The plugin loader needs to be able to check whether a specific
entry point can be overriden by another one if more than one are
registered.

Note, however, that both entry points need to agree that the one
overrides the other in order to prevent accidental overriding.

Currently the check whether an entry point can be overriden by
another is done in a stand alone function in the plugin loader module.
Probably this belongs as a EntryPoint method in the reentry package?