### PR TITLE
Add matplotlib dependency to setup requirements

### DIFF
--- a/docs/requirements_for_rtd.txt
+++ b/docs/requirements_for_rtd.txt
@@ -17,6 +17,7 @@ enum34==1.1.6
 ete3==3.0.0b35
 future==0.16.0
 ipython<6.0
+matplotlib
 meld3==1.0.0
 numpy==1.12.0
 paramiko==2.4.0

--- a/setup_requirements.py
+++ b/setup_requirements.py
@@ -68,6 +68,7 @@ install_requires = [
     'ipython<6.0',
     'scipy<1.0.0',  # At this moment the install of 1.0.0 release is broken
     'plumpy>=0.10.0.dev8',
+    'matplotlib',
 ]
 
 extras_require = {
@@ -104,7 +105,6 @@ extras_require = {
         'docutils==0.13.1',
         'Jinja2==2.9.5',
         'MarkupSafe==0.23',
-        'matplotlib',
         # Required by readthedocs
         'sphinx-rtd-theme==0.2.5b2',
     ],


### PR DESCRIPTION
It cannot be in the 'docs' optional group, because then the
pre-commit hook won't pick it up to allow it in the requirements
text file for RTD, which then won't install it