### PR TITLE
Fix a bug in store method of CifData

### DIFF
--- a/aiida/orm/data/cif.py
+++ b/aiida/orm/data/cif.py
@@ -522,7 +522,9 @@ class CifData(SinglefileData):
         """
         Store the node.
         """
-        self._set_attr('md5', self.generate_md5())
+        if not self.is_stored:
+            self._set_attr('md5', self.generate_md5())
+
         return super(CifData, self).store(*args, **kwargs)
 
     def set_file(self, filename):


### PR DESCRIPTION
The policy is that one can `.store()` on a node as many times as one
wants. If the node is already stored it simply shouldn't do anything.
This was not respected in the overriden store method of the `CifData`
data class, that always tried to set the md5 attribute which would
except when the node was already stored because then attributes are
immutable