### PR TITLE
Temporarily skip a WorkChain kill test until kill implemented

### DIFF
--- a/aiida/backends/tests/work/work_chain.py
+++ b/aiida/backends/tests/work/work_chain.py
@@ -622,6 +622,7 @@ class TestWorkChainAbort(AiidaTestCase):
         self.assertEquals(process.calc.is_excepted, True)
         self.assertEquals(process.calc.is_killed, False)
 
+    @unittest.skip('Process kill needs to be fixed')
     def test_simple_kill_through_process(self):
         """
         Run the workchain for one step and then kill it by calling kill


### PR DESCRIPTION
The kill functionality is currently broken and this test will hang
indefinitely, timing out the tests. The kill functionality is being
implemented in a different branch but this cannot be blocking for
other development in the meatime