### PR TITLE
Fix 1028 structure to pymagen

### DIFF
--- a/aiida/backends/tests/dataclasses.py
+++ b/aiida/backends/tests/dataclasses.py
@@ -2450,8 +2450,8 @@ class TestPymatgenFromStructureData(AiidaTestCase):
                          ['Cl','Cl10','Cla','cl_x','Na1','Na2','Na_Na','Na4'])
         
         c = StructureData(pymatgen=b)
-        self.assertEquals(c.get_site_kindnames(), ['Cl','Cl10','Cla','Cl_x','Na1','Na2','Na_Na','Na4'])
-        self.assertEquals([k.symbol for k in c.kinds], ['Cl','Na'])
+        self.assertEquals(c.get_site_kindnames(), ['Cl','Cl10','Cla','cl_x','Na1','Na2','Na_Na','Na4'])
+        self.assertEquals(c.get_symbols_set(), set(['Cl','Na']))
         self.assertEquals([s.position for s in c.sites],
                           [(0.,0.,0.),(2.8,0,2.8),(0,2.8,2.8),(2.8,2.8,0),(2.8,2.8,2.8),(2.8,0,0),(0,2.8,0),(0,0,2.8)])
 

--- a/aiida/backends/tests/dataclasses.py
+++ b/aiida/backends/tests/dataclasses.py
@@ -1932,6 +1932,9 @@ class TestStructureDataFromAse(AiidaTestCase):
 
     @unittest.skipIf(not has_ase(), "Unable to import ase")
     def test_ase(self):
+        """
+        Tests roundtrip ASE -> StructureData -> ASE
+        """
         from aiida.orm.data.structure import StructureData
         import ase
 
@@ -1957,6 +1960,9 @@ class TestStructureDataFromAse(AiidaTestCase):
 
     @unittest.skipIf(not has_ase(), "Unable to import ase")
     def test_conversion_of_types_1(self):
+        """
+        Tests roundtrip ASE -> StructureData -> ASE, with tags
+        """
         from aiida.orm.data.structure import StructureData
         import ase
 
@@ -1987,6 +1993,10 @@ class TestStructureDataFromAse(AiidaTestCase):
 
     @unittest.skipIf(not has_ase(), "Unable to import ase")
     def test_conversion_of_types_2(self):
+        """
+        Tests roundtrip ASE -> StructureData -> ASE, with tags, and 
+        changing the atomic masses
+        """
         from aiida.orm.data.structure import StructureData
         import ase
 
@@ -2019,6 +2029,9 @@ class TestStructureDataFromAse(AiidaTestCase):
 
     @unittest.skipIf(not has_ase(), "Unable to import ase")
     def test_conversion_of_types_3(self):
+        """
+        Tests StructureData -> ASE, with all sorts of kind names
+        """
         from aiida.orm.data.structure import StructureData
 
         a = StructureData()
@@ -2050,6 +2063,9 @@ class TestStructureDataFromAse(AiidaTestCase):
 
     @unittest.skipIf(not has_ase(), "Unable to import ase")
     def test_conversion_of_types_4(self):
+        """
+        Tests ASE -> StructureData, in particular conversion tags / kind names
+        """
         from aiida.orm.data.structure import StructureData
         import ase
 
@@ -2063,6 +2079,10 @@ class TestStructureDataFromAse(AiidaTestCase):
 
     @unittest.skipIf(not has_ase(), "Unable to import ase")
     def test_conversion_of_types_5(self):
+        """
+        Tests ASE -> StructureData, in particular conversion tags / kind names
+        (subtle variation of test_conversion_of_types_4)
+        """
         from aiida.orm.data.structure import StructureData
         import ase
 
@@ -2090,7 +2110,8 @@ class TestStructureDataFromPymatgen(AiidaTestCase):
                     "Mismatch in the version of pymatgen (expected 4.5.3)")
     def test_1(self):
         """
-        Test's imput is derived from COD entry 9011963, processed with
+        Tests roundtrip pymatgen -> StructureData -> pymatgen
+        Test's input is derived from COD entry 9011963, processed with
         cif_mark_disorder (from cod-tools) and abbreviated.
         """
         from aiida.orm.data.structure import StructureData
@@ -2162,6 +2183,7 @@ class TestStructureDataFromPymatgen(AiidaTestCase):
                      "Mismatch in the version of pymatgen (expected 4.5.3)")
     def test_2(self):
         """
+        Tests xyz -> pymatgen -> StructureData
         Input source: http://pymatgen.org/_static/Molecule.html
         """
         from aiida.orm.data.structure import StructureData
@@ -2219,7 +2241,7 @@ class TestPymatgenFromStructureData(AiidaTestCase):
                      "Mismatch in the version of pymatgen (expected 4.5.3)")
     def test_1(self):
         """
-        Test the check of periodic boundary conditions.
+        Tests the check of periodic boundary conditions.
         """
         from aiida.orm.data.structure import StructureData
 
@@ -2239,6 +2261,9 @@ class TestPymatgenFromStructureData(AiidaTestCase):
                      StrictVersion('4.5.3'),
                      "Mismatch in the version of pymatgen (expected 4.5.3)")
     def test_2(self):
+        """
+        Tests ASE -> StructureData -> pymatgen
+        """
         from aiida.orm.data.structure import StructureData
         import ase
 
@@ -2274,7 +2299,8 @@ class TestPymatgenFromStructureData(AiidaTestCase):
                      "Mismatch in the version of pymatgen (expected 4.5.3)")
     def test_3(self):
         """
-        Test the conversion of StructureData to pymatgen's Molecule.
+        Tests the conversion of StructureData to pymatgen's Molecule
+        (ASE -> StructureData -> pymatgen)
         """
         from aiida.orm.data.structure import StructureData
         import ase

--- a/aiida/backends/tests/dataclasses.py
+++ b/aiida/backends/tests/dataclasses.py
@@ -2064,7 +2064,7 @@ class TestStructureDataFromAse(AiidaTestCase):
     @unittest.skipIf(not has_ase(), "Unable to import ase")
     def test_conversion_of_types_4(self):
         """
-        Tests ASE -> StructureData, in particular conversion tags / kind names
+        Tests ASE -> StructureData -> ASE, in particular conversion tags / kind names
         """
         from aiida.orm.data.structure import StructureData
         import ase
@@ -2076,11 +2076,16 @@ class TestStructureDataFromAse(AiidaTestCase):
         s = StructureData(ase=atoms)
         kindnames = set([k.name for k in s.kinds])
         self.assertEquals(kindnames, set(['Fe', 'Fe1', 'Fe4']))
+        # check roundtrip ASE -> StructureData -> ASE
+        atoms2 = s.get_ase()
+        self.assertEquals(list(atoms2.get_tags()),list(atoms.get_tags()))
+        self.assertEquals(list(atoms2.get_chemical_symbols()),list(atoms.get_chemical_symbols()))
+        self.assertEquals(atoms2.get_chemical_formula(),'Fe5')
 
     @unittest.skipIf(not has_ase(), "Unable to import ase")
     def test_conversion_of_types_5(self):
         """
-        Tests ASE -> StructureData, in particular conversion tags / kind names
+        Tests ASE -> StructureData -> ASE, in particular conversion tags / kind names
         (subtle variation of test_conversion_of_types_4)
         """
         from aiida.orm.data.structure import StructureData
@@ -2093,6 +2098,11 @@ class TestStructureDataFromAse(AiidaTestCase):
         s = StructureData(ase=atoms)
         kindnames = set([k.name for k in s.kinds])
         self.assertEquals(kindnames, set(['Fe', 'Fe1', 'Fe4']))
+        # check roundtrip ASE -> StructureData -> ASE
+        atoms2 = s.get_ase()
+        self.assertEquals(list(atoms2.get_tags()),list(atoms.get_tags()))
+        self.assertEquals(list(atoms2.get_chemical_symbols()),list(atoms.get_chemical_symbols()))
+        self.assertEquals(atoms2.get_chemical_formula(),'Fe5')
 
 
 class TestStructureDataFromPymatgen(AiidaTestCase):

--- a/aiida/backends/tests/dataclasses.py
+++ b/aiida/backends/tests/dataclasses.py
@@ -2446,7 +2446,7 @@ class TestPymatgenFromStructureData(AiidaTestCase):
         a.append_atom(position=(0,0,2.8), symbols='Na',name='Na4')
         
         b = a.get_pymatgen()
-        self.assertEquals([site.as_dict()['properties']['kind_names'] for site in b.sites],
+        self.assertEquals([site.as_dict()['properties']['kind_name'] for site in b.sites],
                          ['Cl','Cl10','Cla','cl_x','Na1','Na2','Na_Na','Na4'])
         
         c = StructureData(pymatgen=b)

--- a/aiida/backends/tests/dataclasses.py
+++ b/aiida/backends/tests/dataclasses.py
@@ -2104,6 +2104,29 @@ class TestStructureDataFromAse(AiidaTestCase):
         self.assertEquals(list(atoms2.get_chemical_symbols()),list(atoms.get_chemical_symbols()))
         self.assertEquals(atoms2.get_chemical_formula(),'Fe5')
 
+    @unittest.skipIf(not has_ase(), "Unable to import ase")
+    def test_conversion_of_types_6(self):
+        """
+        Tests roundtrip StructureData -> ASE -> StructureData, with tags/kind names
+        """
+        from aiida.orm.data.structure import StructureData
+
+        a = StructureData(cell=[[4,0,0],[0,4,0],[0,0,4]])
+        a.append_atom(position=(0,0,0), symbols='Ni', name='Ni1')
+        a.append_atom(position=(2,2,2), symbols='Ni', name='Ni2')
+        a.append_atom(position=(1,0,1), symbols='Cl', name='Cl')
+        a.append_atom(position=(1,3,1), symbols='Cl', name='Cl')
+        
+        b = a.get_ase()
+        self.assertEquals(b.get_chemical_symbols(), ['Ni', 'Ni', 'Cl','Cl'])
+        self.assertEquals(list(b.get_tags()), [1, 2, 0, 0])
+        
+        c = StructureData(ase=b)
+        self.assertEquals(c.get_site_kindnames(), ['Ni1', 'Ni2', 'Cl','Cl'])
+        self.assertEquals([k.symbol for k in c.kinds], ['Ni', 'Ni', 'Cl'])
+        self.assertEquals([s.position for s in c.sites],
+                          [(0.,0.,0.),(2.,2.,2.),(1.,0.,1.),(1.,3.,1.)])
+
 
 class TestStructureDataFromPymatgen(AiidaTestCase):
     """

--- a/aiida/backends/tests/dataclasses.py
+++ b/aiida/backends/tests/dataclasses.py
@@ -2477,7 +2477,7 @@ class TestPymatgenFromStructureData(AiidaTestCase):
         a.append_atom(position=(0,2.8,0), symbols='Mn',name='Mn2')
         a.append_atom(position=(0,0,2.8), symbols='Mn',name='Mn2')
         
-        b = a.get_pymatgen()
+        b = a.get_pymatgen(add_spin=True)
         # check the spins
         self.assertEquals([s.as_dict()['properties']['spin'] for s in b.species],
                           [-1, -1, -1, -1, 1, 1, 1, 1])
@@ -2575,7 +2575,7 @@ class TestPymatgenFromStructureData(AiidaTestCase):
         self.assertEquals(a.get_formula(),'{Al0.20Fe0.80}2')
         
         with self.assertRaises(ValueError): 
-            a.get_pymatgen()
+            a.get_pymatgen(add_spin=True)
         
         # same, with vacancies
         a = StructureData(cell=[[4,0,0],[0,4,0],[0,0,4]])
@@ -2588,7 +2588,7 @@ class TestPymatgenFromStructureData(AiidaTestCase):
         self.assertEquals(a.get_formula(),'{Fe0.80X0.20}2')
         
         with self.assertRaises(ValueError): 
-            a.get_pymatgen()
+            a.get_pymatgen(add_spin=True)
         
         
 class TestArrayData(AiidaTestCase):

--- a/aiida/backends/tests/dataclasses.py
+++ b/aiida/backends/tests/dataclasses.py
@@ -2446,7 +2446,7 @@ class TestPymatgenFromStructureData(AiidaTestCase):
         a.append_atom(position=(0,0,2.8), symbols='Na',name='Na4')
         
         b = a.get_pymatgen()
-        self.assertEquals([site.as_dict()['properties']['kind_name'] for site in b.sites],
+        self.assertEquals([site.properties['kind_name'] for site in b.sites],
                          ['Cl','Cl10','Cla','cl_x','Na1','Na2','Na_Na','Na4'])
         
         c = StructureData(pymatgen=b)

--- a/aiida/orm/data/structure.py
+++ b/aiida/orm/data/structure.py
@@ -1182,9 +1182,9 @@ class StructureData(Data):
         periodic boundary conditions (in three dimensions) and Molecule
         otherwise.
         :param add_spin: True to add the spins to the pymatgen structure according to the rule:
-            if the kind name ends with 1 -> spin=+1
-            if the kind name ends with 2 -> spin=-1
-            Default is False (no spin added).
+          if the kind name ends with 1 -> spin=+1
+          if the kind name ends with 2 -> spin=-1
+          Default is False (no spin added).
 
         .. note:: Requires the pymatgen module (version >= 3.0.13, usage
             of earlier versions may cause errors).
@@ -1195,9 +1195,9 @@ class StructureData(Data):
         """
         Get the pymatgen Structure object.
         :param add_spin: True to add the spins to the pymatgen structure according to the rule:
-            if the kind name ends with 1 -> spin=+1
-            if the kind name ends with 2 -> spin=-1
-            Default is False (no spin added).
+          if the kind name ends with 1 -> spin=+1
+          if the kind name ends with 2 -> spin=-1
+          Default is False (no spin added).
 
         .. note:: Requires the pymatgen module (version >= 3.0.13, usage
             of earlier versions may cause errors).
@@ -1807,9 +1807,9 @@ class StructureData(Data):
         :py:class:`StructureData <aiida.orm.data.structure.StructureData>`
         to pymatgen Structure object
         :param add_spin: True to add the spins to the pymatgen structure according to the rule:
-            if the kind name ends with 1 -> spin=+1
-            if the kind name ends with 2 -> spin=-1
-            Default is False (no spin added).
+          if the kind name ends with 1 -> spin=+1
+          if the kind name ends with 2 -> spin=-1
+          Default is False (no spin added).
 
         :return: a pymatgen Structure object corresponding to this
           :py:class:`StructureData <aiida.orm.data.structure.StructureData>`

--- a/aiida/orm/data/structure.py
+++ b/aiida/orm/data/structure.py
@@ -851,10 +851,13 @@ class StructureData(Data):
         self.pbc = [True, True, True]
         self.clear_kinds()
         for site in struct.sites:
+            additional_kwargs = {}
+            if 'kind_name' in site.properties:
+                additional_kwargs['name'] = site.properties['kind_name']
             self.append_atom(
                 symbols=[x[0].symbol for x in site.species_and_occu.items()],
                 weights=[x[1] for x in site.species_and_occu.items()],
-                position=site.coords.tolist())
+                position=site.coords.tolist(),**additional_kwargs)
 
     def _validate(self):
         """

--- a/aiida/orm/data/structure.py
+++ b/aiida/orm/data/structure.py
@@ -1181,10 +1181,14 @@ class StructureData(Data):
         Get pymatgen object. Returns Structure for structures with
         periodic boundary conditions (in three dimensions) and Molecule
         otherwise.
-        :param add_spin: True to add the spins to the pymatgen structure according to the rule:
-          if the kind name ends with 1 -> spin=+1
-          if the kind name ends with 2 -> spin=-1
-          Default is False (no spin added).
+        :param add_spin: True to add the spins to the pymatgen structure.
+        Default is False (no spin added).
+
+        .. note:: The spins are set according to the following rule:
+            
+            * if the kind name ends with 1 -> spin=+1
+            
+            * if the kind name ends with 2 -> spin=-1
 
         .. note:: Requires the pymatgen module (version >= 3.0.13, usage
             of earlier versions may cause errors).
@@ -1194,10 +1198,14 @@ class StructureData(Data):
     def get_pymatgen_structure(self,**kwargs):
         """
         Get the pymatgen Structure object.
-        :param add_spin: True to add the spins to the pymatgen structure according to the rule:
-          if the kind name ends with 1 -> spin=+1
-          if the kind name ends with 2 -> spin=-1
-          Default is False (no spin added).
+        :param add_spin: True to add the spins to the pymatgen structure.
+        Default is False (no spin added).
+
+        .. note:: The spins are set according to the following rule:
+            
+            * if the kind name ends with 1 -> spin=+1
+            
+            * if the kind name ends with 2 -> spin=-1
 
         .. note:: Requires the pymatgen module (version >= 3.0.13, usage
             of earlier versions may cause errors).
@@ -1806,10 +1814,14 @@ class StructureData(Data):
         Converts
         :py:class:`StructureData <aiida.orm.data.structure.StructureData>`
         to pymatgen Structure object
-        :param add_spin: True to add the spins to the pymatgen structure according to the rule:
-          if the kind name ends with 1 -> spin=+1
-          if the kind name ends with 2 -> spin=-1
-          Default is False (no spin added).
+        :param add_spin: True to add the spins to the pymatgen structure.
+        Default is False (no spin added).
+
+        .. note:: The spins are set according to the following rule:
+            
+            * if the kind name ends with 1 -> spin=+1
+            
+            * if the kind name ends with 2 -> spin=-1
 
         :return: a pymatgen Structure object corresponding to this
           :py:class:`StructureData <aiida.orm.data.structure.StructureData>`

--- a/aiida/orm/data/structure.py
+++ b/aiida/orm/data/structure.py
@@ -543,24 +543,9 @@ def get_formula(symbol_list, mode='hill', separator=""):
                          'reduce, count or count_compact')
 
     if mode in ['hill_compact', 'count_compact']:
-
-        def gcd_list(int_list):
-            """
-            Recursive function to get the greatest common divisor of
-            a list of integers
-            """
-            from fractions import gcd
-            if len(int_list) == 1:
-                return int_list[0]
-            elif len(int_list) == 2:
-                return gcd(int_list[0], int_list[1])
-            else:
-                the_int_list = int_list[2:]
-                the_int_list.append(gcd(int_list[0], int_list[1]))
-                return gcd_list(the_int_list)
-
-        the_gcd = gcd_list([e[0] for e in the_symbol_list])
-        the_symbol_list = [[e[0] / the_gcd, e[1]] for e in the_symbol_list]
+        from fractions import gcd
+        the_gcd = reduce(gcd,[e[0] for e in the_symbol_list])
+        the_symbol_list = [[e[0]/the_gcd,e[1]] for e in the_symbol_list]
 
     return get_formula_from_symbol_list(the_symbol_list, separator=separator)
 
@@ -844,20 +829,51 @@ class StructureData(Data):
 
         .. note:: periodic boundary conditions are set to True in all
             three directions.
-        .. note:: Requires the pymatgen module (version >= 3.0.13, usage
+        .. note:: Requires the pymatgen module (version >= 3.3.5, usage
             of earlier versions may cause errors).
+        
+        :raise ValueError: if there are partial occupancies together with spins.
         """
+        def build_kind_name(species_and_occu):
+            """
+            Build a kind name from a pymatgen Composition, including an
+            additional ordinal if spin is included, e.g. it returns '<element>1'
+            for an atom with spin<0 and '<element>2' for an element with spin>0,
+            ortherwise (no spin) it returns simply '<element>'
+            :param specie: a pymatgen specie
+            :return: a string
+            """
+            has_spin = any([specie.as_dict().get('properties',{}).get('spin',0)!=0
+                            for specie in species_and_occu.keys()])
+                            
+            if has_spin and (len(species_and_occu.items())>1
+                             or any([weight!=1.0 for weight in species_and_occu.values()])):
+                raise ValueError("Cannot set partial occupancies and spins "
+                                     "at the same time")
+            
+            if not has_spin:
+                return Kind(symbols=[x[0].symbol for x in species_and_occu.items()],
+                            weights=[x[1] for x in species_and_occu.items()]).name
+            
+            else:
+                spin = species_and_occu.keys()[0].as_dict().get('properties',{}).get('spin',0)
+                if spin<0:
+                    return specie.symbol+'1'
+                else:
+                    return specie.symbol+'2'
+        
         self.cell = struct.lattice.matrix.tolist()
         self.pbc = [True, True, True]
         self.clear_kinds()
         for site in struct.sites:
-            additional_kwargs = {}
             if 'kind_name' in site.properties:
-                additional_kwargs['name'] = site.properties['kind_name']
-            self.append_atom(
-                symbols=[x[0].symbol for x in site.species_and_occu.items()],
-                weights=[x[1] for x in site.species_and_occu.items()],
-                position=site.coords.tolist(),**additional_kwargs)
+                kind_name = site.properties['kind_name']
+            else:
+                kind_name = build_kind_name(site.species_and_occu)
+            self.append_atom(symbols=[x[0].symbol for x in site.species_and_occu.items()],
+                         weights=[x[1] for x in site.species_and_occu.items()],
+                         position=site.coords.tolist(),
+                         name=kind_name)
 
     def _validate(self):
         """
@@ -1160,20 +1176,28 @@ class StructureData(Data):
         """
         return self._get_object_ase()
 
-    def get_pymatgen(self):
+    def get_pymatgen(self,**kwargs):
         """
         Get pymatgen object. Returns Structure for structures with
         periodic boundary conditions (in three dimensions) and Molecule
         otherwise.
+        :param add_spin: True to add the spins to the pymatgen structure according to the rule:
+            if the kind name ends with 1 -> spin=+1
+            if the kind name ends with 2 -> spin=-1
+            Default is False (no spin added).
 
         .. note:: Requires the pymatgen module (version >= 3.0.13, usage
             of earlier versions may cause errors).
         """
-        return self._get_object_pymatgen()
+        return self._get_object_pymatgen(**kwargs)
 
-    def get_pymatgen_structure(self):
+    def get_pymatgen_structure(self,**kwargs):
         """
         Get the pymatgen Structure object.
+        :param add_spin: True to add the spins to the pymatgen structure according to the rule:
+            if the kind name ends with 1 -> spin=+1
+            if the kind name ends with 2 -> spin=-1
+            Default is False (no spin added).
 
         .. note:: Requires the pymatgen module (version >= 3.0.13, usage
             of earlier versions may cause errors).
@@ -1184,7 +1208,7 @@ class StructureData(Data):
         :raise ValueError: if periodic boundary conditions do not hold
           in at least one dimension of real space.
         """
-        return self._get_object_pymatgen_structure()
+        return self._get_object_pymatgen_structure(**kwargs)
 
     def get_pymatgen_molecule(self):
         """
@@ -1760,7 +1784,7 @@ class StructureData(Data):
             asecell.append(site.get_ase(kinds=_kinds))
         return asecell
 
-    def _get_object_pymatgen(self):
+    def _get_object_pymatgen(self,**kwargs):
         """
         Converts
         :py:class:`StructureData <aiida.orm.data.structure.StructureData>`
@@ -1773,21 +1797,26 @@ class StructureData(Data):
             of earlier versions may cause errors).
         """
         if self.pbc == (True, True, True):
-            return self._get_object_pymatgen_structure()
+            return self._get_object_pymatgen_structure(**kwargs)
         else:
-            return self._get_object_pymatgen_molecule()
+            return self._get_object_pymatgen_molecule(**kwargs)
 
-    def _get_object_pymatgen_structure(self):
+    def _get_object_pymatgen_structure(self,**kwargs):
         """
         Converts
         :py:class:`StructureData <aiida.orm.data.structure.StructureData>`
         to pymatgen Structure object
+        :param add_spin: True to add the spins to the pymatgen structure according to the rule:
+            if the kind name ends with 1 -> spin=+1
+            if the kind name ends with 2 -> spin=-1
+            Default is False (no spin added).
 
         :return: a pymatgen Structure object corresponding to this
           :py:class:`StructureData <aiida.orm.data.structure.StructureData>`
           object
         :raise ValueError: if periodic boundary conditions does not hold
-          in at least one dimension of real space
+          in at least one dimension of real space; if there are partial occupancies
+          together with spins (defined by kind names ending with '1' or '2').
 
         .. note:: Requires the pymatgen module (version >= 3.0.13, usage
             of earlier versions may cause errors)
@@ -1800,21 +1829,40 @@ class StructureData(Data):
 
         species = []
         additional_kwargs = {}
-        for s in self.sites:
-            k = self.get_kind(s.kind_name)
-            species.append({s: w for s, w in zip(k.symbols, k.weights)})
+
+        if (kwargs.pop('add_spin',False) and 
+            any([n.endswith('1') or n.endswith('2') for n in self.get_kind_names()])):
+            # case when spins are defined -> no partial occupancy allowed
+            from pymatgen.core.structure import Specie
+            oxidation_state = 0 # now I always set the oxidation_state to zero
+            for s in self.sites:
+                k = self.get_kind(s.kind_name)
+                if len(k.symbols)!=1 or (len(k.weights)!=1 or sum(k.weights)<1.):
+                    raise ValueError("Cannot set partial occupancies and spins "
+                                     "at the same time")
+                species.append(Specie(k.symbols[0],oxidation_state,
+                                      properties={'spin': -1 if k.name.endswith('1')
+                                            else 1 if k.name.endswith('2') else 0}))
+        else:
+            # case when no spin are defined
+            for s in self.sites:
+                k = self.get_kind(s.kind_name)
+                species.append({s: w for s, w in zip(k.symbols, k.weights)})
+            if any([create_automatic_kind_name(self.get_kind(name).symbols,self.get_kind(name).weights)!=name
+                    for name in self.get_site_kindnames()]):
+                    # add "kind_name" as a properties to each site, whenever
+                    # the kind_name cannot be automatically obtained from the symbols
+                additional_kwargs['site_properties'] = {'kind_name': self.get_site_kindnames()}
         
-        if any([create_automatic_kind_name(self.get_kind(name).symbols,self.get_kind(name).weights)!=name
-                for name in self.get_site_kindnames()]):
-                # add "kind_name" as a properties to each site, whenever
-                # the kind_name cannot be automatically obtained from the symbols
-            additional_kwargs['site_properties'] = {'kind_name': self.get_site_kindnames()}
+        if kwargs:
+            raise ValueError("Unrecognized parameters passed to pymatgen "
+                             "converter: {}".format(kwargs.keys()))
 
         positions = [list(x.position) for x in self.sites]
         return Structure(self.cell, species, positions,
                          coords_are_cartesian=True,**additional_kwargs)
 
-    def _get_object_pymatgen_molecule(self):
+    def _get_object_pymatgen_molecule(self,**kwargs):
         """
         Converts
         :py:class:`StructureData <aiida.orm.data.structure.StructureData>`
@@ -1828,6 +1876,10 @@ class StructureData(Data):
             of earlier versions may cause errors)
         """
         from pymatgen.core.structure import Molecule
+
+        if kwargs:
+            raise ValueError("Unrecognized parameters passed to pymatgen "
+                             "converter: {}".format(kwargs.keys()))
 
         species = []
         for s in self.sites:


### PR DESCRIPTION
Fix for #1028 (for pymatgen).

Now StructureData -> pymatgen -> StructureData roundtrip works with all kinds of kind names, using the 'properties' of pymatgen structure sites. It works even with letters and strings (and not only with ordinals appended to the symbol, as for ASE)
In addition, a number of tests have been added (including for ASE), to test in particular roundtrip behaviour, or conversion to/from pymatgen structure with partial occupancies.
Finally, StructureData -> pymatgen conversion (and vice-versa) now supports spins (only for structure, not for molecule), using the rule that kind names ending with 1 indicate spin +1, and kind name ending with 2 are for spin -1.
To trigger the conversion to a pymatgen structure with spin, one simply needs to do
`structure.get_pymatgen(add_spin=True)`

Note that partial occupancies plus spin and not supported for these conversions; tests have been created to check than an exception is raised when the user tries to do such a conversion.




