### PR TITLE
Fix label and description when submitting jobs as processes

### DIFF
--- a/aiida/work/legacy/job_process.py
+++ b/aiida/work/legacy/job_process.py
@@ -151,3 +151,9 @@ class JobProcess(Process):
 
         if parent_calc:
             self._calc.add_link_from(parent_calc, "CALL", LinkType.CALL)
+
+        if self.raw_inputs:
+            if '_description' in self.raw_inputs:
+                self._calc.description = self.raw_inputs._description
+            if '_label' in self.raw_inputs:
+                self._calc.label = self.raw_inputs._label


### PR DESCRIPTION
Please consider this PR a draft as my understanding of AiiDA's new workflow engine is pretty limited. However, I was surprised to find that doing `submit(PwCalculation.process(), **inputs)` triggered _legacy_ code.