### PR TITLE
fix #1041 update spinx-rtd scheme

### DIFF
--- a/docs/requirements_for_rtd.txt
+++ b/docs/requirements_for_rtd.txt
@@ -1,6 +1,9 @@
+Jinja2==2.9.5
+MarkupSafe==0.23
+Pygments==2.2.0
 SQLAlchemy-Utils==0.31.2
 SQLAlchemy==1.0.12
-Sphinx>=1.5
+Sphinx==1.5.2
 aldjemy==0.6.0
 alembic==0.9.6
 amqp==1.4.9
@@ -12,6 +15,7 @@ click-spinner
 click==6.7
 django-extensions==1.5.0
 django==1.7.11
+docutils==0.13.1
 ecdsa==0.13
 enum34==1.1.6
 ete3==3.0.0b35
@@ -35,6 +39,7 @@ reentry==1.0.2
 scipy<1.0.0
 setuptools==36.6.0
 six==1.11.0
+sphinx-rtd-theme==0.2.5b2
 tabulate==0.7.5
 tzlocal==1.3
 ujson==1.35

--- a/docs/update_req_for_rtd.py
+++ b/docs/update_req_for_rtd.py
@@ -26,11 +26,9 @@ def update_req_for_rtd(pre_commit):
 
     import setup_requirements
 
+    req_for_rtd_lines = list(setup_requirements.extras_require['docs'])
+
     required_packages = list(setup_requirements.install_requires)
-
-    # Required version
-    req_for_rtd_lines = ['Sphinx>=1.5']
-
     for package in required_packages:
         # To avoid that it requires also the postgres libraries
         if package.startswith('psycopg2'):


### PR DESCRIPTION
This fixes an issue with line numbers not being displayed correctly.
(worked in docs created locally, but still broken on the web: Example: Search for "Here is the code:" on http://aiida-core.readthedocs.io/en/latest/work/index.html )

 * update sphinx rtd theme also for read-the-docs documentation
 * update python script for updating reqs