### PR TITLE
Non storable function arguments like None are not allowed for InlineCalculations

### DIFF
--- a/aiida/backends/tests/tcodexporter.py
+++ b/aiida/backends/tests/tcodexporter.py
@@ -355,7 +355,6 @@ class TestTcodDbExporter(AiidaTestCase):
         function = '_get_aiida_structure_ase_inline'
         self.assertNotEqual(script.find(function), script.rfind(function))
 
-    @unittest.skip('skip while InlineCalculation bug allows non-storable defaults')
     @unittest.skipIf(not has_ase(), "Unable to import ase")
     @unittest.skipIf(not has_spglib(), "Unable to import spglib")
     @unittest.skipIf(not has_pycifrw(), "Unable to import PyCifRW")
@@ -410,7 +409,6 @@ class TestTcodDbExporter(AiidaTestCase):
 
         self.assertEqual(options, {})
 
-    @unittest.skip('skip while InlineCalculation bug allows non-storable defaults')
     @unittest.skipIf(not has_ase(), "Unable to import ase")
     @unittest.skipIf(not has_spglib(), "Unable to import spglib")
     @unittest.skipIf(not has_pycifrw(), "Unable to import PyCifRW")

--- a/aiida/orm/data/array/trajectory.py
+++ b/aiida/orm/data/array/trajectory.py
@@ -13,7 +13,7 @@ from aiida.orm.calculation.inline import optional_inline
 
 
 @optional_inline
-def _get_aiida_structure_inline(trajectory=None, parameters=None):
+def _get_aiida_structure_inline(trajectory, parameters):
     """
     Creates :py:class:`aiida.orm.data.structure.StructureData` using ASE.
 

--- a/aiida/orm/data/cif.py
+++ b/aiida/orm/data/cif.py
@@ -93,7 +93,7 @@ def symop_string_from_symop_matrix_tr(matrix, tr=(0, 0, 0), eps=0):
 
 
 @optional_inline
-def _get_aiida_structure_ase_inline(cif=None, parameters=None):
+def _get_aiida_structure_ase_inline(cif, parameters):
     """
     Creates :py:class:`aiida.orm.data.structure.StructureData` using ASE.
 

--- a/aiida/orm/data/structure.py
+++ b/aiida/orm/data/structure.py
@@ -684,7 +684,7 @@ def ase_refine_cell(aseatoms, **kwargs):
 
 
 @optional_inline
-def _get_cif_ase_inline(struct=None, parameters=None):
+def _get_cif_ase_inline(struct, parameters):
     """
     Creates :py:class:`aiida.orm.data.cif.CifData` using ASE.
 

--- a/aiida/tools/dbexporters/tcod.py
+++ b/aiida/tools/dbexporters/tcod.py
@@ -8,8 +8,8 @@
 # For further information please visit http://www.aiida.net               #
 ###########################################################################
 
-
 from aiida.orm import DataFactory
+from aiida.orm.data.parameter import ParameterData
 from aiida.orm.calculation.inline import optional_inline
 
 aiida_executable_name = '_aiidasubmit.sh'
@@ -853,7 +853,7 @@ def _collect_tags(node, calc,parameters=None,
 
 
 @optional_inline
-def add_metadata_inline(what, node=None, parameters=None, args=None):
+def add_metadata_inline(what, node, parameters, args):
     """
     Add metadata of original exported node to the produced TCOD CIF.
 
@@ -1030,6 +1030,8 @@ def export_cifnode(what, parameters=None, trajectory_index=None,
         function_args['node'] = node
     if parameters is not None:
         function_args['parameters'] = parameters
+    else:
+        function_args['parameters'] = ParameterData(dict={})
     ret_dict = add_metadata_inline(**function_args)
 
     return ret_dict['cif']


### PR DESCRIPTION
Fixes #1208 

Various functions that were decorated as `@optional_inline` used `None` as
default for some its arguments. When the functional was triggered as an
inline calculation, the process layer will attempt to store `None` which
will of course fail. The solution is to not use defaults.