### PR TITLE
Properly namespace the logger for sub classes of AbstractNode

### DIFF
--- a/aiida/orm/implementation/general/node.py
+++ b/aiida/orm/implementation/general/node.py
@@ -91,8 +91,7 @@ class AbstractNode(object):
         def __new__(cls, name, bases, attrs):
 
             newcls = ABCMeta.__new__(cls, name, bases, attrs)
-            newcls._logger = logging.getLogger(
-                '{:s}.{:s}'.format(attrs['__module__'], name))
+            newcls._logger = logging.getLogger('aiida.{:s}.{:s}'.format(attrs['__module__'], name))
 
             # Note: the reverse logic (from type_string to name that can
             # be passed to the plugin loader) is implemented in


### PR DESCRIPTION
The __metaclass__ of the AbstractNode class does some magic to
properly set the logger that is configured for AiiDA for all the
sub classes, however it did not properly prepend it with the aiida
namespace. This means that for sub classes that live outside of
the aiida module, their module path will not match the aiida logger
and the configured handlers and adapters will not be applied.
As a result, for example, in JobCalculations that live in separate
plugins, the DbLogHandler will not work as expected.