### PR TITLE
Improve parsing capabilities of CifData class

### DIFF
--- a/aiida/backends/tests/dataclasses.py
+++ b/aiida/backends/tests/dataclasses.py
@@ -597,7 +597,7 @@ _tag   {}
             f.flush()
             a = CifData(file=f.name)
 
-        self.assertEqual(a.has_attached_hydrogens(), False)
+        self.assertEqual(a.has_attached_hydrogens, False)
 
         with tempfile.NamedTemporaryFile() as f:
             f.write('''
@@ -621,7 +621,7 @@ _tag   {}
             f.flush()
             a = CifData(file=f.name)
 
-        self.assertEqual(a.has_attached_hydrogens(), True)
+        self.assertEqual(a.has_attached_hydrogens, True)
 
     @unittest.skipIf(not has_ase(), "Unable to import ase")
     @unittest.skipIf(not has_pycifrw(), "Unable to import PyCifRW")


### PR DESCRIPTION
Fixes #1256 

This PR addresses a couple of points and improvements to the parsing of `CifData` files
into `StructureData` objects. It implements two new properties for `CifData`:

 * `has_atomic_sites`
 * `has_unknown_species`

The former will check if there any atomic sites defined at all and the latter will check whether
any species in the formulae are unknown, which is to say, they are not elements listed in the
`aiida.common.constants.elements` dictionary. In both cases, it will be impossible to create
a `StructureData` node out of those `CifData` objects and so one does not even have to try
to parse them with either `ase` or `pymatgen`.

Additionally, we improve the automatic structure converter `_get_aiida_structure_pymatgen_inline`
that uses `pymatgen` to parse the cif content to return a `pymatgen` structure object, which is
then used to create a `StructureData` node. There are two improvements here:

* The `CifParser` of `pymatgen` allows to set the parameter `site_tolerance` which will be used
to determine whether two sites overlap and if created by symmetry they should be merged as one.
By default this value is `1E-4` in `v4.5.3`, which is rather tight and often leads to a created structure
with overlapping atoms. To prevent this one should be able to specify this parameter, however, 
unfortunately it is not supported by the other library `ase` that AiiDA supports internally for structure
generation from `CifData` nodes.

* The `CifParser` of `pymatgen` will check the atomic occupations of the parsed cif and if they
exceed unity, a warning will be emitted and the parsing of the structure fails. It is possible to give
a certain tolerance to allow invalid occupations through the `occupation_tolerance` of the `CifParser`
constructor. Any occupations between one and this tolerance will be rounded to one. `Pymatgen` does
not distinguish between various parsing errors, any failure just raises a `ValueError`. However, we
would like to distinguish between well defined errors such as the incorrect occupations case.
As a solution, if the parsing fails, we attempt a second time, this time setting the occupation tolerance
to an unrealistic high value. If the parsing now succeeds, the original failure was due to the occupations
being exceeded and we raise a specific error `InvalidOccupationsError`. If the second parse attempt
also failed, there was some unknown parsing error and we simply raise a `ValueError`.