### PR TITLE
Docs: how to install RabbitMQ on Gentoo Linux

### DIFF
--- a/docs/source/install/details.rst
+++ b/docs/source/install/details.rst
@@ -10,3 +10,4 @@ Details
     details/troubleshooting
     details/database
     details/virtual_environment
+    details/os

--- a/docs/source/install/details/os.rst
+++ b/docs/source/install/details/os.rst
@@ -1,0 +1,24 @@
+Other Operating Systems
+=======================
+
+Gentoo Linux
+------------
+
+
+1) To install RabbitMQ do the following
+# emerge -av rabbitmq-server
+
+2) Run RabbitMQ start script at the system boot
+# rc-update add rabbitmq
+
+3) Start RabbitMQ 
+# /etc/init.d/rabbitmq start
+
+4) Check the status of RabbitMQ server
+# /etc/init.d/rabbitmq status
+# rabbitmqctl status
+
+5) If you have an error like 
+"Argument '-smp enable' not supported."
+Remove the mentioned optime from the file /usr/libexec/rabbitmq/rabbitmq-env
+


### PR DESCRIPTION
A short howto describing the installation of RabbitMQ on Gentoo linux.

Please note: in the newest version of erlang the option "-smp enabled" is disabled: http://erlang.org/pipermail/erlang-questions/2018-February/094750.html

So needs some workaround in order to make RabbitMQ work