### PR TITLE
Make verdi daemon stop database backend independent

### DIFF
--- a/aiida/common/profile.py
+++ b/aiida/common/profile.py
@@ -1,21 +1,18 @@
 # -*- coding: utf-8 -*-
 from aiida.backends import settings
-from aiida.cmdline.utils.decorators import with_dbenv
 from aiida.common import setup
 
 
-@with_dbenv()
 def get_current_profile_name():
     """
-    Return the currently configured profile name
+    Return the currently configured profile name or if not set, the default profile
     """
-    return settings.AIIDADB_PROFILE
+    return settings.AIIDADB_PROFILE or setup.get_default_profile()
 
 
-@with_dbenv()
 def get_current_profile_config():
     """
-    Return the configuration of the currently active profile
+    Return the configuration of the currently active profile or if not set, the default profile
     """
     return setup.get_profile_config(get_current_profile_name())
 
@@ -28,9 +25,17 @@ class ProfileConfig(object):
 
     _RMQ_PREFIX = 'aiida-{uuid}'
 
-    def __init__(self):
-        self.profile_name = get_current_profile_name()
-        self.profile_config = get_current_profile_config()
+    def __init__(self, profile_name=None):
+        """
+        Construct the ProfileConfig for the given profile_name or retrieve it from
+        the backend settings
+        """
+        if not profile_name:
+            self.profile_name = get_current_profile_name()
+            self.profile_config = get_current_profile_config()
+        else:
+            self.profile_name = profile_name
+            self.profile_config = setup.get_profile_config(profile_name)
 
     @property
     def circus_port(self):

--- a/aiida/common/setup.py
+++ b/aiida/common/setup.py
@@ -17,6 +17,7 @@ from aiida.common.exceptions import ConfigurationError
 from aiida.utils.find_folder import find_path
 from .additions.config_migrations import check_and_migrate_config, add_config_version
 
+USE_TZ = True
 DEFAULT_AIIDA_USER = 'aiida@localhost'
 
 AIIDA_PATH = [os.path.expanduser(path) for path in os.environ.get('AIIDA_PATH', '').split(':') if path]

--- a/aiida/settings.py
+++ b/aiida/settings.py
@@ -13,7 +13,6 @@ from aiida.common.exceptions import ConfigurationError, MissingConfigurationErro
 from aiida.common.setup import get_config, get_profile_config, parse_repository_uri
 
 
-USE_TZ = True
 TESTING_MODE = False
 
 try:

--- a/aiida/utils/timezone.py
+++ b/aiida/utils/timezone.py
@@ -12,7 +12,7 @@ import pytz
 
 from datetime import datetime
 
-from aiida import settings
+from aiida.common import setup
 
 # All the timezone part here is taken from Django.
 # TODO SP: check license terms ?
@@ -27,7 +27,7 @@ def get_current_timezone():
 
 
 def now():
-    if getattr(settings, "USE_TZ", None):
+    if getattr(setup, 'USE_TZ', None):
         return datetime.utcnow().replace(tzinfo=utc)
     else:
         return datetime.now()


### PR DESCRIPTION
Fixes #1230 

When the database needs to be migrated, the user will be presented with
the instruction to call verdi daemon stop to make sure it is not running.
To not have that raise the same error, it needs to run without loading
the database environment. It only needs the configuration, which should
also not need the backend. Note that we also had to move the definition
of the USE_TZ because importing it led to the check of AIIDADB_PROFILE
being set which requires the backend to be loaded, however, USE_TZ does
not depend on the profile nor backend. So we just moved it out