### PR TITLE
Ensure that Process.kill() cascades down to called children

### DIFF
--- a/aiida/cmdline/commands/work.py
+++ b/aiida/cmdline/commands/work.py
@@ -333,35 +333,6 @@ def checkpoint(pks):
 
 @work.command('kill', context_settings=CONTEXT_SETTINGS)
 @click.argument('pks', nargs=-1, type=int)
-def kill_old(pks):
-    from aiida import try_load_dbenv
-    try_load_dbenv()
-    from aiida.orm import load_node
-    from aiida.orm.calculation.work import WorkCalculation
-
-    nodes = [load_node(pk) for pk in pks]
-    workchain_nodes = [n for n in nodes if isinstance(n, WorkCalculation)]
-    running_workchain_nodes = [n for n in nodes if not n.is_terminated]
-
-    num_workchains = len(running_workchain_nodes)
-    if num_workchains > 0:
-        answer = click.prompt(
-            'Are you sure you want to kill {} workflows and all their children? [y/n]'.format(
-                num_workchains
-            )
-        ).lower()
-        if answer == 'y':
-            click.echo('Killing workflows.')
-            for n in running_workchain_nodes:
-                n.kill()
-        else:
-            click.echo('Abort!')
-    else:
-        click.echo('No pks of valid running workchains given.')
-
-
-@work.command('kill', context_settings=CONTEXT_SETTINGS)
-@click.argument('pks', nargs=-1, type=int)
 def kill(pks):
     from aiida import try_load_dbenv
     try_load_dbenv()

--- a/aiida/orm/implementation/general/calculation/__init__.py
+++ b/aiida/orm/implementation/general/calculation/__init__.py
@@ -327,7 +327,8 @@ class AbstractCalculation(Sealable):
         """
         Delete the checkpoint bundle set for the Calculation
         """
-        return self._del_attr(self.CHECKPOINT_KEY)
+        if self.checkpoint is not None:
+            self._del_attr(self.CHECKPOINT_KEY)
 
     @property
     def called(self):

--- a/aiida/work/processes.py
+++ b/aiida/work/processes.py
@@ -159,6 +159,17 @@ class Process(plumpy.Process):
         else:
             self._pid = self._create_and_setup_db_record()
 
+    def kill(self, msg=None):
+        """
+        Kill the process and all the children calculations it called
+        """
+        result = super(Process, self).kill(msg)
+
+        for child in self.calc.called:
+            self.runner.rmq.kill_process(child.pk, 'Killed by parent<{}>'.format(self.calc.pk))
+
+        return result
+
     @override
     def out(self, output_port, value=None):
         if value is None:

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ if __name__ == '__main__':
         packages=find_packages(),
         # Don't forget to install it as well (by adding to the install_requires)
         setup_requires=[
-            'reentry >= 1.0.2',
+            'reentry >= 1.0.3',
         ],
         reentry_register=True,
         entry_points={


### PR DESCRIPTION
**This is on hold as it is waiting for an addition that depends on a `plumpy` update**

Fixes #1060 

If kill is called on a Process, it needs to make sure that it also
issues the kill command for all the children processes that it called.
This is achieved by first getting all its called children by following
CALL links out of the calculation node, and then calling kill_process
on the rmq control panel of the process' runner with the pids of the
children calculations

This change also allowed to remove the skips from the unittest that
test the cascading of the kill command for processes with children.