### PR TITLE
SQLA migrations for dbpath removal and link update

### DIFF
--- a/aiida/backends/sqlalchemy/migrations/versions/70c7d732f1b2_delete_dbpath.py
+++ b/aiida/backends/sqlalchemy/migrations/versions/70c7d732f1b2_delete_dbpath.py
@@ -1,0 +1,45 @@
+"""Deleting dbpath table and triggers
+
+Revision ID: 70c7d732f1b2
+Revises:
+Create Date: 2017-10-17 10:30:23.327195
+
+"""
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+from sqlalchemy.orm.session import Session
+from aiida.backends.sqlalchemy.utils import install_tc
+
+# revision identifiers, used by Alembic.
+revision = '70c7d732f1b2'
+down_revision = 'e15ef2630a1b'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.drop_table('db_dbpath')
+    conn = op.get_bind()
+    conn.execute("DROP TRIGGER IF EXISTS autoupdate_tc ON db_dblink")
+    conn.execute("DROP FUNCTION IF EXISTS update_tc()")
+
+
+def downgrade():
+    op.create_table('db_dbpath',
+    sa.Column('id', sa.INTEGER(), nullable=False),
+    sa.Column('parent_id', sa.INTEGER(), autoincrement=False, nullable=True),
+    sa.Column('child_id', sa.INTEGER(), autoincrement=False, nullable=True),
+    sa.Column('depth', sa.INTEGER(), autoincrement=False, nullable=True),
+    sa.Column('entry_edge_id', sa.INTEGER(), autoincrement=False, nullable=True),
+    sa.Column('direct_edge_id', sa.INTEGER(), autoincrement=False, nullable=True),
+    sa.Column('exit_edge_id', sa.INTEGER(), autoincrement=False, nullable=True),
+    sa.ForeignKeyConstraint(['child_id'], [u'db_dbnode.id'], name=u'db_dbpath_child_id_fkey', initially=u'DEFERRED', deferrable=True),
+    sa.ForeignKeyConstraint(['parent_id'], [u'db_dbnode.id'], name=u'db_dbpath_parent_id_fkey', initially=u'DEFERRED', deferrable=True),
+    sa.PrimaryKeyConstraint('id', name=u'db_dbpath_pkey')
+    )
+    # I get the session using the alembic connection
+    # (Keep in mind that alembic uses the AiiDA SQLA
+    # session)
+    session = Session(bind=op.get_bind())
+    install_tc(session)

--- a/aiida/backends/sqlalchemy/migrations/versions/a6048f0ffca8_update_linktypes.py
+++ b/aiida/backends/sqlalchemy/migrations/versions/a6048f0ffca8_update_linktypes.py
@@ -1,0 +1,132 @@
+"""Updating link types - This is a copy of the Django migration script
+
+Revision ID: a6048f0ffca8
+Revises:
+Create Date: 2017-10-17 10:51:23.327195
+
+"""
+from alembic import op
+from sqlalchemy.sql import text
+
+# revision identifiers, used by Alembic.
+revision = 'a6048f0ffca8'
+down_revision = '70c7d732f1b2'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    conn = op.get_bind()
+
+    # I am first migrating the wrongly declared returnlinks out of
+    # the InlineCalculations.
+    # This bug is reported #628 https://github.com/aiidateam/aiida_core/issues/628
+    # There is an explicit check in the code of the inline calculation
+    # ensuring that the calculation returns UNSTORED nodes.
+    # Therefore, no cycle can be created with that migration!
+    #
+    # this command:
+    # 1) selects all links that
+    #   - joins an InlineCalculation (or subclass) as input
+    #   - joins a Data (or subclass) as output
+    #   - is marked as a returnlink.
+    # 2) set for these links the type to 'createlink'
+    stmt1 = text("""
+        UPDATE db_dblink set type='createlink' WHERE db_dblink.id IN (
+            SELECT db_dblink_1.id 
+            FROM db_dbnode AS db_dbnode_1
+                JOIN db_dblink AS db_dblink_1 ON db_dblink_1.input_id = db_dbnode_1.id
+                JOIN db_dbnode AS db_dbnode_2 ON db_dblink_1.output_id = db_dbnode_2.id
+            WHERE db_dbnode_1.type LIKE 'calculation.inline.%'
+                AND db_dbnode_2.type LIKE 'data.%'
+                AND db_dblink_1.type = 'returnlink'
+        )
+    """)
+    conn.execute(stmt1)
+    # Now I am updating the link-types that are null because of either an export and subsequent import
+    # https://github.com/aiidateam/aiida_core/issues/685
+    # or because the link types don't exist because the links were added before the introduction of link types.
+    # This is reported here: https://github.com/aiidateam/aiida_core/issues/687
+    #
+    # The following sql statement:
+    # 1) selects all links that
+    #   - joins Data (or subclass) or Code as input
+    #   - joins Calculation (or subclass) as output. This includes WorkCalculation, InlineCalcuation, JobCalculations...
+    #   - has no type (null)
+    # 2) set for these links the type to 'inputlink'
+    stmt2 = text("""
+         UPDATE db_dblink set type='inputlink' where id in (
+            SELECT db_dblink_1.id
+            FROM db_dbnode AS db_dbnode_1
+                JOIN db_dblink AS db_dblink_1 ON db_dblink_1.input_id = db_dbnode_1.id
+                JOIN db_dbnode AS db_dbnode_2 ON db_dblink_1.output_id = db_dbnode_2.id
+            WHERE ( db_dbnode_1.type LIKE 'data.%' or db_dbnode_1.type = 'code.Code.' )
+                AND db_dbnode_2.type LIKE 'calculation.%'
+                AND ( db_dblink_1.type = null OR db_dblink_1.type = '')
+        );
+    """)
+    conn.execute(stmt2)
+    #
+    # The following sql statement:
+    # 1) selects all links that
+    #   - join JobCalculation (or subclass) or InlineCalculation as input
+    #   - joins Data (or subclass) as output.
+    #   - has no type (null)
+    # 2) set for these links the type to 'createlink'
+    stmt3 = text("""
+         UPDATE db_dblink set type='createlink' where id in (
+            SELECT db_dblink_1.id
+            FROM db_dbnode AS db_dbnode_1
+                JOIN db_dblink AS db_dblink_1 ON db_dblink_1.input_id = db_dbnode_1.id
+                JOIN db_dbnode AS db_dbnode_2 ON db_dblink_1.output_id = db_dbnode_2.id
+            WHERE db_dbnode_2.type LIKE 'data.%'
+                AND (
+                    db_dbnode_1.type LIKE 'calculation.job.%'
+                    OR
+                    db_dbnode_1.type = 'calculation.inline.InlineCalculation.'
+                )
+                AND ( db_dblink_1.type = null OR db_dblink_1.type = '')
+        )
+    """)
+    conn.execute(stmt3)
+    # The following sql statement:
+    # 1) selects all links that
+    #   - join WorkCalculation as input. No subclassing was introduced so far, so only one type string is checked for.
+    #   - join Data (or subclass) as output.
+    #   - has no type (null)
+    # 2) set for these links the type to 'returnlink'
+    stmt4 = text("""
+         UPDATE db_dblink set type='returnlink' where id in (
+            SELECT db_dblink_1.id
+            FROM db_dbnode AS db_dbnode_1
+                JOIN db_dblink AS db_dblink_1 ON db_dblink_1.input_id = db_dbnode_1.id
+                JOIN db_dbnode AS db_dbnode_2 ON db_dblink_1.output_id = db_dbnode_2.id 
+            WHERE db_dbnode_2.type LIKE 'data.%'
+                AND db_dbnode_1.type = 'calculation.work.WorkCalculation.'
+                AND ( db_dblink_1.type = null OR db_dblink_1.type = '')
+        )
+    """)
+    conn.execute(stmt4)
+    # Now I update links that are CALLS:
+    # The following sql statement:
+    # 1) selects all links that
+    #   - join WorkCalculation as input. No subclassing was introduced so far, so only one type string is checked for.
+    #   - join Calculation (or subclass) as output. Includes JobCalculation and WorkCalculations and all subclasses.
+    #   - has no type (null)
+    # 2) set for these links the type to 'calllink'
+    stmt5 = text("""
+         UPDATE db_dblink set type='calllink' where id in (
+            SELECT db_dblink_1.id
+            FROM db_dbnode AS db_dbnode_1
+                JOIN db_dblink AS db_dblink_1 ON db_dblink_1.input_id = db_dbnode_1.id
+                JOIN db_dbnode AS db_dbnode_2 ON db_dblink_1.output_id = db_dbnode_2.id 
+            WHERE db_dbnode_1.type = 'calculation.work.WorkCalculation.'
+                AND db_dbnode_2.type LIKE 'calculation.%'
+                AND ( db_dblink_1.type = null  OR db_dblink_1.type = '')
+        )
+    """)
+    conn.execute(stmt5)
+
+
+def downgrade():
+    print "There is no downgrade for the link types"

--- a/aiida/backends/sqlalchemy/migrations/versions/e15ef2630a1b_initial_schema.py
+++ b/aiida/backends/sqlalchemy/migrations/versions/e15ef2630a1b_initial_schema.py
@@ -8,7 +8,7 @@ Create Date: 2017-06-28 17:12:23.327195
 from alembic import op
 import sqlalchemy as sa
 from sqlalchemy.dialects import postgresql
-from sqlalchemy.schema import Sequence, CreateSequence
+from sqlalchemy.orm.session import Session
 from aiida.backends.sqlalchemy.utils import install_tc
 
 # revision identifiers, used by Alembic.
@@ -247,6 +247,11 @@ def upgrade():
     sa.PrimaryKeyConstraint('id', name=u'db_dbworkflowstep_sub_workflows_pkey'),
     sa.UniqueConstraint('dbworkflowstep_id', 'dbworkflow_id', name=u'db_dbworkflowstep_sub_workflo_dbworkflowstep_id_dbworkflow__key')
     )
+    # I get the session using the alembic connection
+    # (Keep in mind that alembic uses the AiiDA SQLA
+    # session)
+    session = Session(bind=op.get_bind())
+    install_tc(session)
 
 
 def downgrade():


### PR DESCRIPTION
This is the SQLA equivalent of what was done for Django at issue #687.
