### PR TITLE
Docs addition: old-style workflows not supported by plugin system

### DIFF
--- a/docs/source/developer_guide/plugins/entry_points.rst
+++ b/docs/source/developer_guide/plugins/entry_points.rst
@@ -186,6 +186,11 @@ Usage::
    from aiida.orm import WorkflowFactory
    wf = WorkflowFactory('mycode.mywf')
 
+.. note:: For old-style workflows the entry point mechanism of the plugin system is not supported. 
+   Therefore one cannot load these workflows with the ``WorkflowFactory``.
+   The only way to run these, is to store their source code in the ``aiida/workflows/user`` directory and use normal python imports to load the classes.
+
+
 ``aiida.cmdline``
 -----------------
 


### PR DESCRIPTION
Fixes #594 

There is an issue with loading an old-style workflow through the
plugin system with the WorkflowFactory. There is a check in the
constructor of the Workflow class, that will check whether the
class is located in the 'aiida.workflows' module:

```
if caller_module == None or not caller_module.__name__.startswith("aiida.workflows"):
    raise SystemError("The superclass can't be called directly")
```

The whole point of the plugin system is of course that subclasses
do not necessarily have to live in that module. Rather than removing
the conditional, we chose to leave it and not support old-style
workflows for the new plugin system. Since they will be soon deprecated
and no longer maintainted, doing so would give the wrong signal.

Rather, we add a note to the developer documentation in the plugin
system section, that old-style workflows are not supported