### PR TITLE
[BLOCKED]: Add 'rmq' extra in plumpy requirement

### DIFF
--- a/setup_requirements.py
+++ b/setup_requirements.py
@@ -39,7 +39,7 @@ install_requires = [
     'supervisor==3.1.3',
     'meld3==1.0.0',
     'numpy==1.12.0',
-    'plumpy>=0.9.0',
+    'plumpy[rmq]>=0.9.0',
     'portalocker==1.1.0',
     'SQLAlchemy==1.0.12',  # upgrade to SQLalchemy 1.1.5 does break tests, see #465
     'SQLAlchemy-Utils==0.31.2',


### PR DESCRIPTION
If plumpy doesn't have the ``rmq`` extra it will just silently ignore it.