### PR TITLE
Setting log level of Alembic to WARNING

### DIFF
--- a/aiida/common/setup.py
+++ b/aiida/common/setup.py
@@ -909,7 +909,7 @@ _property_table = {
         "logging_alembic_log_level",
         "string",
         "Minimum level to log to the console",
-        "INFO",
+        "WARNING",
         ["CRITICAL", "ERROR", "WARNING", "REPORT", "INFO", "DEBUG"]),
     "logging.sqlalchemy_loglevel": (
         "logging_sqlalchemy_loglevel",


### PR DESCRIPTION
This removes the unnecessary INFO log messages of Alembic to the console.