### PR TITLE
Fix #966

### DIFF
--- a/aiida/control/postgres.py
+++ b/aiida/control/postgres.py
@@ -100,7 +100,7 @@ class Postgres(object):
                 break
 
         # This will work for the default Debian postgres setup
-        if not self.pg_execute:
+        if self.pg_execute == _pg_execute_not_connected:
             dbinfo['user'] = 'postgres'
             if _try_subcmd(
                     non_interactive=bool(not self.interactive), **dbinfo):

--- a/aiida/control/tests/test_postgres.py
+++ b/aiida/control/tests/test_postgres.py
@@ -9,10 +9,16 @@
 ###########################################################################
 """Unit tests for postgres database maintenance functionality"""
 import unittest
+import mock
 
 from pgtest.pgtest import PGTest
 
 from aiida.control.postgres import Postgres
+
+
+def _try_connect_always_fail(**kwargs):  # pylint: disable=unused-argument
+    """Always return False"""
+    return False
 
 
 class PostgresTest(unittest.TestCase):
@@ -50,6 +56,14 @@ class PostgresTest(unittest.TestCase):
         self.postgres.set_setup_fail_callback(correct_setup)
         self.postgres.determine_setup()
         self.assertTrue(self.postgres.pg_execute)
+
+    @mock.patch(
+        'aiida.control.postgres._try_connect', new=_try_connect_always_fail)
+    @mock.patch('aiida.control.postgres._try_subcmd')
+    def test_fallback_on_subcmd(self, try_subcmd):
+        """Ensure that accessing postgres via subcommand is tried if psychopg does not work."""
+        self._setup_postgres()
+        self.assertTrue(try_subcmd.call_count >= 1)
 
     def test_create_drop_db_user(self):
         """Check creating and dropping a user works"""


### PR DESCRIPTION
fix #966 

* Quicksetup now again falls back on psql subcommands if psychopg can not be used to connect.
* The error was in `control.postgres.Postgres.determine_setup` (Thanks to @ltalirz for finding it!)
* Regression test added in `control.tests.test_postgres`.