### PR TITLE
Remove the backend dependent code from verdi daemon stop

### DIFF
--- a/aiida/cmdline/commands/daemon.py
+++ b/aiida/cmdline/commands/daemon.py
@@ -231,12 +231,6 @@ class Daemon(VerdiCommandWithSubcommands):
         :return: None if ``wait_for_death`` is False. True/False if the process was
             actually dead or after all the retries it was still alive.
         """
-        if not is_dbenv_loaded():
-            from aiida.backends.utils import load_dbenv
-            load_dbenv(process='daemon')
-
-        from aiida.daemon.timestamps import get_last_daemon_timestamp,set_daemon_timestamp
-
         if args:
             print >> sys.stderr, (
                 "No arguments allowed for the '{}' command.".format(
@@ -261,24 +255,6 @@ class Daemon(VerdiCommandWithSubcommands):
                 if pid is None:
                     dead = True
                     print "AiiDA Daemon shut down correctly."
-                    # The following lines are needed for the workflow_stepper
-                    # (re-initialize the timestamps used to lock the task, in case
-                    # it crashed for some reason).
-                    # TODO: remove them when the old workflow system will be
-                    # taken away.
-                    try:
-                        if (get_last_daemon_timestamp('workflow',when='stop')
-                            -get_last_daemon_timestamp('workflow',when='start'))<timedelta(0):
-                            logger.info("Workflow stop timestamp was {}; re-initializing"
-                                        " it to current time".format(
-                                        get_last_daemon_timestamp('workflow',when='stop')))
-                            print "Re-initializing workflow stepper stop timestamp"
-                            set_daemon_timestamp(task_name='workflow', when='stop')
-                    except TypeError:
-                        # when some timestamps are None (i.e. not present), we make
-                        # sure that at least the stop timestamp is defined
-                        print "Re-initializing workflow stepper stop timestamp"
-                        set_daemon_timestamp(task_name='workflow', when='stop')
                     break
                 else:
                     print "Waiting for the AiiDA Daemon to shut down..."


### PR DESCRIPTION
Fixes #831 

The verdi daemon stop command was backend dependent because
it contained code that tried to reset the timestamps of the
legacy workflow stepper. However, this code is also code in
the verdi daemon start command and as such is not necessary.
Removing this code from verdi daemon stop means that it can
now be called without having to load the database environment.
This solves the problem that occurs when people upgrade their
AiiDA installation and a database migration is needed, for
which they needed to stop their daemon, but the necessity of
having to load the database environment, triggered the very
same database schema check, resulting in an exception.

With this change, people can call verdi daemon stop to stop
the daemon before performing a database migration, even when
there is a database version mismatch