### PR TITLE
Fix import error and unnecessary backend check in verdi import

### DIFF
--- a/aiida/cmdline/commands/importfile.py
+++ b/aiida/cmdline/commands/importfile.py
@@ -30,7 +30,7 @@ class Import(VerdiCommand):
         import urllib2
 
         from aiida.common.folders import SandboxFolder
-        from aiida.orm.importexport import get_valid_import_links, import_data_dj, import_data_sqla
+        from aiida.orm.importexport import get_valid_import_links, import_data
 
         parser = argparse.ArgumentParser(
             prog=self.get_full_command_name(),
@@ -82,12 +82,7 @@ class Import(VerdiCommand):
         for filename in files:
             try:
                 print "**** Importing file {}".format(filename)
-                from aiida.backends.settings import BACKEND
-                from aiida.backends.profile import BACKEND_DJANGO, BACKEND_SQLA
-                if BACKEND == BACKEND_SQLA:
-                    import_data_sqla(filename)
-                elif BACKEND == BACKEND_DJANGO:
-                    import_data_dj(filename)
+                import_data(filename)
             except Exception:
                 traceback.print_exc()
 


### PR DESCRIPTION
The import functionality for files was still using the backend specific
import functions, `import_data_dj` and `import_data_sqla`, while the one for
URL's was using the generalized `import_data`. However, the latter was not
imported. Hence an import error was raised.

The solution is to import `import_data` function and update the section
for files to use this one as well and not check the backend itself