### PR TITLE
Plugin fixtures: improve for pytest, add computer fixture to PluginTestCase

### DIFF
--- a/.travis-data/test_plugin_testcase.py
+++ b/.travis-data/test_plugin_testcase.py
@@ -6,6 +6,8 @@ Since the dbenv gets loaded on the temporary profile.
 """
 import os
 import unittest
+import tempfile
+import shutil
 
 from aiida.utils.fixtures import PluginTestCase
 from aiida.backends.profile import BACKEND_DJANGO, BACKEND_SQLA
@@ -22,20 +24,45 @@ class PluginTestcaseTestCase(PluginTestCase):
 
     def setUp(self):
         from aiida.orm import DataFactory
-        self.data = DataFactory('parameter')(dict={'data': 'test'})
-        self.data.store()
+        from aiida.orm import Computer
+        self.temp_dir = tempfile.mkdtemp()
+        self.data = self.get_data()
         self.data_pk = self.data.pk
+        self.computer = self.get_computer(temp_dir=self.temp_dir)
+
+    def get_data(self):
+        from aiida.orm import DataFactory
+        data = DataFactory('parameter')(dict={'data': 'test'})
+        data.store()
+        return data
+
+    def get_computer(self, temp_dir):
+        from aiida.orm import Computer
+        computer = Computer(
+            name='localhost',
+            description='my computer',
+            hostname='localhost',
+            workdir=temp_dir,
+            transport_type='local',
+            scheduler_type='direct',
+            enabled_state=True)
+        computer.store()
+        return computer
 
     def test_data_loaded(self):
+        from aiida.orm import Computer
         from aiida.orm import load_node
         self.assertTrue(is_dbenv_loaded())
-        load_node(self.data_pk)
+        self.assertEqual(load_node(self.data_pk).uuid, self.data.uuid)
+        self.assertEqual(Computer.get('localhost').uuid, self.computer.uuid)
+
 
     def test_tear_down(self):
         from aiida.orm import load_node
         super(PluginTestcaseTestCase, self).tearDown()
         with self.assertRaises(Exception):
             load_node(self.data_pk)
+        shutil.rmtree(self.temp_dir)
 
 
 if __name__ == '__main__':

--- a/aiida/utils/fixtures.py
+++ b/aiida/utils/fixtures.py
@@ -389,6 +389,12 @@ class FixtureManager(object):
         # that deleted our user, we need to recreate it
         new_user.force_save()
 
+    def has_profile_open(self):
+        return self.__is_running_on_test_profile
+
+
+_PYTEST_FIXTURE_MANAGER = FixtureManager()
+
 
 @contextmanager
 def fixture_manager():
@@ -409,11 +415,12 @@ def fixture_manager():
                 fixture_mgr.create_profile()
                 yield fixture_mgr
     """
-    manager = FixtureManager()
     try:
-        yield manager
+        if not _PYTEST_FIXTURE_MANAGER.has_profile_open():
+            _PYTEST_FIXTURE_MANAGER.create_profile()
+        yield _PYTEST_FIXTURE_MANAGER
     finally:
-        manager.destroy_all()
+        _PYTEST_FIXTURE_MANAGER.destroy_all()
 
 
 class PluginTestCase(unittest.TestCase):


### PR DESCRIPTION
* the fixture context manager now always returns the same FixtureManager instance (more would be useless, because it could not reload the dbenv anyway)
* `.travis-data/test_plugin_testcase.py` now contains an example for a Computer fixture

Motivation for the second item: https://github.com/aiidateam/aiida-plugin-template/issues/6

@ltalirz: The only significant thing i can see i am doing different is that i am ensuring that the workdir of the Computer is an existing directory.