### PR TITLE
Change verdi profile list to use colors by default and improve output format

### DIFF
--- a/aiida/cmdline/commands/daemon.py
+++ b/aiida/cmdline/commands/daemon.py
@@ -310,7 +310,7 @@ def restart(ctx, reset, no_wait):
     wait = not no_wait
 
     if reset:
-        ctx.invoke(stop, wait=True)
+        ctx.invoke(stop)
         ctx.invoke(start)
     else:
         restart_cmd = {

--- a/aiida/cmdline/commands/profile.py
+++ b/aiida/cmdline/commands/profile.py
@@ -72,46 +72,46 @@ class Profile(VerdiCommandWithSubcommands):
             click.echo(err_msg, err=True)
             sys.exit(1)
 
-        use_colors = False
+        use_colors = True
         if args:
             try:
                 if len(args) != 1:
                     raise ValueError
-                if args[0] != "--color":
+                if args[0] != '--no-color':
                     raise ValueError
-                use_colors = True
+                use_colors = False
             except ValueError:
-                print >> sys.stderr, ("You can pass only one further argument, "
-                                      "--color, to show the results with colors")
+                print >> sys.stderr, ('You can pass only one further argument, '
+                                      '--no-color, to show the results without colors')
                 sys.exit(1)
 
         if default_profile is None:
             print >> sys.stderr, "### No default profile configured yet, run 'verdi install'! ###"
             return
         else:
-            print >> sys.stderr, "The default profile is marked by the '>' symbol"
+            print >> sys.stderr, 'The default profile is highlighted and marked by the * symbol'
 
         for profile in get_profiles_list():
             color_id = 39  # Default foreground color
             if profile == default_profile:
-                symbol = ">"
-                color_id = 31
+                symbol = '*'
+                color_id = 32
             else:
-                symbol = "*"
+                symbol = ' '
 
             if use_colors:
-                start_color = "\x1b[{}m".format(color_id)
-                end_color = "\x1b[0m"
-                bold_sequence = "\x1b[1;{}m".format(color_id)
-                nobold_sequence = "\x1b[0;{}m".format(color_id)
+                start_color = '\x1b[{}m'.format(color_id)
+                end_color = '\x1b[0m'
+                bold_sequence = '\x1b[1;{}m'.format(color_id)
+                nobold_sequence = '\x1b[0;{}m'.format(color_id)
             else:
-                start_color = ""
-                end_color = ""
-                bold_sequence = ""
-                nobold_sequence = ""
+                start_color = ''
+                end_color = ''
+                bold_sequence = ''
+                nobold_sequence = ''
 
-            print "{}{} {}{} {}{}".format(
-                start_color, symbol, bold_sequence, profile, nobold_sequence, end_color)
+            print '{}{} {}{} {}{}'.format(
+                start_color, symbol, nobold_sequence, profile, nobold_sequence, end_color)
 
     def profile_delete(self, *args):
         """ Deletes profile


### PR DESCRIPTION
This also includes a crucial bug fix for the `verdi daemon restart --reset` command

The method of `verdi profile list` to indicate the default profile
was not very clear, because it used symbols in the itemization for
all profiles, just the default profile had a different symbol, and
colors were switched off by default. The `--colors` switch could be
used to turn it on.

I have reversed that logic and made colors the default, providing
the switch `--no-colors` to switch it off and I have removed all
itemization symbols, except for the default profile. The output
now matches exactly that of for example `git branch` which is a
lot clearer