### PR TITLE
Add support for InlineCalculation to ascii_vis.calc_info

### DIFF
--- a/aiida/utils/ascii_vis.py
+++ b/aiida/utils/ascii_vis.py
@@ -155,9 +155,10 @@ def _ctime(node):
 
 
 def calc_info(calc_node):
-    from aiida.orm.calculation.work import WorkCalculation
-    from aiida.orm.calculation.job import JobCalculation
     from aiida.orm.calculation.function import FunctionCalculation
+    from aiida.orm.calculation.inline import InlineCalculation
+    from aiida.orm.calculation.job import JobCalculation
+    from aiida.orm.calculation.work import WorkCalculation
 
     if isinstance(calc_node, WorkCalculation):
         plabel = calc_node.process_label
@@ -173,7 +174,7 @@ def calc_info(calc_node):
         clabel = type(calc_node).__name__
         cstate = str(calc_node.get_state())
         s = u'{} <pk={}> [{}]'.format(clabel, calc_node.pk, cstate)
-    elif isinstance(calc_node, FunctionCalculation):
+    elif isinstance(calc_node, (FunctionCalculation, InlineCalculation)):
         plabel = calc_node.process_label
         pstate = calc_node.process_state
         s = u'{} <pk={}> [{}]'.format(plabel, calc_node.pk, pstate)


### PR DESCRIPTION
This utility function is used a.o. `verdi work status` to draw an
ascii representation of the call graph and `InlineCalculations`
were not taken into account yet, raising an exception. Now they
will be treated just like `FunctionCalculations`