### PR TITLE
 Fix bug in CifData.has_unknown_species for cifs without formulae 

### DIFF
--- a/aiida/common/exceptions.py
+++ b/aiida/common/exceptions.py
@@ -154,17 +154,20 @@ class ConfigurationError(AiidaException):
     """
     pass
 
+
 class ProfileConfigurationError(ConfigurationError):
     """
     Configuration error raised when a wrong/inexistent profile is requested.
     """
     pass
 
+
 class MissingConfigurationError(ConfigurationError):
     """
     Configuration error raised when the configuration file is missing.
     """
     pass
+
 
 class ConfigurationVersionError(ConfigurationError):
     """
@@ -173,6 +176,7 @@ class ConfigurationVersionError(ConfigurationError):
     """
     pass
 
+
 class DbContentError(AiidaException):
     """
     Raised when the content of the DB is not valid.
@@ -180,6 +184,7 @@ class DbContentError(AiidaException):
     with the DB.
     """
     pass
+
 
 class InputValidationError(ValidationError):
     """
@@ -225,10 +230,18 @@ class LicensingException(AiidaException):
     """
     pass
 
+
 class TestsNotAllowedError(AiidaException):
     """
     Raised when tests are required to be run/loaded, but we are not in a testing environment.
 
     This is to prevent data loss.
+    """
+    pass
+
+
+class UnsupportedSpeciesError(ValueError):
+    """
+    Raised when StructureData operations are fed species that are not supported by AiiDA such as Deuterium
     """
     pass

--- a/aiida/orm/data/cif.py
+++ b/aiida/orm/data/cif.py
@@ -698,15 +698,20 @@ class CifData(SinglefileData):
         Returns whether the cif contains atomic species that are not recognized by AiiDA.
         The known species are taken from the elements dictionary in aiida.common.constants.
         If any of the formula of the cif data contain species that are not in that elements
-        dictionary, the function will return True and False in all other cases
+        dictionary, the function will return True and False in all other cases. If there is
+        no formulae to be found, it will return None
 
-        :returns: True when there are unknown species in any of the formulae
+        :returns: True when there are unknown species in any of the formulae, False if not, None if no formula found
         """
         from aiida.common.constants import elements
 
         known_species = [element['symbol'] for element in elements.values()]
 
         for formula in self.get_formulae():
+
+            if formula is None:
+                return None
+
             species = parse_formula(formula).keys()
             if any([specie not in known_species for specie in species]):
                 return True

--- a/aiida/orm/data/structure.py
+++ b/aiida/orm/data/structure.py
@@ -13,6 +13,7 @@ functions to operate on them.
 """
 
 from aiida.orm import Data
+from aiida.common.exceptions import UnsupportedSpeciesError
 from aiida.common.utils import classproperty, xyz_parser_iterator
 from aiida.orm.calculation.inline import optional_inline
 import itertools
@@ -222,8 +223,8 @@ def validate_symbols_tuple(symbols_tuple):
     Used to validate whether the chemical species are valid.
 
     :param symbols_tuple: a tuple (or list) with the chemical symbols name.
-    :raises: ValueError if any symbol in the tuple is not a valid chemical
-        symbols (with correct capitalization).
+    :raises: UnsupportedSpeciesError if any symbol in the tuple is not a valid chemical
+        symbol (with correct capitalization).
 
     Refer also to the documentation of :func:is_valid_symbol
     """
@@ -232,8 +233,8 @@ def validate_symbols_tuple(symbols_tuple):
     else:
         valid = all(is_valid_symbol(sym) for sym in symbols_tuple)
     if not valid:
-        raise ValueError("At least one element of the symbol list {} has "
-                         "not been recognized.".format(symbols_tuple))
+        raise UnsupportedSpeciesError("At least one element of the symbol list {} has "
+                                      "not been recognized.".format(symbols_tuple))
 
 
 def is_ase_atoms(ase_atoms):


### PR DESCRIPTION
Fixes #1308 

The function assumed that the `CifData` would return a valid string for
the `get_formulae` call, but it can return `None`. In that case the
`has_unknown_species` method should also return `None`

Also made the  `valid_symbols_tuple` raise `UnsupportedSpeciesError` instead
of a plain `ValueError`. This is a new exception that subclasses `ValueError`, so 
the change is backwards compatible, however it makes it easier to specifically
catch this error mode