### PR TITLE
Fix #132 - CIF syntax errors from PyCifRW - upgrade to PyCifRW 4.2.1

### DIFF
--- a/aiida/backends/tests/dataclasses.py
+++ b/aiida/backends/tests/dataclasses.py
@@ -1480,6 +1480,7 @@ class TestStructureData(AiidaTestCase):
         Tests the conversion to CifData
         """
         from aiida.orm.data.structure import StructureData
+        import re
 
         a = StructureData(cell=((2., 0., 0.), (0., 2., 0.), (0., 0., 2.)))
 
@@ -1492,20 +1493,13 @@ class TestStructureData(AiidaTestCase):
         # Exception thrown if ase can't be found
         except ImportError:
             return
-        self.assertEquals(simplify(c._prepare_cif()[0]),
-                          simplify("""#\#CIF1.1
-##########################################################################
-#               Crystallographic Information Format file
-#               Produced by PyCifRW module
-#
-#  This is a CIF file.  CIF has been adopted by the International
-#  Union of Crystallography as the standard for data archiving and
-#  transmission.
-#
-#  For information on this file format, follow the CIF links at
-#  http://www.iucr.org
-##########################################################################
-
+        lines = c._prepare_cif()[0].split('\n')
+        non_comments = []
+        for line in lines:
+            if not re.search('^#', line):
+                non_comments.append(line)
+        self.assertEquals(simplify("\n".join(non_comments)),
+                          simplify("""
 data_0
 loop_
   _atom_site_label

--- a/aiida/backends/tests/dataclasses.py
+++ b/aiida/backends/tests/dataclasses.py
@@ -1066,6 +1066,7 @@ class TestStructureData(AiidaTestCase):
     Tests the creation of StructureData objects (cell and pbc).
     """
     from aiida.orm.data.structure import has_ase, has_spglib
+    from aiida.orm.data.cif import has_pycifrw
 
     def test_cell_ok_and_atoms(self):
         """
@@ -1475,6 +1476,8 @@ class TestStructureData(AiidaTestCase):
                                       mode="count_compact"),
                           'BaTiO3')
 
+    @unittest.skipIf(not has_ase(), "Unable to import ase")
+    @unittest.skipIf(not has_pycifrw(), "Unable to import PyCifRW")
     def test_get_cif(self):
         """
         Tests the conversion to CifData
@@ -1488,11 +1491,7 @@ class TestStructureData(AiidaTestCase):
         a.append_atom(position=(0.5, 0.5, 0.5), symbols=['Ba'])
         a.append_atom(position=(1., 1., 1.), symbols=['Ti'])
 
-        try:
-            c = a._get_cif()
-        # Exception thrown if ase can't be found
-        except ImportError:
-            return
+        c = a._get_cif()
         lines = c._prepare_cif()[0].split('\n')
         non_comments = []
         for line in lines:

--- a/aiida/backends/tests/dataclasses.py
+++ b/aiida/backends/tests/dataclasses.py
@@ -2588,6 +2588,7 @@ class TestTrajectoryData(AiidaTestCase):
         import os
         import tempfile
         from aiida.orm.data.array.trajectory import TrajectoryData
+        from aiida.orm.data.cif import has_pycifrw
 
         n = TrajectoryData()
 
@@ -2640,7 +2641,11 @@ class TestTrajectoryData(AiidaTestCase):
         os.close(handle)
         os.remove(filename)
 
-        for format in ['cif', 'xsf']:
+        if has_pycifrw():
+            formats_to_test = ['cif', 'xsf']
+        else:
+            formats_to_test = ['xsf']
+        for format in formats_to_test:
             files_created = [] # In case there is an exception
             try:
                 files_created = n.export(filename, fileformat=format)

--- a/aiida/backends/tests/dataclasses.py
+++ b/aiida/backends/tests/dataclasses.py
@@ -14,7 +14,7 @@ from aiida.orm import load_node
 from aiida.common.exceptions import ModificationNotAllowed
 from aiida.backends.testbase import AiidaTestCase
 import unittest
-
+from aiida.common.utils import HiddenPrints
 
 
 def has_seekpath():
@@ -147,6 +147,7 @@ class TestCifData(AiidaTestCase):
     from aiida.orm.data.structure import has_ase, has_pymatgen, has_spglib, \
         get_pymatgen_version
     from distutils.version import StrictVersion
+    
 
     @unittest.skipIf(not has_pycifrw(), "Unable to import PyCifRW")
     def test_reload_cifdata(self):
@@ -408,7 +409,8 @@ Te2 0.00000 0.00000 0.79030 0.01912
                 '_publ_section_title': 'Test CIF'
             }
         ]
-        lines = pycifrw_from_cif(datablocks).WriteOut().split('\n')
+        with HiddenPrints():
+            lines = pycifrw_from_cif(datablocks).WriteOut().split('\n')
         non_comments = []
         for line in lines:
             if not re.search('^#', line):
@@ -432,7 +434,8 @@ _publ_section_title                     'Test CIF'
 '''))
 
         loops = {'_atom_site': ['_atom_site_label', '_atom_site_occupancy']}
-        lines = pycifrw_from_cif(datablocks, loops).WriteOut().split('\n')
+        with HiddenPrints():
+            lines = pycifrw_from_cif(datablocks, loops).WriteOut().split('\n')
         non_comments = []
         for line in lines:
             if not re.search('^#', line):
@@ -463,7 +466,8 @@ _publ_section_title                     'Test CIF'
                 '_tag': '[value]',
             }
         ]
-        lines = pycifrw_from_cif(datablocks).WriteOut().split('\n')
+        with HiddenPrints():
+            lines = pycifrw_from_cif(datablocks).WriteOut().split('\n')
         non_comments = []
         for line in lines:
             if not re.search('^#', line):

--- a/aiida/backends/tests/dataclasses.py
+++ b/aiida/backends/tests/dataclasses.py
@@ -450,6 +450,30 @@ loop_
 _publ_section_title                     'Test CIF'
 '''))
 
+    @unittest.skipIf(not has_pycifrw(), "Unable to import PyCifRW")
+    def test_pycifrw_syntax(self):
+        """
+        Tests CifData.pycifrw_from_cif() - check syntax pb in PyCifRW 3.6
+        """
+        from aiida.orm.data.cif import pycifrw_from_cif
+        import re
+
+        datablocks = [
+            {
+                '_tag': '[value]',
+            }
+        ]
+        lines = pycifrw_from_cif(datablocks).WriteOut().split('\n')
+        non_comments = []
+        for line in lines:
+            if not re.search('^#', line):
+                non_comments.append(line)
+        self.assertEquals(simplify("\n".join(non_comments)),
+                          simplify('''
+data_0
+_tag                                    '[value]'
+'''))
+
     @unittest.skipIf(not has_ase(), "Unable to import ase")
     @unittest.skipIf(not has_pycifrw(), "Unable to import PyCifRW")
     def test_cif_roundtrip(self):

--- a/aiida/backends/tests/dataclasses.py
+++ b/aiida/backends/tests/dataclasses.py
@@ -478,6 +478,24 @@ data_0
 _tag                                    '[value]'
 '''))
 
+    @unittest.skipIf(not has_pycifrw(), "Unable to import PyCifRW")
+    def test_cif_with_long_line(self):
+        """
+        Tests CifData - check that long lines (longer than 2048 characters)
+        are supported.
+        Should not raise any error.
+        """
+        import tempfile
+        from aiida.orm.data.cif import CifData
+
+        with tempfile.NamedTemporaryFile() as f:
+            f.write('''
+data_0
+_tag   {}
+ '''.format('a'*5000))
+            f.flush()
+            _ = CifData(file=f.name)
+
     @unittest.skipIf(not has_ase(), "Unable to import ase")
     @unittest.skipIf(not has_pycifrw(), "Unable to import PyCifRW")
     def test_cif_roundtrip(self):

--- a/aiida/backends/tests/restapi.py
+++ b/aiida/backends/tests/restapi.py
@@ -756,6 +756,7 @@ class RESTApiTestSuite(RESTApiTestCase):
         """
         Get the list of give calculation inputs
         """
+        from aiida.backends.tests.dataclasses import simplify
         node_uuid = self.get_dummy_data()["data"][3]["uuid"]
         url = self.get_url_prefix() + '/structures/' + str(
             node_uuid) + '/content/visualization?visformat=cif'
@@ -763,8 +764,8 @@ class RESTApiTestSuite(RESTApiTestCase):
         with self.app.test_client() as client:
             rv = client.get(url)
             response = json.loads(rv.data)
-            expected_visdata = """#\\#CIF1.1\n##########################################################################\n#               Crystallographic Information Format file \n#               Produced by PyCifRW module\n# \n#  This is a CIF file.  CIF has been adopted by the International\n#  Union of Crystallography as the standard for data archiving and \n#  transmission.\n#\n#  For information on this file format, follow the CIF links at\n#  http://www.iucr.org\n##########################################################################\n\ndata_0\nloop_\n  _atom_site_label\n  _atom_site_fract_x\n  _atom_site_fract_y\n  _atom_site_fract_z\n  _atom_site_type_symbol\n   Ba1  0.0  0.0  0.0  Ba\n \n_cell_angle_alpha                       90.0\n_cell_angle_beta                        90.0\n_cell_angle_gamma                       90.0\n_cell_length_a                          2.0\n_cell_length_b                          2.0\n_cell_length_c                          2.0\nloop_\n  _symmetry_equiv_pos_as_xyz\n   'x, y, z'\n \n_symmetry_int_tables_number             1\n_symmetry_space_group_name_H-M          'P 1'\n"""
-            self.assertEquals(response["data"]["visualization"]["str_viz_info"]["data"],expected_visdata)
+            expected_visdata = """\n##########################################################################\n#               Crystallographic Information Format file \n#               Produced by PyCifRW module\n# \n#  This is a CIF file.  CIF has been adopted by the International\n#  Union of Crystallography as the standard for data archiving and \n#  transmission.\n#\n#  For information on this file format, follow the CIF links at\n#  http://www.iucr.org\n##########################################################################\n\ndata_0\nloop_\n  _atom_site_label\n  _atom_site_fract_x\n  _atom_site_fract_y\n  _atom_site_fract_z\n  _atom_site_type_symbol\n   Ba1  0.0  0.0  0.0  Ba\n \n_cell_angle_alpha                       90.0\n_cell_angle_beta                        90.0\n_cell_angle_gamma                       90.0\n_cell_length_a                          2.0\n_cell_length_b                          2.0\n_cell_length_c                          2.0\nloop_\n  _symmetry_equiv_pos_as_xyz\n   'x, y, z'\n \n_symmetry_int_tables_number             1\n_symmetry_space_group_name_H-M          'P 1'\n"""
+            self.assertEquals(simplify(response["data"]["visualization"]["str_viz_info"]["data"]),simplify(expected_visdata))
             self.assertEquals(response["data"]["visualization"]["str_viz_info"]["format"],"cif")
             self.assertEquals(response["data"]["visualization"]["dimensionality"],
                               {u'dim': 3, u'value': 8.0, u'label': u'volume'})

--- a/aiida/backends/tests/tcodexporter.py
+++ b/aiida/backends/tests/tcodexporter.py
@@ -464,24 +464,24 @@ class TestTcodDbExporter(AiidaTestCase):
             '_cell_length_b',
             '_cell_length_c',
             '_chemical_formula_sum',
-            '_symmetry_Int_Tables_number',
             '_symmetry_equiv_pos_as_xyz',
-            '_symmetry_space_group_name_H-M',
-            '_symmetry_space_group_name_Hall'
+            '_symmetry_int_tables_number',
+            '_symmetry_space_group_name_h-m',
+            '_symmetry_space_group_name_hall'
         ]
 
         tcod_file_tags = [
             '_tcod_content_encoding_id',
             '_tcod_content_encoding_layer_id',
             '_tcod_content_encoding_layer_type',
-            '_tcod_file_URI',
             '_tcod_file_content_encoding',
             '_tcod_file_contents',
             '_tcod_file_id',
             '_tcod_file_md5sum',
             '_tcod_file_name',
             '_tcod_file_role',
-            '_tcod_file_sha1sum'
+            '_tcod_file_sha1sum',
+            '_tcod_file_uri',
         ]
 
         # Not stored and not to be stored:
@@ -500,7 +500,7 @@ class TestTcodDbExporter(AiidaTestCase):
         v = export_values(td, trajectory_index=1, store=True)
         self.assertEqual(sorted(v['0'].keys()),
                          expected_tags + tcod_file_tags)
-
+        
         # Both stored and expected to be stored:
         td = TrajectoryData(structurelist=structurelist)
         td.store()

--- a/aiida/common/utils.py
+++ b/aiida/common/utils.py
@@ -1265,3 +1265,22 @@ def get_mode_string(mode):
         else:
             perm.append("-")
     return "".join(perm)
+
+
+class HiddenPrints:
+    """
+    Class to prevent any print to the std output.
+    Usage:
+    
+    with HiddenPrints():
+        print("I won't print this")
+    """
+    
+    def __enter__(self):
+        from os import devnull
+        self._original_stdout = sys.stdout
+        sys.stdout = open(devnull, 'w')
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        sys.stdout = self._original_stdout
+

--- a/aiida/orm/data/array/trajectory.py
+++ b/aiida/orm/data/array/trajectory.py
@@ -476,6 +476,7 @@ class TrajectoryData(ArrayData):
         import CifFile
         from aiida.orm.data.cif \
             import ase_loops, cif_from_ase, pycifrw_from_cif
+        from aiida.common.utils import HiddenPrints
 
         cif = ""
         indices = range(self.numsteps)
@@ -485,7 +486,8 @@ class TrajectoryData(ArrayData):
             structure = self.get_step_structure(idx)
             ciffile = pycifrw_from_cif(cif_from_ase(structure.get_ase()),
                                        ase_loops)
-            cif = cif + ciffile.WriteOut()
+            with HiddenPrints():
+                cif = cif + ciffile.WriteOut()
         return cif.encode('utf-8'), {}
 
     def _prepare_tcod(self, main_file_name="", **kwargs):

--- a/aiida/orm/data/cif.py
+++ b/aiida/orm/data/cif.py
@@ -296,7 +296,8 @@ def refine_inline(node):
     refined_atoms, symmetry = ase_refine_cell(original_atoms)
 
     cif = CifData(ase=refined_atoms)
-    cif.values.rename(str(0),name)
+    if name != str(0):
+        cif.values.rename(str(0),name)
 
     # Remove all existing symmetry tags before overwriting:
     for tag in symmetry_tags:

--- a/aiida/orm/data/cif.py
+++ b/aiida/orm/data/cif.py
@@ -9,6 +9,7 @@
 ###########################################################################
 from aiida.orm.data.singlefile import SinglefileData
 from aiida.orm.calculation.inline import optional_inline
+from aiida.common.utils import HiddenPrints
 
 
 ase_loops = {
@@ -467,7 +468,8 @@ class CifData(SinglefileData):
         import tempfile
         cif = cif_from_ase(aseatoms)
         with tempfile.NamedTemporaryFile() as f:
-            f.write(pycifrw_from_cif(cif, loops=ase_loops).WriteOut())
+            with HiddenPrints():
+                f.write(pycifrw_from_cif(cif, loops=ase_loops).WriteOut())
             f.flush()
             self.set_file(f.name)
 
@@ -498,7 +500,8 @@ class CifData(SinglefileData):
     def set_values(self, values):
         import tempfile
         with tempfile.NamedTemporaryFile() as f:
-            f.write(values.WriteOut())
+            with HiddenPrints():
+                f.write(values.WriteOut())
             f.flush()
             self.set_file(f.name)
 

--- a/aiida/tools/dbexporters/tcod.py
+++ b/aiida/tools/dbexporters/tcod.py
@@ -875,8 +875,8 @@ def add_metadata_inline(what, node=None, parameters=None, args=None):
     for tag in node.values[dataname].keys():
         datablock[tag] = node.values[dataname][tag]
     datablocks.append(datablock)
-    for loop in node.values[dataname].loops:
-        loops[loop.keys()[0]] = loop.keys()
+    for loop in node.values[dataname].loops.values():
+        loops[loop[0]] = loop
 
     # Unpacking the kwargs from ParameterData
     kwargs = {}

--- a/setup_requirements.py
+++ b/setup_requirements.py
@@ -113,7 +113,7 @@ extras_require = {
         'pymatgen==4.5.3',  # support for NWChem I/O
         'ase==3.12.0',  # support for crystal structure manipulation
         'PyMySQL==0.7.9',  # required by ICSD tools
-        'PyCifRW==3.6.2.1',
+        'PyCifRW==4.2.1',
         'seekpath==1.8.0',
         'qe-tools==1.0',
         # support for the AiiDA CifData class. Update to version 4 does

--- a/setup_requirements.py
+++ b/setup_requirements.py
@@ -113,11 +113,9 @@ extras_require = {
         'pymatgen==4.5.3',  # support for NWChem I/O
         'ase==3.12.0',  # support for crystal structure manipulation
         'PyMySQL==0.7.9',  # required by ICSD tools
-        'PyCifRW==4.2.1',
+        'PyCifRW==4.2.1', # support for the AiiDA CifData class
         'seekpath==1.8.0',
         'qe-tools==1.0',
-        # support for the AiiDA CifData class. Update to version 4 does
-        # break tests
     ],
     # Requirements for jupyter notebook
     'notebook': [


### PR DESCRIPTION
Fix issue #132:
* Upgrade from PyCifRW 3.6.2.1 to PyCifRW 4.2.1 (setup_requirements updated)
* All uses of PyCifRW (CifFile) modified accordingly
* Two news tests created for CifData (failing with the previous use of PyCifRW 3.6.2.1), for the square bracket syntax error and the long line error
* One test on StructureData modified (avoid asserting all the CIF comments)
* Two tests (StructureData and TrajectoryData) modified to handle better the possible absence of the PyCifRW module
* New class HiddenPrints created in aiida.common.utils, to avoid wild printouts from external modules  such as PyCifRW. Used in CifData, TrajectoryData and dataclasses tests.