### PR TITLE
Revert the DEFAULT_TRANSPORT_INTERVAL to 30

### DIFF
--- a/aiida/common/setup.py
+++ b/aiida/common/setup.py
@@ -487,6 +487,7 @@ def generate_new_circus_port(profiles=None):
     :param profiles: the profiles dictionary of the configuration file
     :returns: integer for the circus daemon port
     """
+    from aiida.common.exceptions import MissingConfigurationError
     port = 6000
 
     if profiles is None:

--- a/aiida/utils/__init__.py
+++ b/aiida/utils/__init__.py
@@ -12,4 +12,4 @@
 # This is used both in the work.transports.TransportQueue and in the
 # transport.Transport class
 # (unless replaced in plugins, as it actually is the case for SSH and local)
-DEFAULT_TRANSPORT_INTERVAL = 5.
+DEFAULT_TRANSPORT_INTERVAL = 30.


### PR DESCRIPTION
Fixes #1173 

This was temporarily set to 5. because for a larger interval the daemon
tests on Travis would fail. The final JobCalculation would not properly
be put into the ProcessState.FINISHED causing the loop that checks that
all calculations are terminated, to time out. With the new circus daemon
and fixes to the ProcessState system, this problem now seems to have
been solved