### PR TITLE
Update sphinx_rtd_theme to 0.2.5b2 to fix line numbers of code snippets in docs

### DIFF
--- a/setup_requirements.py
+++ b/setup_requirements.py
@@ -102,7 +102,7 @@ extras_require = {
         'Jinja2==2.9.5',
         'MarkupSafe==0.23',
         # Required by readthedocs
-        'sphinx-rtd-theme==0.1.9',
+        'sphinx-rtd-theme==0.2.5b2',
     ],
     # Requirements for non-core funciontalities that rely on external atomic
     # manipulation/processing software


### PR DESCRIPTION
Fixes #1041 

To correct the appearance of line numbers in the documentation I
updated the sphinx_rtd_theme to the latest version (0.2.5b2). The bug
was fixed in the version 0.2.5b1
