### PR TITLE
Fix running inlinecalculations in submitted workchains.

### DIFF
--- a/.travis-data/test_daemon.py
+++ b/.travis-data/test_daemon.py
@@ -18,7 +18,7 @@ from aiida.orm.data.int import Int
 from aiida.orm.data.str import Str
 from aiida.orm.data.list import List
 from aiida.work.launch import run_get_node, submit
-from workchains import NestedWorkChain, ListEcho, InlineCalcRunnerWorkChain
+from workchains import NestedWorkChain, ListEcho, InlineCalcRunnerWorkChain, WorkFunctionRunnerWorkChain
 
 ParameterData = DataFactory('parameter')
 
@@ -249,6 +249,11 @@ def main():
     list_value.extend([1, 2, 3])
     pk = submit(ListEcho, list=list_value).pk
     expected_results_workchains[pk] = list_value
+
+    print "Submitting a WorkChain which contains a workfunction."
+    value = Str('workfunction test string')
+    pk = submit(WorkFunctionRunnerWorkChain, input=value).pk
+    expected_results_workchains[pk] = value
 
     print "Submitting a WorkChain which contains an InlineCalculation."
     value = Str('test_string')

--- a/.travis-data/test_daemon.py
+++ b/.travis-data/test_daemon.py
@@ -15,6 +15,7 @@ from aiida.common.exceptions import NotExistent
 from aiida.daemon.client import ProfileDaemonClient
 from aiida.orm import DataFactory
 from aiida.orm.data.int import Int
+from aiida.orm.data.str import Str
 from aiida.orm.data.list import List
 from aiida.work.launch import run_get_node, submit
 from workchains import NestedWorkChain, ListEcho, InlineCalcRunnerWorkChain

--- a/.travis-data/test_daemon.py
+++ b/.travis-data/test_daemon.py
@@ -17,7 +17,7 @@ from aiida.orm import DataFactory
 from aiida.orm.data.int import Int
 from aiida.orm.data.list import List
 from aiida.work.launch import run_get_node, submit
-from workchains import NestedWorkChain, ListEcho
+from workchains import NestedWorkChain, ListEcho, InlineCalcRunnerWorkChain
 
 ParameterData = DataFactory('parameter')
 
@@ -248,6 +248,11 @@ def main():
     list_value.extend([1, 2, 3])
     pk = submit(ListEcho, list=list_value).pk
     expected_results_workchains[pk] = list_value
+
+    print "Submitting a WorkChain which contains an InlineCalculation."
+    value = Str('test_string')
+    pk = submit(InlineCalcRunnerWorkChain, input=value).pk
+    expected_results_workchains[pk] = value
 
     calculation_pks = sorted(expected_results_calculations.keys())
     workchains_pks = sorted(expected_results_workchains.keys())

--- a/.travis-data/workchains.py
+++ b/.travis-data/workchains.py
@@ -9,6 +9,8 @@
 ###########################################################################
 from aiida.orm.data.int import Int
 from aiida.orm.data.list import List
+from aiida.orm.data.str import Str 
+from aiida.orm.calculation.inline import make_inline
 from aiida.work import submit
 from aiida.work.workchain import WorkChain, ToContext, append_
 
@@ -60,3 +62,20 @@ class ListEcho(WorkChain):
 
     def do_echo(self):
         self.out('output', self.inputs.list)
+
+class InlineCalcRunnerWorkChain(WorkChain):
+    @classmethod
+    def define(cls, spec):
+        super(InlineCalcRunnerWorkChain, cls).define(spec)
+
+        spec.input('input', valid_type=Str)
+        spec.output('output', valid_type=Str)
+
+        spec.outline(cls.do_run)
+
+    def do_run(self):
+        self.out('output', echo_inline(input_string=self.inputs.input)[1]['output'])
+
+@make_inline
+def echo_inline(input_string):
+    return {'output': input_string}

--- a/.travis-data/workchains.py
+++ b/.travis-data/workchains.py
@@ -9,9 +9,10 @@
 ###########################################################################
 from aiida.orm.data.int import Int
 from aiida.orm.data.list import List
-from aiida.orm.data.str import Str 
+from aiida.orm.data.str import Str
 from aiida.orm.calculation.inline import make_inline
 from aiida.work import submit
+from aiida.work.workfunctions import workfunction
 from aiida.work.workchain import WorkChain, ToContext, append_
 
 class NestedWorkChain(WorkChain):
@@ -64,6 +65,9 @@ class ListEcho(WorkChain):
         self.out('output', self.inputs.list)
 
 class InlineCalcRunnerWorkChain(WorkChain):
+    """
+    WorkChain which calls an InlineCalculation in its step.
+    """
     @classmethod
     def define(cls, spec):
         super(InlineCalcRunnerWorkChain, cls).define(spec)
@@ -75,6 +79,26 @@ class InlineCalcRunnerWorkChain(WorkChain):
 
     def do_run(self):
         self.out('output', echo_inline(input_string=self.inputs.input)[1]['output'])
+
+class WorkFunctionRunnerWorkChain(WorkChain):
+    """
+    WorkChain which calls a workfunction in its step
+    """
+    @classmethod
+    def define(cls, spec):
+        super(WorkFunctionRunnerWorkChain, cls).define(spec)
+
+        spec.input('input', valid_type=Str)
+        spec.output('output', valid_type=Str)
+
+        spec.outline(cls.do_run)
+
+    def do_run(self):
+        self.out('output', echo(self.inputs.input))
+
+@workfunction
+def echo(value):
+    return value
 
 @make_inline
 def echo_inline(input_string):


### PR DESCRIPTION
The ``run_get_node`` of the ``workfunction`` didn't create its own runner, unlike calling the function directly.

Fixes #1250.