### PR TITLE
Add two band types in JSON output

### DIFF
--- a/aiida/orm/data/array/bands.py
+++ b/aiida/orm/data/array/bands.py
@@ -448,9 +448,11 @@ class BandsData(KpointsData):
         if len(stored_bands.shape) == 2:
             bands = stored_bands
             band_type_idx = numpy.array([0]*stored_bands.shape[1])
+            two_band_types = False
         elif len(stored_bands.shape) == 3:
             bands = numpy.concatenate([_ for _ in stored_bands], axis=1)
             band_type_idx = numpy.array([0] * stored_bands.shape[2] + [1] * stored_bands.shape[2])
+            two_band_types = True
         else:
             raise ValueError("Unexpected shape of bands")
 
@@ -510,6 +512,7 @@ class BandsData(KpointsData):
                                  'to': label_to,
                                  'values': bands[position_from:position_to + 1, :].transpose().tolist(),
                                  'x': x[position_from:position_to + 1],
+                                 'two_band_types': two_band_types,
                                  }
                     plot_info['paths'].append(path_dict)
             else:
@@ -520,6 +523,7 @@ class BandsData(KpointsData):
                              'to': label_to,
                              'values': bands.transpose().tolist(),
                              'x': x,
+                             'two_band_types': two_band_types,
                              }
                 plot_info['paths'].append(path_dict)
                 plot_info['path'].append([label_from, label_to])


### PR DESCRIPTION
Adding a flag to indicate, in the JSON of BandsData, that there are two band types (typically for spin)