### PR TITLE
Renamed get_query_set to get_queryset to avoid django warning

### DIFF
--- a/aiida/backends/djsite/db/models.py
+++ b/aiida/backends/djsite/db/models.py
@@ -46,7 +46,7 @@ class AiidaQuerySet(QuerySet):
 
 
 class AiidaObjectManager(m.Manager):
-    def get_query_set(self):
+    def get_queryset(self):
         return AiidaQuerySet(self.model, using=self._db)
 
 


### PR DESCRIPTION
(the method was renamed already in django 1.7 and will be removed in 1.8)