### PR TITLE
Remove `verdi work tree`

### DIFF
--- a/aiida/cmdline/commands/work.py
+++ b/aiida/cmdline/commands/work.py
@@ -43,7 +43,6 @@ class Work(VerdiCommandWithSubcommands):
             'play': (self.cli, self.complete_none),
             'report': (self.cli, self.complete_none),
             'status': (self.cli, self.complete_none),
-            'tree': (self.cli, self.complete_none),
             'checkpoint': (self.cli, self.complete_none),
             'kill': (self.cli, self.complete_none),
             'plugins': (self.cli, self.complete_plugins),
@@ -286,26 +285,6 @@ def report(pk, levelname, order_by, indent_size, max_depth):
         )
 
     return
-
-
-@work.command('tree', context_settings=CONTEXT_SETTINGS)
-@click.option('--node-label', default='_process_label', type=str)
-@click.option('--depth', '-d', type=int, default=1)
-@click.argument('pks', nargs=-1, type=int)
-def tree(node_label, depth, pks):
-    from aiida.backends.utils import load_dbenv, is_dbenv_loaded
-    from aiida.utils.ascii_vis import build_tree
-    if not is_dbenv_loaded():
-        load_dbenv()
-
-    from aiida.orm import load_node
-    from ete3 import Tree
-
-    for pk in pks:
-        node = load_node(pk=pk)
-        t = Tree("({});".format(build_tree(node, node_label, max_depth=depth)),
-                 format=1)
-        print(t.get_ascii(show_internal=True))
 
 
 @work.command('checkpoint', context_settings=CONTEXT_SETTINGS)

--- a/docs/source/verdi/verdi_user_guide.rst
+++ b/docs/source/verdi/verdi_user_guide.rst
@@ -391,7 +391,7 @@ Manage workflows, valid subcommands:
   * **list**: list the workflows present in the database
   * **plugins**: show the registered workflow plugins
   * **report**: show the log messages for a workflow
-  * **tree**: shows an ASCII tree for a workflow
+  * **status**: shows an ASCII tree for a workflow showing the status of itself and the calculations it called
 
 
 .. _workflow:


### PR DESCRIPTION
Fixes #316 

This command has been superseded by the `verdi work status` command,
which will print the status of the workchain and that of the calculations
it called. The output will be formatted in a tree like structure.
For an overview of the inputs and outputs of the workchain, a user
can better use the `verdi calculation show` command.