### PR TITLE
Attempt to properly wrap up nodes belonging to corrupt pickles

### DIFF
--- a/aiida/backends/tests/work/daemon.py
+++ b/aiida/backends/tests/work/daemon.py
@@ -155,4 +155,4 @@ class TestDaemon(AiidaTestCase):
             i += 1
 
         self.assertTrue(registry.has_finished(dp_rinfo.pid))
-        self.assertFalse(registry.has_finished(fail_rinfo.pid))
+        self.assertTrue(registry.has_finished(fail_rinfo.pid))

--- a/aiida/work/persistence.py
+++ b/aiida/work/persistence.py
@@ -171,8 +171,8 @@ class Persistence(plum.persistence.pickle_persistence.PicklePersistence):
             try:
                 process = self.create_from_file_and_persist(f)
                 processes.append(process)
-            except (portalocker.LockException, IOError):
-                continue
+            except BaseException:
+                pass
 
         return processes
 
@@ -194,7 +194,7 @@ class Persistence(plum.persistence.pickle_persistence.PicklePersistence):
             checkpoint = self.load_checkpoint_from_file_object(handle)
             try:
                 process = Process.create_from(checkpoint)
-            except BaseException:
+            except BaseException as e:
                 LOGGER.warning(
                     "Failed to load checkpoint '{}'\n{}".format(filepath, traceback.format_exc())
                 )
@@ -218,7 +218,7 @@ class Persistence(plum.persistence.pickle_persistence.PicklePersistence):
                     except OSError:
                         pass
 
-                    raise ValueError("Failed creating process from '{}'".format(filepath))
+                raise
             else:
                 try:
                     # Listen to the process - state transitions will trigger pickling

--- a/aiida/work/persistence.py
+++ b/aiida/work/persistence.py
@@ -140,6 +140,10 @@ class Persistence(plum.persistence.pickle_persistence.PicklePersistence):
         )
         self._filelocks = {}
 
+        self._ensure_directory(running_directory)
+        self._ensure_directory(finished_directory)
+        self._ensure_directory(failed_directory)
+
     @property
     def store_directory(self):
         return self._running_directory
@@ -169,11 +173,12 @@ class Persistence(plum.persistence.pickle_persistence.PicklePersistence):
             except (portalocker.LockException, IOError):
                 continue
             except BaseException:
-                LOGGER.warning("Failed to load checkpoint '{}' (deleting)\n{}"
+                LOGGER.warning("Failed to load checkpoint '{}' (moving to failed directory)\n{}"
                                .format(f, traceback.format_exc()))
 
                 try:
-                    os.remove(f)
+                    filename = os.path.basename(f)
+                    os.rename(f, os.path.join(self.failed_directory, filename))
                 except OSError:
                     pass
 

--- a/aiida/work/persistence.py
+++ b/aiida/work/persistence.py
@@ -173,14 +173,25 @@ class Persistence(plum.persistence.pickle_persistence.PicklePersistence):
             except (portalocker.LockException, IOError):
                 continue
             except BaseException:
-                LOGGER.warning("Failed to load checkpoint '{}' (moving to failed directory)\n{}"
-                               .format(f, traceback.format_exc()))
+                LOGGER.warning("Failed to load checkpoint '{}'\n{}".format(f, traceback.format_exc()))
 
+                # Try to load the node corresponding to the corrupt pickle, set it to FAILED and seal it
+                # At the end we will also move the pickle to the failed directory so it can be inspected for debugging
                 try:
-                    filename = os.path.basename(f)
-                    os.rename(f, os.path.join(self.failed_directory, filename))
-                except OSError:
-                    pass
+                    from aiida.orm import load_node
+                    pk, extension = os.path.splitext(os.path.basename(f))
+                    node = load_node(int(pk))
+                    node._set_attr(node.FAILED_KEY, True)
+                    node.seal()
+                except BaseException as exception:
+                    LOGGER.warning('failed to clean up the node of the corrupt pickle {}'.format(traceback.format_exc()))
+                finally:
+                    LOGGER.warning("moving '{}' to failed directory".format(f))
+                    try:
+                        filename = os.path.basename(f)
+                        os.rename(f, os.path.join(self.failed_directory, filename))
+                    except OSError:
+                        pass
 
             else:
                 processes.append(process)


### PR DESCRIPTION
Fixes #900 

When a pickle is corrupted, attempt to neatly seal the node

If the daemon attempts to load a Process from a pickle that
excepts, because it is corrupted, we should at least try to
load the corresponding node, set it to failed and seal it, such
that any parent processes that might have called it, get a proper
signal that the process they were waiting on has finished, albeit
unsuccessfully. The parent processes will then not linger in a
forever unfinished state, but will be taken out of limbo.

To this end we try to load the node, by getting the pk from the
pickle filename. Note that this is not very robust as if at some
point the format of the pickle name changes and it no longer is
{node_ppk}.pickle than there is no way to retrieve the
corresponding node.