### PR TITLE
Print stack trace after catching ImportError upon entrypoint.load()

### DIFF
--- a/aiida/common/pluginloader.py
+++ b/aiida/common/pluginloader.py
@@ -118,8 +118,10 @@ def get_plugin(category, name):
 
     try:
         plugin = entrypoint.load()
-    except ImportError:
-        raise LoadingPluginFailed("Loading the plugin '{}' failed".format(name))
+    except ImportError as exception:
+        import traceback
+        raise LoadingPluginFailed("Loading the plugin '{}' failed:\n{}"
+            .format(name, traceback.format_exc()))
 
     return plugin
 


### PR DESCRIPTION
Fixes #1019 

The exception handling of the caught ImportError when calling
entrypoint.load() in the get_plugin() method caused the original
ImportError to be swallowed and just raised the LoadingPluginFailed.
We now also print the stack trace of the ImportError so that the
user knows why the loading of the plugin failed.