### PR TITLE
Allow 'non_db' inputs in dynamic namespaces

### DIFF
--- a/.travis-data/test_daemon.py
+++ b/.travis-data/test_daemon.py
@@ -243,16 +243,16 @@ def main():
         result, node = run_get_node(NestedWorkChain, inp=inp)
         expected_results_workchains[node.pk] = index
 
+    print "Submitting a workchain with a dynamic non-db input."
+    value = [4, 2, 3]
+    pk = submit(DynamicNonDbInput, namespace={'input': value}).pk
+    expected_results_workchains[pk] = value
+
     print "Submitting the ListEcho workchain."
     list_value = List()
     list_value.extend([1, 2, 3])
     pk = submit(ListEcho, list=list_value).pk
     expected_results_workchains[pk] = list_value
-
-    print "Submitting a workchain with a dynamic non-db input."
-    value = [1, 2, 3]
-    pk = submit(DynamicNonDbInput, namespace={'input': value})
-    expected_results_workchains[pk] = value
 
     calculation_pks = sorted(expected_results_calculations.keys())
     workchains_pks = sorted(expected_results_workchains.keys())

--- a/.travis-data/test_daemon.py
+++ b/.travis-data/test_daemon.py
@@ -16,7 +16,7 @@ from aiida.daemon.client import ProfileDaemonClient
 from aiida.orm import DataFactory
 from aiida.orm.data.int import Int
 from aiida.work.launch import run_get_node, submit
-from workchains import NestedWorkChain
+from workchains import NestedWorkChain, DynamicNonDbInput
 
 ParameterData = DataFactory('parameter')
 
@@ -214,7 +214,7 @@ def create_cache_calc(code, counter, inputval):
 def main():
     expected_results_calculations = {}
     expected_results_workchains = {}
-    
+
     code = Code.get_from_string(codename)
 
     # Submitting the Calculations the old way, creating and storing a JobCalc first and submitting it
@@ -241,6 +241,11 @@ def main():
         inp = Int(index)
         result, node = run_get_node(NestedWorkChain, inp=inp)
         expected_results_workchains[node.pk] = index
+
+    print "Submitting a workchain with a dynamic non-db input."
+    value = [1, 2, 3]
+    pk = submit(DynamicNonDbInput, namespace={'input': value})
+    expected_results_workchains[pk] = value
 
     calculation_pks = sorted(expected_results_calculations.keys())
     workchains_pks = sorted(expected_results_workchains.keys())

--- a/.travis-data/workchains.py
+++ b/.travis-data/workchains.py
@@ -66,10 +66,11 @@ class DynamicNonDbInput(WorkChain):
     def define(cls, spec):
         super(DynamicNonDbInput, cls).define(spec)
         spec.input_namespace('namespace', dynamic=True)
+        spec.output('output', valid_type=List)
         spec.outline(cls.do_test)
 
     def do_test(self):
         input_list = self.inputs.namespace.input
-        assert isinstance(input_list, list)
+        assert isinstance(input_list, tuple)
         assert not isinstance(input_list, List)
-        self.out('output', List(list=input_list))
+        self.out('output', List(list=list(input_list)))

--- a/.travis-data/workchains.py
+++ b/.travis-data/workchains.py
@@ -8,6 +8,7 @@
 # For further information please visit http://www.aiida.net               #
 ###########################################################################
 from aiida.orm.data.int import Int
+from aiida.orm.data.list import List
 from aiida.work import submit
 from aiida.work.workchain import WorkChain, ToContext, append_
 
@@ -46,3 +47,16 @@ class NestedWorkChain(WorkChain):
         else:
             self.report('Bottom-level workchain reached.')
             self.out('output', Int(0))
+
+class DynamicNonDbInput(WorkChain):
+    @classmethod
+    def define(cls, spec):
+        super(DynamicNonDbInput, cls).define(spec)
+        spec.input_namespace('namespace', dynamic=True)
+        spec.outline(cls.do_test)
+
+    def do_test(self):
+        input_list = self.inputs.namespace.input
+        assert isinstance(input_list, list)
+        assert not isinstance(input_list, List)
+        self.out('output', List(list=input_list))

--- a/aiida/backends/tests/work/test_process_spec.py
+++ b/aiida/backends/tests/work/test_process_spec.py
@@ -30,9 +30,9 @@ class TestProcessSpec(AiidaTestCase):
 
         n = Node()
         d = Data()
-        self.assertFalse(self.spec.validate_inputs({'key': 'foo'})[0])
-        self.assertFalse(self.spec.validate_inputs({'key': 5})[0])
-        self.assertFalse(self.spec.validate_inputs({'key': n})[0])
+        self.assertTrue(self.spec.validate_inputs({'key': 'foo'})[0])
+        self.assertTrue(self.spec.validate_inputs({'key': 5})[0])
+        self.assertTrue(self.spec.validate_inputs({'key': n})[0])
         self.assertTrue(self.spec.validate_inputs({'key': d})[0])
 
     def test_dynamic_output(self):
@@ -41,7 +41,7 @@ class TestProcessSpec(AiidaTestCase):
 
         n = Node()
         d = Data()
-        self.assertFalse(self.spec.validate_inputs({'key': 'foo'})[0])
-        self.assertFalse(self.spec.validate_inputs({'key': 5})[0])
-        self.assertFalse(self.spec.validate_inputs({'key': n})[0])
-        self.assertTrue(self.spec.validate_inputs({'key': d})[0])
+        self.assertFalse(self.spec.validate_outputs({'key': 'foo'})[0])
+        self.assertFalse(self.spec.validate_outputs({'key': 5})[0])
+        self.assertFalse(self.spec.validate_outputs({'key': n})[0])
+        self.assertTrue(self.spec.validate_outputs({'key': d})[0])

--- a/aiida/backends/tests/work/test_process_spec.py
+++ b/aiida/backends/tests/work/test_process_spec.py
@@ -30,9 +30,9 @@ class TestProcessSpec(AiidaTestCase):
 
         n = Node()
         d = Data()
-        self.assertTrue(self.spec.validate_inputs({'key': 'foo'})[0])
-        self.assertTrue(self.spec.validate_inputs({'key': 5})[0])
-        self.assertTrue(self.spec.validate_inputs({'key': n})[0])
+        self.assertFalse(self.spec.validate_inputs({'key': 'foo'})[0])
+        self.assertFalse(self.spec.validate_inputs({'key': 5})[0])
+        self.assertFalse(self.spec.validate_inputs({'key': n})[0])
         self.assertTrue(self.spec.validate_inputs({'key': d})[0])
 
     def test_dynamic_output(self):

--- a/aiida/backends/tests/work/work_chain.py
+++ b/aiida/backends/tests/work/work_chain.py
@@ -520,6 +520,25 @@ class TestWorkchain(AiidaTestCase):
         proc = run_and_check_success(wf_class, **inputs)
         return proc.finished_steps
 
+    def test_nondb_dynamic(self):
+        """
+        Test that non-db inputs can be passed in a dynamic input namespace.
+        """
+        value = [1, 2, {'a': 1}]
+        class TestWorkChain(WorkChain):
+            @classmethod
+            def define(cls, spec):
+                super(TestWorkChain, cls).define(spec)
+
+                spec.input_namespace('namespace', dynamic=True)
+                spec.outline(cls.check_input)
+
+            def check_input(self):
+                assert self.inputs.namespace.value == value
+
+        run_and_check_success(TestWorkChain, namespace={'value': value})
+
+
 
 class TestWorkchainWithOldWorkflows(AiidaTestCase):
     def setUp(self):

--- a/aiida/sphinxext/tests/reference_results/workchain.xml
+++ b/aiida/sphinxext/tests/reference_results/workchain.xml
@@ -13,8 +13,7 @@
                 <paragraph>
                         A demo workchain to show how the workchain auto-documentation works.
                         </paragraph>
-                <paragraph><strong>Inputs:</strong><bullet_list bullet="*"><list_item><paragraph><literal_strong>x</literal_strong>, <emphasis>Float</emphasis>, required -- First input argument.</paragraph></list_item><list_item><literal_strong>y</literal_strong>, <emphasis>Namespace</emphasis><bullet_list bullet="*"><list_item><paragraph><literal_strong>z</literal_strong>, <emphasis>Int</emphasis>, required -- Input in a separate namespace.</paragraph></list_item></bullet_list></list_item></bullet_list></paragraph>
-                <paragraph><strong>Inputs not stored in the database:</strong><bullet_list bullet="*"><list_item><paragraph><literal_strong>description</literal_strong>, <emphasis>basestring</emphasis>, optional</paragraph></list_item><list_item><paragraph><literal_strong>label</literal_strong>, <emphasis>basestring</emphasis>, optional</paragraph></list_item><list_item><paragraph><literal_strong>store_provenance</literal_strong>, <emphasis>bool</emphasis>, optional</paragraph></list_item></bullet_list></paragraph>
+                <paragraph><strong>Inputs:</strong><bullet_list bullet="*"><list_item><paragraph><literal_strong>description</literal_strong>, <emphasis>basestring</emphasis>, optional, <emphasis>non_db</emphasis></paragraph></list_item><list_item><paragraph><literal_strong>label</literal_strong>, <emphasis>basestring</emphasis>, optional, <emphasis>non_db</emphasis></paragraph></list_item><list_item><paragraph><literal_strong>store_provenance</literal_strong>, <emphasis>bool</emphasis>, optional, <emphasis>non_db</emphasis></paragraph></list_item><list_item><paragraph><literal_strong>x</literal_strong>, <emphasis>Float</emphasis>, required -- First input argument.</paragraph></list_item><list_item><literal_strong>y</literal_strong>, <emphasis>Namespace</emphasis><bullet_list bullet="*"><list_item><paragraph><literal_strong>z</literal_strong>, <emphasis>Int</emphasis>, required -- Input in a separate namespace.</paragraph></list_item></bullet_list></list_item></bullet_list></paragraph>
                 <paragraph><strong>Outputs:</strong><bullet_list bullet="*"><list_item><paragraph><literal_strong>z</literal_strong>, <emphasis>Bool</emphasis>, required -- Output of the demoworkchain.</paragraph></list_item></bullet_list></paragraph>
             </desc_content>
         </desc>
@@ -39,8 +38,7 @@
                 <paragraph>
                         A demo workchain to show how the workchain auto-documentation works.
                         </paragraph>
-                <paragraph><strong>Inputs:</strong><bullet_list bullet="*"><list_item><paragraph><literal_strong>x</literal_strong>, <emphasis>Float</emphasis>, required -- First input argument.</paragraph></list_item><list_item><literal_strong>y</literal_strong>, <emphasis>Namespace</emphasis><bullet_list bullet="*"><list_item><paragraph><literal_strong>z</literal_strong>, <emphasis>Int</emphasis>, required -- Input in a separate namespace.</paragraph></list_item></bullet_list></list_item></bullet_list></paragraph>
-                <paragraph><strong>Inputs not stored in the database:</strong><bullet_list bullet="*"><list_item><paragraph><literal_strong>description</literal_strong>, <emphasis>basestring</emphasis>, optional</paragraph></list_item><list_item><paragraph><literal_strong>label</literal_strong>, <emphasis>basestring</emphasis>, optional</paragraph></list_item><list_item><paragraph><literal_strong>store_provenance</literal_strong>, <emphasis>bool</emphasis>, optional</paragraph></list_item></bullet_list></paragraph>
+                <paragraph><strong>Inputs:</strong><bullet_list bullet="*"><list_item><paragraph><literal_strong>description</literal_strong>, <emphasis>basestring</emphasis>, optional, <emphasis>non_db</emphasis></paragraph></list_item><list_item><paragraph><literal_strong>label</literal_strong>, <emphasis>basestring</emphasis>, optional, <emphasis>non_db</emphasis></paragraph></list_item><list_item><paragraph><literal_strong>store_provenance</literal_strong>, <emphasis>bool</emphasis>, optional, <emphasis>non_db</emphasis></paragraph></list_item><list_item><paragraph><literal_strong>x</literal_strong>, <emphasis>Float</emphasis>, required -- First input argument.</paragraph></list_item><list_item><literal_strong>y</literal_strong>, <emphasis>Namespace</emphasis><bullet_list bullet="*"><list_item><paragraph><literal_strong>z</literal_strong>, <emphasis>Int</emphasis>, required -- Input in a separate namespace.</paragraph></list_item></bullet_list></list_item></bullet_list></paragraph>
                 <paragraph><strong>Outputs:</strong><bullet_list bullet="*"><list_item><paragraph><literal_strong>z</literal_strong>, <emphasis>Bool</emphasis>, required -- Output of the demoworkchain.</paragraph></list_item></bullet_list></paragraph>
             </desc_content>
         </desc>
@@ -48,7 +46,7 @@
         <desc desctype="class" domain="py" noindex="False" objtype="class">
             <desc_signature class="" first="False" fullname="NormalClass" ids="demo_workchain.NormalClass" module="demo_workchain" names="demo_workchain.NormalClass"><desc_annotation>class </desc_annotation><desc_addname>demo_workchain.</desc_addname><desc_name>NormalClass</desc_name></desc_signature>
             <desc_content>
-                <paragraph>This is here to check that we didn't break the regular 'autoclass.</paragraph>
+                <paragraph>This is here to check that we didn't break the regular autoclass.</paragraph>
             </desc_content>
         </desc>
     </section>

--- a/aiida/sphinxext/tests/workchain_source/demo_workchain.py
+++ b/aiida/sphinxext/tests/workchain_source/demo_workchain.py
@@ -24,4 +24,4 @@ class DemoWorkChain(WorkChain):  # pylint: disable=abstract-method
         spec.output('z', valid_type=Bool, help='Output of the demoworkchain.')
 
 class NormalClass(object):
-    """This is here to check that we didn't break the regular 'autoclass."""
+    """This is here to check that we didn't break the regular autoclass."""

--- a/aiida/work/job_processes.py
+++ b/aiida/work/job_processes.py
@@ -336,7 +336,7 @@ class JobProcess(processes.Process):
 
             port = self.spec().inputs[name]
 
-            if input_value is None or port.non_db:
+            if input_value is None or getattr(port, 'non_db', False):
                 continue
 
             # Call the 'use' methods to set up the data-calc links

--- a/aiida/work/ports.py
+++ b/aiida/work/ports.py
@@ -25,5 +25,5 @@ class InputPort(WithNonDb, ports.InputPort):
     pass
 
 
-class PortNamespace(WithNonDb, ports.PortNamespace):
+class PortNamespace(ports.PortNamespace):
     pass

--- a/aiida/work/processes.py
+++ b/aiida/work/processes.py
@@ -409,7 +409,7 @@ class Process(plumpy.Process):
                     sub_items = self._flatten_inputs(nested_port, value, prefixed_key, separator)
                     items.extend(sub_items)
         else:
-            if not port.non_db:
+            if not getattr(port, 'non_db', False):
                 items.append((parent_name, port_value))
 
         return items

--- a/aiida/work/processes.py
+++ b/aiida/work/processes.py
@@ -63,6 +63,7 @@ class Process(plumpy.Process):
         spec.input('store_provenance', valid_type=bool, default=True, non_db=True)
         spec.input('description', valid_type=basestring, required=False, non_db=True)
         spec.input('label', valid_type=basestring, required=False, non_db=True)
+        spec.inputs.valid_type = None
         spec.outputs.valid_type = (Data)
 
     @classmethod

--- a/aiida/work/processes.py
+++ b/aiida/work/processes.py
@@ -63,7 +63,7 @@ class Process(plumpy.Process):
         spec.input('store_provenance', valid_type=bool, default=True, non_db=True)
         spec.input('description', valid_type=basestring, required=False, non_db=True)
         spec.input('label', valid_type=basestring, required=False, non_db=True)
-        spec.inputs.valid_type = None
+        spec.inputs.valid_type = (Calculation, Data)
         spec.outputs.valid_type = (Data)
 
     @classmethod

--- a/aiida/work/processes.py
+++ b/aiida/work/processes.py
@@ -63,7 +63,6 @@ class Process(plumpy.Process):
         spec.input('store_provenance', valid_type=bool, default=True, non_db=True)
         spec.input('description', valid_type=basestring, required=False, non_db=True)
         spec.input('label', valid_type=basestring, required=False, non_db=True)
-        spec.inputs.valid_type = (Data, Calculation)
         spec.outputs.valid_type = (Data)
 
     @classmethod

--- a/aiida/work/processes.py
+++ b/aiida/work/processes.py
@@ -63,7 +63,7 @@ class Process(plumpy.Process):
         spec.input('store_provenance', valid_type=bool, default=True, non_db=True)
         spec.input('description', valid_type=basestring, required=False, non_db=True)
         spec.input('label', valid_type=basestring, required=False, non_db=True)
-        spec.inputs.valid_type = (Calculation, Data)
+        spec.inputs.valid_type = (Data, Calculation)
         spec.outputs.valid_type = (Data)
 
     @classmethod

--- a/aiida/work/processes.py
+++ b/aiida/work/processes.py
@@ -24,6 +24,7 @@ from aiida.common.lang import override, protected
 from aiida.common.links import LinkType
 from aiida.common.log import LOG_LEVEL_REPORT
 from aiida.orm import load_node
+from aiida.orm.node import Node
 from aiida.orm.calculation import Calculation
 from aiida.orm.calculation.function import FunctionCalculation
 from aiida.orm.calculation.work import WorkCalculation
@@ -400,8 +401,9 @@ class Process(plumpy.Process):
                 try:
                     nested_port = port[name]
                 except KeyError:
-                    # Port does not exist in the port namespace, add it regardless of type of value
-                    items.append((prefixed_key, value))
+                    # For dynamic PortNamespaces, only add Node values.
+                    if isinstance(value, Node):
+                        items.append((prefixed_key, value))
                 else:
                     sub_items = self._flatten_inputs(nested_port, value, prefixed_key, separator)
                     items.extend(sub_items)


### PR DESCRIPTION
Decides whether a dynamic input should be ``non_db`` by checking if it is a ``Node`` instance.

The potential issue with this could be accidentally creating ``non_db`` inputs. Maybe we should add an `allow_non_db` flag to the `PortNamespace`, to toggle whether ``non_db`` dynamic inputs can be made.

The `PortNamespace` already has a `non_db` attribute, but it's not entirely clear to me what this does. In `_flatten_inputs` at least, the `non_db` attribute isn't checked when expanding `PortNamespace`s.