### PR TITLE
Improve and fix issues with the plugin loader tests

### DIFF
--- a/aiida/backends/tests/test_plugin_loader.py
+++ b/aiida/backends/tests/test_plugin_loader.py
@@ -36,19 +36,20 @@ class TestExistingPlugins(AiidaTestCase):
         calculations = all_plugins('calculations')
         self.assertIsInstance(calculations, list)
         for i in calculations:
-            self.assertTrue(
-                issubclass(CalculationFactory(i), JobCalculation),
-                'Calculation plugin class {} is not subclass of JobCalculation'.format(
-                    CalculationFactory(i)))
+            cls = CalculationFactory(i)
+            self.assertTrue(issubclass(cls, JobCalculation),
+                'Calculation plugin class {} is not subclass of {}'.format(cls, JobCalculation))
 
     def test_existing_data(self):
         """
-        Test listing all preinstalled data formats
+        Test listing all preinstalled data classes
         """
         data = all_plugins('data')
         self.assertIsInstance(data, list)
         for i in data:
-            self.assertTrue(issubclass(DataFactory(i), Data))
+            cls = DataFactory(i)
+            self.assertTrue(issubclass(cls, Data),
+                'Data plugin class {} is not subclass of {}'.format(cls, Data))
 
     def test_existing_schedulers(self):
         """
@@ -57,7 +58,9 @@ class TestExistingPlugins(AiidaTestCase):
         schedulers = all_plugins('schedulers')
         self.assertIsInstance(schedulers, list)
         for i in schedulers:
-            self.assertTrue(issubclass(SchedulerFactory(i), Scheduler))
+            cls = SchedulerFactory(i)
+            self.assertTrue(issubclass(cls, Scheduler),
+                'Scheduler plugin class {} is not subclass of {}'.format(cls, Scheduler))
 
     def test_existing_transports(self):
         """
@@ -66,7 +69,9 @@ class TestExistingPlugins(AiidaTestCase):
         transports = all_plugins('transports')
         self.assertIsInstance(transports, list)
         for i in transports:
-            self.assertTrue(issubclass(TransportFactory(i), Transport))
+            cls = TransportFactory(i)
+            self.assertTrue(issubclass(cls, Transport),
+                'Transport plugin class {} is not subclass of {}'.format(cls, Transport))
 
     def test_existing_workflows(self):
         """
@@ -75,7 +80,9 @@ class TestExistingPlugins(AiidaTestCase):
         workflows = all_plugins('workflows')
         self.assertIsInstance(workflows, list)
         for i in workflows:
-            self.assertTrue(issubclass(WorkflowFactory(i), (Workflow, WorkChain)))
+            cls = WorkflowFactory(i)
+            self.assertTrue(issubclass(cls, (Workflow, WorkChain)),
+                'Workflow plugin class {} is neither a subclass of {} nor {}'.format(cls, Workflow, WorkChain))
 
     def test_existing_tcod_plugins(self):
         """

--- a/aiida/backends/tests/test_plugin_loader.py
+++ b/aiida/backends/tests/test_plugin_loader.py
@@ -11,6 +11,7 @@ from aiida.backends.testbase import AiidaTestCase
 from aiida.common.pluginloader import all_plugins
 from aiida.orm import CalculationFactory, DataFactory, WorkflowFactory
 from aiida.orm import Workflow
+from aiida.parsers import Parser, ParserFactory
 from aiida.orm.data import Data
 from aiida.orm import JobCalculation
 from aiida.scheduler import Scheduler, SchedulerFactory
@@ -48,6 +49,17 @@ class TestExistingPlugins(AiidaTestCase):
             cls = DataFactory(i)
             self.assertTrue(issubclass(cls, Data),
                 'Data plugin class {} is not subclass of {}'.format(cls, Data))
+
+    def test_existing_parsers(self):
+        """
+        Test listing all preinstalled parsers
+        """
+        parsers = all_plugins('parsers')
+        self.assertIsInstance(parsers, list)
+        for i in parsers:
+            cls = ParserFactory(i)
+            self.assertTrue(issubclass(cls, Parser),
+                'Parser plugin class {} is not subclass of {}'.format(cls, Parser))
 
     def test_existing_schedulers(self):
         """

--- a/aiida/backends/tests/test_plugin_loader.py
+++ b/aiida/backends/tests/test_plugin_loader.py
@@ -10,15 +10,13 @@
 from aiida.backends.testbase import AiidaTestCase
 from aiida.common.pluginloader import all_plugins
 from aiida.orm import CalculationFactory, DataFactory, WorkflowFactory
-from aiida.scheduler import SchedulerFactory
-from aiida.transport import TransportFactory
 from aiida.orm import Workflow
 from aiida.orm.data import Data
 from aiida.orm import JobCalculation
+from aiida.scheduler import Scheduler, SchedulerFactory
+from aiida.transport import Transport, TransportFactory
+from aiida.tools.dbexporters.tcod_plugins import BaseTcodtranslator, TcodExporterFactory
 from aiida.work import WorkChain
-from aiida.scheduler import Scheduler
-from aiida.tools.dbexporters.tcod_plugins import BaseTcodtranslator
-from aiida.transport import Transport
 
 
 class TestExistingPlugins(AiidaTestCase):
@@ -88,5 +86,9 @@ class TestExistingPlugins(AiidaTestCase):
         """
         Test listing all preinstalled tcod exporter plugins
         """
-        tcod_plugins = all_plugins('transports')
+        tcod_plugins = all_plugins('tools.dbexporters.tcod_plugins')
         self.assertIsInstance(tcod_plugins, list)
+        for i in tcod_plugins:
+            cls = TcodExporterFactory(i)
+            self.assertTrue(issubclass(cls, BaseTcodtranslator),
+                'TcodExporter plugin class {} is not subclass of {}'.format(cls, BaseTcodtranslator))

--- a/aiida/backends/tests/test_plugin_loader.py
+++ b/aiida/backends/tests/test_plugin_loader.py
@@ -15,6 +15,7 @@ from aiida.transport import TransportFactory
 from aiida.orm import Workflow
 from aiida.orm.data import Data
 from aiida.orm import JobCalculation
+from aiida.work import WorkChain
 from aiida.scheduler import Scheduler
 from aiida.tools.dbexporters.tcod_plugins import BaseTcodtranslator
 from aiida.transport import Transport
@@ -74,7 +75,7 @@ class TestExistingPlugins(AiidaTestCase):
         workflows = all_plugins('workflows')
         self.assertIsInstance(workflows, list)
         for i in workflows:
-            self.assertTrue(issubclass(WorkflowFactory(i), Workflow))
+            self.assertTrue(issubclass(WorkflowFactory(i), (Workflow, WorkChain)))
 
     def test_existing_tcod_plugins(self):
         """

--- a/aiida/common/pluginloader.py
+++ b/aiida/common/pluginloader.py
@@ -27,7 +27,7 @@ from aiida.common.exceptions import LoadingPluginFailed, MissingPluginError
 _category_mapping = {
     'calculations': 'aiida.orm.calculation.job',
     'data': 'aiida.orm.data',
-    'parsers': 'aiida.parsers.plugins',
+    'parsers': 'aiida.parsers',
     'schedulers': 'aiida.scheduler.plugins',
     'transports': 'aiida.transport.plugins',
     'workflows': 'aiida.workflows',

--- a/aiida/parsers/__init__.py
+++ b/aiida/parsers/__init__.py
@@ -18,4 +18,4 @@ def ParserFactory(module):
     from aiida.common.pluginloader import BaseFactory
     from aiida.common.exceptions import MissingPluginError
 
-    return BaseFactory(module, Parser, 'aiida.parsers.plugins')
+    return BaseFactory(module, Parser, 'aiida.parsers')

--- a/aiida/tools/dbexporters/tcod_plugins/__init__.py
+++ b/aiida/tools/dbexporters/tcod_plugins/__init__.py
@@ -9,6 +9,15 @@
 ###########################################################################
 
 
+def TcodExporterFactory(module):
+    """
+    Return a suitable BaseTcodtranslator subclass.
+    """
+    from aiida.common.pluginloader import BaseFactory
+
+    return BaseFactory(module, BaseTcodtranslator, 'aiida.tools.dbexporters.tcod_plugins')
+
+
 class BaseTcodtranslator(object):
     """
     Base translator from calculation-specific input and output parameters


### PR DESCRIPTION
Fixes #1023 

This addresses the main problem that was outlined in the original issue but I also addressed some other problems:

* Added the `WorkChain` class as acceptable subclass for plugins in `aiida.workflows` entry point
* Added assertion error messages to all tests
* Implemented a `TcodExporterFactory` and added the same plugin loading tests for `aiida.tools.dbexporters.tcod_plugins` as for the other entry points
* Updated the `aiida.parsers` entry point mapping to remove the superfluous `.plugins` suffix and updated the `ParserFactory` accordingly
* Added plugin loading tests for the `aiida.parsers` entry point
