### PR TITLE
Issue 665 remove warnings restapi unittests

### DIFF
--- a/aiida/restapi/translator/node.py
+++ b/aiida/restapi/translator/node.py
@@ -296,7 +296,7 @@ class NodeTranslator(BaseTranslator):
                 full_path = full_path_base + '.py'
                 # I could use load_module but it takes lots of arguments,
                 # then I use load_source
-                app_module = imp.load_source(package_path, full_path)
+                app_module = imp.load_source("rst"+name, full_path)
 
             # Go through the content of the module
             if not is_pkg:

--- a/aiida/restapi/translator/node.py
+++ b/aiida/restapi/translator/node.py
@@ -296,7 +296,7 @@ class NodeTranslator(BaseTranslator):
                 full_path = full_path_base + '.py'
                 # I could use load_module but it takes lots of arguments,
                 # then I use load_source
-                app_module = imp.load_source(full_path, full_path)
+                app_module = imp.load_source(package_path, full_path)
 
             # Go through the content of the module
             if not is_pkg:


### PR DESCRIPTION
In imp.load_source() first parameter is basically the name that you load the module with will be used in other files who import that module and in import statement dots are used to separate packages. In travis,  aiida is installed in "/home/travis/virtualenv/python2.7.13/lib/python2.7/site-packages/" path where "python2.7.13" contains the dots which were considered as separate packages.

This issues is fixed now.