### PR TITLE
Implement verdi command: verdi work plugins

### DIFF
--- a/aiida/cmdline/commands/work.py
+++ b/aiida/cmdline/commands/work.py
@@ -36,11 +36,26 @@ class Work(VerdiCommandWithSubcommands):
             'tree': (self.cli, self.complete_none),
             'checkpoint': (self.cli, self.complete_none),
             'kill': (self.cli, self.complete_none),
-            'plugins': (self.cli, self.complete_none),
+            'plugins': (self.cli, self.complete_plugins),
         }
 
     def cli(self, *args):
         verdi()
+
+    def complete_plugins(self, subargs_idx, subargs):
+        """
+        Return the list of plugins registered under the 'workflows' category
+        """
+        from aiida import try_load_dbenv
+        try_load_dbenv()
+
+        from aiida.common.pluginloader import plugin_list
+
+        plugins = sorted(plugin_list('workflows'))
+        # Do not return plugins that are already on the command line
+        other_subargs = subargs[:subargs_idx] + subargs[subargs_idx + 1:]
+        return_plugins = [_ for _ in plugins if _ not in other_subargs]
+        return "\n".join(return_plugins)
 
 
 @work.command('list', context_settings=CONTEXT_SETTINGS)

--- a/aiida/work/workchain.py
+++ b/aiida/work/workchain.py
@@ -511,19 +511,19 @@ class _Block(_Instruction):
         return self.Stepper(workflow, self._commands)
 
     @override
-    def get_description(self):
+    def get_description(self, indent_level=0, indent_increment=4):
+        indent = ' ' * (indent_level * indent_increment)
         desc = []
         for c in self._commands:
             if isinstance(c, _Instruction):
                 desc.append(c.get_description())
             else:
+                desc.append('{}* {}'.format(indent, c.__name__))
                 if c.__doc__:
-                    doc = "\n" + c.__doc__
-                    doc.replace('\n', '    \n')
-                    desc.append("::\n{}\n::".format(doc))
-                desc.append(c.__name__)
+                    doc = c.__doc__
+                    desc.append('{}{}'.format(indent,doc))
 
-        return "\n".join(desc)
+        return '\n'.join(desc)
 
 
 class _Conditional(object):
@@ -653,13 +653,11 @@ class _If(_Instruction):
 
     @override
     def get_description(self):
-        description = [
-            "if {}:\n{}".format(
-                self._ifs[0].condition.__name__, self._ifs[0].body)]
+        description = ['if {}:\n{}'.format(self._ifs[0].condition.__name__, self._ifs[0].body.get_description(indent_level=1))]
         for conditional in self._ifs[1:]:
-            description.append("elif {}:\n{}".format(
-                conditional.condition.__name__, conditional.body))
-        return "\n".join(description)
+            description.append('elif {}:\n{}'.format(
+                conditional.condition.__name__, conditional.body.get_description(indent_level=1)))
+        return '\n'.join(description)
 
 
 class _While(_Conditional, _Instruction):
@@ -729,7 +727,7 @@ class _While(_Conditional, _Instruction):
 
     @override
     def get_description(self):
-        return "while {}:\n{}".format(self.condition.__name__, self.body)
+        return "while {}:\n{}".format(self.condition.__name__, self.body.get_description(indent_level=1))
 
 
 class _PropagateReturn(BaseException):

--- a/docs/source/verdi/verdi_user_guide.rst
+++ b/docs/source/verdi/verdi_user_guide.rst
@@ -4,25 +4,26 @@ The ``verdi`` commands
 
 For some of the most common operations in AiiDA, you can work directly from the command line using the a set of ``verdi`` commands. You already used ``verdi install`` when installing the software. There are quite some more functionalities attached to this command; here's a list:
 
-* :ref:`calculation<calculation>`:				query and interact with calculations
-* :ref:`code<code>`:                			setup and manage codes to be used
-* :ref:`comment<comment>`:          			manage general properties of nodes in the database
-* :ref:`completioncommand<completioncommand>`:	return the bash completion function to put in ~/.bashrc
-* :ref:`computer<computer>`:            		setup and manage computers to be used
-* :ref:`daemon<daemon>`:              			manage the AiiDA daemon
-* :ref:`data<data>`:                			setup and manage data specific types
-* :ref:`devel<devel>`:               			AiiDA commands for developers
-* :ref:`export<export>`:              			export nodes and group of nodes
-* :ref:`graph<graph>`:                    create a graph from a given root node
-* :ref:`group<group>`:               			setup and manage groups
-* :ref:`import<import>`:              			export nodes and group of nodes
-* :ref:`install<install>`:             			install/setup aiida for the current user/create a new profile
-* :ref:`node<node>`:                			manage operations on AiiDA nodes
-* :ref:`profile<profile>`:                		list and manage AiiDA profiles
-* :ref:`run<run>`:                  			execute an AiiDA script
-* :ref:`shell<shell>`:               			run the interactive shell with the Django environment
-* :ref:`user<user>`:                			list and configure new AiiDA users.
-* :ref:`workflow<workflow>`:            		manage the AiiDA worflow manager
+* :ref:`calculation<calculation>`:              query and interact with calculations
+* :ref:`code<code>`:                            setup and manage codes to be used
+* :ref:`comment<comment>`:                      manage general properties of nodes in the database
+* :ref:`completioncommand<completioncommand>`:  return the bash completion function to put in ~/.bashrc
+* :ref:`computer<computer>`:                    setup and manage computers to be used
+* :ref:`daemon<daemon>`:                        manage the AiiDA daemon
+* :ref:`data<data>`:                            setup and manage data specific types
+* :ref:`devel<devel>`:                          AiiDA commands for developers
+* :ref:`export<export>`:                        export nodes and group of nodes
+* :ref:`graph<graph>`:                          create a graph from a given root node
+* :ref:`group<group>`:                          setup and manage groups
+* :ref:`import<import>`:                        export nodes and group of nodes
+* :ref:`install<install>`:                      install/setup aiida for the current user/create a new profile
+* :ref:`node<node>`:                            manage operations on AiiDA nodes
+* :ref:`profile<profile>`:                      list and manage AiiDA profiles
+* :ref:`run<run>`:                              execute an AiiDA script
+* :ref:`shell<shell>`:                          run the interactive shell with the Django environment
+* :ref:`user<user>`:                            list and configure new AiiDA users.
+* :ref:`work<work>`:                            manage the AiiDA worflow manager
+* :ref:`workflow<workflow>`:                    manage the AiiDA legacy worflow manager
 
 
 Each command above can be preceded by the ``-p <profile>`` or ``--profile=<profile>``
@@ -371,15 +372,27 @@ Manages the AiiDA users. Two valid subcommands.
   *  **list**: list existing users configured for your AiiDA installation.
   *  **configure**: configure a new AiiDA user.
 
+.. _work:
+
+``verdi work``
+++++++++++++++++++
+Manage workflows, valid subcommands:
+
+  * **checkpoint**: display the last recorded checkpoint of a workflow
+  * **kill**: kill a workflow
+  * **list**: list the workflows present in the database
+  * **plugins**: show the registered workflow plugins
+  * **report**: show the log messages for a workflow
+  * **tree**: shows an ASCII tree for a workflow
+
 
 .. _workflow:
 
 ``verdi workflow``
 ++++++++++++++++++
-Manages the workflow. Valid subcommands:
+Manage legacy workflows, valid subcommands:
 
-  * **report**: display the information on how the workflow is evolving.
-  * **kill**: kills a workflow.
-  * **list**: lists the workflows present in the database. By default, shows only the running ones. 
-  * **logshow**: shows the log messages for the workflow.
-
+  * **report**: display the information on how the workflow is evolving
+  * **kill**: kills a workflow
+  * **list**: lists the workflows present in the database. By default, shows only the running ones
+  * **logshow**: shows the log messages for the workflow


### PR DESCRIPTION
Fixes #1048 

Implemented the command `verdi work plugins`
This verdi command will show all the registered entry points for the
workflow category, considering only those installed through the plugin
system. This means that old-style workflows are not included. Passing
the entry point as an argument will show detailed information about
the workflow registered at the entry point