### PR TITLE
fix #1143 failing read-the-docs build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,8 +42,7 @@ install:
     # Upgrade pip setuptools and wheel to be able to run the next command
     - pip install -U pip wheel setuptools
     # Install AiiDA with some optional dependencies
-    - pip install .[REST,docs,atomic_tools,testing,dev_precommit]
-
+    - if [ "$TEST_TYPE" == "docs" ]; then pip install . && pip install -r docs/requirements_for_rtd.txt; else pip install .[rest,docs,atomic_tools,testing,dev_precommit]; fi
 
 env:
 ## Build matrix to test both backends, and the docs

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -44,6 +44,7 @@ needs_sphinx = '1.5.0'
 # Add any Sphinx extension module names here, as strings. They can be extensions
 # coming with Sphinx (named 'sphinx.ext.*') or your custom ones.
 extensions = ['sphinx.ext.autodoc', 'sphinx.ext.doctest', 'sphinx.ext.todo', 'sphinx.ext.coverage', 'sphinx.ext.imgmath', 'sphinx.ext.ifconfig', 'sphinx.ext.viewcode', 'IPython.sphinxext.ipython_console_highlighting', 'IPython.sphinxext.ipython_directive']
+ipython_mplbackend = ""
 
 todo_include_todos = True
 


### PR DESCRIPTION
* disable matplotlib requirement for rtd (was not needed)
* make sure that travis installs the same python packages as
  rtd for building the docs