### PR TITLE
Catch and reroute JobCalculation.submit through Process layer

### DIFF
--- a/aiida/cmdline/commands/daemon.py
+++ b/aiida/cmdline/commands/daemon.py
@@ -158,15 +158,7 @@ class Daemon(VerdiCommandWithSubcommands):
 
         print "Starting AiiDA Daemon (log file: {})...".format(self.logfile)
         currenv = _get_env_with_venv_bin()
-        process = subprocess.Popen([
-                "celery",  "worker",
-                "--app", "tasks",
-                "--loglevel", "INFO",
-                "--beat",
-                "--schedule", self.celerybeat_schedule,
-                "--logfile", self.logfile,
-                "--pidfile", self._get_pid_full_path(),
-                ],
+        process = subprocess.Popen(['verdi', 'devel', 'run_daemon'],
             cwd=self.workdir,
             close_fds=True,
             stdout=subprocess.PIPE,

--- a/aiida/work/job_processes.py
+++ b/aiida/work/job_processes.py
@@ -379,9 +379,9 @@ class JobProcess(processes.Process):
             except exceptions.ModificationNotAllowed:
                 pass
             raise
-
-        # Delete the temporary folder
-        shutil.rmtree(retrieved_temporary_folder)
+        finally:
+            # Delete the temporary folder
+            shutil.rmtree(retrieved_temporary_folder)
 
         # Finally link up the outputs and we're done
         for label, node in self.calc.get_outputs_dict().iteritems():

--- a/aiida/work/job_processes.py
+++ b/aiida/work/job_processes.py
@@ -166,14 +166,14 @@ class Waiting(plumpy.Waiting):
             else:
                 raise RuntimeError("Unknown waiting command")
 
-        except plumpy.CancelledError:
-            self.transition_to(processes.ProcessState.CANCELLED)
+        except plumpy.KilledError:
+            self.transition_to(processes.ProcessState.KILLED)
             if self._cancelling_future is not None:
                 self._cancelling_future.set_result(True)
                 self._cancelling_future = None
         except BaseException:
             exc_info = sys.exc_info()
-            self.transition_to(processes.ProcessState.FAILED, exc_info[1], exc_info[2])
+            self.transition_to(processes.ProcessState.EXCEPTED, exc_info[1], exc_info[2])
         finally:
             self._task = None
 
@@ -344,8 +344,16 @@ class JobProcess(processes.Process):
         Run the calculation, we put it in the TOSUBMIT state and then wait for it
         to be copied over, submitted, retrieved, etc.
         """
-        # Put the calculation in the TOSUBMIT state
-        self.calc.submit()
+        calc_state = self.calc.get_state()
+
+        if calc_state != calc_states.NEW:
+            raise exceptions.InvalidOperation(
+                'Cannot submit a calculation not in {} state (the current state is {})'.format(
+                    calc_states.NEW, calc_state
+                ))
+
+        self.calc._set_state(calc_states.TOSUBMIT)
+
         # Launch the submit operation
         return plumpy.Wait(msg='Waiting to submit', data=SUBMIT_COMMAND)
 
@@ -355,7 +363,6 @@ class JobProcess(processes.Process):
         for the calculation to be finished and the data has been retrieved.
         """
         try:
-            print(retrieved_temporary_folder.folder.abspath)
             execmanager.parse_results(self.calc, retrieved_temporary_folder)
         except BaseException:
             try:
@@ -373,14 +380,11 @@ class JobProcess(processes.Process):
 
 
 class ContinueJobCalculation(JobProcess):
-    ACTIVE_CALC_STATES = [calc_states.TOSUBMIT, calc_states.SUBMITTING,
-                          calc_states.WITHSCHEDULER, calc_states.COMPUTED,
-                          calc_states.RETRIEVING, calc_states.PARSING]
 
     @classmethod
     def define(cls, spec):
         super(ContinueJobCalculation, cls).define(spec)
-        spec.input("_calc", valid_type=JobCalculation, required=True, non_db=False)
+        spec.input('_calc', valid_type=JobCalculation, required=True, non_db=False)
 
     def run(self):
         state = self.calc.get_state()
@@ -389,13 +393,13 @@ class ContinueJobCalculation(JobProcess):
             return super(ContinueJobCalculation, self).run()
 
         if state in [calc_states.TOSUBMIT, calc_states.SUBMITTING]:
-            return self._submit()
+            return plumpy.Wait(msg='Waiting to submit', data=SUBMIT_COMMAND)
 
         elif state in calc_states.WITHSCHEDULER:
-            return self._update_scheduler_state(job_done=False)
+            return plumpy.Wait(msg='Waiting for scheduler', data=UPDATE_SCHEDULER_COMMAND)
 
         elif state in [calc_states.COMPUTED, calc_states.RETRIEVING]:
-            return self._update_scheduler_state(job_done=True)
+            return plumpy.Wait(msg='Waiting to retrieve', data=RETRIEVE_COMMAND)
 
         elif state == calc_states.PARSING:
             return self.retrieved(True)

--- a/aiida/work/processes.py
+++ b/aiida/work/processes.py
@@ -92,8 +92,7 @@ class Process(plumpy.Process):
         self._parent_pid = parent_pid
         self._enable_persistence = enable_persistence
         if self._enable_persistence and self.runner.persister is None:
-            self.logger.warning(
-                "Disabling persistence, runner does not have a persister")
+            self.logger.warning('Disabling persistence, runner does not have a persister')
             self._enable_persistence = False
 
     def on_create(self):
@@ -193,6 +192,10 @@ class Process(plumpy.Process):
             self.calc.seal()
         except exceptions.ModificationNotAllowed:
             pass
+
+    def on_except(self, exc_info):
+        super(Process, self).on_except(exc_info)
+        self.report(traceback.format_exc())
 
     @override
     def on_fail(self, exc_info):


### PR DESCRIPTION
Fixes #1126 

In the `JobCalculation.submit()` method, instead of setting the calc state to
`TOSUBMIT` and let the daemon discover it for submission, we now instantiate
a `ContinueJobCalculation` `JobProcess`, which will continue the already stored
`JobCalculation` through its states through the Process machinery, making sure
that it will appear identical as a calculation that was launched directly
as a `JobProcess`

This also restores the logger in the execmanager, making sure that the
`DbLogHandler` is properly configured and that log messages will be attached
to the node in the `DbLog` table.