### PR TITLE
Fix serialization when submitting.

### DIFF
--- a/.travis-data/test_daemon.py
+++ b/.travis-data/test_daemon.py
@@ -100,8 +100,8 @@ def validate_workchains(expected_results):
                 pk, expected_value, type(exception), exception)
 
         if actual_value != expected_value:
-            print "* UNEXPECTED VALUE {} for workchain pk={}: I expected {}".format(
-                actual_value, pk, expected_value)
+            print "* UNEXPECTED VALUE {}, type {} for workchain pk={}: I expected {}, type {}".format(
+                actual_value, type(actual_value), pk, expected_value, type(expected_value))
             valid = False
 
     return valid

--- a/.travis-data/test_daemon.py
+++ b/.travis-data/test_daemon.py
@@ -15,8 +15,9 @@ from aiida.common.exceptions import NotExistent
 from aiida.daemon.client import ProfileDaemonClient
 from aiida.orm import DataFactory
 from aiida.orm.data.int import Int
+from aiida.orm.data.list import List
 from aiida.work.launch import run_get_node, submit
-from workchains import NestedWorkChain
+from workchains import NestedWorkChain, ListEcho
 
 ParameterData = DataFactory('parameter')
 
@@ -214,7 +215,7 @@ def create_cache_calc(code, counter, inputval):
 def main():
     expected_results_calculations = {}
     expected_results_workchains = {}
-    
+
     code = Code.get_from_string(codename)
 
     # Submitting the Calculations the old way, creating and storing a JobCalc first and submitting it
@@ -241,6 +242,12 @@ def main():
         inp = Int(index)
         result, node = run_get_node(NestedWorkChain, inp=inp)
         expected_results_workchains[node.pk] = index
+
+    print "Submitting the ListEcho workchain."
+    list_value = List()
+    list_value.extend([1, 2, 3])
+    pk = submit(ListEcho, list=list_value).pk
+    expected_results_workchains[pk] = list_value
 
     calculation_pks = sorted(expected_results_calculations.keys())
     workchains_pks = sorted(expected_results_workchains.keys())

--- a/.travis-data/workchains.py
+++ b/.travis-data/workchains.py
@@ -8,6 +8,7 @@
 # For further information please visit http://www.aiida.net               #
 ###########################################################################
 from aiida.orm.data.int import Int
+from aiida.orm.data.list import List
 from aiida.work import submit
 from aiida.work.workchain import WorkChain, ToContext, append_
 
@@ -46,3 +47,16 @@ class NestedWorkChain(WorkChain):
         else:
             self.report('Bottom-level workchain reached.')
             self.out('output', Int(0))
+
+class ListEcho(WorkChain):
+    @classmethod
+    def define(cls, spec):
+        super(ListEcho, cls).define(spec)
+
+        spec.input('list', valid_type=List)
+        spec.output('list', valid_type=List)
+
+        spec.outline(cls.do_echo)
+
+    def do_echo(self):
+        self.out('list', self.inputs.list)

--- a/.travis-data/workchains.py
+++ b/.travis-data/workchains.py
@@ -54,9 +54,9 @@ class ListEcho(WorkChain):
         super(ListEcho, cls).define(spec)
 
         spec.input('list', valid_type=List)
-        spec.output('list', valid_type=List)
+        spec.output('output', valid_type=List)
 
         spec.outline(cls.do_echo)
 
     def do_echo(self):
-        self.out('list', self.inputs.list)
+        self.out('output', self.inputs.list)

--- a/aiida/orm/data/list.py
+++ b/aiida/orm/data/list.py
@@ -35,6 +35,12 @@ class List(Data, MutableSequence):
     def __str__(self):
         return self.get_list().__str__()
 
+    def __eq__(self, other):
+        try:
+            return self.get_list() == other.get_list()
+        except AttributeError:
+            return self.get_list() == other
+
     def append(self, value):
         l = self.get_list()
         l.append(value)

--- a/aiida/orm/data/list.py
+++ b/aiida/orm/data/list.py
@@ -41,6 +41,9 @@ class List(Data, MutableSequence):
         except AttributeError:
             return self.get_list() == other
 
+    def __ne__(self, other):
+        return not self == other
+
     def append(self, value):
         l = self.get_list()
         l.append(value)

--- a/aiida/utils/serialize.py
+++ b/aiida/utils/serialize.py
@@ -42,20 +42,20 @@ def serialize_data(data):
     Serialize a value or collection that may potentially contain AiiDA nodes, which
     will be serialized to their UUID. Keys encountered in any mappings, such as a dictionary,
     will also be encoded if necessary. An example is where tuples are used as keys in the
-    pseudo potential input dictionaries. These operations will ensure that the returned data is 
+    pseudo potential input dictionaries. These operations will ensure that the returned data is
     JSON serializable.
 
     :param data: a single value or collection
     :return: the serialized data with the same internal structure
     """
-    if isinstance(data, collections.Mapping):
-        return {encode_key(key): serialize_data(value) for key, value in data.iteritems()}
-    elif isinstance(data, collections.Sequence) and not isinstance(data, (str, unicode)):
-        return tuple(serialize_data(value) for value in data)
-    elif isinstance(data, Node):
+    if isinstance(data, Node):
         return '{}{}'.format(_PREFIX_VALUE_NODE, data.uuid)
     elif isinstance(data, Group):
         return '{}{}'.format(_PREFIX_VALUE_GROUP, data.uuid)
+    elif isinstance(data, collections.Mapping):
+        return {encode_key(key): serialize_data(value) for key, value in data.iteritems()}
+    elif isinstance(data, collections.Sequence) and not isinstance(data, (str, unicode)):
+        return tuple(serialize_data(value) for value in data)
     else:
         return data
 


### PR DESCRIPTION
Fixes #1244.

AiiDA types should have preference in serialization compared to the catch-all ``Iterable`` and ``Mapping``. Otherwise e.g. a ``List`` will be turned into a ``tuple`` upon serializing / de-serializing.

Also adds a test which submits a workchain with a list input, that just echoes it back.