### PR TITLE
add subcommand tab completion for data plugin commands

### DIFF
--- a/aiida/cmdline/baseclass.py
+++ b/aiida/cmdline/baseclass.py
@@ -7,7 +7,7 @@
 # For further information on the license, see the LICENSE.txt file        #
 # For further information please visit http://www.aiida.net               #
 ###########################################################################
-
+import click
 
 
 class VerdiCommand(object):
@@ -146,8 +146,16 @@ class VerdiCommandRouter(VerdiCommand):
                 first_subarg = ''
 
             try:
-                complete_function = self.routed_subcommands[
-                    first_subarg]().complete
+                cmd_or_class = self.routed_subcommands[first_subarg]
+                if isinstance(cmd_or_class, (click.Command, click.MultiCommand)):
+                    import sys
+                    from aiida.cmdline.commands import click_subcmd_complete
+
+                    for i in sys.argv[4:len(sys.argv)-1]:
+                        cmd_or_class = cmd_or_class.commands[i]
+                    complete_function = click_subcmd_complete(cmd_or_class)
+                else:
+                    complete_function = cmd_or_class().complete
             except KeyError:
                 print ""
                 return

--- a/aiida/cmdline/commands/__init__.py
+++ b/aiida/cmdline/commands/__init__.py
@@ -11,10 +11,27 @@ import click
 from click_plugins import with_plugins
 
 
+def click_subcmd_complete(cmd_group):
+    def complete(subargs_idx, subargs):
+        if subargs_idx >= 1:
+            return None
+        incomplete = subargs[-1]
+        print '\n'.join(cmd_group.list_commands({'parameters': [incomplete]}))
+    return complete
+
+
 @click.group()
 @click.option('--profile', '-p')
 def verdi(profile):
     pass
+
+
+@verdi.command()
+@click.argument('completion_args', nargs=-1, type=click.UNPROCESSED)
+def completion(completion_args):
+    from aiida.cmdline.verdilib import Completion
+    Completion().run(*completion_args)
+
 
 @verdi.group()
 def export():

--- a/aiida/cmdline/commands/__init__.py
+++ b/aiida/cmdline/commands/__init__.py
@@ -12,7 +12,9 @@ from click_plugins import with_plugins
 
 
 def click_subcmd_complete(cmd_group):
+    """Create a subcommand completion function for a click command group."""
     def complete(subargs_idx, subargs):
+        """List valid subcommands for a command group that start with the last subarg."""
         if subargs_idx >= 1:
             return None
         incomplete = subargs[-1]
@@ -23,12 +25,28 @@ def click_subcmd_complete(cmd_group):
 @click.group()
 @click.option('--profile', '-p')
 def verdi(profile):
+    """
+    Toplevel command for click-implemented verdi commands.
+
+    Might eventually replace ``execute_from_cmdline``, however, there is no way to directly call this command from the commandline
+    currently. Instead, it is used for subcommand routing of commands written in click, see aiida/cmdline/commands/work.py for an
+    example. In short it exists, so the name by which the subcommand is called ('verdi something something') matches it's command
+    group hierarchy (group ``verdi``, subgroup ``something``, command ``something``).
+
+    """
     pass
 
 
 @verdi.command()
 @click.argument('completion_args', nargs=-1, type=click.UNPROCESSED)
 def completion(completion_args):
+    """
+    Completion command alias for click-implemented verdi commands.
+
+    Due to the roundabout process by which click-implemented verdi commands are called, pressing <Tab><Tab> on one of them tries to
+    call aiida.cmdline.commands.verdi with subcommand completion. Therefore in order to enable the same behaviour as on older commands,
+    such a subcommand with the same signature must exist and must run the same code with the same arguments.
+    """
     from aiida.cmdline.verdilib import Completion
     Completion().run(*completion_args)
 


### PR DESCRIPTION
I am not sure if this should be in the release but it makes the recently added data plugin commands more user friendly, usage example:

```
$ verdi data mydata <Tab>
export list show
$ verdi data mydata ex<Tab> # will complete to export
```

The way it works is by inserting code in the current completion system that recognizes click commands and treats them specially:

All click type commands are actually invoked by invoking aiida.cmdline.commands.verdi (a click group).
Therefore I had to use sys.argv in the completion code to find the class of the actual subcommands in order to create a completion function for it using the `.listcommands` functionality that all `click.MultiCommands` have.

It may look hackish but I don't see a much cleaner way without changing more about how the current completion system works.