### PR TITLE
Add a set of click based cli utilities to simplify writing launch scripts

### DIFF
--- a/aiida/utils/cli/__init__.py
+++ b/aiida/utils/cli/__init__.py
@@ -1,0 +1,17 @@
+# -*- coding: utf-8 -*-
+from __future__ import absolute_import 
+import click
+
+
+def command():
+    """
+    Wrapped decorator for click's command decorator, which makes sure
+    that the database environment is loaded
+    """
+    from aiida import try_load_dbenv
+    try_load_dbenv()
+
+    @click.decorators.command
+    def inner():
+        func(*args, **kwargs)
+    return inner

--- a/aiida/utils/cli/options.py
+++ b/aiida/utils/cli/options.py
@@ -1,0 +1,106 @@
+# -*- coding: utf-8 -*-
+from __future__ import absolute_import 
+import click
+from . import validators
+
+
+class overridable_option(object):
+    """
+    Wrapper around click option that allows to store the name
+    and some defaults but also to override them later, for example
+    to change the help message for a certain command.
+    """
+
+    def __init__(self, *args, **kwargs):
+        """
+        Store the defaults
+        """
+        self.args = args
+        self.kwargs = kwargs
+
+    def __call__(self, *args, **kwargs):
+        """
+        Override args if passed and update the kwargs and return the click.option
+        If a callback is specified in the kwargs make sure to bind the callback_kwargs
+        to it using the partial lambda construct of functools
+        """
+        import functools
+
+        if not args:
+            args_copy = self.args
+        else:
+            args_copy = args
+
+        kw_copy = self.kwargs.copy()
+        kw_copy.update(kwargs)
+
+        # Pop the optional callback_kwargs if present
+        callback_kwargs = kw_copy.pop('callback_kwargs', {})
+
+        if 'callback' in kw_copy:
+            callback_plain = kw_copy['callback']
+            callback_bound = functools.partial(callback_plain, callback_kwargs)
+            kw_copy['callback'] = callback_bound
+
+        return click.option(*args_copy, **kw_copy)
+
+code = overridable_option(
+    '-c', '--code', type=click.STRING, required=True,
+    callback=validators.validate_code,
+    help='the label of the AiiDA code object to use'
+)
+
+structure = overridable_option(
+    '-s', '--structure', type=click.INT, required=True,
+    callback=validators.validate_structure,
+    help='the node pk of the structure'
+)
+
+pseudo_family = overridable_option(
+    '-p', '--pseudo-family', type=click.STRING, required=True,
+    callback=validators.validate_pseudo_family,
+    help='the name of the pseudo potential family to use'
+)
+
+kpoint_mesh = overridable_option(
+    '-k', '--kpoint-mesh', 'kpoints', nargs=3, type=click.INT, default=[2, 2, 2], show_default=True,
+    callback=validators.validate_kpoint_mesh,
+    help='the number of points in the kpoint mesh along each basis vector'
+)
+
+parent_calc = overridable_option(
+    '-r', '--parent-calc', type=click.INT, required=True,
+    callback=validators.validate_parent_calc,
+    help='the node pk of the parent calculation'
+)
+
+max_num_machines = overridable_option(
+    '-m', '--max-num-machines', type=click.INT, default=1, show_default=True,
+    help='the maximum number of machines (nodes) to use for the calculations'
+)
+
+max_wallclock_seconds = overridable_option(
+    '-w', '--max-wallclock-seconds', type=click.INT, default=1800, show_default=True,
+    help='the maximum wallclock time in seconds to set for the calculations'
+)
+
+automatic_parallelization = overridable_option(
+    '-a', '--automatic-parallelization', is_flag=True, default=False, show_default=True,
+    help='enable the automatic parallelization option of the workchain'
+)
+
+daemon = overridable_option(
+    '-d', '--daemon', is_flag=True, default=False, show_default=True,
+    help='submit the workchain to the daemon instead of running it locally'
+)
+
+clean_workdir = overridable_option(
+    '-x', '--clean-workdir', is_flag=True, default=False, show_default=True,
+    help='clean the remote folder of all the launched calculations after completion of the workchain'
+)
+
+group = overridable_option(
+    '-g', '--group', type=click.STRING, required=True,
+    callback=validators.validate_group,
+    help='the name or pk of a Group'
+)

--- a/aiida/utils/cli/validators.py
+++ b/aiida/utils/cli/validators.py
@@ -1,0 +1,186 @@
+# -*- coding: utf-8 -*-
+from __future__ import absolute_import 
+import click
+
+
+def validate_structure(callback_kwargs, ctx, param, value):
+    """
+    Command line option validator for an AiiDA structure data pk. It expects
+    an integer for the value and will try to load the corresponding node. it
+    will also check if successful if the node is a StructureData instance.
+
+    :param callback_kwargs: an optional dictionary with arguments for internal use in the validator
+    :param ctx: internal context of the click.command
+    :param param: the click Parameter, i.e. either the Option or Argument to which the validator is hooked up
+    :param value: a StructureData node pk
+    :returns: a StructureData instance
+    """
+    from aiida.common.exceptions import NotExistent
+    from aiida.orm import load_node
+    from aiida.orm.data.structure import StructureData
+
+    try:
+        structure = load_node(int(value))
+    except NotExistent as exception:
+        raise click.BadParameter('failed to load the node<{}>\n{}'.format(value, exception))
+
+    if not isinstance(structure, StructureData):
+        raise click.BadParameter('node<{}> is not of type StructureData'.format(value))
+
+    return structure
+
+def validate_code(callback_kwargs, ctx, param, value):
+    """
+    Command line option validator for an AiiDA code. It expects a string for the value
+    that corresponds to the label of an AiiDA code that has been setup.
+
+    Accepted callback_kwargs:
+        * entry_point: a calculation entry point string to define the expected calculation class.
+            For example, 'quantumespresso.ph' will check that the Code that is resolved has its
+            'input_plugin' attribute set to the same calculation entry point.
+            If the calculation class cannot be loaded from the entry point a ValueError is thrown
+
+    :param callback_kwargs: an optional dictionary with arguments for internal use in the validator
+    :param ctx: internal context of the click.command
+    :param param: the click Parameter, i.e. either the Option or Argument to which the validator is hooked up
+    :param value: a Code label
+    :returns: a Code instance
+    """
+    from aiida.common.exceptions import NotExistent, LoadingPluginFailed, MissingPluginError
+    from aiida.orm import Code, CalculationFactory
+
+    try:
+        code = Code.get_from_string(value)
+    except NotExistent as exception:
+        raise click.BadParameter("failed to load the code with the label '{}'\n{}".format(value, exception))
+
+    if 'entry_point' in callback_kwargs:
+        entry_point = callback_kwargs['entry_point']
+        try:
+            cls = CalculationFactory(entry_point)
+        except (LoadingPluginFailed, MissingPluginError):
+            raise click.BadParameter("could not load calculation plugin for entry point '{}'".format(entry_point))
+
+        if code.get_attr('input_plugin') != entry_point:
+            raise click.BadParameter("code 'input_plugin' attribute '{}' does not match the required entry point '{}'"
+                .format(code.get_attr('input_plugin'), entry_point))
+
+    return code
+
+def validate_pseudo_family(callback_kwargs, ctx, param, value):
+    """
+    Command line option validator for a pseudo potential family. The value should be a
+    string that corresponds to a registered UpfData family, which is an AiiDA Group.
+
+    :param callback_kwargs: an optional dictionary with arguments for internal use in the validator
+    :param ctx: internal context of the click.command
+    :param param: the click Parameter, i.e. either the Option or Argument to which the validator is hooked up
+    :param value: a UpfData pseudo potential family label
+    :returns: the pseudo potential family label
+    """
+    from aiida.common.exceptions import NotExistent
+    from aiida.orm.data.upf import UpfData
+
+    try:
+        pseudo_family = UpfData.get_upf_group(value)
+    except NotExistent as exception:
+        raise click.BadParameter("failed to load the pseudo family the label '{}'\n{}".format(value, exception))
+
+    return value
+
+def validate_kpoint_mesh(callback_kwargs, ctx, param, value):
+    """
+    Command line option validator for a kpoints mesh tuple. The value should be a tuple
+    of three positive integers out of which a KpointsData object will be created with
+    a mesh equal to the tuple.
+
+    :param callback_kwargs: an optional dictionary with arguments for internal use in the validator
+    :param ctx: internal context of the click.command
+    :param param: the click Parameter, i.e. either the Option or Argument to which the validator is hooked up
+    :param value: a tuple of three positive integers
+    :returns: a KpointsData instance
+    """
+    from aiida.orm.data.array.kpoints import KpointsData
+
+    if any([type(i) != int for i in value]) or any([int(i) <= 0 for i in value]):
+        raise click.BadParameter('all values of the tuple should be positive greater than zero integers')
+
+    try:
+        kpoints = KpointsData()
+        kpoints.set_kpoints_mesh(value)
+    except ValueError as exception:
+        raise click.BadParameter("failed to create a KpointsData mesh out of {}\n{}".format(value, exception))
+
+    return kpoints
+
+def validate_parent_calc(callback_kwargs, ctx, param, value):
+    """
+    Command line option validator for an AiiDA JobCalculation pk. It expects
+    an integer for the value and will try to load the corresponding node. it
+    will also check if successful if the node is a JobCalculation instance.
+
+    Accepted callback_kwargs:
+        * entry_point: a calculation entry point string to define the expected calculation class
+            For example, 'quantumespresso.ph' will check that value is instance of PhCalculation
+            The default will simply check whether the value is an instance of JobCalculation.
+            If the class cannot be loaded from the entry point a ValueError is thrown
+
+    :param callback_kwargs: an optional dictionary with arguments for internal use in the validator
+    :param ctx: internal context of the click.command
+    :param param: the click Parameter, i.e. either the Option or Argument to which the validator is hooked up
+    :param value: a JobCalculation node pk
+    :returns: a JobCalculation instance
+    """
+    from aiida.common.exceptions import NotExistent, LoadingPluginFailed, MissingPluginError
+    from aiida.orm import load_node, CalculationFactory
+    from aiida.orm.calculation import JobCalculation
+
+    if 'entry_point' in callback_kwargs:
+        entry_point = callback_kwargs['entry_point']
+        try:
+            cls = CalculationFactory(entry_point)
+        except (LoadingPluginFailed, MissingPluginError):
+            raise click.BadParameter("could not load calculation plugin for entry point '{}'".format(entry_point))
+    else:
+        cls = JobCalculation
+
+    try:
+        parent_calc = load_node(int(value))
+    except NotExistent as exception:
+        raise click.BadParameter('failed to load the node<{}>\n{}'.format(value, exception))
+
+    if not isinstance(parent_calc, cls):
+        raise click.BadParameter('node<{}> is not of type {}'.format(value, cls.__name__))
+
+    return parent_calc
+
+def validate_group(callback_kwargs, ctx, param, value):
+    """
+    Command line option validator for an AiiDA Group. It expects a string for the value
+    that corresponds to the label or a pk of an AiiDA group.
+
+    :param callback_kwargs: an optional dictionary with arguments for internal use in the validator
+    :param ctx: internal context of the click.command
+    :param param: the click Parameter, i.e. either the Option or Argument to which the validator is hooked up
+    :param value: a Group label or pk
+    :returns: a Group instance
+    """
+    from aiida.common.exceptions import NotExistent
+    from aiida.orm import Group
+
+    if value is None:
+        return value
+
+    try:
+        group = Group.get_from_string(value)
+    except NotExistent as exception:
+        pass
+    else:
+        return group
+
+    try:
+        group = Group.get(pk=int(value))
+    except NotExistent as exception:
+        raise click.BadParameter("failed to load the Group with the label or pk '{}'\n{}".format(value, exception))
+    else:
+        return group


### PR DESCRIPTION
Fixes #1193 

Note: I know Rico has been working on porting `verdi` to `click` at which point part of this may be tackled, but until that time I really need this functionality in different plugins that is currently included in `aiida-quantumespresso`.

These utilities simplify the writing of command line interface scripts
that are very useful for plugin developers to write launch scripts with
minimal effort. It provides a decorator `@command` that will turn a
function into a click command that automatically loads the database
environment. It also provides various other `@option` like decorators
which predefine commonly used input arguments and their validators for
AiiDA types such as `Code`, `StructureData` and `Calculation`. For
example a minimal script that will take a structure data id and print
its cell would look like:

	# -*- coding: utf-8 -*-
	import click
	from aiida.utils.cli import command
	from aiida.utils.cli import options

	@options.structure()
	def launch(structure):
		click.echo(structure.cell)