### PR TITLE
 Implement the concept of 'finish status' for Calculations 

### DIFF
--- a/aiida/backends/tests/calculation_node.py
+++ b/aiida/backends/tests/calculation_node.py
@@ -54,13 +54,13 @@ class TestCalcNode(AiidaTestCase):
         Check that updatable attributes of Calculation are not copied
         """
         a = Calculation()
-        a._set_attr('state', self.stateval)
+        a._set_attr(Calculation.PROCESS_STATE_KEY, self.stateval)
         a.store()
         b = a.copy()
 
         # updatable attributes are not copied
         with self.assertRaises(AttributeError):
-            b.get_attr('state')
+            b.get_attr(Calculation.PROCESS_STATE_KEY)
 
     def test_calculation_updatable_attribute(self):
         """
@@ -81,16 +81,17 @@ class TestCalcNode(AiidaTestCase):
             a._set_attr(k, v)
 
         # Check before storing
-        self.assertEquals(a.get_attr('state'), self.stateval)
+        a._set_attr(Calculation.PROCESS_STATE_KEY, self.stateval)
+        self.assertEquals(a.get_attr(Calculation.PROCESS_STATE_KEY), self.stateval)
 
         a.store()
 
         # Check after storing
-        self.assertEquals(a.get_attr('state'), self.stateval)
+        self.assertEquals(a.get_attr(Calculation.PROCESS_STATE_KEY), self.stateval)
 
         # I should be able to mutate the updatable attribute but not the others
-        a._set_attr('state', 'FINISHED')
-        a._del_attr('state')
+        a._set_attr(Calculation.PROCESS_STATE_KEY, 'FINISHED')
+        a._del_attr(Calculation.PROCESS_STATE_KEY)
 
         with self.assertRaises(ModificationNotAllowed):
             a._set_attr('bool', False)
@@ -102,7 +103,7 @@ class TestCalcNode(AiidaTestCase):
 
         # After sealing, even updatable attributes should be immutable
         with self.assertRaises(ModificationNotAllowed):
-            a._set_attr('state', 'FINISHED')
+            a._set_attr(Calculation.PROCESS_STATE_KEY, 'FINISHED')
 
         with self.assertRaises(ModificationNotAllowed):
-            a._del_attr('state')
+            a._del_attr(Calculation.PROCESS_STATE_KEY)

--- a/aiida/backends/tests/inline_calculation.py
+++ b/aiida/backends/tests/inline_calculation.py
@@ -40,6 +40,17 @@ class TestInlineCalculation(AiidaTestCase):
         self.assertEquals(calculation.is_finished_ok, True)
         self.assertEquals(calculation.is_failed, False)
 
+    def test_finish_status(self):
+        """
+        If an InlineCalculation reaches the FINISHED process state, it has to have been successful
+        which means that the finish status always has to be 0
+        """
+        calculation, result = self.incr_inline(inp=Int(11))
+        self.assertEquals(calculation.is_finished, True)
+        self.assertEquals(calculation.is_finished_ok, True)
+        self.assertEquals(calculation.is_failed, False)
+        self.assertEquals(calculation.finish_status, 0)
+
     def test_incr(self):
         """
         Simple test for the inline increment function.

--- a/aiida/backends/tests/work/test_workfunctions.py
+++ b/aiida/backends/tests/work/test_workfunctions.py
@@ -73,6 +73,16 @@ class TestWf(AiidaTestCase):
 
         result = add_mul_wf(Int(3), Int(4), Int(5))
 
+    def test_finish_status(self):
+        """
+        If a workfunction reaches the FINISHED process state, it has to have been successful
+        which means that the finish status always has to be 0
+        """
+        result, calculation = single_return_value.run_get_node()
+        self.assertEquals(calculation.finish_status, 0)
+        self.assertEquals(calculation.is_finished_ok, True)
+        self.assertEquals(calculation.is_failed, False)
+
     def test_hashes(self):
         result, w1 = run_get_node(return_input, inp=Int(2))
         result, w2 = run_get_node(return_input, inp=Int(2))

--- a/aiida/orm/calculation/job/__init__.py
+++ b/aiida/orm/calculation/job/__init__.py
@@ -8,4 +8,4 @@
 # For further information please visit http://www.aiida.net               #
 ###########################################################################
 from aiida.orm.calculation import Calculation
-from aiida.orm.implementation.calculation import JobCalculation, _input_subfolder
+from aiida.orm.implementation.calculation import JobCalculation, _input_subfolder, JobCalculationFinishStatus

--- a/aiida/orm/implementation/calculation.py
+++ b/aiida/orm/implementation/calculation.py
@@ -16,6 +16,7 @@ from aiida.backends.profile import BACKEND_DJANGO, BACKEND_SQLA
 
 from aiida.common.old_pluginloader import from_type_to_pluginclassname
 from aiida.orm.implementation.general.calculation.job import _input_subfolder
+from aiida.orm.implementation.general.calculation.job import JobCalculationFinishStatus
 
 
 if BACKEND == BACKEND_SQLA:

--- a/aiida/orm/implementation/django/calculation/job/__init__.py
+++ b/aiida/orm/implementation/django/calculation/job/__init__.py
@@ -42,6 +42,7 @@ class JobCalculation(AbstractJobCalculation, Calculation):
           from ``aiida.common.datastructures.calc_states``.
         :raise: ModificationNotAllowed if the given state was already set.
         """
+        super(JobCalculation, self)._set_state(state)
 
         from aiida.common.datastructures import sort_states
         from aiida.backends.djsite.db.models import DbCalcState

--- a/aiida/orm/implementation/general/calculation/__init__.py
+++ b/aiida/orm/implementation/general/calculation/__init__.py
@@ -266,11 +266,11 @@ class AbstractCalculation(Sealable):
         """
         return self._set_attr(self.CHECKPOINT_KEY, checkpoint)
 
-    def _del_checkpoint(self, checkpoint):
+    def _del_checkpoint(self):
         """
         Delete the checkpoint bundle set for the Calculation
         """
-        return self._det_attr(self.CHECKPOINT_KEY)
+        return self._del_attr(self.CHECKPOINT_KEY)
 
     @property
     def called(self):

--- a/aiida/orm/implementation/general/calculation/__init__.py
+++ b/aiida/orm/implementation/general/calculation/__init__.py
@@ -27,9 +27,9 @@ class AbstractCalculation(Sealable):
     calculations run via a scheduler.
     """
 
-    STATE_KEY = 'state'
-    CHECKPOINT_KEY = 'checkpoints'
     PROCESS_STATE_KEY = 'process_state'
+    FINISH_STATUS_KEY = 'finish_status'
+    CHECKPOINT_KEY = 'checkpoints'
 
     # The link_type might not be correct while the object is being created.
     _hash_ignored_inputs = ['CALL']
@@ -39,6 +39,7 @@ class AbstractCalculation(Sealable):
     def _updatable_attributes(cls):
         return super(AbstractCalculation, cls)._updatable_attributes + (
             cls.PROCESS_STATE_KEY,
+            cls.FINISH_STATUS_KEY,
             cls.CHECKPOINT_KEY,
         )
 
@@ -230,24 +231,45 @@ class AbstractCalculation(Sealable):
         """
         Returns whether the Calculation has finished successfully, which means that it
         terminated nominally and had a zero exit code indicating a successful execution
-        # TODO when finish_status is implemented add that in return value determination
 
         :return: True if the calculation has finished successfully, False otherwise
         :rtype: bool
         """
-        return self.process_state == ProcessState.FINISHED
+        return self.is_finished and self.finish_status == 0
 
     @property
     def is_failed(self):
         """
         Returns whether the Calculation has failed, which means that it terminated nominally
         but it had a non-zero exit status
-        # TODO when finish_status is implemented add that in return value determination
 
         :return: True if the calculation has failed, False otherwise
         :rtype: bool
         """
-        return self.process_state == ProcessState.FINISHED and False
+        return self.is_finished and self.finish_status != 0
+
+    @property
+    def finish_status(self):
+        """
+        Return the finish status of the Calculation
+
+        :returns: the finish status, an integer exit code or None
+        """
+        return self.get_attr(self.FINISH_STATUS_KEY, None)
+
+    def _set_finish_status(self, status):
+        """
+        Set the finish status of the Calculation
+
+        :param state: an integer exit code or None, which will be interpreted as zero
+        """
+        if status is None:
+            status = 0
+
+        if not isinstance(status, int):
+            raise ValueError('finish status has to be an integer, got {}'.format(status))
+
+        return self._set_attr(self.FINISH_STATUS_KEY, status)
 
     @property
     def checkpoint(self):

--- a/aiida/orm/implementation/general/calculation/__init__.py
+++ b/aiida/orm/implementation/general/calculation/__init__.py
@@ -44,13 +44,6 @@ class AbstractCalculation(Sealable):
         )
 
     @classproperty
-    def _hash_ignored_attributes(cls):
-        return super(AbstractCalculation, cls)._hash_ignored_attributes + [
-            '_sealed',
-            '_finished',
-        ]
-
-    @classproperty
     def _use_methods(cls):
         """
         Return the list of valid input nodes that can be set using the

--- a/aiida/orm/implementation/general/calculation/__init__.py
+++ b/aiida/orm/implementation/general/calculation/__init__.py
@@ -9,67 +9,13 @@
 ###########################################################################
 
 import collections
+import logging
 
 from plumpy import ProcessState
-from aiida.common.utils import classproperty
 from aiida.common.links import LinkType
+from aiida.common.log import get_dblogger_extra
+from aiida.common.utils import classproperty
 from aiida.orm.mixins import Sealable
-
-def _parse_single_arg(function_name, additional_parameter,
-                      args, kwargs):
-    """
-    Verifies that a single additional argument has been given (or no
-    additional argument, if additional_parameter is None). Also
-    verifies its name.
-
-    :param function_name: the name of the caller function, used for
-        the output messages
-    :param additional_parameter: None if no additional parameters
-        should be passed, or a string with the name of the parameter
-        if one additional parameter should be passed.
-
-    :return: None, if additional_parameter is None, or the value of
-        the additional parameter
-    :raise TypeError: on wrong number of inputs
-    """
-    # Here all the logic to check if the parameters are correct.
-    if additional_parameter is not None:
-        if len(args) == 1:
-            if kwargs:
-                raise TypeError("{}() received too many args".format(
-                    function_name))
-            additional_parameter_data = args[0]
-        elif len(args) == 0:
-            kwargs_copy = kwargs.copy()
-            try:
-                additional_parameter_data = kwargs_copy.pop(
-                    additional_parameter)
-            except KeyError:
-                if kwargs_copy:
-                    raise TypeError("{}() got an unexpected keyword "
-                                    "argument '{}'".format(
-                        function_name, kwargs_copy.keys()[0]))
-                else:
-                    raise TypeError("{}() requires more "
-                                    "arguments".format(function_name))
-            if kwargs_copy:
-                raise TypeError("{}() got an unexpected keyword "
-                                "argument '{}'".format(
-                    function_name, kwargs_copy.keys()[0]))
-        else:
-            raise TypeError("{}() received too many args".format(
-                function_name))
-        return additional_parameter_data
-    else:
-        if kwargs:
-            raise TypeError("{}() got an unexpected keyword "
-                            "argument '{}'".format(
-                function_name, kwargs.keys()[0]))
-        if len(args) != 0:
-            raise TypeError("{}() received too many args".format(
-                function_name))
-
-        return None
 
 
 class AbstractCalculation(Sealable):
@@ -81,15 +27,20 @@ class AbstractCalculation(Sealable):
     calculations run via a scheduler.
     """
 
+    STATE_KEY = 'state'
     CHECKPOINT_KEY = 'checkpoints'
     PROCESS_STATE_KEY = 'process_state'
 
-    _cacheable = False
-
-    _updatable_attributes = Sealable._updatable_attributes + ('state', PROCESS_STATE_KEY, CHECKPOINT_KEY)
-
     # The link_type might not be correct while the object is being created.
     _hash_ignored_inputs = ['CALL']
+    _cacheable = False
+
+    @classproperty
+    def _updatable_attributes(cls):
+        return super(AbstractCalculation, cls)._updatable_attributes + (
+            cls.PROCESS_STATE_KEY,
+            cls.CHECKPOINT_KEY,
+        )
 
     @classproperty
     def _hash_ignored_attributes(cls):
@@ -98,7 +49,6 @@ class AbstractCalculation(Sealable):
             '_finished',
         ]
 
-    # Nodes that can be added as input using the use_* methods
     @classproperty
     def _use_methods(cls):
         """
@@ -135,32 +85,23 @@ class AbstractCalculation(Sealable):
     @property
     def logger(self):
         """
-        Get the logger of the Calculation object, so that it also logs to the
-        DB.
+        Get the logger of the Calculation object, so that it also logs to the DB.
 
-        :return: LoggerAdapter object, that works like a logger, but also has
-          the 'extra' embedded
+        :return: LoggerAdapter object, that works like a logger, but also has the 'extra' embedded
         """
-        import logging
-        from aiida.common.log import get_dblogger_extra
-
-        return logging.LoggerAdapter(
-            logger=self._logger, extra=get_dblogger_extra(self))
+        return logging.LoggerAdapter(logger=self._logger, extra=get_dblogger_extra(self))
 
     def __dir__(self):
         """
         Allow to list all valid attributes, adding also the use_* methods
         """
-        return sorted(dir(type(self)) + list(['use_{}'.format(k)
-                                              for k in
-                                              self._use_methods.iterkeys()]))
+        return sorted(dir(type(self)) + list(['use_{}'.format(k) for k in self._use_methods.iterkeys()]))
 
     def __getattr__(self, name):
         """
-        Expand the methods with the use_* calls. Note that this method only
-        gets called if 'name' is not already defined as a method. Returning
-        None will then automatically raise the standard AttributeError
-        exception.
+        Expand the methods with the use_* calls. Note that this method only gets called if 'name'
+        is not already defined as a method. Returning one will then automatically raise the
+        standard AttributeError exception.
         """
         if name == '_use_methods':
             raise AttributeError("'{0}' object has no attribute '{1}'".format(type(self), name))
@@ -177,6 +118,7 @@ class AbstractCalculation(Sealable):
                 self.node = node
                 self.actual_name = actual_name
                 self.data = data
+
                 try:
                     self.__doc__ = data['docstring']
                 except KeyError:
@@ -184,9 +126,8 @@ class AbstractCalculation(Sealable):
                     pass
 
             def __call__(self, parent_node, *args, **kwargs):
-                # Not really needed, will be checked in get_linkname
-                # But I do anyway in order to raise an exception as soon as
-                # possible, with the most intuitive caller function name
+                # Not really needed, will be checked in get_linkname but I do anyway in order to raise
+                # an exception as soon as possible, with the most intuitive caller function name
                 additional_parameter = _parse_single_arg(
                     function_name='use_{}'.format(self.actual_name),
                     additional_parameter=self.data['additional_parameter'],
@@ -194,25 +135,18 @@ class AbstractCalculation(Sealable):
 
                 # Type check
                 if not isinstance(parent_node, self.data['valid_types']):
-                    if isinstance(self.data['valid_types'],
-                                  collections.Iterable):
-                        valid_types_string = ",".join([_.__name__ for _ in
-                                                       self.data[
-                                                           'valid_types']])
+                    if isinstance(self.data['valid_types'], collections.Iterable):
+                        valid_types_string = ','.join([_.__name__ for _ in self.data['valid_types']])
                     else:
                         valid_types_string = self.data['valid_types'].__name__
 
-                    raise TypeError("The given node is not of the valid type "
-                                    "for use_{}. Valid types are: {}, while "
-                                    "you provided {}".format(
-                        self.actual_name, valid_types_string,
-                        parent_node.__class__.__name__))
+                    raise TypeError(
+                        'The given node is not of the valid type for use_{}.'
+                        'Valid types are: {}, while you provided {}'.format(
+                            self.actual_name, valid_types_string, parent_node.__class__.__name__))
 
                 # Get actual link name
-                actual_linkname = self.node.get_linkname(actual_name, *args,
-                                                         **kwargs)
-                # Checks that such an argument exists have already been
-                # made inside actual_linkname
+                actual_linkname = self.node.get_linkname(actual_name, *args, **kwargs)
 
                 # Here I do the real job
                 self.node._replace_link_from(parent_node, actual_linkname)
@@ -222,11 +156,9 @@ class AbstractCalculation(Sealable):
 
         if name in valid_use_methods:
             actual_name = name[len(prefix):]
-            return UseMethod(node=self, actual_name=actual_name,
-                             data=self._use_methods[actual_name])
+            return UseMethod(node=self, actual_name=actual_name, data=self._use_methods[actual_name])
         else:
-            raise AttributeError("'{}' object has no attribute '{}'".format(
-                self.__class__.__name__, name))
+            raise AttributeError("'{}' object has no attribute '{}'".format(self.__class__.__name__, name))
 
     @property
     def process_state(self):
@@ -342,10 +274,20 @@ class AbstractCalculation(Sealable):
 
     @property
     def called(self):
+        """
+        Return a list of nodes that the Calculation called
+
+        :returns: list of Calculation nodes called by this Calculation instance
+        """
         return self.get_outputs(link_type=LinkType.CALL)
 
     @property
     def called_by(self):
+        """
+        Return the Calculation that called this Calculation, or None if it does not have a caller
+
+        :returns: Calculation that called this Calculation instance or None
+        """
         called_by = self.get_inputs(link_type=LinkType.CALL)
         if called_by:
             return called_by[0]
@@ -363,8 +305,7 @@ class AbstractCalculation(Sealable):
         try:
             data = self._use_methods[link]
         except KeyError:
-            raise ValueError("No '{}' link is defined for this "
-                             "calculation".format(link))
+            raise ValueError("No '{}' link is defined for this calculation".format(link))
 
         # Raises if the wrong # of parameters is passed
         additional_parameter = _parse_single_arg(
@@ -391,18 +332,14 @@ class AbstractCalculation(Sealable):
 
         if link_type is LinkType.CREATE or link_type is LinkType.RETURN:
             if not isinstance(dest, Data):
-                raise ValueError(
-                    "The output of a calculation node can only be a data node")
+                raise ValueError('The output of a calculation node can only be a data node')
         elif link_type is LinkType.CALL:
             if not isinstance(dest, AbstractCalculation):
-                raise ValueError("Call links can only link two calculations.")
+                raise ValueError('Call links can only link two calculations')
         else:
-            raise ValueError(
-                "Calculation cannot have links of type {} as output".format(
-                    link_type))
+            raise ValueError('Calculation cannot have links of type {} as output'.format(link_type))
 
-        return super(AbstractCalculation, self)._linking_as_output(
-            dest, link_type)
+        return super(AbstractCalculation, self)._linking_as_output(dest, link_type)
 
     def add_link_from(self, src, label=None, link_type=LinkType.INPUT):
         """
@@ -416,24 +353,19 @@ class AbstractCalculation(Sealable):
         :param link_type: The type of link, must be one of the enum values form
           :class:`~aiida.common.links.LinkType`
         """
-        from aiida.orm.data import Data
         from aiida.orm.code import Code
+        from aiida.orm.data import Data
 
         if link_type is LinkType.INPUT:
             if not isinstance(src, (Data, Code)):
-                raise ValueError(
-                    "Nodes entering calculation as input link can only be of "
-                    "type data or code")
+                raise ValueError('Nodes entering calculation as input link can only be of type data or code')
         elif link_type is LinkType.CALL:
             if not isinstance(src, AbstractCalculation):
-                raise ValueError("Call links can only link two calculations.")
+                raise ValueError('Call links can only link two calculations')
         else:
-            raise ValueError(
-                "Calculation cannot have links of type {} as input".format(
-                    link_type))
+            raise ValueError('Calculation cannot have links of type {} as input'.format(link_type))
 
-        return super(AbstractCalculation, self).add_link_from(
-            src, label, link_type)
+        return super(AbstractCalculation, self).add_link_from( src, label, link_type)
 
     def get_code(self):
         """
@@ -441,6 +373,7 @@ class AbstractCalculation(Sealable):
         was not set.
         """
         from aiida.orm.code import Code
+
         return dict(self.get_inputs(node_type=Code, also_labels=True)).get(
             self._use_methods['code']['linkname'], None)
 
@@ -451,17 +384,20 @@ class AbstractCalculation(Sealable):
         :param src: a node of the database. It cannot be a Calculation object.
         :param str label: Name of the link.
         """
-        from aiida.orm.data import Data
         from aiida.orm.code import Code
+        from aiida.orm.data import Data
 
         if not isinstance(src, (Data, Code)):
-            raise ValueError("Nodes entering in calculation can only be of "
-                             "type data or code")
+            raise ValueError('Nodes entering in calculation can only be of type data or code')
 
-        return super(AbstractCalculation, self)._replace_link_from(
-            src, label, link_type)
+        return super(AbstractCalculation, self)._replace_link_from(src, label, link_type)
 
     def _is_valid_cache(self):
+        """
+        Return whether the node is valid for caching
+
+        :returns: True if Calculation is valid to be used for caching, False otherwise
+        """
         return super(AbstractCalculation, self)._is_valid_cache() and self.is_finished_ok
 
     def _get_objects_to_hash(self):
@@ -471,9 +407,63 @@ class AbstractCalculation(Sealable):
         res = super(AbstractCalculation, self)._get_objects_to_hash()
         res.append({
             key: value.get_hash()
-            for key, value in self.get_inputs_dict(
-                link_type=LinkType.INPUT
-            ).items()
+            for key, value in self.get_inputs_dict(link_type=LinkType.INPUT).items()
             if key not in self._hash_ignored_inputs
         })
         return res
+
+
+def _parse_single_arg(function_name, additional_parameter, args, kwargs):
+    """
+    Verifies that a single additional argument has been given (or no
+    additional argument, if additional_parameter is None). Also
+    verifies its name.
+
+    :param function_name: the name of the caller function, used for
+        the output messages
+    :param additional_parameter: None if no additional parameters
+        should be passed, or a string with the name of the parameter
+        if one additional parameter should be passed.
+
+    :return: None, if additional_parameter is None, or the value of
+        the additional parameter
+    :raise TypeError: on wrong number of inputs
+    """
+    # Here all the logic to check if the parameters are correct.
+    if additional_parameter is not None:
+        if len(args) == 1:
+            if kwargs:
+                raise TypeError("{}() received too many args".format(
+                    function_name))
+            additional_parameter_data = args[0]
+        elif len(args) == 0:
+            kwargs_copy = kwargs.copy()
+            try:
+                additional_parameter_data = kwargs_copy.pop(
+                    additional_parameter)
+            except KeyError:
+                if kwargs_copy:
+                    raise TypeError("{}() got an unexpected keyword "
+                                    "argument '{}'".format(
+                        function_name, kwargs_copy.keys()[0]))
+                else:
+                    raise TypeError("{}() requires more "
+                                    "arguments".format(function_name))
+            if kwargs_copy:
+                raise TypeError("{}() got an unexpected keyword "
+                                "argument '{}'".format(
+                    function_name, kwargs_copy.keys()[0]))
+        else:
+            raise TypeError("{}() received too many args".format(
+                function_name))
+        return additional_parameter_data
+    else:
+        if kwargs:
+            raise TypeError("{}() got an unexpected keyword "
+                            "argument '{}'".format(
+                function_name, kwargs.keys()[0]))
+        if len(args) != 0:
+            raise TypeError("{}() received too many args".format(
+                function_name))
+
+        return None

--- a/aiida/orm/implementation/general/calculation/__init__.py
+++ b/aiida/orm/implementation/general/calculation/__init__.py
@@ -9,6 +9,7 @@
 ###########################################################################
 
 import collections
+import enum
 import logging
 
 from plumpy import ProcessState
@@ -258,6 +259,9 @@ class AbstractCalculation(Sealable):
         """
         if status is None:
             status = 0
+
+        if isinstance(status, enum.Enum):
+            status = status.value
 
         if not isinstance(status, int):
             raise ValueError('finish status has to be an integer, got {}'.format(status))

--- a/aiida/orm/implementation/general/calculation/job/__init__.py
+++ b/aiida/orm/implementation/general/calculation/job/__init__.py
@@ -39,11 +39,14 @@ class AbstractJobCalculation(AbstractCalculation):
     remotely on a job scheduler.
     """
 
-    _updatable_attributes = AbstractCalculation._updatable_attributes + (
-        'job_id', 'scheduler_state','scheduler_lastchecktime', 'last_jobinfo', 'remote_workdir',
-        'retrieve_list', 'retrieve_temporary_list', 'retrieve_singlefile_list')
-
     _cacheable = True
+
+    @classproperty
+    def _updatable_attributes(cls):
+        return super(AbstractJobCalculation, cls)._updatable_attributes + (
+            'job_id', 'scheduler_state','scheduler_lastchecktime', 'last_jobinfo', 'remote_workdir',
+            'retrieve_list', 'retrieve_temporary_list', 'retrieve_singlefile_list', 'state'
+        )
 
     @classproperty
     def _hash_ignored_attributes(cls):
@@ -55,12 +58,7 @@ class AbstractJobCalculation(AbstractCalculation):
             'max_memory_kb',
         ]
 
-    def get_hash(
-        self,
-        ignore_errors=True,
-        ignored_folder_content=('raw_input',),
-        **kwargs
-    ):
+    def get_hash(self, ignore_errors=True, ignored_folder_content=('raw_input',), **kwargs):
         return super(AbstractJobCalculation, self).get_hash(
             ignore_errors=ignore_errors,
             ignored_folder_content=ignored_folder_content,
@@ -78,16 +76,15 @@ class AbstractJobCalculation(AbstractCalculation):
 
     def _init_internal_params(self):
         """
-        Define here internal parameters that should be defined
-        right after the __init__. This function is actually called
-        by the __init__.
+        Define here internal parameters that should be defined right after the __init__
+        This function is actually called by the __init__
 
-        :note: if you inherit this function, ALWAYS remember to
-          call super()._init_internal_params() as the first thing
-          in your inherited function.
+        :note: if you inherit this function, ALWAYS remember to call super()._init_internal_params()
+            as the first thing in your inherited function.
         """
         # By default, no output parser
         self._default_parser = None
+
         # Set default for the link to the retrieved folder (after calc is done)
         self._linkname_retrieved = 'retrieved'
 
@@ -96,8 +93,7 @@ class AbstractJobCalculation(AbstractCalculation):
         self._SCHED_OUTPUT_FILE = '_scheduler-stdout.txt'
         self._SCHED_ERROR_FILE = '_scheduler-stderr.txt'
 
-        # Files that should be shown by default
-        # Set it to None if you do not have a default file
+        # Files that should be shown by default, set it to None if you do not have a default file
         # Used, e.g., by 'verdi calculation inputshow/outputshow
         self._DEFAULT_INPUT_FILE = None
         self._DEFAULT_OUTPUT_FILE = None

--- a/aiida/orm/implementation/general/calculation/job/__init__.py
+++ b/aiida/orm/implementation/general/calculation/job/__init__.py
@@ -10,6 +10,7 @@
 import abc
 import copy
 import datetime
+import enum
 
 from aiida.backends.utils import get_automatic_user
 from aiida.common.datastructures import calc_states
@@ -33,11 +34,47 @@ DEPRECATION_DOCS_URL = 'http://aiida-core.readthedocs.io/en/latest/process/index
 _input_subfolder = 'raw_input'
 
 
+class JobCalculationFinishStatus(enum.Enum):
+    """
+    This enumeration maps specific calculation states to an integer. This integer can
+    then be used to set the finish status of a JobCalculation node. The values defined
+    here map directly on the failed calculation states, but the idea is that sub classes
+    of AbstractJobCalculation can extend this enum with additional error codes
+    """
+    FINISHED = 0
+    SUBMISSIONFAILED = 100
+    RETRIEVALFAILED = 200
+    PARSINGFAILED = 300
+    FAILED = 400
+    I_AM_A_TEAPOT = 418
+
+
 class AbstractJobCalculation(AbstractCalculation):
     """
     This class provides the definition of an AiiDA calculation that is run
     remotely on a job scheduler.
     """
+
+    @classproperty
+    def finish_status_enum(cls):
+        return JobCalculationFinishStatus
+
+    @property
+    def finish_status_label(self):
+        """
+        Return the label belonging to the finish status of the Calculation
+
+        :returns: the finish status, an integer exit code or None
+        """
+        finish_status = self.finish_status
+
+        try:
+            finish_status_enum = self.finish_status_enum(finish_status)
+            finish_status_label = finish_status_enum.name
+        except ValueError:
+            finish_status_label = 'UNKNOWN'
+
+        return finish_status_label
 
     _cacheable = True
 

--- a/aiida/orm/implementation/general/calculation/job/__init__.py
+++ b/aiida/orm/implementation/general/calculation/job/__init__.py
@@ -50,13 +50,12 @@ class AbstractJobCalculation(AbstractCalculation):
 
     @classproperty
     def _hash_ignored_attributes(cls):
-        # _updatable_attributes are ignored automatically.
-        return super(AbstractJobCalculation, cls)._hash_ignored_attributes + [
+        return super(AbstractJobCalculation, cls)._hash_ignored_attributes + (
             'queue_name',
             'priority',
             'max_wallclock_seconds',
             'max_memory_kb',
-        ]
+        )
 
     def get_hash(self, ignore_errors=True, ignored_folder_content=('raw_input',), **kwargs):
         return super(AbstractJobCalculation, self).get_hash(

--- a/aiida/orm/implementation/general/calculation/work.py
+++ b/aiida/orm/implementation/general/calculation/work.py
@@ -8,6 +8,7 @@
 # For further information please visit http://www.aiida.net               #
 ###########################################################################
 
+from aiida.common.utils import classproperty
 from aiida.orm.implementation.calculation import Calculation
 
 
@@ -19,7 +20,9 @@ class WorkCalculation(Calculation):
 
     STEPPER_STATE_INFO_KEY = 'stepper_state_info'
 
-    _updatable_attributes = Calculation._updatable_attributes + (STEPPER_STATE_INFO_KEY,)
+    @classproperty
+    def _updatable_attributes(cls):
+        return super(WorkCalculation, cls)._updatable_attributes + (cls.STEPPER_STATE_INFO_KEY,)
 
     @property
     def stepper_state_info(self):

--- a/aiida/orm/implementation/general/node.py
+++ b/aiida/orm/implementation/general/node.py
@@ -144,8 +144,12 @@ class AbstractNode(object):
     # See documentation in the set() method.
     _set_incompatibilities = []
 
-    # A list of attribute names that will be ignored when creating the hash.
-    _hash_ignored_attributes = []
+    # A tuple of attribute names that can be updated even after node is stored
+    # Requires Sealable mixin, but needs empty tuple for base class
+    _updatable_attributes = tuple()
+
+    # A tuple of attribute names that will be ignored when creating the hash.
+    _hash_ignored_attributes = tuple()
 
     # Flag that determines whether the class can be cached.
     _cacheable = True
@@ -1700,8 +1704,8 @@ class AbstractNode(object):
             {
                 key: val for key, val in self.get_attrs().items()
                 if (
-                    (key not in self._hash_ignored_attributes) and
-                    (key not in getattr(self, '_updatable_attributes', tuple()))
+                    key not in self._hash_ignored_attributes and
+                    key not in self._updatable_attributes
                 )
             },
             self.folder,

--- a/aiida/orm/implementation/sqlalchemy/calculation/job/__init__.py
+++ b/aiida/orm/implementation/sqlalchemy/calculation/job/__init__.py
@@ -51,6 +51,7 @@ class JobCalculation(AbstractJobCalculation, Calculation):
           from ``aiida.common.datastructures.calc_states``.
         :raise: ModificationNotAllowed if the given state was already set.
         """
+        super(JobCalculation, self)._set_state(state)
 
         if not self.is_stored:
             raise ModificationNotAllowed("Cannot set the calculation state "

--- a/aiida/orm/mixins.py
+++ b/aiida/orm/mixins.py
@@ -11,6 +11,7 @@
 from aiida.common.exceptions import ModificationNotAllowed
 from aiida.common.lang import override
 from aiida.common.links import LinkType
+from aiida.common.utils import classproperty
 
 
 class Sealable(object):
@@ -18,7 +19,9 @@ class Sealable(object):
     # The name of the attribute to indicate if the node is sealed or not
     SEALED_KEY = '_sealed'
 
-    _updatable_attributes = (SEALED_KEY,)
+    @classproperty
+    def _updatable_attributes(cls):
+        return (cls.SEALED_KEY,)
 
     def add_link_from(self, src, label=None, link_type=LinkType.UNSPECIFIED):
         """
@@ -90,12 +93,11 @@ class Sealable(object):
     @override
     def copy(self, include_updatable_attrs=False):
         """
-        Create a copy of the node minus the updatable attributes
+        Create a copy of the node minus the updatable attributes if include_updatable_attrs is False
         """
         clone = super(Sealable, self).copy()
 
         if include_updatable_attrs is False:
-            # Remove the updatable attributes
             for key, value in self._iter_updatable_attributes():
                 clone._del_attr(key)
 

--- a/aiida/work/job_processes.py
+++ b/aiida/work/job_processes.py
@@ -98,8 +98,7 @@ class UpdateSchedulerState(TransportTask):
             # Has the state changed?
             last_jobinfo = self._calc._get_last_jobinfo()
 
-            if last_jobinfo is not None and info.job_state != last_jobinfo.job_state:
-                execmanager.update_job_calc_from_job_info(self._calc, info)
+            execmanager.update_job_calc_from_job_info(self._calc, info)
 
             job_done = info.job_state == job_states.DONE
 

--- a/aiida/work/job_processes.py
+++ b/aiida/work/job_processes.py
@@ -386,8 +386,7 @@ class JobProcess(processes.Process):
         for label, node in self.calc.get_outputs_dict().iteritems():
             self.out(label, node)
 
-        # Done, so return the output
-        return self.outputs
+        return
 
 
 class ContinueJobCalculation(JobProcess):

--- a/aiida/work/job_processes.py
+++ b/aiida/work/job_processes.py
@@ -22,6 +22,7 @@ from aiida.common.lang import override
 from aiida.daemon import execmanager
 from aiida.orm.authinfo import AuthInfo
 from aiida.orm.calculation.job import JobCalculation
+from aiida.orm.calculation.job import JobCalculationFinishStatus
 from aiida.scheduler.datastructures import job_states
 from aiida.work.process_spec import DictSchema
 
@@ -33,6 +34,12 @@ __all__ = ['JobProcess']
 SUBMIT_COMMAND = 'submit'
 UPDATE_SCHEDULER_COMMAND = 'update_scheduler'
 RETRIEVE_COMMAND = 'retrieve'
+
+
+class TransportTaskException(Exception):
+
+    def __init__(self, calc_state):
+        self.calc_state = calc_state
 
 
 class TransportTask(plumpy.Future):
@@ -60,12 +67,17 @@ class TransportTask(plumpy.Future):
 
 class SubmitJob(TransportTask):
     """ A task to submit a job calculation """
+
     def execute(self, transport):
-        return execmanager.submit_calc(self._calc, self._authinfo, transport)
+        try:
+            execmanager.submit_calc(self._calc, self._authinfo, transport)
+        except Exception as exception:
+            raise TransportTaskException(calc_states.SUBMISSIONFAILED)
 
 
 class UpdateSchedulerState(TransportTask):
     """ A task to update the scheduler state of a job calculation """
+
     def execute(self, transport):
         scheduler = self._calc.get_computer().get_scheduler()
         scheduler.set_transport(transport)
@@ -117,7 +129,10 @@ class RetrieveJob(TransportTask):
 
     def execute(self, transport):
         """ This returns the retrieved temporary folder """
-        return execmanager.retrieve_all(self._calc, transport, self._retrieved_temporary_folder)
+        try:
+            return execmanager.retrieve_all(self._calc, transport, self._retrieved_temporary_folder)
+        except Exception as exception:
+            raise TransportTaskException(calc_states.RETRIEVALFAILED)
 
 
 class Waiting(plumpy.Waiting):
@@ -153,6 +168,7 @@ class Waiting(plumpy.Waiting):
             if self.data == SUBMIT_COMMAND:
                 self._task = SubmitJob(calc, transport_queue)
                 yield self._task
+
                 # Now get scheduler updates
                 self.scheduler_update()
 
@@ -177,6 +193,10 @@ class Waiting(plumpy.Waiting):
             else:
                 raise RuntimeError("Unknown waiting command")
 
+        except TransportTaskException as exception:
+            # calc._set_state(exception.calc_state)
+            finish_status = JobCalculationFinishStatus[exception.calc_state]
+            self.finished(finish_status)
         except plumpy.KilledError:
             self.transition_to(processes.ProcessState.KILLED)
             if self._cancelling_future is not None:
@@ -207,6 +227,9 @@ class Waiting(plumpy.Waiting):
             processes.ProcessState.RUNNING,
             self.process.retrieved,
             retrieved_temporary_folder)
+
+    def finished(self, result):
+        self.transition_to(processes.ProcessState.FINISHED, result)
 
     def cancel(self, msg=None):
         if self._cancelling_future is not None:
@@ -371,7 +394,7 @@ class JobProcess(processes.Process):
         for the calculation to be finished and the data has been retrieved.
         """
         try:
-            execmanager.parse_results(self.calc, retrieved_temporary_folder)
+            exit_code = execmanager.parse_results(self.calc, retrieved_temporary_folder)
         except BaseException:
             try:
                 self.calc._set_state(calc_states.PARSINGFAILED)
@@ -386,7 +409,7 @@ class JobProcess(processes.Process):
         for label, node in self.calc.get_outputs_dict().iteritems():
             self.out(label, node)
 
-        return
+        return exit_code
 
 
 class ContinueJobCalculation(JobProcess):

--- a/aiida/work/persistence.py
+++ b/aiida/work/persistence.py
@@ -105,6 +105,8 @@ class AiiDAPersister(plumpy.Persister):
         calc = process.calc
         calc._set_checkpoint(yaml.dump(bundle))
 
+        return bundle
+
     def load_checkpoint(self, pid, tag=None):
         if tag is not None:
             raise NotImplementedError("Checkpoint tags not supported yet")

--- a/aiida/work/processes.py
+++ b/aiida/work/processes.py
@@ -206,14 +206,21 @@ class Process(plumpy.Process):
         self.report(traceback.format_exc())
 
     @override
+    def on_finish(self, result):
+        """
+        Set the finish status on the Calculation node
+        """
+        super(Process, self).on_finish(result)
+        self.calc._set_finish_status(result)
+
+    @override
     def on_fail(self, exc_info):
+        """
+        Format the exception info into a string and log it as an error
+        """
         super(Process, self).on_fail(exc_info)
-
-        exc = traceback.format_exception(exc_info[0], exc_info[1], exc_info[2])
-        self.logger.error("{} failed:\n{}".format(self.pid, "".join(exc)))
-
-        exception = exc_info[1]
-        self.calc._set_attr(WorkCalculation.FAILED_KEY, True)
+        exception = traceback.format_exception(exc_info[0], exc_info[1], exc_info[2])
+        self.logger.error('{} failed:\n{}'.format(self.pid, ''.join(exception)))
 
     @override
     def on_output_emitting(self, output_port, value):
@@ -652,4 +659,5 @@ class FunctionProcess(Process):
                     "Must be a Data type or a Mapping of {{string: Data}}".
                         format(result.__class__))
 
-        return result
+        # Execution successful so we return exit code (finish status) 0
+        return 0

--- a/aiida/work/processes.py
+++ b/aiida/work/processes.py
@@ -47,9 +47,7 @@ class Process(plumpy.Process):
 
     _spec_type = ProcessSpec
 
-    SINGLE_RETURN_LINKNAME = '[return]'
-    # This is used for saving node pks in the saved instance state
-    NODE_TYPE = uuid.UUID('5cac9bab-6f46-485b-9e81-d6a666cfdc1b')
+    SINGLE_RETURN_LINKNAME = 'return'
 
     class SaveKeys(enum.Enum):
         """
@@ -413,8 +411,8 @@ class Process(plumpy.Process):
         # Second priority: config
         except KeyError:
             return (
-                    caching.get_use_cache(type(self)) or
-                    caching.get_use_cache(type(self._calc))
+                caching.get_use_cache(type(self)) or
+                caching.get_use_cache(type(self._calc))
             )
 
 

--- a/aiida/work/runners.py
+++ b/aiida/work/runners.py
@@ -18,8 +18,8 @@ __all__ = ['Runner', 'DaemonRunner', 'new_daemon_runner', 'new_runner',
 
 _LOGGER = logging.getLogger(__name__)
 
-ResultAndCalcNode = namedtuple("ResultWithPid", ["result", "calc"])
-ResultAndPid = namedtuple("ResultWithPid", ["result", "pid"])
+ResultAndCalcNode = namedtuple('ResultAndCalcNode', ['result', 'calc'])
+ResultAndPid = namedtuple('ResultAndPid', ['result', 'pid'])
 
 _runner = None
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -144,4 +144,4 @@ wcwidth==0.1.7
 Werkzeug==0.14.1
 wrapt==1.10.11
 yapf==0.19.0
--e git://github.com/muhrin/plumpy.git@c9a306414a7e13f321707484ac406e52b65f9ea0#egg=plumpy
+-e git://github.com/muhrin/plumpy.git@3fc79acaa3ca0b9c568897616d5f01182df10171#egg=plumpy

--- a/requirements.txt
+++ b/requirements.txt
@@ -144,5 +144,4 @@ wcwidth==0.1.7
 Werkzeug==0.14.1
 wrapt==1.10.11
 yapf==0.19.0
--e git://github.com/muhrin/plumpy.git@6be7b2d9b6d2d6704bc605c97432512ca38f181f#egg=plumpy
--e git://github.com/muhrin/kiwipy.git@249fe038f109424b6cdd007092d6f3535346aa7f#egg=kiwipy
+-e git://github.com/muhrin/plumpy.git@c9a306414a7e13f321707484ac406e52b65f9ea0#egg=plumpy


### PR DESCRIPTION
Fixes #1065 

In the new Process paradigm, all Calculations function simply as records
of what happened during execution of the process. The state of the process
is inscribed on the calculation at every state change, so that it can
be reached by proxy through the node. The terminal process state FINISHED
means that it executed nominally and was not killed nor did an exception
occur. However, calculations may want to still distinguish in this case
between a successful and unsuccessful result.

This is now facilitated by the 'finish status'. If a process finishes
nominally, the return value will be interpreted as an exit code and set
as the finish status, a new attribute for the calculation classes.
The properties 'is_finished_ok' and 'is_failed' now allow a user to
distinguish between a successful and an unsuccessful finished process.

This is currently implemented for InlineCalculation and WorkCalculations.
Since inline and workfuntions either return successfully or except, their
finish status will always be 0, so if they are FINISHED they will always
necessarily be FINISHED_OK.

For WorkChains however, this new schema allows users to exit the workchain
with a specific non-zero error code to indicate that it failed, while still
running through nominally. This can be achieved by simply returning a non
zero value from within an outline function. It can also be done in the
outline directly by using the 'return_' instruction. By default this will
pass a zero return value, but a non-zero value can be set by calling it,
e.g. as 'return_(255)'. This will set the finish status of the work
calculation node to 255 and will cause 'is_failed' to return false