### PR TITLE
Improved error import exception tests

### DIFF
--- a/aiida/backends/testbase.py
+++ b/aiida/backends/testbase.py
@@ -161,7 +161,19 @@ def run_aiida_db_tests(tests_to_run, verbose=False):
 
         for modulename in modulenames:
             if modulename not in found_modulenames:
-                test_suite.addTest(test_loader.loadTestsFromName(modulename))
+                try:
+                    test_suite.addTest(test_loader.loadTestsFromName(modulename))
+                except AttributeError as exception:
+                    try:
+                        import importlib
+                        import traceback
+                        importlib.import_module(modulename)
+                    except ImportError as exception:
+                        print >> sys.stderr, (
+                            "[CRITICAL] The module '{}' has an import error and the tests cannot be run:\n{}"
+                            .format(modulename, traceback.format_exc(exception))
+                        )
+                        sys.exit(1)
                 found_modulenames.add(modulename)
 
         num_tests_expected = test_suite.countTestCases()


### PR DESCRIPTION
Fixes #953 

When attempting to load db tests through the `loadTestsFromName` of the
test loader that contained import errors, an `AttributeError` would be
thrown with the cryptic message

```
AttributeError: 'module' object has no attribute 'process'
```

To provide a more clear description of the problem we put the call to
load the tests in a try except block and catch the `AttributeError`.
If it is caught we attempt to import it, which should then trigger the
actual import error, which we then print to screen and exit
