### PR TITLE
Fix the RMQ connection automatically closing

### DIFF
--- a/aiida/common/log.py
+++ b/aiida/common/log.py
@@ -136,6 +136,11 @@ LOGGING = {
             'propagate': False,
             'qualname': 'sqlalchemy.engine',
         },
+        'pika': {
+            'handlers': ['console'],
+            'level': 'ERROR',
+            'propagate': False,
+        },
     },
 }
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -143,3 +143,4 @@ Werkzeug==0.14.1
 wrapt==1.10.11
 yapf==0.19.0
 -e git://github.com/muhrin/plumpy.git@1dc151bbb5ee5f9a1f615589e545d29f547d93cf#egg=plumpy
+-e git://github.com/muhrin/kiwipy.git@249fe038f109424b6cdd007092d6f3535346aa7f#egg=kiwipy


### PR DESCRIPTION
Fixes #1247 

The last released version of kiwipy `0.2.0dev2` contains a bug that
will lead to the connection of the daemon automatically closing
after some time out, causing the daemon to have to be restarted.
Until this is fixed in a release we fix the commit requirement