### PR TITLE
Filter expected log messages during testing

### DIFF
--- a/aiida/__init__.py
+++ b/aiida/__init__.py
@@ -27,6 +27,15 @@ __paper_short__ = """G. Pizzi et al., Comp. Mat. Sci 111, 218 (2016)."""
 LOG_LEVEL_REPORT = 23
 logging.addLevelName(LOG_LEVEL_REPORT, 'REPORT')
 
+
+# A logging filter that can be used to disable logging
+class NotInTestingFilter(logging.Filter):
+
+    def filter(self, record):
+        from aiida import settings
+        return not settings.TESTING_MODE
+
+
 # A sample logging configuration. The only tangible logging
 # performed by this configuration is to send an email to
 # the site admins on every HTTP 500 error when DEBUG=False.
@@ -45,11 +54,17 @@ LOGGING = {
             'datefmt': '%m/%d/%Y %I:%M:%S %p',
         },
     },
+    'filters': {
+        'testing': {
+            '()': NotInTestingFilter
+        }
+    },
     'handlers': {
         'console': {
             'level': 'DEBUG',
             'class': 'logging.StreamHandler',
             'formatter': 'halfverbose',
+            'filters': ['testing']
         },
         'dblogger': {
             # get_property takes the property from the config json file

--- a/aiida/backends/djsite/db/subtests/djangomigrations.py
+++ b/aiida/backends/djsite/db/subtests/djangomigrations.py
@@ -15,8 +15,6 @@ class CalcStateChanges(AiidaTestCase):
     # Class to check if the migration code that deals with removing the
     # NOTFOUND and UNDETERMINED calc states works properly
     def test_unexpected_calc_states(self):
-        import logging
-
         from django.utils import timezone
         from aiida.orm.calculation import Calculation
 
@@ -32,8 +30,7 @@ class CalcStateChanges(AiidaTestCase):
 
         calc_params = {
             'computer': self.computer,
-            'resources': {'num_machines': 1,
-                          'num_mpiprocs_per_machine': 1}
+            'resources': {'num_machines': 1, 'num_mpiprocs_per_machine': 1}
         }
 
         for state in ['NOTFOUND', 'UNDETERMINED']:
@@ -45,24 +42,8 @@ class CalcStateChanges(AiidaTestCase):
 
             time_before_fix = timezone.now()
 
-            # First of all, I re-enable logging in case it was disabled by
-            # mistake by a previous test (e.g. one that disables and reenables
-            # again, but that failed)
-            logging.disable(logging.NOTSET)
-            # Temporarily disable logging to the stream handler (i.e. screen)
-            # because otherwise fix_calc_states will print warnings
-            handler = next((h for h in logging.getLogger('aiida').handlers if
-                            isinstance(h, logging.StreamHandler)), None)
-
-            if handler:
-                original_level = handler.level
-                handler.setLevel(logging.ERROR)
-
             # Call the code that deals with updating these states
             state_change.fix_calc_states(None, None)
-
-            if handler:
-                handler.setLevel(original_level)
 
             current_state = job.get_state()
             self.assertNotEqual(current_state, state,

--- a/aiida/backends/djsite/db/subtests/djangomigrations.py
+++ b/aiida/backends/djsite/db/subtests/djangomigrations.py
@@ -10,11 +10,11 @@
 from aiida.backends.testbase import AiidaTestCase
 
 
-
 class CalcStateChanges(AiidaTestCase):
     # Class to check if the migration code that deals with removing the
     # NOTFOUND and UNDETERMINED calc states works properly
     def test_unexpected_calc_states(self):
+        import logging
         from django.utils import timezone
         from aiida.orm.calculation import Calculation
 

--- a/aiida/backends/djsite/utils.py
+++ b/aiida/backends/djsite/utils.py
@@ -8,7 +8,6 @@
 # For further information please visit http://www.aiida.net               #
 ###########################################################################
 
-import logging
 import os
 import django
 from aiida.utils.logger import get_dblogger_extra

--- a/aiida/backends/sqlalchemy/tests/migrations.py
+++ b/aiida/backends/sqlalchemy/tests/migrations.py
@@ -9,7 +9,6 @@
 ###########################################################################
 
 import copy
-import logging
 import unittest
 
 import os
@@ -49,8 +48,6 @@ class TestMigrationApplicationSQLA(AiidaTestCase):
     # The path of the migration configuration (the actual configuration - not
     # the testing)
     alembic_dpath = None
-    # The initial alembic log level - to be restored after the testing
-    init_alemb_log_level = ''
 
     @classmethod
     def setUpClass(cls, *args, **kwargs):
@@ -59,15 +56,10 @@ class TestMigrationApplicationSQLA(AiidaTestCase):
             os.path.realpath(utils.__file__))
 
     def setUp(self):
-        self.init_alemb_log_level = get_property('logging.alembic_loglevel')
-        set_property('logging.alembic_loglevel',
-                     logging.getLevelName(logging.ERROR))
         self.migrate_db_with_non_testing_migrations("base")
 
     def tearDown(self):
         self.migrate_db_with_non_testing_migrations("head")
-        set_property('logging.alembic_loglevel',
-                     logging.getLevelName(self.init_alemb_log_level))
 
     def migrate_db_with_non_testing_migrations(self, destination):
         if destination not in ["head", "base"]:

--- a/aiida/backends/tests/backup_script.py
+++ b/aiida/backends/tests/backup_script.py
@@ -199,11 +199,7 @@ class TestBackupScriptUnit(AiidaTestCase):
         In the parsed JSON string, the endDateOfBackup & daysToBackuplimit
         are set which should lead to an exception.
         """
-        import logging
         from aiida.common.additions.backup_script.backup_base import BackupError
-
-        # Disable the logging messages
-        logging.disable(logging.ERROR)
 
         backup_variables = json.loads(self._json_test_input_5)
         self._backup_setup_inst._ignore_backup_dir_existence_check = True
@@ -211,9 +207,6 @@ class TestBackupScriptUnit(AiidaTestCase):
         # & daysToBackuplimit have been defined in the same time.
         with self.assertRaises(BackupError):
             self._backup_setup_inst._read_backup_info_from_dict(backup_variables)
-
-        # Enable the logging messages
-        logging.disable(logging.NOTSET)
 
     def check_full_deserialization_serialization(self, input_string, backup_inst):
         input_variables = json.loads(input_string)
@@ -274,10 +267,6 @@ class TestBackupScriptUnit(AiidaTestCase):
         that don't have a timezone. Moreover, it checks if the given directory
         paths are normalized as expected.
         """
-        import logging
-
-        # Disable the logging messages
-        logging.disable(logging.INFO)
 
         backup_variables = json.loads(self._json_test_input_6)
         self._backup_setup_inst._ignore_backup_dir_existence_check = True
@@ -305,9 +294,6 @@ class TestBackupScriptUnit(AiidaTestCase):
             "_backup_setup_inst destination directory is "
             "not normalized as expected.")
 
-        # Enable the logging messages
-        logging.disable(logging.NOTSET)
-
 
 class TestBackupScriptIntegration(AiidaTestCase):
 
@@ -318,11 +304,7 @@ class TestBackupScriptIntegration(AiidaTestCase):
     _bs_instance = backup_setup.BackupSetup()
 
     def test_integration(self):
-        import logging
         from aiida.utils.capturing import Capturing
-
-        # Disable the logging messages
-        logging.disable(logging.INFO)
 
         # Fill in the repository with data
         self.fill_repo()
@@ -358,9 +340,6 @@ class TestBackupScriptIntegration(AiidaTestCase):
                             "to the original one.")
         finally:
             shutil.rmtree(temp_folder, ignore_errors=True)
-
-            # Enable the logging messages
-            logging.disable(logging.NOTSET)
 
     def fill_repo(self):
         from aiida.orm import JobCalculation, CalculationFactory, Data, DataFactory

--- a/aiida/backends/tests/daemon.py
+++ b/aiida/backends/tests/daemon.py
@@ -51,7 +51,7 @@ class TestDaemonBasic(AiidaTestCase):
 
         # Killing the head workflow
         wf_cmd = WfCmd()
-        wf_cmd.workflow_kill(*[str(head_wf.pk), "-f"])
+        wf_cmd.workflow_kill(*[str(head_wf.pk), '-f', '-q'])
 
         # At this point no running workflow should be found
         running_no = 0

--- a/aiida/backends/tests/daemon.py
+++ b/aiida/backends/tests/daemon.py
@@ -19,16 +19,6 @@ from aiida.workflows.test import WFTestSimpleWithSubWF
 
 class TestDaemonBasic(AiidaTestCase):
 
-    def setUp(self):
-        super(TestDaemonBasic, self).setUp()
-        import logging
-        logging.disable(logging.CRITICAL)
-
-    def tearDown(self):
-        super(TestDaemonBasic, self).tearDown()
-        import logging
-        logging.disable(logging.NOTSET)
-
     def test_workflow_fast_kill(self):
         from aiida.cmdline.commands.workflow import Workflow as WfCmd
 

--- a/aiida/backends/tests/orm/log.py
+++ b/aiida/backends/tests/orm/log.py
@@ -137,16 +137,6 @@ class TestBackendLog(AiidaTestCase):
         # Make sure that global logging is not accidentally disabled
         logging.disable(logging.NOTSET)
 
-        # # Temporarily disable logging to the stream handler (i.e. screen)
-        # # because otherwise fix_calc_states will print warnings
-        # handler = next((h for h in logging.getLogger('aiida').handlers if
-        #                 isinstance(h, logging.StreamHandler)), None)
-
-        # # try:
-        # if handler:
-        #     original_level = handler.level
-        #     handler.setLevel(logging.CRITICAL + 1)
-
         # Firing a log for an unstored should not end up in the database
         calc.logger.critical(message)
 
@@ -161,7 +151,3 @@ class TestBackendLog(AiidaTestCase):
 
         self.assertEquals(len(logs), 1)
         self.assertEquals(logs[0].message, message)
-
-        # finally:
-        #     if handler:
-        #         handler.setLevel(original_level)

--- a/aiida/backends/tests/orm/log.py
+++ b/aiida/backends/tests/orm/log.py
@@ -134,9 +134,6 @@ class TestBackendLog(AiidaTestCase):
         message = 'Testing logging of critical failure'
         calc = Calculation()
 
-        # Make sure that global logging is not accidentally disabled
-        logging.disable(logging.NOTSET)
-
         # Firing a log for an unstored should not end up in the database
         calc.logger.critical(message)
 

--- a/aiida/backends/tests/work/workChain.py
+++ b/aiida/backends/tests/work/workChain.py
@@ -387,15 +387,6 @@ class TestWorkchain(AiidaTestCase):
 
 
 class TestWorkchainWithOldWorkflows(AiidaTestCase):
-    def setUp(self):
-        super(TestWorkchainWithOldWorkflows, self).setUp()
-        import logging
-        logging.disable(logging.CRITICAL)
-
-    def tearDown(self):
-        super(TestWorkchainWithOldWorkflows, self).tearDown()
-        import logging
-        logging.disable(logging.NOTSET)
 
     def test_call_old_wf(self):
         wf = WorkflowDemo()

--- a/aiida/backends/tests/workflows.py
+++ b/aiida/backends/tests/workflows.py
@@ -207,13 +207,6 @@ class TestWorkflowBasic(AiidaTestCase):
             # mistake by a previous test (e.g. one that disables and reenables
             # again, but that failed)
             logging.disable(logging.NOTSET)
-            # Temporarily disable logging to the stream handler (i.e. screen)
-            # because otherwise fix_calc_states will print warnings
-            handler = next((h for h in logging.getLogger('aiida').handlers if
-                            isinstance(h, logging.StreamHandler)), None)
-            if handler:
-                original_level = handler.level
-                handler.setLevel(logging.ERROR)
 
             # Testing the error propagation of a simple workflow
             wf = FailingWFTestSimple()
@@ -238,8 +231,7 @@ class TestWorkflowBasic(AiidaTestCase):
                 self.assertLess(step_no, 5, "This workflow should have stopped "
                                             "since it is failing")
         finally:
-            if handler:
-                handler.setLevel(original_level)
+            pass
 
     def test_result_parameter_name_colision(self):
         """

--- a/aiida/backends/tests/workflows.py
+++ b/aiida/backends/tests/workflows.py
@@ -197,17 +197,11 @@ class TestWorkflowBasic(AiidaTestCase):
         sub-workflows) that has an exception at one of its steps stops
         properly and it is not left as RUNNING.
         """
-        import logging
         from aiida.daemon.workflowmanager import execute_steps
         from aiida.workflows.test import (FailingWFTestSimple,
                                           FailingWFTestSimpleWithSubWF)
 
         try:
-            # First of all, I re-enable logging in case it was disabled by
-            # mistake by a previous test (e.g. one that disables and reenables
-            # again, but that failed)
-            logging.disable(logging.NOTSET)
-
             # Testing the error propagation of a simple workflow
             wf = FailingWFTestSimple()
             wf.store()

--- a/aiida/cmdline/commands/devel.py
+++ b/aiida/cmdline/commands/devel.py
@@ -493,6 +493,9 @@ class Devel(VerdiCommandWithSubcommands):
         from aiida.backends import settings
         from aiida.backends.testbase import run_aiida_db_tests
         from aiida.backends.testbase import check_if_tests_can_run
+        from aiida import settings
+
+        settings.TESTING_MODE = True
 
         # For final summary
         test_failures = []

--- a/aiida/cmdline/commands/workflow.py
+++ b/aiida/cmdline/commands/workflow.py
@@ -134,6 +134,7 @@ class Workflow(VerdiCommandWithSubcommands):
 
         Pass a list of workflow PKs to kill them.
         If you also pass the -f option, no confirmation will be asked.
+        If you pass the -q option, additional information will be suppressed
         """
         from aiida.backends.utils import load_dbenv, is_dbenv_loaded
         if not is_dbenv_loaded():
@@ -145,6 +146,7 @@ class Workflow(VerdiCommandWithSubcommands):
         from aiida.orm.workflow import WorkflowKillError, WorkflowUnkillable
 
         force = False
+        verbose = True
         wfs = []
 
         args = list(args)
@@ -153,6 +155,8 @@ class Workflow(VerdiCommandWithSubcommands):
             param = args.pop()
             if param == '-f':
                 force = True
+            elif param == '-q':
+                verbose = False
             else:
                 try:
                     wfs.append(int(param))
@@ -177,7 +181,7 @@ class Workflow(VerdiCommandWithSubcommands):
         counter = 0
         for wf_pk in wfs:
             try:
-                kill_from_pk(wf_pk, verbose=True)
+                kill_from_pk(wf_pk, verbose=verbose)
                 counter += 1
             except NotExistent:
                 print >> sys.stderr, ("WARNING: workflow {} "
@@ -192,8 +196,9 @@ class Workflow(VerdiCommandWithSubcommands):
                 sys.stdout.write("{}: {}\n".format(e.__class__.__name__,
                                                    e.message))
 
-        print >> sys.stderr, "{} workflow{} killed.".format(counter,
-                                                            "" if counter <= 1 else "s")
+        if verbose:
+            print >> sys.stderr, "{} workflow{} killed.".format(counter,
+                                                                "" if counter <= 1 else "s")
 
     def print_logshow(self, *args):
         from aiida.backends.utils import load_dbenv, is_dbenv_loaded

--- a/aiida/common/additions/backup_script/backup_base.py
+++ b/aiida/common/additions/backup_script/backup_base.py
@@ -82,7 +82,7 @@ class AbstractBackup(object):
             format='%(asctime)s %(name)-12s %(levelname)-8s %(message)s')
 
         # The logger of the backup script
-        self._logger = logging.getLogger("aiida_backup")
+        self._logger = logging.getLogger('aiida.aiida_backup')
 
     def _read_backup_info_from_file(self, backup_info_file_name):
         """

--- a/aiida/settings.py
+++ b/aiida/settings.py
@@ -7,20 +7,16 @@
 # For further information on the license, see the LICENSE.txt file        #
 # For further information please visit http://www.aiida.net               #
 ###########################################################################
-
 import os
-
-
 from aiida.backends import settings
-
 from aiida.common.exceptions import ConfigurationError
 from aiida.common.setup import (get_config, get_secret_key, get_property,
                                 get_profile_config, get_default_profile,
                                 parse_repository_uri)
 
 
-
 USE_TZ = True
+TESTING_MODE = False
 
 try:
     confs = get_config()


### PR DESCRIPTION
Fixes #1013 

Add a filter to the aiida.console StreamHandler to suppress logs during testing
    
Many tests require the logging of messages to test the functionality
but these messages are not actually required to be read in the
test output and rather just clutter the output and obscure the
actually important error messages.
    
We add a filter to the console StreamHandler of the aiida logger
which based on the value of the TESTING_MODE setting will suppress
the log record or not. This setting is defined in aiida.settings
and is False by default. In the run_tests method of the verdi devel
command we import the setting and set it to True. This will cause
the filter to swallow all non-important log messages.
Doing this in the run_tests method guarantees that this filter is
only active during the call of verdi devel tests