### PR TITLE
 Ensure that check_outputs in on_finish of process does not raise 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,7 +41,7 @@ install:
     # Upgrade pip setuptools and wheel to be able to run the next command
     - pip install -U pip wheel setuptools
     # Install AiiDA with some optional dependencies
-    - if [ "$TEST_TYPE" == "docs" ]; then pip install . && pip install -r docs/requirements_for_rtd.txt && pip install -e git://github.com/muhrin/plumpy.git@3fc79acaa3ca0b9c568897616d5f01182df10171#egg=plumpy; else pip install .[rest,docs,atomic_tools,testing,dev_precommit] && pip install -r requirements.txt; fi
+    - if [ "$TEST_TYPE" == "docs" ]; then pip install . && pip install -r docs/requirements_for_rtd.txt && pip install -e git://github.com/muhrin/plumpy.git@1dc151bbb5ee5f9a1f615589e545d29f547d93cf#egg=plumpy; else pip install .[rest,docs,atomic_tools,testing,dev_precommit] && pip install -r requirements.txt; fi
 
 env:
 ## Build matrix to test both backends, and the docs

--- a/aiida/work/processes.py
+++ b/aiida/work/processes.py
@@ -206,11 +206,11 @@ class Process(plumpy.Process):
         self.report(traceback.format_exc())
 
     @override
-    def on_finish(self, result):
+    def on_finish(self, result, successful):
         """
         Set the finish status on the Calculation node
         """
-        super(Process, self).on_finish(result)
+        super(Process, self).on_finish(result, successful)
         self.calc._set_finish_status(result)
 
     @override

--- a/requirements.txt
+++ b/requirements.txt
@@ -142,4 +142,4 @@ wcwidth==0.1.7
 Werkzeug==0.14.1
 wrapt==1.10.11
 yapf==0.19.0
--e git://github.com/muhrin/plumpy.git@3fc79acaa3ca0b9c568897616d5f01182df10171#egg=plumpy
+-e git://github.com/muhrin/plumpy.git@1dc151bbb5ee5f9a1f615589e545d29f547d93cf#egg=plumpy


### PR DESCRIPTION
Fixes #1219 

Previously, in the on_finish call of a Process, the outputs would
be validated by calling _check_outputs, which would raise if the
validation failed. This was called regardless of the result that
was passed as the return value. This meant that even when a process
returned a non-zero value, indicating it should got to the FINISHED
state with a non-zero FINISH_STATUS, indicating failure, the outputs
would still be checked even though it would be to be expected that
they would not be correct.

The solution for this happened in plum so this commit merely updates
the requirement and function signature. The on_finish method now
takes an additional argument 'successful' which if false, the outputs
will not be checked. On the other hand, if successful is True, the
outputs will be checked, however, if they are not valid an exception
will not be raised but the transition to FINISHED state is rejected
and another transition to FINISHED is scheduled but this time with
the 'successful' argument set to False