### PR TITLE
 Update serialize and deserialize to handle Group nodes

### DIFF
--- a/aiida/backends/tests/__init__.py
+++ b/aiida/backends/tests/__init__.py
@@ -42,6 +42,7 @@ db_test_list = {
         'parsers': ['aiida.backends.tests.parsers'],
         'tcodexporter': ['aiida.backends.tests.tcodexporter'],
         'query': ['aiida.backends.tests.query'],
+        'utils.serialize': ['aiida.backends.tests.utils.serialize'],
         'workflows': ['aiida.backends.tests.workflows'],
         'calculation_node': ['aiida.backends.tests.calculation_node'],
         'backup_script': ['aiida.backends.tests.backup_script'],

--- a/aiida/backends/tests/__init__.py
+++ b/aiida/backends/tests/__init__.py
@@ -52,6 +52,7 @@ db_test_list = {
         'examplehelpers': ['aiida.backends.tests.example_helpers'],
         'orm.data.frozendict': ['aiida.backends.tests.orm.data.frozendict'],
         'orm.log': ['aiida.backends.tests.orm.log'],
+        'orm.utils': ['aiida.backends.tests.orm.utils'],
         'work.class_loader': ['aiida.backends.tests.work.class_loader'],
         'work.daemon': ['aiida.backends.tests.work.daemon'],
         'work.futures': ['aiida.backends.tests.work.test_futures'],

--- a/aiida/backends/tests/orm/utils.py
+++ b/aiida/backends/tests/orm/utils.py
@@ -1,0 +1,76 @@
+# -*- coding: utf-8 -*-
+from aiida.backends.testbase import AiidaTestCase
+from aiida.common.exceptions import NotExistent
+from aiida.orm import Group, Node
+from aiida.orm.utils import load_group, load_node
+
+
+class TestOrmUtils(AiidaTestCase):
+
+    def test_load_group(self):
+        """
+        Test the functionality of load_group
+        """
+        name = 'groupie'
+        group = Group(name=name).store()
+
+        # Load through uuid
+        loaded_group = load_group(group.uuid)
+        self.assertEquals(loaded_group.uuid, group.uuid)
+
+        # Load through pk
+        loaded_group = load_group(group.pk)
+        self.assertEquals(loaded_group.uuid, group.uuid)
+
+        # Load through uuid explicitly
+        loaded_group = load_group(uuid=group.uuid)
+        self.assertEquals(loaded_group.uuid, group.uuid)
+
+        # Load through pk explicitly
+        loaded_group = load_group(pk=group.pk)
+        self.assertEquals(loaded_group.uuid, group.uuid)
+
+        # Load through partial uuid
+        loaded_group = load_group(group.uuid[:2])
+        self.assertEquals(loaded_group.uuid, group.uuid)
+
+        # Load through partial uuid
+        loaded_group = load_group(group.uuid[:10])
+        self.assertEquals(loaded_group.uuid, group.uuid)
+
+        with self.assertRaises(NotExistent):
+            load_group('non-existent-uuid')
+
+
+    def test_load_node(self):
+        """
+        Test the functionality of load_node
+        """
+        node = Node().store()
+
+        # Load through uuid
+        loaded_node = load_node(node.uuid)
+        self.assertEquals(loaded_node.uuid, node.uuid)
+
+        # Load through pk
+        loaded_node = load_node(node.pk)
+        self.assertEquals(loaded_node.uuid, node.uuid)
+
+        # Load through uuid explicitly
+        loaded_node = load_node(uuid=node.uuid)
+        self.assertEquals(loaded_node.uuid, node.uuid)
+
+        # Load through pk explicitly
+        loaded_node = load_node(pk=node.pk)
+        self.assertEquals(loaded_node.uuid, node.uuid)
+
+        # Load through partial uuid
+        loaded_node = load_node(node.uuid[:2])
+        self.assertEquals(loaded_node.uuid, node.uuid)
+
+        # Load through partial uuid
+        loaded_node = load_node(node.uuid[:10])
+        self.assertEquals(loaded_node.uuid, node.uuid)
+
+        with self.assertRaises(NotExistent):
+            load_group('non-existent-uuid')

--- a/aiida/backends/tests/utils/serialize.py
+++ b/aiida/backends/tests/utils/serialize.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
-from aiida.orm import Node
+import json
+from aiida.orm import Group, Node
 from aiida.utils.serialize import serialize_data, deserialize_data
 from aiida.backends.testbase import AiidaTestCase
 
@@ -8,6 +9,8 @@ class TestSerialize(AiidaTestCase):
 
     def test_serialize_round_trip(self):
         """
+        Test the serialization of a dictionary with Nodes in various data structure
+        Also make sure that the serialized data is json-serializable
         """
         node_a = Node().store()
         node_b = Node().store()
@@ -23,6 +26,7 @@ class TestSerialize(AiidaTestCase):
         }
 
         serialized_data = serialize_data(data)
+        json_dumped = json.dumps(serialized_data)
         deserialized_data = deserialize_data(serialized_data)
 
         # For now manual element-for-element comparison until we come up with general
@@ -32,3 +36,22 @@ class TestSerialize(AiidaTestCase):
         self.assertEqual(data['list'][:3], deserialized_data['list'][:3])
         self.assertEqual(data['list'][3].uuid, deserialized_data['list'][3].uuid)
         self.assertEqual(data['dict'][('Si',)].uuid, deserialized_data['dict'][('Si',)].uuid)
+
+    def test_serialize_group(self):
+        """
+        Test that serialization and deserialization of Groups works.
+        Also make sure that the serialized data is json-serializable
+        """
+        group_name = 'groupie'
+        group_a = Group(name=group_name).store()
+
+        data = {
+            'group': group_a
+        }
+
+        serialized_data = serialize_data(data)
+        json_dumped = json.dumps(serialized_data)
+        deserialized_data = deserialize_data(serialized_data)
+
+        self.assertEqual(data['group'].uuid, deserialized_data['group'].uuid)
+        self.assertEqual(data['group'].name, deserialized_data['group'].name)

--- a/aiida/utils/serialize.py
+++ b/aiida/utils/serialize.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 import collections
 from ast import literal_eval
-from aiida.orm import Group, Node, load_node
+from aiida.orm import Group, Node, load_group, load_node
 
 _PREFIX_KEY_TUPLE = 'tuple():'
 _PREFIX_VALUE_NODE = 'aiida_node:'
@@ -76,6 +76,6 @@ def deserialize_data(data):
     elif isinstance(data, (str, unicode)) and data.startswith(_PREFIX_VALUE_NODE):
         return load_node(uuid=data[len(_PREFIX_VALUE_NODE):])
     elif isinstance(data, (str, unicode)) and data.startswith(_PREFIX_VALUE_GROUP):
-        return Group.query(uuid=data[len(_PREFIX_VALUE_GROUP):])[0]
+        return load_group(uuid=data[len(_PREFIX_VALUE_GROUP):])
     else:
         return data

--- a/aiida/utils/serialize.py
+++ b/aiida/utils/serialize.py
@@ -1,10 +1,11 @@
 # -*- coding: utf-8 -*-
 import collections
 from ast import literal_eval
-from aiida.orm import Node, load_node
+from aiida.orm import Group, Node, load_node
 
 _PREFIX_KEY_TUPLE = 'tuple():'
 _PREFIX_VALUE_NODE = 'aiida_node:'
+_PREFIX_VALUE_GROUP = 'aiida_group:'
 
 
 def encode_key(key):
@@ -53,6 +54,8 @@ def serialize_data(data):
         return tuple(serialize_data(value) for value in data)
     elif isinstance(data, Node):
         return '{}{}'.format(_PREFIX_VALUE_NODE, data.uuid)
+    elif isinstance(data, Group):
+        return '{}{}'.format(_PREFIX_VALUE_GROUP, data.uuid)
     else:
         return data
 
@@ -72,5 +75,7 @@ def deserialize_data(data):
         return tuple(deserialize_data(value) for value in data)
     elif isinstance(data, (str, unicode)) and data.startswith(_PREFIX_VALUE_NODE):
         return load_node(uuid=data[len(_PREFIX_VALUE_NODE):])
+    elif isinstance(data, (str, unicode)) and data.startswith(_PREFIX_VALUE_GROUP):
+        return Group.query(uuid=data[len(_PREFIX_VALUE_GROUP):])[0]
     else:
         return data


### PR DESCRIPTION
Fixes #1220 

The serialization and deserialization functions are used to serialize
for example input dictionaries in such a way that they become json
and or yaml serializable, such that it can be sent as a string payload
over RabbitMQ to launch the process over the daemon. Group nodes were
not yet supported. This PR implements the required functionality. I also
implemented the `load_group` analogue of `load_node`.