### PR TITLE
Fix minor naming and import bugs in verdi commands

### DIFF
--- a/aiida/cmdline/commands/calculation.py
+++ b/aiida/cmdline/commands/calculation.py
@@ -270,7 +270,7 @@ class Calculation(VerdiCommandWithSubcommands):
 
     def calculation_show(self, *args):
         from aiida.common.exceptions import NotExistent
-        from aiida.cmdline.common import print_node_info
+        from aiida.cmdline.utils.common import print_node_info
 
         if not is_dbenv_loaded():
             load_dbenv()

--- a/aiida/cmdline/commands/node.py
+++ b/aiida/cmdline/commands/node.py
@@ -277,7 +277,7 @@ class _Show(VerdiCommand):
                 print ""
 
     def print_node_info(self, node, print_groups=False):
-        from aiida.cmdline.common import print_node_info
+        from aiida.cmdline.utils.common import print_node_info
 
 ###TODO
 #Add a check here on the node type, otherwise it might try to access attributes such as code which are not necessarily there

--- a/aiida/utils/delete_nodes.py
+++ b/aiida/utils/delete_nodes.py
@@ -99,7 +99,7 @@ def delete_nodes(pks, follow_calls=False, follow_returns=False,
             calculation_pks_losing_called = set(zip(*caller_to_called2delete)[0])
             print "\n{} calculation{} {} lose at least one called instance".format(
                     len(calculation_pks_losing_called),
-                    's' if len(calculation_pks_losing_created) > 1 else '',
+                    's' if len(calculation_pks_losing_called) > 1 else '',
                     'would' if dry_run else 'will')
             if verbosity > 1:
                 print "These are the calculations that {} lose a called instance:".format('would' if dry_run else 'will')


### PR DESCRIPTION
There was a naming bug in 'verdi node delete' when call links would
be involved and in 'verdi calculation show' and 'verdi node show'
there were import errors