### PR TITLE
Reduce number of workchains launched in travis daemon test

### DIFF
--- a/.travis-data/test_daemon.py
+++ b/.travis-data/test_daemon.py
@@ -22,7 +22,7 @@ ParameterData = DataFactory('parameter')
 codename = 'doubler@torquessh'
 timeout_secs = 4 * 60 # 4 minutes
 number_calculations = 30 # Number of calculations to submit
-number_workchains = 30 # Number of workchains to submit
+number_workchains = 8 # Number of workchains to submit
 
 def print_daemon_log():
     home = os.environ['HOME']


### PR DESCRIPTION
In a recent commit the WorkChain class that was used for testing the
daemon on Travis was changed to have arbitrary levels of nesting. The
number of workchains being launched was still 30, leading to roughly 450
workchains in total being launched. This is a bit excessive and was
slowing down the tests. Reducing the number to 8, which will have a
maximum nesting of 8, is still fine.