### PR TITLE
Fix the DatabaseIntegrityErrors being thrown in the tests

### DIFF
--- a/aiida/backends/tests/dataclasses.py
+++ b/aiida/backends/tests/dataclasses.py
@@ -275,6 +275,10 @@ _cell_angle_alpha 90
 _cell_angle_beta  90
 _cell_angle_gamma 90
 loop_
+_symmetry_equiv_pos_site_id
+_symmetry_equiv_pos_as_xyz
+1 +x,+y,+z
+loop_
 _atom_site_label
 _atom_site_fract_x
 _atom_site_fract_y
@@ -370,6 +374,18 @@ _cell_length_a                   4.395
 _cell_length_b                   4.395
 _cell_length_c                   30.440
 _cod_database_code               9012064
+loop_
+_symmetry_equiv_pos_as_xyz
+x,y,z
+2/3+x,1/3+y,1/3+z
+1/3+x,2/3+y,2/3+z
+x,x-y,z
+2/3+x,1/3+x-y,1/3+z
+1/3+x,2/3+x-y,2/3+z
+y,x,-z
+2/3+y,1/3+x,1/3-z
+1/3+y,2/3+x,2/3-z
+-x+y,y,z
 loop_
 _atom_site_label
 _atom_site_fract_x

--- a/aiida/backends/tests/work/persistence.py
+++ b/aiida/backends/tests/work/persistence.py
@@ -22,6 +22,7 @@ class TestProcess(AiidaTestCase):
 
     def setUp(self):
         super(TestProcess, self).setUp()
+        work.runners.set_runner(None)
         self.assertEquals(len(util.ProcessStack.stack()), 0)
 
     def tearDown(self):
@@ -43,6 +44,7 @@ class TestAiiDAPersister(AiidaTestCase):
 
     def setUp(self):
         super(TestAiiDAPersister, self).setUp()
+        work.runners.set_runner(None)
         self.persister = AiiDAPersister()
 
     def test_save_load_checkpoint(self):

--- a/aiida/backends/tests/work/test_rmq.py
+++ b/aiida/backends/tests/work/test_rmq.py
@@ -2,6 +2,7 @@
 
 import plumpy
 import uuid
+from tornado.testing import ExpectLog
 
 from aiida.backends.testbase import AiidaTestCase
 from aiida.orm.calculation import Calculation
@@ -57,11 +58,12 @@ class TestProcessControl(AiidaTestCase):
             self.runner.submit(test_utils.AddProcess, a=Int(5))
 
     def test_exception_process(self):
-        calc_node = self.runner.submit(test_utils.ExceptionProcess)
-        self._wait_for_calc(calc_node)
+        with ExpectLog('tornado.application', "Future exception was never retrieved: RemoteException: CRASH"):
+            calc_node = self.runner.submit(test_utils.ExceptionProcess)
+            self._wait_for_calc(calc_node)
 
-        self.assertFalse(calc_node.is_finished_ok)
-        self.assertEqual(calc_node.process_state.value, plumpy.ProcessState.EXCEPTED.value)
+            self.assertFalse(calc_node.is_finished_ok)
+            self.assertEqual(calc_node.process_state.value, plumpy.ProcessState.EXCEPTED.value)
 
     def test_pause(self):
         """ Testing sending a pause message to the process """


### PR DESCRIPTION
Fixes #1211 

Reset the global runner to None between running tests.
With the runner being persisted between tests meant that at new
tests it still had references to database entries that had already
been purged during the tests transition. This was causing the
DatabaseIntegrityErrors to be thrown.

Also fixed some other issues in the tests that were throwing undesirable
warnings and printed exceptions. The output is now clean again.