### PR TITLE
Fix sphinxext error 

### DIFF
--- a/aiida/sphinxext/tests/workchain_source/demo_workchain.py
+++ b/aiida/sphinxext/tests/workchain_source/demo_workchain.py
@@ -1,5 +1,9 @@
 """This module defines an example workchain for the aiida-workchain documentation directive."""
 
+# This import is here to test an error which is triggered if
+# can_document_member raises an exception.
+import re
+
 from aiida.work.workchain import WorkChain
 from aiida.orm.data.base import Int, Float, Bool
 

--- a/aiida/sphinxext/tests/workchain_source/index.rst
+++ b/aiida/sphinxext/tests/workchain_source/index.rst
@@ -21,9 +21,3 @@ The command is also hooked into ``sphinx.ext.autodoc``, so you can also use that
 
 .. automodule:: demo_workchain
     :members:
-
-This is an additional test which checks that
-
-.. autoclass:: demo_workchain.DemoWorkChain
-
-    .. :module:

--- a/aiida/sphinxext/tests/workchain_source/index.rst
+++ b/aiida/sphinxext/tests/workchain_source/index.rst
@@ -21,3 +21,9 @@ The command is also hooked into ``sphinx.ext.autodoc``, so you can also use that
 
 .. automodule:: demo_workchain
     :members:
+
+This is an additional test which checks that
+
+.. autoclass:: demo_workchain.DemoWorkChain
+
+    .. :module:

--- a/aiida/sphinxext/workchain.py
+++ b/aiida/sphinxext/workchain.py
@@ -23,10 +23,13 @@ class WorkChainDocumenter(ClassDocumenter):
 
     @classmethod
     def can_document_member(cls, member, membername, isattr, parent):
-        import aiida
-        aiida.try_load_dbenv()
-        from aiida.work.workchain import WorkChain
-        return issubclass(member, WorkChain)
+        try:
+            import aiida
+            aiida.try_load_dbenv()
+            from aiida.work.workchain import WorkChain
+            return issubclass(member, WorkChain)
+        except:
+            return False
 
 class AiidaWorkchainDirective(Directive):
     """


### PR DESCRIPTION
The ``can_document_member`` failed when a module was passed, since ``issubclass(module, WorkChain)`` apparently doesn't work.