### PR TITLE
 Shutdown the DaemonRunner neatly when killed

### DIFF
--- a/aiida/backends/tests/work/process.py
+++ b/aiida/backends/tests/work/process.py
@@ -80,14 +80,14 @@ class ProcessStackTest(work.Process):
 
 
 class TestProcess(AiidaTestCase):
+
     def setUp(self):
         super(TestProcess, self).setUp()
-
+        work.runners.set_runner(None)
         self.assertEquals(len(utils.ProcessStack.stack()), 0)
 
     def tearDown(self):
         super(TestProcess, self).tearDown()
-
         self.assertEquals(len(utils.ProcessStack.stack()), 0)
 
     def test_process_stack(self):

--- a/aiida/cmdline/commands/daemon.py
+++ b/aiida/cmdline/commands/daemon.py
@@ -245,8 +245,12 @@ def _start_circus(foreground):
     from circus.util import check_future_exception_and_log, configure_logger
 
     client = DaemonClient()
+
     loglevel = client.loglevel
-    logoutput = client.circus_log_file
+    logoutput = '-'
+
+    if not foreground:
+        logoutput = client.circus_log_file
 
     arbiter_config = {
         'controller': client.get_controller_endpoint(),
@@ -264,7 +268,7 @@ def _start_circus(foreground):
             'copy_env': True,
             'stdout_stream': {
                 'class': 'FileStream',
-                'filename': client.daemon_log_file
+                'filename': client.daemon_log_file,
             },
             'env': get_env_with_venv_bin(),
         }]
@@ -272,8 +276,6 @@ def _start_circus(foreground):
 
     if not foreground:
         daemonize()
-    else:
-        logoutput = '-'
 
     arbiter = get_arbiter(**arbiter_config)
     pidfile = Pidfile(arbiter.pidfile)

--- a/aiida/common/log.py
+++ b/aiida/common/log.py
@@ -117,7 +117,7 @@ LOGGING = {
         },
         'plumpy': {
             'handlers': ['console'],
-            'level': setup.get_property('logging.plum_loglevel'),
+            'level': setup.get_property('logging.plumpy_loglevel'),
             'propagate': False,
         },
         'paramiko': {

--- a/aiida/common/setup.py
+++ b/aiida/common/setup.py
@@ -792,8 +792,8 @@ _property_table = {
         "to the database",
         "REPORT",
         ["CRITICAL", "ERROR", "WARNING", "REPORT", "INFO", "DEBUG"]),
-    "logging.plum_loglevel": (
-        "logging_plum_log_level",
+    "logging.plumpy_loglevel": (
+        "logging_plumpy_log_level",
         "string",
         "Minimum level to log to the file ~/.aiida/daemon/log/aiida_daemon.log ",
         "WARNING",

--- a/aiida/daemon/runner.py
+++ b/aiida/daemon/runner.py
@@ -34,7 +34,6 @@ def start_daemon():
     def shutdown_daemon(num, frame):
         logger.info('Received signal to shut down the daemon runner')
         runner.close()
-        runner.stop()
 
     signal.signal(signal.SIGINT, shutdown_daemon)
     signal.signal(signal.SIGTERM, shutdown_daemon)
@@ -49,7 +48,6 @@ def start_daemon():
     except SystemError as exception:
         logger.info('Received a SystemError: {}'.format(exception))
         runner.close()
-        runner.stop()
 
     logger.info('Daemon runner stopped')
 

--- a/aiida/daemon/runner.py
+++ b/aiida/daemon/runner.py
@@ -7,6 +7,7 @@
 # For further information on the license, see the LICENSE.txt file        #
 # For further information please visit http://www.aiida.net               #
 ###########################################################################
+import signal
 from functools import partial
 
 from aiida.common.log import aiidalogger
@@ -29,15 +30,28 @@ def start_daemon():
     configure_logging(daemon=True, daemon_log_file=daemon_client.daemon_log_file)
 
     runner = DaemonRunner(rmq_config=get_rmq_config(), rmq_submit=False)
-    set_runner(runner)
 
+    def shutdown_daemon(num, frame):
+        logger.info('Received signal to shut down the daemon runner')
+        runner.close()
+        runner.stop()
+
+    signal.signal(signal.SIGINT, shutdown_daemon)
+    signal.signal(signal.SIGTERM, shutdown_daemon)
+
+    logger.info('Starting a daemon runner')
+
+    set_runner(runner)
     tick_legacy_workflows(runner)
 
     try:
         runner.start()
-    except (SystemError, KeyboardInterrupt):
-        logger.warning('Shutting down daemon')
+    except SystemError as exception:
+        logger.info('Received a SystemError: {}'.format(exception))
         runner.close()
+        runner.stop()
+
+    logger.info('Daemon runner stopped')
 
 
 def tick_legacy_workflows(runner, interval=DAEMON_LEGACY_WORKFLOW_INTERVAL):

--- a/aiida/orm/data/upf.py
+++ b/aiida/orm/data/upf.py
@@ -385,6 +385,9 @@ class UpfData(SinglefileData):
         from aiida.common.exceptions import ParsingError, ValidationError
         import aiida.common.utils
 
+        if self._to_be_stored is False:
+            return self
+
         upf_abspath = self.get_file_abs_path()
         if not upf_abspath:
             raise ValidationError("No valid UPF was passed!")

--- a/aiida/work/rmq.py
+++ b/aiida/work/rmq.py
@@ -196,7 +196,7 @@ class ProcessControlPanel(object):
         )
 
     def connect(self):
-        return self._communicator.init()
+        return self._communicator.connect()
 
     def pause_process(self, pid):
         return self.execute_action(plumpy.PauseAction(pid))

--- a/aiida/work/rmq.py
+++ b/aiida/work/rmq.py
@@ -25,6 +25,7 @@ DeliveryFailed = plumpy.DeliveryFailed
 _RMQ_URL = 'amqp://127.0.0.1'
 _LAUNCH_QUEUE = 'process.queue'
 _MESSAGE_EXCHANGE = 'messages'
+_TASK_EXCHANGE = 'tasks'
 
 
 def get_rmq_prefix():
@@ -79,6 +80,15 @@ def get_message_exchange_name(prefix):
     :returns: message exchange name
     """
     return '{}.{}'.format(prefix, _MESSAGE_EXCHANGE)
+
+
+def get_task_exchange_name(prefix):
+    """
+    Return the task exchange name for a given prefix
+
+    :returns: task exchange name
+    """
+    return '{}.{}'.format(prefix, _TASK_EXCHANGE)
 
 
 def encode_response(response):
@@ -172,10 +182,13 @@ class ProcessControlPanel(object):
         self._connector = rmq_connector
 
         message_exchange = get_message_exchange_name(prefix)
+        task_exchange = get_task_exchange_name(prefix)
+
         task_queue = get_launch_queue_name(prefix)
         self._communicator = plumpy.rmq.RmqCommunicator(
             rmq_connector,
             exchange_name=message_exchange,
+            task_exchange=task_exchange,
             task_queue=task_queue,
             encoder=encode_response,
             decoder=decode_response,

--- a/aiida/work/runners.py
+++ b/aiida/work/runners.py
@@ -274,6 +274,10 @@ class Runner(object):
 class DaemonRunner(Runner):
     """ Overwrites some of the behaviour of a runner to be daemon specific"""
 
+    def __init__(self, *args, **kwargs):
+        kwargs['rmq_submit'] = True
+        super(DaemonRunner, self).__init__(*args, **kwargs)
+
     def _setup_rmq(self, url, prefix=None, testing_mode=False):
         super(DaemonRunner, self)._setup_rmq(url, prefix, testing_mode)
 

--- a/aiida/work/runners.py
+++ b/aiida/work/runners.py
@@ -253,7 +253,7 @@ class Runner(object):
         self._communicator = self._rmq._communicator
 
         # Establish RMQ connection
-        self._communicator.init()
+        self._communicator.connect()
 
     def _create_child_runner(self):
         return Runner(**self._kwargs)

--- a/aiida/work/runners.py
+++ b/aiida/work/runners.py
@@ -165,6 +165,7 @@ class Runner(object):
         return self._loop.run_sync(lambda: future)
 
     def close(self):
+        self.stop()
         if self._rmq_connector is not None:
             self._rmq_connector.disconnect()
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -142,5 +142,5 @@ wcwidth==0.1.7
 Werkzeug==0.14.1
 wrapt==1.10.11
 yapf==0.19.0
--e git://github.com/muhrin/plumpy.git@1dc151bbb5ee5f9a1f615589e545d29f547d93cf#egg=plumpy
--e git://github.com/muhrin/kiwipy.git@249fe038f109424b6cdd007092d6f3535346aa7f#egg=kiwipy
+-e git://github.com/muhrin/plumpy.git@7c78b11e8ef8a0a35792ba82674679c1185f63f0#egg=plumpy
+-e git://github.com/muhrin/kiwipy.git@c9102c1d8c3a95cc49087960e4ce47754485973e#egg=kiwipy


### PR DESCRIPTION
Fixes #1304 

The killing of the DaemonRunner, which is launched by the start_daemon
command, can be accomplished by two signals, SIGINT and SIGTERM. The
SIGINT will be sent when a keyboard interrupt is fired, for example
when the daemon is being ran in the foreground and the user fires CTL+C.
The SIGTERM is the signal sent by the circus arbiter when it is asked
to quit, which is done by calling `verdi daemon stop`. To make sure that
for both these cases the DaemonRunner shuts down neatly, we simply bind
both signals to a function that when triggered will close the connection
of the DaemonRunner and stop the loop. The loop is a Tornodo library
event loop and should take care of shutting down neatly. Any running
tasks that were picked up from RabbitMQ should be rescheduled by RMQ
when it realizes the subscriber died. When it is revived, i.e. when
the daemon is restarted, these tasks will be redelivered.

N.B.: this was tested for `JobCalculations` and `WorkCalculations`. The rescheduling of continuation tasks of `JobCalculation` and the subsequent continuation when the daemon is killed and restarted seems to work well. However, in contrast, the continuation of `WorkCalculations` does not yet seem to work, but this is expected to be a problem of the `WorkChain` class and not the `DaemonRunner` so this will be dealt with in a different issue.