### PR TITLE
Fix precommit regex (and format / linter errors)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,10 +8,10 @@
       (?x)^(   # (?x) -> multiline regex, ^ -> beginning of file path
         aiida/control/.*.py|        # must match the whole path, therefore
         aiida/cmdline/tests/.*.py|  # the .*.py (.* matches everything)
+        aiida/backends/tests/verdi_commands.py|
         docs/update_req_for_rtd.py| # a|b -> match a OR b
         .travis_data/test_setup.py|
         .travis-data/test_plugin_testcase.py|
-        aiida/backends/tests/verdi_commands.py|
         aiida/utils/fixtures.py
       )$  # $ -> end of file path, to add a directory, give full/path/.*
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,13 +4,17 @@
   hooks:
   - id: yapf
     language: system
+    types: [file, python]
     files: >-
-      ^(aiida/control/)
-      |(aiida/cmdline/tests)
-      |(docs/update_req_for_rtd.py)
-      |(.travis_data/test_setup.py)
-      |(aiida/backends/tests/verdi_commands.py)
-      |(aiida/utils/.*fixtures.py)
+      (?x)^(
+        aiida/control/|
+        aiida/cmdline/tests|
+        docs/update_req_for_rtd.py|
+        .travis_data/test_setup.py|
+        .travis_data/test_plugin_testcase.py|
+        aiida/backends/tests/verdi_commands.py|
+        aiida/utils/.*fixtures.py
+      )
 
 # prospector: collection of linters
 - repo: git://github.com/guykisel/prospector-mirror
@@ -18,14 +22,18 @@
   hooks:
   - id: prospector
     language: system
-    exclude: '^(tests/)|(examples/)'
+    exclude: ^(tests/|examples/)
+    types: [file, python]
     files: >-
-      ^(aiida/control/)
-      |(aiida/cmdline/tests)
-      |(docs/update_req_for_rtd.py)
-      |(.travis_data/test_setup.py)
-      |(aiida/backends/tests/verdi_commands.py)
-      |(aiida/utils/.*fixtures.py)
+      (?x)^(
+        aiida/control/.*|
+        aiida/cmdline/tests.*|
+        docs/update_req_for_rtd.py|
+        .travis_data/test_setup.py|
+        .travis_data/test_plugin_testcase.py|
+        aiida/backends/tests/verdi_commands.py|
+        aiida/utils/.*fixtures.py|
+      )
 
 - repo: local
   hooks: 
@@ -34,9 +42,11 @@
     entry: python ./docs/update_req_for_rtd.py --pre-commit
     language: system
     files: >-
-      ^(setup_requirements.py)
-      |(docs/requirements_for_rtd.txt)
-      |(docs/update_req_for_rtd.py)
+      (?x)^(
+        setup_requirements.py|
+        docs/requirements_for_rtd.txt|
+        docs/update_req_for_rtd.py|
+      )$
     pass_filenames: false
 
 - repo: git://github.com/pre-commit/pre-commit-hooks

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 # yet another python formatter
 - repo: git://github.com/pre-commit/mirrors-yapf
-  sha: v0.17.0
+  sha: v0.19.0
   hooks:
   - id: yapf
     language: system
@@ -49,7 +49,7 @@
     pass_filenames: false
 
 - repo: git://github.com/pre-commit/pre-commit-hooks
-  sha: v0.9.4
+  sha: v1.1.1
   hooks:
   - id: check-yaml
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,10 +8,10 @@
       (?x)^(   # (?x) -> multiline regex, ^ -> beginning of file path
         aiida/control/.*.py|        # must match the whole path, therefore
         aiida/cmdline/tests/.*.py|  # the .*.py (.* matches everything)
-        aiida/backends/tests/verdi_commands.py|
         docs/update_req_for_rtd.py| # a|b -> match a OR b
         .travis_data/test_setup.py|
         .travis-data/test_plugin_testcase.py|
+        aiida/backends/tests/verdi_commands.py|
         aiida/utils/fixtures.py
       )$  # $ -> end of file path, to add a directory, give full/path/.*
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,17 +4,16 @@
   hooks:
   - id: yapf
     language: system
-    types: [file, python]
-    files: >-
-      (?x)^(
-        aiida/control/|
-        aiida/cmdline/tests/|
-        docs/update_req_for_rtd.py|
+    files: >-  # begin multiline string
+      (?x)^(   # (?x) -> multiline regex, ^ -> beginning of file path
+        aiida/control/.*.py|        # must match the whole path, therefore
+        aiida/cmdline/tests/.*.py|  # the .*.py (.* matches everything)
+        docs/update_req_for_rtd.py| # a|b -> match a OR b
         .travis_data/test_setup.py|
-        .travis_data/test_plugin_testcase.py|
+        .travis-data/test_plugin_testcase.py|
         aiida/backends/tests/verdi_commands.py|
-        aiida/utils/.*fixtures.py|
-      )
+        aiida/utils/fixtures.py
+      )$  # $ -> end of file path, to add a directory, give full/path/.*
 
 # prospector: collection of linters
 - repo: git://github.com/guykisel/prospector-mirror
@@ -26,14 +25,14 @@
     types: [file, python]
     files: >-
       (?x)^(
-        aiida/control/.*|
-        aiida/cmdline/tests.*|
+        aiida/control/.*.py|
+        aiida/cmdline/tests/.*.py|
         docs/update_req_for_rtd.py|
         .travis_data/test_setup.py|
-        .travis_data/test_plugin_testcase.py|
+        .travis-data/test_plugin_testcase.py|
         aiida/backends/tests/verdi_commands.py|
-        aiida/utils/.*fixtures.py|
-      )
+        aiida/utils/fixtures.py
+      )$
 
 - repo: local
   hooks: 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,12 +8,12 @@
     files: >-
       (?x)^(
         aiida/control/|
-        aiida/cmdline/tests|
+        aiida/cmdline/tests/|
         docs/update_req_for_rtd.py|
         .travis_data/test_setup.py|
         .travis_data/test_plugin_testcase.py|
         aiida/backends/tests/verdi_commands.py|
-        aiida/utils/.*fixtures.py
+        aiida/utils/.*fixtures.py|
       )
 
 # prospector: collection of linters

--- a/.travis-data/test_plugin_testcase.py
+++ b/.travis-data/test_plugin_testcase.py
@@ -14,10 +14,12 @@ from aiida import is_dbenv_loaded
 
 def determine_backend():
     return BACKEND_DJANGO if os.environ.get(
-        'TEST_AIIDA_BACKEND', BACKEND_DJANGO) == BACKEND_DJANGO else BACKEND_SQLA
+        'TEST_AIIDA_BACKEND',
+        BACKEND_DJANGO) == BACKEND_DJANGO else BACKEND_SQLA
 
 
 class PluginTestcaseTestCase(PluginTestCase):
+    """Test the PluginTestcase from utils.fixtures"""
     BACKEND = determine_backend()
 
     def setUp(self):

--- a/.travis-data/test_script.sh
+++ b/.travis-data/test_script.sh
@@ -21,6 +21,6 @@ case "$TEST_TYPE" in
         verdi -p $TEST_AIIDA_BACKEND run ${TRAVIS_BUILD_DIR}/.travis-data/test_daemon.py
         ;;
     pre-commit)
-        pre-commit run --all-files
+        pre-commit run --all-files || git status --short
         ;;
 esac

--- a/.travis-data/test_script.sh
+++ b/.travis-data/test_script.sh
@@ -21,6 +21,6 @@ case "$TEST_TYPE" in
         verdi -p $TEST_AIIDA_BACKEND run ${TRAVIS_BUILD_DIR}/.travis-data/test_daemon.py
         ;;
     pre-commit)
-        pre-commit run --all-files || git status --short
+        pre-commit run --all-files || git status --short && git diff
         ;;
 esac

--- a/aiida/backends/tests/verdi_commands.py
+++ b/aiida/backends/tests/verdi_commands.py
@@ -93,18 +93,24 @@ class TestVerdiCalculationCommands(AiidaTestCase):
         # Create some calculation
         calc1 = JobCalculation(
             computer=cls.computer,
-            resources={'num_machines': 1,
-                       'num_mpiprocs_per_machine': 1}).store()
+            resources={
+                'num_machines': 1,
+                'num_mpiprocs_per_machine': 1
+            }).store()
         calc1._set_state(calc_states.TOSUBMIT)
         calc2 = JobCalculation(
             computer=cls.computer.name,
-            resources={'num_machines': 1,
-                       'num_mpiprocs_per_machine': 1}).store()
+            resources={
+                'num_machines': 1,
+                'num_mpiprocs_per_machine': 1
+            }).store()
         calc2._set_state(calc_states.COMPUTED)
         calc3 = JobCalculation(
             computer=cls.computer.id,
-            resources={'num_machines': 1,
-                       'num_mpiprocs_per_machine': 1}).store()
+            resources={
+                'num_machines': 1,
+                'num_mpiprocs_per_machine': 1
+            }).store()
         calc3._set_state(calc_states.FINISHED)
 
     def test_calculation_list(self):
@@ -130,7 +136,7 @@ class TestVerdiCalculationCommands(AiidaTestCase):
                          "simple calculation list.")
 
         with Capturing() as output:
-            calc_cmd.calculation_list(* ['-a'])
+            calc_cmd.calculation_list(*['-a'])
 
         out_str = ''.join(output)
         self.assertTrue(calc_states.FINISHED in out_str,
@@ -201,7 +207,7 @@ class TestVerdiCodeCommands(AiidaTestCase):
         # Run a verdi code list -a, capture the output and check if the result
         # is the same as the previous one
         with Capturing() as output:
-            code_cmd.code_list(* ['-a'])
+            code_cmd.code_list(*['-a'])
         out_str_2 = ''.join(output)
         self.assertEqual(out_str_1, out_str_2,
                          "verdi code list & verdi code list -a should provide "
@@ -209,7 +215,7 @@ class TestVerdiCodeCommands(AiidaTestCase):
 
         # Run a verdi code list -c, capture the output and check the result
         with Capturing() as output:
-            code_cmd.code_list(* ['-c', computer_name_1])
+            code_cmd.code_list(*['-c', computer_name_1])
         out_str = ''.join(output)
         self.assertTrue(computer_name_1 in out_str,
                         "The computer 1 name should be included into "

--- a/aiida/backends/tests/verdi_commands.py
+++ b/aiida/backends/tests/verdi_commands.py
@@ -93,24 +93,18 @@ class TestVerdiCalculationCommands(AiidaTestCase):
         # Create some calculation
         calc1 = JobCalculation(
             computer=cls.computer,
-            resources={
-                'num_machines': 1,
-                'num_mpiprocs_per_machine': 1
-            }).store()
+            resources={'num_machines': 1,
+                       'num_mpiprocs_per_machine': 1}).store()
         calc1._set_state(calc_states.TOSUBMIT)
         calc2 = JobCalculation(
             computer=cls.computer.name,
-            resources={
-                'num_machines': 1,
-                'num_mpiprocs_per_machine': 1
-            }).store()
+            resources={'num_machines': 1,
+                       'num_mpiprocs_per_machine': 1}).store()
         calc2._set_state(calc_states.COMPUTED)
         calc3 = JobCalculation(
             computer=cls.computer.id,
-            resources={
-                'num_machines': 1,
-                'num_mpiprocs_per_machine': 1
-            }).store()
+            resources={'num_machines': 1,
+                       'num_mpiprocs_per_machine': 1}).store()
         calc3._set_state(calc_states.FINISHED)
 
     def test_calculation_list(self):
@@ -136,7 +130,7 @@ class TestVerdiCalculationCommands(AiidaTestCase):
                          "simple calculation list.")
 
         with Capturing() as output:
-            calc_cmd.calculation_list(*['-a'])
+            calc_cmd.calculation_list(* ['-a'])
 
         out_str = ''.join(output)
         self.assertTrue(calc_states.FINISHED in out_str,
@@ -207,7 +201,7 @@ class TestVerdiCodeCommands(AiidaTestCase):
         # Run a verdi code list -a, capture the output and check if the result
         # is the same as the previous one
         with Capturing() as output:
-            code_cmd.code_list(*['-a'])
+            code_cmd.code_list(* ['-a'])
         out_str_2 = ''.join(output)
         self.assertEqual(out_str_1, out_str_2,
                          "verdi code list & verdi code list -a should provide "
@@ -215,7 +209,7 @@ class TestVerdiCodeCommands(AiidaTestCase):
 
         # Run a verdi code list -c, capture the output and check the result
         with Capturing() as output:
-            code_cmd.code_list(*['-c', computer_name_1])
+            code_cmd.code_list(* ['-c', computer_name_1])
         out_str = ''.join(output)
         self.assertTrue(computer_name_1 in out_str,
                         "The computer 1 name should be included into "


### PR DESCRIPTION
In .pre-commit-config.yaml:
* the `file:` regex were reformatted to the style documented at http://pre-commit.com/#regular-expressions
* since every sub-expression in the regex must now match the full path, folders were extended to match `path/to/folder/.*.py`
* The format was documented with comments where such a regex first occurs
* hook versions were updated using `pre-commit autoupdate`

Other changes:
* all other changes are formatting and linter fixes that previously weren't caught by `pre-comit run --all-files`

fix #860