### PR TITLE
update psycopg2, sqlalchemy and sqlalchemy utils

### DIFF
--- a/docs/requirements_for_rtd.txt
+++ b/docs/requirements_for_rtd.txt
@@ -1,5 +1,5 @@
-SQLAlchemy-Utils==0.31.2
-SQLAlchemy==1.0.12
+SQLAlchemy-Utils==0.33.0
+SQLAlchemy==1.0.19
 Sphinx>=1.5
 aldjemy==0.6.0
 alembic==0.9.6

--- a/setup_requirements.py
+++ b/setup_requirements.py
@@ -43,8 +43,8 @@ install_requires = [
     'numpy==1.12.0',
     'plumpy==0.7.10',
     'portalocker==1.1.0',
-    'SQLAlchemy==1.0.12',  # upgrade to SQLalchemy 1.1.5 does break tests, see #465
-    'SQLAlchemy-Utils==0.31.2',
+    'SQLAlchemy==1.0.19',  # upgrade to SQLalchemy 1.1.5 does break tests, see #465
+    'SQLAlchemy-Utils==0.33.0',
     'alembic==0.9.6',
     'ujson==1.35',
     'enum34==1.1.6',
@@ -58,7 +58,7 @@ install_requires = [
     'tabulate==0.7.5',
     'ete3==3.0.0b35',
     'uritools==1.0.2',
-    'psycopg2==2.7.1',
+    'psycopg2-binary==2.7.4',
     # Requirements for ssh transport
     'paramiko==2.4.0',
     'ecdsa==0.13',


### PR DESCRIPTION
On Materialscloud, we need psycopg2 2.7.3 for compatibility with other
tools, and wheels are then available as psycopg2-binary

/usr/local/lib/python2.7/dist-packages/psycopg2/__init__.py:144: UserWarning: The psycopg2 wheel package will be renamed from release 2.8; in order to keep installing from binary please use "pip install psycopg2-binary" instead. For details see: <http://initd.org/psycopg/docs/install.html#binary-install-from-pypi>.
  """)

Also update sqlalchemy + sqlalchemy_utils which was giving a deprecation
warning

/usr/local/lib/python2.7/dist-packages/sqlalchemy_utils/i18n.py:15: ExtDeprecationWarning: Importing flask.ext.babel is deprecated, use flask_babel instead.