### PR TITLE
The verdi daemon start command still used old '-f' flag instead of '--foreground'

### DIFF
--- a/aiida/cmdline/commands/daemon.py
+++ b/aiida/cmdline/commands/daemon.py
@@ -124,7 +124,7 @@ def start(foreground):
     click.echo('Starting the daemon... ', nl=False)
 
     if foreground:
-        command = ['verdi', 'daemon', '_start_circus', '-f']
+        command = ['verdi', 'daemon', '_start_circus', '--foreground']
     else:
         command = ['verdi', 'daemon', '_start_circus']
 


### PR DESCRIPTION
Another tiny bug introduced after refactoring...