### PR TITLE
Fix a bug in List base type when used in verdi shell

### DIFF
--- a/aiida/backends/djsite/db/migrations/0009_base_data_plugin_type_string.py
+++ b/aiida/backends/djsite/db/migrations/0009_base_data_plugin_type_string.py
@@ -30,6 +30,7 @@ class Migration(migrations.Migration):
             UPDATE db_dbnode SET type = 'data.float.Float.' WHERE type = 'data.base.Float.';
             UPDATE db_dbnode SET type = 'data.int.Int.' WHERE type = 'data.base.Int.';
             UPDATE db_dbnode SET type = 'data.str.Str.' WHERE type = 'data.base.Str.';
+            UPDATE db_dbnode SET type = 'data.list.List.' WHERE type = 'data.base.List.';
         """),
         update_schema_version(SCHEMA_VERSION)
     ]

--- a/aiida/backends/sqlalchemy/migrations/versions/0aebbeab274d_base_data_plugin_type_string.py
+++ b/aiida/backends/sqlalchemy/migrations/versions/0aebbeab274d_base_data_plugin_type_string.py
@@ -27,6 +27,7 @@ def upgrade():
         UPDATE db_dbnode SET type = 'data.float.Float.' WHERE type = 'data.base.Float.';
         UPDATE db_dbnode SET type = 'data.int.Int.' WHERE type = 'data.base.Int.';
         UPDATE db_dbnode SET type = 'data.str.Str.' WHERE type = 'data.base.Str.';
+        UPDATE db_dbnode SET type = 'data.list.List.' WHERE type = 'data.base.List.';
     """)
     conn.execute(statement)
 
@@ -39,5 +40,6 @@ def downgrade():
         UPDATE db_dbnode SET type = 'data.base.Float.' WHERE type = 'data.float.Float.';
         UPDATE db_dbnode SET type = 'data.base.Int.' WHERE type = 'data.int.Int.';
         UPDATE db_dbnode SET type = 'data.base.Str.' WHERE type = 'data.str.Str.';
+        UPDATE db_dbnode SET type = 'data.base.List.' WHERE type = 'data.list.List.';
     """)
     conn.execute(statement)

--- a/aiida/backends/tests/base_dataclasses.py
+++ b/aiida/backends/tests/base_dataclasses.py
@@ -14,13 +14,11 @@ from aiida.backends.testbase import AiidaTestCase
 from aiida.common.exceptions import ModificationNotAllowed
 from aiida.orm import load_node
 from aiida.orm.data.numeric import NumericType
-from aiida.orm.data import List
+from aiida.orm.data.list import List
 from aiida.orm.data.bool import Bool, get_true_node, get_false_node
 from aiida.orm.data.float import Float
 from aiida.orm.data.int import Int
 from aiida.orm.data.str import Str
-import aiida.orm.data.base as base
-
 
 
 class TestList(AiidaTestCase):

--- a/aiida/backends/tests/nodes.py
+++ b/aiida/backends/tests/nodes.py
@@ -1135,17 +1135,17 @@ class TestNodeBasic(AiidaTestCase):
         """
         Test that setting a basetype as an attribute works transparently
         """
-        from aiida.orm.data import List
+        from aiida.orm.data.list import List
         from aiida.orm.data.parameter import ParameterData
         from aiida.orm.data.str import Str
 
         # This one is unstored
         l1 = List()
-        l1._set_list(['b', [1, 2]])
+        l1.set_list(['b', [1, 2]])
 
         # This one is stored
         l2 = List()
-        l2._set_list(['f', True, {'gg': None}])
+        l2.set_list(['f', True, {'gg': None}])
         l2.store()
 
         # Manages to store, and value is converted to its base type
@@ -1178,16 +1178,16 @@ class TestNodeBasic(AiidaTestCase):
         """
         Test that setting a basetype as an attribute works transparently
         """
-        from aiida.orm.data import List
+        from aiida.orm.data.list import List
         from aiida.orm.data.str import Str
 
         # This one is unstored
         l1 = List()
-        l1._set_list(['b', [1, 2]])
+        l1.set_list(['b', [1, 2]])
 
         # This one is stored
         l2 = List()
-        l2._set_list(['f', True, {'gg': None}])
+        l2.set_list(['f', True, {'gg': None}])
         l2.store()
 
         # Check also before storing

--- a/aiida/orm/data/__init__.py
+++ b/aiida/orm/data/__init__.py
@@ -471,6 +471,10 @@ class List(Data, MutableSequence):
     """
     _LIST_KEY = 'list'
 
+    def __init__(self):
+        super(List, self).__init__()
+        self._set_list(list())
+
     def __getitem__(self, item):
         return self._get_list()[item]
 

--- a/aiida/orm/data/__init__.py
+++ b/aiida/orm/data/__init__.py
@@ -8,7 +8,6 @@
 # For further information please visit http://www.aiida.net               #
 ###########################################################################
 from abc import ABCMeta
-from collections import MutableSequence
 
 try:
     from functools import singledispatch
@@ -18,7 +17,6 @@ except ImportError:
 from aiida.orm.node import Node
 from aiida.common.links import LinkType
 from aiida.common.lang import override
-from aiida.common.exceptions import ModificationNotAllowed
 
 
 @singledispatch
@@ -462,109 +460,3 @@ class BaseType(Data):
                 "When specifying dbnode it can be the only kwarg"
 
         return kwargs
-
-
-
-class List(Data, MutableSequence):
-    """
-    Class to store python lists as AiiDA nodes
-    """
-    _LIST_KEY = 'list'
-
-    def __init__(self):
-        super(List, self).__init__()
-        self._set_list(list())
-
-    def __getitem__(self, item):
-        return self._get_list()[item]
-
-    def __setitem__(self, key, value):
-        l = self._get_list()
-        l[key] = value
-        if not self._using_list_reference():
-            self._set_list(l)
-
-    def __delitem__(self, key):
-        l = self._get_list()
-        del l[key]
-        if not self._using_list_reference():
-            self._set_list(l)
-
-    def __len__(self):
-        return len(self._get_list())
-
-    def __str__(self):
-        return self._get_list().__str__()
-
-    def append(self, value):
-        l = self._get_list()
-        l.append(value)
-        if not self._using_list_reference():
-            self._set_list(l)
-
-    def extend(self, L):
-        l = self._get_list()
-        l.extend(L)
-        if not self._using_list_reference():
-            self._set_list(l)
-
-    def insert(self, i, value):
-        l = self._get_list()
-        l.insert(i, value)
-        if not self._using_list_reference():
-            self._set_list(l)
-
-    def remove(self, value):
-        del self[value]
-
-    def pop(self, **kwargs):
-        l = self._get_list()
-        l.pop(**kwargs)
-        if not self._using_list_reference():
-            self._set_list(l)
-
-    def index(self, value):
-        return self._get_list().index(value)
-
-    def count(self, value):
-        return self._get_list().count(value)
-
-    def sort(self, cmp=None, key=None, reverse=False):
-        l = self._get_list()
-        l.sort(cmp, key, reverse)
-        if not self._using_list_reference():
-            self._set_list(l)
-
-    def reverse(self):
-        l = self._get_list()
-        l.reverse()
-        if not self._using_list_reference():
-            self._set_list(l)
-
-    def _get_list(self):
-        try:
-            return self.get_attr(self._LIST_KEY)
-        except AttributeError:
-            self._set_list(list())
-            return self.get_attr(self._LIST_KEY)
-
-    def _set_list(self, list_):
-        if not isinstance(list_, list):
-            raise TypeError("Must supply list type")
-        self._set_attr(self._LIST_KEY, list_)
-
-    def _using_list_reference(self):
-        """
-        This function tells the class if we are using a list reference.  This
-        means that calls to self.get_list return a reference rather than a copy
-        of the underlying list and therefore self._set_list need not be called.
-        This knwoledge is essential to make sure this class is performant.
-
-        Currently the implementation assumes that if the node needs to be
-        stored then it is using the attributes cache which is a reference.
-
-        :return: True if using self._get_list returns a reference to the
-            underlying sequence.  False otherwise.
-        :rtype: bool
-        """
-        return not self.is_stored

--- a/aiida/orm/data/base.py
+++ b/aiida/orm/data/base.py
@@ -13,3 +13,4 @@ from aiida.orm.data.bool import Bool
 from aiida.orm.data.float import Float
 from aiida.orm.data.int import Int
 from aiida.orm.data.str import Str
+from aiida.orm.data.list import List

--- a/aiida/orm/data/list.py
+++ b/aiida/orm/data/list.py
@@ -1,0 +1,109 @@
+# -*- coding: utf-8 -*-
+from collections import MutableSequence
+from aiida.orm.data import Data
+
+
+class List(Data, MutableSequence):
+    """
+    Class to store python lists as AiiDA nodes
+    """
+    _LIST_KEY = 'list'
+
+    def __init__(self, **kwargs):
+        if 'list' not in kwargs:
+            kwargs['list'] = list()
+        super(List, self).__init__(**kwargs)
+
+    def __getitem__(self, item):
+        return self.get_list()[item]
+
+    def __setitem__(self, key, value):
+        l = self.get_list()
+        l[key] = value
+        if not self._using_list_reference():
+            self.set_list(l)
+
+    def __delitem__(self, key):
+        l = self.get_list()
+        del l[key]
+        if not self._using_list_reference():
+            self.set_list(l)
+
+    def __len__(self):
+        return len(self.get_list())
+
+    def __str__(self):
+        return self.get_list().__str__()
+
+    def append(self, value):
+        l = self.get_list()
+        l.append(value)
+        if not self._using_list_reference():
+            self.set_list(l)
+
+    def extend(self, L):
+        l = self.get_list()
+        l.extend(L)
+        if not self._using_list_reference():
+            self.set_list(l)
+
+    def insert(self, i, value):
+        l = self.get_list()
+        l.insert(i, value)
+        if not self._using_list_reference():
+            self.set_list(l)
+
+    def remove(self, value):
+        del self[value]
+
+    def pop(self, **kwargs):
+        l = self.get_list()
+        l.pop(**kwargs)
+        if not self._using_list_reference():
+            self.set_list(l)
+
+    def index(self, value):
+        return self.get_list().index(value)
+
+    def count(self, value):
+        return self.get_list().count(value)
+
+    def sort(self, cmp=None, key=None, reverse=False):
+        l = self.get_list()
+        l.sort(cmp, key, reverse)
+        if not self._using_list_reference():
+            self.set_list(l)
+
+    def reverse(self):
+        l = self.get_list()
+        l.reverse()
+        if not self._using_list_reference():
+            self.set_list(l)
+
+    def get_list(self):
+        try:
+            return self.get_attr(self._LIST_KEY)
+        except AttributeError:
+            self.set_list(list())
+            return self.get_attr(self._LIST_KEY)
+
+    def set_list(self, list_):
+        if not isinstance(list_, list):
+            raise TypeError('Must supply list type')
+        self._set_attr(self._LIST_KEY, list_)
+
+    def _using_list_reference(self):
+        """
+        This function tells the class if we are using a list reference.  This
+        means that calls to self.get_list return a reference rather than a copy
+        of the underlying list and therefore self.set_list need not be called.
+        This knwoledge is essential to make sure this class is performant.
+
+        Currently the implementation assumes that if the node needs to be
+        stored then it is using the attributes cache which is a reference.
+
+        :return: True if using self.get_list returns a reference to the
+            underlying sequence.  False otherwise.
+        :rtype: bool
+        """
+        return not self.is_stored

--- a/docs/source/datatypes/index.rst
+++ b/docs/source/datatypes/index.rst
@@ -37,7 +37,7 @@ Each of these classes can most often be used transparently (e.g. you can sum two
 :py:class:`~aiida.orm.data.int.Int` objects, etc.). If you need to access the bare
 value and not the whole AiiDA class, use the `.value` property.
 
-In the same module, there is also a :py:class:`~aiida.orm.data.List` class to
+In the same module, there is also a :py:class:`~aiida.orm.data.list.List` class to
 store a list of base data types.
 
 ParameterData

--- a/docs/source/orm/dev.rst
+++ b/docs/source/orm/dev.rst
@@ -146,6 +146,10 @@ BaseType and NumericType
 .. automodule:: aiida.orm.data.base
    :members:
 
+List
+----
+.. autoclass:: aiida.orm.data.list.List
+
 Bool
 ----
 .. automodule:: aiida.orm.data.bool


### PR DESCRIPTION
Fixes #1171 

Instantiating a new List instance and storing it before calling any method
that would set the internal list would trigger a ModificationNotAllowed
exception. That is to say the following in verdi shell would except:

	from aiida.orm.data import List
	l = List()
	l.store()

This has to do with the fact that the internal list, stored in an attribute,
would not be created until it was accessed. This was done in the _get_list()
However, in this example when calling store, the internal set was not yet
defined as it was stored and afterwards ipython tried to pretty print it
invoking repr() which tried to get the internal list, which didn't exist.

Long story short, this was a bug that only appeared in this way in verdi
shell. For that reason I could not write a test that reproduced the problem.