### PR TITLE
Enable the Trusty platform and postgres 9.5 on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,5 @@
-# Next two to activate the beta Ubuntu Trusty machine without sudo
-# But apparently, SSH does not work, to check
-#dist: trusty
-#sudo: false
+dist: trusty
+sudo: required
 
 language: python
 
@@ -16,8 +14,8 @@ services:
     - docker
 
 addons:
-    postgresql: "9.4"
-#  postgresql: "9.5" # Available in Trusty only
+    postgresql: "9.5"
+
     apt:
         packages:
             - texlive-base


### PR DESCRIPTION
Trusty on Travis now seems to be working. This is needed to upgrade to postgres 9.5 which is needed for another PR #1111 