### PR TITLE
support the visualization of the structure with VESTA

### DIFF
--- a/aiida/cmdline/commands/data.py
+++ b/aiida/cmdline/commands/data.py
@@ -1247,6 +1247,34 @@ class _Structure(VerdiCommandWithSubcommands,
         except ImportError:
             raise
 
+    def _show_vesta(self, exec_name, structure_list):
+        """
+        Plugin for VESTA
+        This VESTA plugin was added by Yue-Wen FANG and Abel Carreras 
+        at Kyoto University in the group of Prof. Isao Tanaka's lab
+        
+        """
+        import tempfile, subprocess
+
+        with tempfile.NamedTemporaryFile(suffix='.cif') as f:
+            for structure in structure_list:
+                f.write(structure._exportstring('cif')[0])
+            f.flush()
+
+            try:
+                subprocess.check_output([exec_name, f.name])
+            except subprocess.CalledProcessError:
+                # The program died: just print a message
+                print "Note: the call to {} ended with an error.".format(
+                        exec_name)
+            except OSError as e:
+                if e.errno == 2:
+                    print ("No executable '{}' found. Add to the path, "
+                            "or try with an absolute path.".format(exec_name))
+                    sys.exit(1)
+                else:
+                    raise
+
     def _show_vmd(self, exec_name, structure_list):
         """
         Plugin for vmd


### PR DESCRIPTION
I added a feature to visualize the structure using VESTA. It worked well in my testing with v0.10.0 and v0.11.1. Now, in addition to Jmol, VMD, ase and XCrysden, we have this new choice. I think some colleagues will be happy to use it.