### PR TITLE
WIP: Plugin fixtures

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,3 +24,16 @@
     files: '^(setup_requirements.py)|(docs/requirements_for_rtd.txt)|(docs/update_req_for_rtd.py)'
     pass_filenames: false
 
+- repo: git://github.com/pre-commit/pre-commit-hooks
+  sha: v0.9.4
+  hooks:
+  - id: check-yaml
+
+- repo: local
+  hooks:
+  - id: travis-linter
+    name: travis
+    entry: travis lint
+    files: .travis.yml
+    language: ruby
+    additional_dependencies: ['travis']

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,7 +4,7 @@
   hooks:
   - id: yapf
     language: system
-    files: '^(aiida/control/)|(aiida/cmdline/tests)|(docs/update_req_for_rtd.py)|(.travis_data/test_setup.py)'
+    files: '^(aiida/control/)|(aiida/cmdline/tests)|(docs/update_req_for_rtd.py)|(.travis_data/test_setup.py)|(aiida/utils/fixtures)'
 
 # prospector: collection of linters
 - repo: git://github.com/guykisel/prospector-mirror
@@ -13,7 +13,7 @@
   - id: prospector
     language: system
     exclude: '^(tests/)|(examples/)'
-    files: '^(aiida/control/)|(aiida/cmdline/tests)|(docs/update_req_for_rtd.py)|(.travis_data/test_setup.py)'
+    files: '^(aiida/control/)|(aiida/cmdline/tests)|(docs/update_req_for_rtd.py)|(.travis_data/test_setup.py)|(aiida/utils/fixtures)'
 
 - repo: local
   hooks: 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,7 +4,7 @@
   hooks:
   - id: yapf
     language: system
-    files: '^(aiida/control/)|(aiida/cmdline/tests)|(docs/update_req_for_rtd.py)|(.travis_data/test_setup.py)|(aiida/utils/fixtures)'
+    files: '^(aiida/control/)|(aiida/cmdline/tests)|(docs/update_req_for_rtd.py)|(\.travis_data/test_setup.py)|(aiida/utils/.*fixtures.py)'
 
 # prospector: collection of linters
 - repo: git://github.com/guykisel/prospector-mirror
@@ -13,7 +13,7 @@
   - id: prospector
     language: system
     exclude: '^(tests/)|(examples/)'
-    files: '^(aiida/control/)|(aiida/cmdline/tests)|(docs/update_req_for_rtd.py)|(.travis_data/test_setup.py)|(aiida/utils/fixtures)'
+    files: '^(aiida/control/)|(aiida/cmdline/tests)|(docs/update_req_for_rtd.py)|(\.travis_data/test_setup.py)|(aiida/utils/.*fixtures.py)'
 
 - repo: local
   hooks: 

--- a/.pylintrc
+++ b/.pylintrc
@@ -375,7 +375,7 @@ known-third-party=enchant
 max-args=6
 
 # Maximum number of attributes for a class (see R0902).
-max-attributes=7
+max-attributes=12
 
 # Maximum number of boolean expressions in a if statement
 max-bool-expr=5

--- a/.travis-data/test_fixtures.py
+++ b/.travis-data/test_fixtures.py
@@ -6,6 +6,7 @@ from pgtest import pgtest
 
 from aiida.utils.fixtures import FixtureManager, FixtureError
 from aiida.utils.capturing import Capturing
+from aiida.backends.profile import BACKEND_DJANGO, BACKEND_SQLA
 
 
 class FixtureManagerTestCase(unittest.TestCase):
@@ -13,8 +14,8 @@ class FixtureManagerTestCase(unittest.TestCase):
 
     def setUp(self):
         self.fixture_manager = FixtureManager()
-        self.backend = 'django' if os.environ.get(
-            'TEST_AIIDA_BACKEND', 'django') == 'django' else 'sqlalchemy'
+        self.backend = BACKEND_DJANGO if os.environ.get(
+            'TEST_AIIDA_BACKEND', BACKEND_DJANGO) == BACKEND_DJANGO else BACKEND_SQLA
         self.fixture_manager.backend = self.backend
 
     def test_create_db_cluster(self):

--- a/.travis-data/test_fixtures.py
+++ b/.travis-data/test_fixtures.py
@@ -75,3 +75,7 @@ class FixtureManagerTestCase(unittest.TestCase):
 
     def tearDown(self):
         self.fixture_manager.destroy_all()
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/.travis-data/test_plugin_testcase.py
+++ b/.travis-data/test_plugin_testcase.py
@@ -22,7 +22,7 @@ class PluginTestcaseTestCase(PluginTestCase):
     def setUp(self):
         from aiida.orm import DataFactory
         self.data = DataFactory('parameter')(dict={'data': 'test'})
-        self.data.save()
+        self.data.store()
         self.data_pk = self.data.pk
 
     def test_data_loaded(self):

--- a/.travis-data/test_plugin_testcase.py
+++ b/.travis-data/test_plugin_testcase.py
@@ -1,5 +1,11 @@
-"""Test the plugin test case"""
+"""
+Test the plugin test case
+
+This must be in a separate file because it would clash with other tests,
+Since the dbenv gets loaded on the temporary profile.
+"""
 import os
+import unittest
 
 from aiida.utils.fixtures import PluginTestCase
 from aiida.backends.profile import BACKEND_DJANGO, BACKEND_SQLA
@@ -29,3 +35,6 @@ class PluginTestcaseTestCase(PluginTestCase):
         with self.assertRaises(Exception):
             load_node(self.data_pk)
 
+
+if __name__ == '__main__':
+    unittest.main()

--- a/.travis-data/test_plugin_testcase.py
+++ b/.travis-data/test_plugin_testcase.py
@@ -1,0 +1,31 @@
+"""Test the plugin test case"""
+import os
+
+from aiida.utils.fixtures import PluginTestCase
+from aiida.backends.profile import BACKEND_DJANGO, BACKEND_SQLA
+
+
+def determine_backend():
+    return BACKEND_DJANGO if os.environ.get(
+        'TEST_AIIDA_BACKEND', BACKEND_DJANGO) == BACKEND_DJANGO else BACKEND_SQLA
+
+
+class PluginTestcaseTestCase(PluginTestCase):
+    BACKEND = determine_backend()
+
+    def setUp(self):
+        from aiida.orm import DataFactory
+        self.data = DataFactory('parameter')(dict={'data': 'test'})
+        self.data.save()
+        self.data_pk = self.data.pk
+
+    def test_data_loaded(self):
+        from aiida.orm import load_node
+        load_node(self.data_pk)
+
+    def tearDown(self):
+        from aiida.orm import load_node
+        super(PluginTestCase, self).tearDown()
+        with self.assertRaises(Exception):
+            load_node(self.data_pk)
+

--- a/.travis-data/test_plugin_testcase.py
+++ b/.travis-data/test_plugin_testcase.py
@@ -1,7 +1,7 @@
 """
 Test the plugin test case
 
-This must be in a separate file because it would clash with other tests,
+This must be in a standalone script because it would clash with other tests,
 Since the dbenv gets loaded on the temporary profile.
 """
 import os
@@ -9,6 +9,7 @@ import unittest
 
 from aiida.utils.fixtures import PluginTestCase
 from aiida.backends.profile import BACKEND_DJANGO, BACKEND_SQLA
+from aiida import is_dbenv_loaded
 
 
 def determine_backend():
@@ -27,11 +28,12 @@ class PluginTestcaseTestCase(PluginTestCase):
 
     def test_data_loaded(self):
         from aiida.orm import load_node
+        self.assertTrue(is_dbenv_loaded())
         load_node(self.data_pk)
 
-    def tearDown(self):
+    def test_tear_down(self):
         from aiida.orm import load_node
-        super(PluginTestCase, self).tearDown()
+        super(PluginTestcaseTestCase, self).tearDown()
         with self.assertRaises(Exception):
             load_node(self.data_pk)
 

--- a/.travis-data/test_script.sh
+++ b/.travis-data/test_script.sh
@@ -13,6 +13,7 @@ case "$TEST_TYPE" in
         # Run the AiiDA tests
         python ${TRAVIS_BUILD_DIR}/.travis-data/test_setup.py
         python ${TRAVIS_BUILD_DIR}/.travis-data/test_fixtures.py
+        python ${TRAVIS_BUILD_DIR}/.travis-data/test_plugin_testcase.py
 
         verdi -p test_$TEST_AIIDA_BACKEND devel tests
 

--- a/.travis-data/test_script.sh
+++ b/.travis-data/test_script.sh
@@ -12,6 +12,7 @@ case "$TEST_TYPE" in
     tests)
         # Run the AiiDA tests
         python ${TRAVIS_BUILD_DIR}/.travis-data/test_setup.py
+        python ${TRAVIS_BUILD_DIR}/.travis-data/test_fixtures.py
 
         verdi -p test_$TEST_AIIDA_BACKEND devel tests
 

--- a/aiida/backends/utils.py
+++ b/aiida/backends/utils.py
@@ -283,5 +283,3 @@ def _get_column(colname, alias):
                     '\n'.join(alias._sa_class_manager.mapper.c.keys())
                 )
         )
-
-

--- a/aiida/cmdline/commands/user.py
+++ b/aiida/cmdline/commands/user.py
@@ -51,7 +51,7 @@ class User(VerdiCommandWithSubcommands):
         return "\n".join(emails)
 
 
-def do_configure(email, first_name, last_name, institution, no_password):
+def do_configure(email, first_name, last_name, institution, no_password, non_interactive=False, force=False, **kwargs):
     if not is_dbenv_loaded():
         load_dbenv()
 
@@ -65,32 +65,41 @@ def do_configure(email, first_name, last_name, institution, no_password):
     if created:
         click.echo("\nAn AiiDA user for email '{}' is already present "
                    "in the DB:".format(email))
-        reply = click.confirm("Do you want to reconfigure it?")
-        if reply:
+        if not non_interactive:
+            reply = click.confirm("Do you want to reconfigure it?")
+            if reply:
+                configure_user = True
+        elif force:
             configure_user = True
     else:
         configure_user = True
         click.echo("Configuring a new user with email '{}'".format(email))
 
     if configure_user:
-        try:
-            kwargs = {}
-            for field in UserModel.REQUIRED_FIELDS:
-                verbose_name = field.capitalize()
-                readline.set_startup_hook(lambda: readline.insert_text(
-                    getattr(user, field)))
-                if field == 'first_name' and first_name:
-                    kwargs[field] = first_name
-                elif field == 'last_name' and last_name:
-                    kwargs[field] = last_name
-                elif field == 'institution' and institution:
-                    kwargs[field] = institution
-                else:
-                    kwargs[field] = raw_input('{}: '.format(verbose_name))
-        finally:
-            readline.set_startup_hook(lambda: readline.insert_text(""))
+        if not non_interactive:
+            try:
+                attributes = {}
+                for field in UserModel.REQUIRED_FIELDS:
+                    verbose_name = field.capitalize()
+                    readline.set_startup_hook(lambda: readline.insert_text(
+                        getattr(user, field)))
+                    if field == 'first_name' and first_name:
+                        attributes[field] = first_name
+                    elif field == 'last_name' and last_name:
+                        attributes[field] = last_name
+                    elif field == 'institution' and institution:
+                        attributes[field] = institution
+                    else:
+                        attributes[field] = raw_input('{}: '.format(verbose_name))
+            finally:
+                readline.set_startup_hook(lambda: readline.insert_text(""))
+        else:
+            attributes = kwargs.copy()
+            attributes['first_name'] = first_name
+            attributes['last_name'] = last_name
+            attributes['institution'] = institution
 
-        for k, v in kwargs.iteritems():
+        for k, v in attributes.iteritems():
             setattr(user, k, v)
 
         change_password = False

--- a/aiida/cmdline/verdilib.py
+++ b/aiida/cmdline/verdilib.py
@@ -592,9 +592,15 @@ def setup(profile, only_config, non_interactive=False, **kwargs):
             user.configure.main(args=[email])
         else:
             # or don't ask
-            aiida.cmdline.commands.user.do_configure(kwargs['email'], kwargs.get('first_name'),
-                                                       kwargs.get('last_name'), kwargs.get('institution'),
-                                                       True)
+            aiida.cmdline.commands.user.do_configure(
+                email=kwargs['email'],
+                first_name=kwargs.get('first_name'),
+                last_name=kwargs.get('last_name'),
+                institution=kwargs.get('institution'),
+                no_password=True,
+                non_interactive=non_interactive,
+                force=True
+            )
 
     print "Setup finished."
 

--- a/aiida/control/postgres.py
+++ b/aiida/control/postgres.py
@@ -245,8 +245,9 @@ def _try_connect(**kwargs):
     from psycopg2 import connect
     success = False
     try:
-        connect(**kwargs)
+        conn = connect(**kwargs)
         success = True
+        conn.close()
     except Exception:  # pylint: disable=broad-except
         pass
     return success
@@ -286,6 +287,7 @@ def _pg_execute_psyco(command, **kwargs):
                 output = cur.fetchall()
             except ProgrammingError:
                 pass
+    conn.close()
     return output
 
 

--- a/aiida/control/postgres.py
+++ b/aiida/control/postgres.py
@@ -13,6 +13,7 @@ _DROP_DB_COMMAND = 'DROP DATABASE "{}"'
 _GRANT_PRIV_COMMAND = 'GRANT ALL PRIVILEGES ON DATABASE "{}" TO "{}"'
 _GET_USERS_COMMAND = "SELECT usename FROM pg_user WHERE usename='{}'"
 _CHECK_DB_EXISTS_COMMAND = "SELECT datname FROM pg_database WHERE datname='{}'"
+_COPY_DB_COMMAND = 'CREATE DATABASE "{}" WITH TEMPLATE "{}" OWNER "{}"'
 
 
 class Postgres(object):
@@ -156,6 +157,10 @@ class Postgres(object):
         :param dbname: (str), Name of the database.
         """
         self.pg_execute(_DROP_DB_COMMAND.format(dbname), **self.dbinfo)
+
+    def copy_db(self, src_db, dest_db, dbuser):
+        self.pg_execute(
+            _COPY_DB_COMMAND.format(dest_db, src_db, dbuser), **self.dbinfo)
 
     def db_exists(self, dbname):
         """

--- a/aiida/utils/fixtures.py
+++ b/aiida/utils/fixtures.py
@@ -1,0 +1,265 @@
+"""Test fixtures for use in related projects"""
+import unittest
+import tempfile
+import shutil
+from os import path
+
+from pgtest.pgtest import PGTest
+
+from aiida.control.postgres import Postgres
+
+
+class FixtureError(Exception):
+
+    def __init__(self, msg):
+        self.msg = msg
+
+    def __str__(self):
+        return repr(self.msg)
+
+
+class FixtureBuilder(object):
+
+    def __init__(self):
+        self.db_params = {}
+        self.fs_env = {}
+        self.profile = {
+            'backend': 'django',
+            'email': 'test@aiida.mail',
+        }
+        self.temp_dir = None
+        self.pg_cluster = None
+        self.postgres = None
+
+    def create_db_cluster(self):
+        self.pg_cluster = PGTest()
+        self.db_params.update(self.pg_cluster.dsn)
+
+    def create_aiida_db(self):
+        if not db_params:
+            self.create_db_cluster()
+        self.postgres = Postgres(interactive=False, quiet=True)
+        self.postgres.dbinfo = self.db_params
+        self.postgres.determine_setup()
+        self.db_params = self.postgres.dbinfo
+        if not self.postgres.pg_execute:
+            raise FixtureError(
+                'Could not connect to the test postgres instance')
+        self.postgres.create_dbuser(self.db_user, self.db_pass)
+        self.postgres.create_db(self.db_user, self.db_name)
+
+    def create_root_dir(self):
+        self.root_dir = tempfile.mkdtemp()
+
+    def create_config_dir(self):
+        self.fs_env['config'] = path.join(self.root_dir, '.aiida')
+
+    def create_profile(self):
+        from aiida.common import setup as aiida_cfg
+        from aiida.cmdline.verdilib import setup
+        aiida_cfg.AIIDA_CONFIG_FOLDER = self.config_dir
+        aiida_cfg.create_base_dirs()
+        profile_name = 'test_profile'
+        profile = {
+            'repo': path.join(temp_dir, 'test_repo'),
+            'db_host': db_fixture.pg_test.dsn['host'],
+            'db_port': db_fixture.pg_test.port,
+            'db_user': db_fixture.pg_test.dsn['user'],
+            'db_pass': db_fixture.DB_PASS,
+            'db_name': db_fixture.DB_NAME,
+            'first_name': 'AiiDA',
+            'last_name': 'Tester',
+            'institution': 'aiidateam'
+        }
+        setup(
+            profile=profile_name,
+            only_config=False,
+            non_interactive=True,
+            **profile)
+        aiida_cfg.set_default_profile('verdi', profile_name)
+        aiida_cfg.set_default_profile('daemon', profile_name)
+
+    @property
+    def repo(self):
+        if not self.repo:
+            self.repo = path.join(self.root_dir, 'test_repo')
+        return self.profile.get('repo', None)
+
+    @repo.setter
+    def repo(self, path):
+        self.profile['repo'] = path
+
+    @property
+    def email(self):
+        return self.profile.get('email', None)
+
+    @email.setter
+    def email(self, email):
+        self.profile['email'] = email
+
+    @property
+    def backend(self):
+        return self.profile.get('backend', None)
+
+    @backend.setter
+    def backend(self, backend):
+        self.profile['backend'] = backend
+
+    @property
+    def config_dir_ok(self):
+        return bool(self.config_dir and path.isdir(self.config_dir))
+
+    @property
+    def config_dir(self):
+        if not self.config_dir_ok:
+            self.create_config_dir(
+            )  # TODO: Should never overwrite user set path but fail instead
+        return self.fs_env.get('config', None)
+
+    @config_dir.setter
+    def config_dir(self, path):
+        self.fs_env['config'] = path
+
+    @property
+    def db_user(self):
+        return self.db_params['user']
+
+    @db_user.setter
+    def db_user(self, user):
+        self.db_params['user'] = user
+
+    @property
+    def db_pass(self):
+        return self.db_params['password']
+
+    @db_pass.setter
+    def db_pass(self, passwd):
+        self.db_params['password'] = passwd
+
+    @property
+    def db_name(self):
+        return self.db_params['database']
+
+    @db_name.setter
+    def db_name(self, name):
+        self.db_params['database'] = name
+
+    @property
+    def root_dir(self):
+        if not self.root_dir_ok:
+            self.create_root_dir()
+        return self.fs_env.get('root', None)
+
+    @root_dir.setter
+    def root_dir(self, path):
+        self.fs_env['root'] = path
+
+    @property
+    def root_dir_ok(self):
+        return bool(self.temp_dir and path.isdir(self.temp_dir))
+
+    def __del__(self):
+        if self.temp_dir:
+            shutil.rmtree(self.temp_dir)
+        if self.pg_cluster:
+            self.pg_cluster.close()
+
+
+class DbFixture(object):
+    """Create temporary AiiDA db environment"""
+
+    DB_USER = 'aiida'
+    DB_NAME = 'aiida_db'
+    DB_PASS = 'aiida_pw'
+
+    def __init__(self):
+        self.pg_test = PGTest()
+        self.postgres = Postgres(
+            port=self.pg_test.port, interactive=False, quiet=True)
+        self.postgres.dbinfo = self.pg_test.dsn
+        self.postgres.determine_setup()
+        self.success = bool(self.postgres.pg_execute)
+        if self.success:
+            self.postgres.create_dbuser(self.DB_USER, self.DB_PASS)
+            self.postgres.create_db(self.DB_USER, self.DB_NAME)
+
+    def __del__(self):
+        self.pg_test.close()
+
+    def init_success(self):
+        return self.success
+
+
+def setup_fs_env():
+    """Create temporary config / repo folders"""
+    temp_dir = tempfile.mkdtemp()
+    return temp_dir
+
+
+def setup_aiida(temp_dir):
+    from aiida.common import setup as aiida_cfg
+    aiida_cfg.AIIDA_CONFIG_FOLDER = path.join(temp_dir, '.aiida')
+    aiida_cfg.create_base_dirs()
+    return aiida_cfg.get_or_create_config()
+
+
+def create_test_profile(temp_dir, db_fixture, backend):
+    from aiida.common import setup as aiida_cfg
+    from aiida.cmdline.verdilib import setup
+    profile_name = 'test_profile'
+    profile = {
+        'backend': backend,
+        'email': 'test@aiida.mail',
+        'repo': path.join(temp_dir, 'test_repo'),
+        'db_host': db_fixture.pg_test.dsn['host'],
+        'db_port': db_fixture.pg_test.port,
+        'db_user': db_fixture.pg_test.dsn['user'],
+        'db_pass': db_fixture.DB_PASS,
+        'db_name': db_fixture.DB_NAME,
+        'first_name': 'AiiDA',
+        'last_name': 'Tester',
+        'institution': 'aiidateam'
+    }
+    setup(
+        profile=profile_name,
+        only_config=False,
+        non_interactive=True,
+        **profile)
+    aiida_cfg.set_default_profile('verdi', profile_name)
+    aiida_cfg.set_default_profile('daemon', profile_name)
+
+
+class PluginTestCase(unittest.TestCase):
+    """
+    Set up a complete temporary AiiDA environment for plugin tests
+
+    Filesystem:
+
+        * temporary config (``.aiida``) folder
+        * temporary repository folder
+
+    Database:
+
+        * temporary database cluster via the ``pgtest`` package
+        * with aiida database user
+        * with aiida_db database
+
+    AiiDA:
+
+        * set to use the temporary config folder
+        * create and configure a profile
+    """
+    BACKEND = 'django'
+
+    @classmethod
+    def setUpClass(cls):
+        cls.db_fixture = DbFixture()
+        assert cls.db_fixture.init_success()
+        cls.temp_dir = setup_fs_env()
+        cls.aiida_cfg = setup_aiida(cls.temp_dir)
+        create_test_profile(cls.temp_dir, cls.db_fixture, cls.BACKEND)
+
+    @classmethod
+    def tearDownClass(cls):
+        del cls.db_fixture
+        shutil.rmtree(cls.temp_dir, ignore_errors=True)

--- a/aiida/utils/fixtures.py
+++ b/aiida/utils/fixtures.py
@@ -35,6 +35,13 @@ class FixtureManager(object):
 
         # ready for testing
 
+        # run test 1
+
+        fixtures.reset_db()
+        # database ready for independent test 2
+
+        # run test 2
+
         fixtures.destroy_all()
         # everything cleaned up
     """
@@ -108,6 +115,16 @@ class FixtureManager(object):
         aiida_cfg.set_default_profile('verdi', profile_name)
         aiida_cfg.set_default_profile('daemon', profile_name)
         self.__is_running_on_test_profile = True
+
+    def reset_db(self):
+        """Cleans all data from the database between tests"""
+        if not self.__is_running_on_test_profile:
+            raise FixtureError(
+                'No test profile has been set up yet, can not reset the db')
+        if self.profile_info['backend'] == 'django':
+            self.__clean_db_django()
+        elif self.profile_info['backend'] == 'sqla':
+            self.__clean_db_sqla()
 
     @property
     def profile(self):
@@ -256,6 +273,16 @@ class FixtureManager(object):
             shutil.rmtree(self.root_dir)
         if self.pg_cluster:
             self.pg_cluster.close()
+
+    @staticmethod
+    def __clean_db_django():
+        from aiida.backends.djsite.db.testbase import DjangoTests
+        DjangoTests().clean_db()
+
+    @staticmethod
+    def __clean_db_sqla():
+        from aiida.backends.sqlalchemy.tests.testbase import SqlAlchemyTests
+        SqlAlchemyTests().clean_db()
 
 
 @contextmanager

--- a/aiida/utils/fixtures.py
+++ b/aiida/utils/fixtures.py
@@ -3,6 +3,7 @@ import unittest
 import tempfile
 import shutil
 from os import path
+from contextlib import contextmanager
 
 from pgtest.pgtest import PGTest
 
@@ -233,11 +234,20 @@ class FixtureManager(object):
     def root_dir_ok(self):
         return bool(self.root_dir and path.isdir(self.root_dir))
 
-    def __del__(self):
+    def destroy_all(self):
         if self.root_dir:
             shutil.rmtree(self.root_dir)
         if self.pg_cluster:
             self.pg_cluster.close()
+
+
+@contextmanager
+def plugin_fixture():
+    manager = FixtureManager()
+    try:
+        yield manager
+    finally:
+        manager.destroy_all()
 
 
 class PluginTestCase(unittest.TestCase):
@@ -270,4 +280,4 @@ class PluginTestCase(unittest.TestCase):
 
     @classmethod
     def tearDownClass(cls):
-        del cls.fixture_builder
+        cls.fixture_builder.destroy_all()

--- a/aiida/utils/fixtures.py
+++ b/aiida/utils/fixtures.py
@@ -24,7 +24,20 @@ class FixtureError(Exception):
 
 # pylint: disable=too-many-public-methods
 class FixtureManager(object):
-    """Manage AiiDA fixtures"""
+    """
+    Manage AiiDA fixtures
+
+    Example::
+
+        fixtures = FixtureManager()
+        fixtures.create_aiida_db()
+        fixtures.create_profile()
+
+        # ready for testing
+
+        fixtures.destroy_all()
+        # everything cleaned up
+    """
 
     def __init__(self):
         self.db_params = {}
@@ -243,6 +256,17 @@ class FixtureManager(object):
 
 @contextmanager
 def plugin_fixture():
+    """
+    Context manager for FixtureManager objects
+
+    Example::
+
+        with plugin_fixture() as fixtures:
+            fixtures.create_aiida_db()
+            fixtures.create_profile()
+            # ready for tests
+        # everything cleaned up
+    """
     manager = FixtureManager()
     try:
         yield manager

--- a/aiida/utils/fixtures.py
+++ b/aiida/utils/fixtures.py
@@ -3,9 +3,14 @@ Testing tools for related projects like plugins
 
 Usage (unittest)::
 
+    import os
+
     MyTestCase(aiida.utils.fixtures.PluginTestCase):
 
-        BACKEND = <load from env variable etc>
+        BACKEND = os.environ.get('TEST_BACKEND')
+        # load the backend to be tested from the environment variable
+        # proceed the test command with TEST_BACKEND='django' | 'sqlalchemy'
+        # or set the TEST_BACKEND in your CI configuration
 
         def setUp(self):
             # load my test data
@@ -38,6 +43,7 @@ Usage (pytest)::
 import unittest
 import tempfile
 import shutil
+import os
 from os import path
 from contextlib import contextmanager
 
@@ -421,7 +427,7 @@ class PluginTestCase(unittest.TestCase):
         * set to use the temporary config folder
         * create and configure a profile
     """
-    BACKEND = BACKEND_DJANGO
+    BACKEND = os.environ.get('TEST_BACKEND')
 
     @classmethod
     def setUpClass(cls):

--- a/aiida/utils/fixtures.py
+++ b/aiida/utils/fixtures.py
@@ -141,7 +141,7 @@ class FixtureManager(object):
 
     def create_db_cluster(self):
         if not self.pg_cluster:
-            self.pg_cluster = PGTest()
+            self.pg_cluster = PGTest(max_connections=256)
         self.db_params.update(self.pg_cluster.dsn)
 
     def create_aiida_db(self):

--- a/aiida/utils/fixtures.py
+++ b/aiida/utils/fixtures.py
@@ -54,6 +54,8 @@ class FixtureManager(object):
         }
         self.pg_cluster = None
         self.postgres = None
+        self.__is_running_on_test_db = False
+        self.__is_running_on_test_profile = False
 
     def create_db_cluster(self):
         self.pg_cluster = PGTest()
@@ -76,6 +78,7 @@ class FixtureManager(object):
                 'Could not connect to the test postgres instance')
         self.postgres.create_dbuser(self.db_user, self.db_pass)
         self.postgres.create_db(self.db_user, self.db_name)
+        self.__is_running_on_test_db = True
 
     def create_root_dir(self):
         self.root_dir = tempfile.mkdtemp()
@@ -104,6 +107,7 @@ class FixtureManager(object):
             **self.profile)
         aiida_cfg.set_default_profile('verdi', profile_name)
         aiida_cfg.set_default_profile('daemon', profile_name)
+        self.__is_running_on_test_profile = True
 
     @property
     def profile(self):

--- a/aiida/utils/fixtures.py
+++ b/aiida/utils/fixtures.py
@@ -99,6 +99,8 @@ class FixtureManager(object):
         if is_dbenv_loaded():
             raise FixtureError(
                 'AiiDA dbenv can not be loaded while creating a test profile')
+        if not self.__is_running_on_test_db:
+            self.create_aiida_db()
         from aiida.common import setup as aiida_cfg
         from aiida.cmdline.verdilib import setup
         if not self.root_dir:
@@ -269,10 +271,15 @@ class FixtureManager(object):
         return bool(self.root_dir and path.isdir(self.root_dir))
 
     def destroy_all(self):
+        """Remove all traces of the test run"""
         if self.root_dir:
             shutil.rmtree(self.root_dir)
+            self.root_dir = None
         if self.pg_cluster:
             self.pg_cluster.close()
+            self.pg_cluster = None
+        self.__is_running_on_test_db = False
+        self.__is_running_on_test_profile = False
 
     @staticmethod
     def __clean_db_django():

--- a/aiida/utils/fixtures.py
+++ b/aiida/utils/fixtures.py
@@ -9,7 +9,7 @@ Usage (unittest)::
 
         BACKEND = os.environ.get('TEST_BACKEND')
         # load the backend to be tested from the environment variable
-        # proceed the test command with TEST_BACKEND='django' | 'sqlalchemy'
+        # on bash, simply prepend the test command with TEST_BACKEND='django' or TEST_BACKEND='sqlalchemy'
         # or set the TEST_BACKEND in your CI configuration
 
         def setUp(self):

--- a/aiida/utils/fixtures.py
+++ b/aiida/utils/fixtures.py
@@ -26,7 +26,11 @@ class FixtureError(Exception):
 # pylint: disable=too-many-public-methods
 class FixtureManager(object):
     """
-    Manage AiiDA fixtures
+    Manage the life cycle of a completely separated and temporary AiiDA environment
+
+    * No previously created database of profile is required to run tests using this
+    environment
+    * Tests using this environment will never pollute the user's work environment
 
     Example::
 
@@ -45,6 +49,28 @@ class FixtureManager(object):
 
         fixtures.destroy_all()
         # everything cleaned up
+
+    Unittest Example::
+
+        class PluginTestCase(unittest.TestCase):
+            @classmethod
+            def setUpClass(cls):
+                cls.fixture_manager = FixtureManager()
+                cls.fixture_manager.create_profile()
+
+            def setUp(self):
+                # load your specific test data
+
+            def tearDown(self):
+                cls.fixture_manager.reset_db()
+
+            @classmethod
+            def tearDownClass(cls):
+                cls.fixture_manager.destroy_all()
+
+            def test_my_plugin(self):
+                # execute tests
+
     """
 
     def __init__(self):
@@ -358,7 +384,6 @@ class PluginTestCase(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         cls.fixture_builder = FixtureManager()
-        cls.fixture_builder.create_aiida_db()
         cls.fixture_builder.create_profile()
 
     @classmethod

--- a/aiida/utils/test_fixtures.py
+++ b/aiida/utils/test_fixtures.py
@@ -1,9 +1,11 @@
 """Unittests for plugin test fixture manager"""
+import os
 import unittest
 
 from pgtest import pgtest
 
-from aiida.utils.fixtures import FixtureManager
+from aiida.utils.fixtures import FixtureManager, FixtureError
+from aiida.utils.capturing import Capturing
 
 
 class FixtureManagerTestCase(unittest.TestCase):
@@ -11,11 +13,67 @@ class FixtureManagerTestCase(unittest.TestCase):
 
     def setUp(self):
         self.fixture_manager = FixtureManager()
+        self.backend = 'django' if os.environ.get(
+            'TEST_AIIDA_BACKEND', 'django') == 'django' else 'sqlalchemy'
+        self.fixture_manager.backend = self.backend
 
     def test_create_db_cluster(self):
         self.fixture_manager.create_db_cluster()
         self.assertTrue(
             pgtest.is_server_running(self.fixture_manager.pg_cluster.cluster))
+
+    def test_create_aiida_db(self):
+        self.fixture_manager.create_db_cluster()
+        self.fixture_manager.create_aiida_db()
+        self.assertTrue(
+            self.fixture_manager.postgres.db_exists(
+                self.fixture_manager.db_name))
+
+    def test_create_use_destroy_profile(self):
+        """
+        Test temporary test profile creation
+
+        * The profile gets created, the dbenv loaded
+        * Data can be stored in the db
+        * reset_db deletes all data added after profile creation
+        * destroy_all removes all traces of the test run
+        """
+        from aiida.backends import settings as backend_settings
+        from aiida.common import setup as aiida_cfg
+        from aiida import is_dbenv_loaded
+        backend_settings.AIIDADB_PROFILE = None
+        with Capturing() as output:
+            self.fixture_manager.create_profile()
+        self.assertTrue(self.fixture_manager.root_dir_ok, msg=output)
+        self.assertTrue(self.fixture_manager.config_dir_ok, msg=output)
+        self.assertTrue(self.fixture_manager.repo_ok, msg=output)
+        self.assertEqual(
+            aiida_cfg.AIIDA_CONFIG_FOLDER,
+            self.fixture_manager.config_dir,
+            msg=output)
+        self.assertTrue(is_dbenv_loaded())
+
+        from aiida.orm import DataFactory, load_node
+        data = DataFactory('parameter')(dict={'key': 'value'})
+        data.store()
+        data_pk = data.pk
+        self.assertTrue(load_node(data_pk))
+
+        with self.assertRaises(FixtureError):
+            self.test_create_aiida_db()
+
+        self.fixture_manager.reset_db()
+        with self.assertRaises(Exception):
+            load_node(data_pk)
+
+        temp_dir = self.fixture_manager.root_dir
+        self.fixture_manager.destroy_all()
+        with self.assertRaises(Exception):
+            self.fixture_manager.postgres.db_exists(
+                self.fixture_manager.db_name)
+        self.assertFalse(os.path.exists(temp_dir))
+        self.assertIsNone(self.fixture_manager.root_dir)
+        self.assertIsNone(self.fixture_manager.pg_cluster)
 
     def tearDown(self):
         self.fixture_manager.destroy_all()

--- a/aiida/utils/test_fixtures.py
+++ b/aiida/utils/test_fixtures.py
@@ -1,0 +1,21 @@
+"""Unittests for plugin test fixture manager"""
+import unittest
+
+from pgtest import pgtest
+
+from aiida.utils.fixtures import FixtureManager
+
+
+class FixtureManagerTestCase(unittest.TestCase):
+    """Test the FixtureManager class"""
+
+    def setUp(self):
+        self.fixture_manager = FixtureManager()
+
+    def test_create_db_cluster(self):
+        self.fixture_manager.create_db_cluster()
+        self.assertTrue(
+            pgtest.is_server_running(self.fixture_manager.pg_cluster.cluster))
+
+    def tearDown(self):
+        self.fixture_manager.destroy_all()

--- a/aiida/utils/test_fixtures.py
+++ b/aiida/utils/test_fixtures.py
@@ -38,10 +38,8 @@ class FixtureManagerTestCase(unittest.TestCase):
         * reset_db deletes all data added after profile creation
         * destroy_all removes all traces of the test run
         """
-        from aiida.backends import settings as backend_settings
         from aiida.common import setup as aiida_cfg
         from aiida import is_dbenv_loaded
-        backend_settings.AIIDADB_PROFILE = None
         with Capturing() as output:
             self.fixture_manager.create_profile()
         self.assertTrue(self.fixture_manager.root_dir_ok, msg=output)

--- a/setup_requirements.py
+++ b/setup_requirements.py
@@ -120,7 +120,7 @@ extras_require = {
     # Requirements for testing
     'testing': [
         'mock',
-        'pgtest'
+        'pgtest>=1.1.0'
     ],
     'dev_precommit': [
         'pre-commit',


### PR DESCRIPTION
Add fixtures that plugins can use in their tests.

The FixtureManager class can set up a complete separate, temporary aiida environment for the duration of a test.

A simple use example is:
```python
fixtures = FixtureManager()
fixtures.create_aiida_db()
fixtures.create_profile()
# now, the dbenv is loaded, all is ready
fixtures.destroy_all()
# now the db and all files are deleted
```

Alternatively the contextmanager may be used:
```python
with plugin_fixture() as fixtures:
    fixtures.create_aiida_db()
    fixtures.create_profile()
    # ready for tests
# everything cleaned up
```

* An example of how to use it with unittest is included in `aiida.utils.fixtures.PluginTestCase`.
* An example for `pytest` is to be found in github.com/DropD/aiida-vasp in `aiida_vasp.calcs.tests.test_base`