### PR TITLE
Trigger the DbLogHandler for exceptions in WorkChains run by daemon

### DIFF
--- a/aiida/work/daemon.py
+++ b/aiida/work/daemon.py
@@ -49,6 +49,7 @@ def tick_workflow_engine(storage=None, print_exceptions=True):
             proc.stop()
             proc.run_until(ProcessState.DESTROYED)
         except BaseException:
+            proc.logger.error('exception occurred:\n{}'.format(traceback.format_exc()))
             if print_exceptions:
                 traceback.print_exc()
             continue


### PR DESCRIPTION
Exceptions that are encountered when ticking processes only got
logged to the daemon log but did not go through the logger of the
process itself and therefore the exception message was not in any
retrievable through the WorkCalculation node.
In the tick_workflow_engine of the daemon, when an exception occurs
in the ticking of the process, a log message is sent to the logger
of the process which should have the DbLogHandler configured, which
will cause the message to end up in the DbLog table. This message
will then be accessible through for example 'verdi work report'