### PR TITLE
Plum verdi calculation kill through the new plumpy machinery

### DIFF
--- a/aiida/backends/tests/work/test_rmq.py
+++ b/aiida/backends/tests/work/test_rmq.py
@@ -2,7 +2,6 @@
 
 import plumpy
 import uuid
-from tornado.testing import ExpectLog
 
 from aiida.backends.testbase import AiidaTestCase
 from aiida.orm.calculation import Calculation
@@ -58,12 +57,11 @@ class TestProcessControl(AiidaTestCase):
             self.runner.submit(test_utils.AddProcess, a=Int(5))
 
     def test_exception_process(self):
-        with ExpectLog('tornado.application', "Future exception was never retrieved: RemoteException: CRASH"):
-            calc_node = self.runner.submit(test_utils.ExceptionProcess)
-            self._wait_for_calc(calc_node)
+        calc_node = self.runner.submit(test_utils.ExceptionProcess)
+        self._wait_for_calc(calc_node)
 
-            self.assertFalse(calc_node.is_finished_ok)
-            self.assertEqual(calc_node.process_state.value, plumpy.ProcessState.EXCEPTED.value)
+        self.assertFalse(calc_node.is_finished_ok)
+        self.assertEqual(calc_node.process_state.value, plumpy.ProcessState.EXCEPTED.value)
 
     def test_pause(self):
         """ Testing sending a pause message to the process """

--- a/aiida/cmdline/commands/calculation.py
+++ b/aiida/cmdline/commands/calculation.py
@@ -611,56 +611,70 @@ class Calculation(VerdiCommandWithSubcommands):
             else:
                 raise
 
-    def calculation_kill(self, *args):
-        """
-        Kill a calculation.
+    # def calculation_kill(self, *args):
+    #     """
+    #     Kill a calculation.
+    #
+    #     Pass a list of calculation PKs to kill them.
+    #     If you also pass the -f option, no confirmation will be asked.
+    #     """
+    #     if not is_dbenv_loaded():
+    #         load_dbenv()
+    #
+    #     from aiida.cmdline import wait_for_confirmation
+    #     from aiida.orm.calculation.job import JobCalculation as Calc
+    #     from aiida.common.exceptions import NotExistent, InvalidOperation, \
+    #         RemoteOperationError
+    #
+    #     import argparse
+    #
+    #     parser = argparse.ArgumentParser(
+    #         prog=self.get_full_command_name(),
+    #         description='Kill AiiDA calculations.')
+    #     parser.add_argument('calcs', metavar='PK', type=int, nargs='+',
+    #                         help='The principal key (PK) of the calculations to kill')
+    #     parser.add_argument('-f', '--force',
+    #                         help='Force the kill of calculations',
+    #                         action="store_true")
+    #     args = list(args)
+    #     parsed_args = parser.parse_args(args)
+    #
+    #     if not parsed_args.force:
+    #         sys.stderr.write(
+    #             "Are you sure to kill {} calculation{}? [Y/N] ".format(
+    #                 len(parsed_args.calcs),
+    #                 "" if len(parsed_args.calcs) == 1 else "s"))
+    #         if not wait_for_confirmation():
+    #             sys.exit(0)
+    #
+    #     counter = 0
+    #     for calc_pk in parsed_args.calcs:
+    #         try:
+    #             c = load_node(calc_pk, parent_class=Calc)
+    #
+    #             c.kill()  # Calc.kill(calc_pk)
+    #             counter += 1
+    #         except NotExistent:
+    #             print >> sys.stderr, ("WARNING: calculation {} "
+    #                                   "does not exist.".format(calc_pk))
+    #         except (InvalidOperation, RemoteOperationError) as e:
+    #             print >> sys.stderr, (e.message)
+    #     print >> sys.stderr, "{} calculation{} killed.".format(counter,
+    #                                                            "" if counter == 1 else "s")
 
-        Pass a list of calculation PKs to kill them.
-        If you also pass the -f option, no confirmation will be asked.
-        """
-        if not is_dbenv_loaded():
-            load_dbenv()
+    def calculation_kill(self, pk):
+        from aiida import try_load_dbenv
+        try_load_dbenv()
+        from aiida import work
 
-        from aiida.cmdline import wait_for_confirmation
-        from aiida.orm.calculation.job import JobCalculation as Calc
-        from aiida.common.exceptions import NotExistent, InvalidOperation, \
-            RemoteOperationError
-
-        import argparse
-
-        parser = argparse.ArgumentParser(
-            prog=self.get_full_command_name(),
-            description='Kill AiiDA calculations.')
-        parser.add_argument('calcs', metavar='PK', type=int, nargs='+',
-                            help='The principal key (PK) of the calculations to kill')
-        parser.add_argument('-f', '--force',
-                            help='Force the kill of calculations',
-                            action="store_true")
-        args = list(args)
-        parsed_args = parser.parse_args(args)
-
-        if not parsed_args.force:
-            sys.stderr.write(
-                "Are you sure to kill {} calculation{}? [Y/N] ".format(
-                    len(parsed_args.calcs),
-                    "" if len(parsed_args.calcs) == 1 else "s"))
-            if not wait_for_confirmation():
-                sys.exit(0)
-
-        counter = 0
-        for calc_pk in parsed_args.calcs:
+        with work.new_blocking_control_panel() as control_panel:
             try:
-                c = load_node(calc_pk, parent_class=Calc)
-
-                c.kill()  # Calc.kill(calc_pk)
-                counter += 1
-            except NotExistent:
-                print >> sys.stderr, ("WARNING: calculation {} "
-                                      "does not exist.".format(calc_pk))
-            except (InvalidOperation, RemoteOperationError) as e:
-                print >> sys.stderr, (e.message)
-        print >> sys.stderr, "{} calculation{} killed.".format(counter,
-                                                               "" if counter == 1 else "s")
+                if control_panel.kill_process(pk):
+                    print("Killed '{}'".format(pk))
+                else:
+                    print("Problem killing '{}'".format(pk))
+            except (work.RemoteException, work.DeliveryFailed) as e:
+                print("Failed to kill '{}': {}".format(pk, e.message))
 
     def calculation_cleanworkdir(self, *args):
         """

--- a/aiida/cmdline/commands/calculation.py
+++ b/aiida/cmdline/commands/calculation.py
@@ -611,70 +611,49 @@ class Calculation(VerdiCommandWithSubcommands):
             else:
                 raise
 
-    # def calculation_kill(self, *args):
-    #     """
-    #     Kill a calculation.
-    #
-    #     Pass a list of calculation PKs to kill them.
-    #     If you also pass the -f option, no confirmation will be asked.
-    #     """
-    #     if not is_dbenv_loaded():
-    #         load_dbenv()
-    #
-    #     from aiida.cmdline import wait_for_confirmation
-    #     from aiida.orm.calculation.job import JobCalculation as Calc
-    #     from aiida.common.exceptions import NotExistent, InvalidOperation, \
-    #         RemoteOperationError
-    #
-    #     import argparse
-    #
-    #     parser = argparse.ArgumentParser(
-    #         prog=self.get_full_command_name(),
-    #         description='Kill AiiDA calculations.')
-    #     parser.add_argument('calcs', metavar='PK', type=int, nargs='+',
-    #                         help='The principal key (PK) of the calculations to kill')
-    #     parser.add_argument('-f', '--force',
-    #                         help='Force the kill of calculations',
-    #                         action="store_true")
-    #     args = list(args)
-    #     parsed_args = parser.parse_args(args)
-    #
-    #     if not parsed_args.force:
-    #         sys.stderr.write(
-    #             "Are you sure to kill {} calculation{}? [Y/N] ".format(
-    #                 len(parsed_args.calcs),
-    #                 "" if len(parsed_args.calcs) == 1 else "s"))
-    #         if not wait_for_confirmation():
-    #             sys.exit(0)
-    #
-    #     counter = 0
-    #     for calc_pk in parsed_args.calcs:
-    #         try:
-    #             c = load_node(calc_pk, parent_class=Calc)
-    #
-    #             c.kill()  # Calc.kill(calc_pk)
-    #             counter += 1
-    #         except NotExistent:
-    #             print >> sys.stderr, ("WARNING: calculation {} "
-    #                                   "does not exist.".format(calc_pk))
-    #         except (InvalidOperation, RemoteOperationError) as e:
-    #             print >> sys.stderr, (e.message)
-    #     print >> sys.stderr, "{} calculation{} killed.".format(counter,
-    #                                                            "" if counter == 1 else "s")
 
-    def calculation_kill(self, pk):
+    def calculation_kill(self, *args):
+        import argparse
         from aiida import try_load_dbenv
         try_load_dbenv()
         from aiida import work
+        from aiida.cmdline import wait_for_confirmation
 
-        with work.new_blocking_control_panel() as control_panel:
-            try:
-                if control_panel.kill_process(pk):
-                    print("Killed '{}'".format(pk))
+        parser = argparse.ArgumentParser(
+            prog=self.get_full_command_name(),
+            description='Kill AiiDA calculations.')
+        parser.add_argument('calcs', metavar='PK', type=int, nargs='+',
+                            help='The principal key (PK) of the calculations to kill')
+        parser.add_argument('-f', '--force',
+                            help='Force the kill of calculations',
+                            action="store_true")
+        args = list(args)
+        parsed_args = parser.parse_args(args)
+
+        if not parsed_args.force:
+            sys.stderr.write(
+                "Are you sure to kill {} calculation{}? [Y/N] ".format(
+                    len(parsed_args.calcs),
+                    "" if len(parsed_args.calcs) == 1 else "s"))
+            if not wait_for_confirmation():
+                sys.exit(0)
+
+        with work.new_control_panel() as control_panel:
+            futures = []
+            for calc in parsed_args.calcs:
+                try:
+                    future = control_panel.kill_process(calc)
+                    futures.append((calc, future))
+                except (work.RemoteException, work.DeliveryFailed) as e:
+                    print('Calculation<{}> killing failed {}'.format(calc, e.message))
+
+            for future in futures:
+                result = control_panel._communicator.await(future[1])
+                if result:
+                    print('Calculation<{}> successfully killed'.format(future[0]))
                 else:
-                    print("Problem killing '{}'".format(pk))
-            except (work.RemoteException, work.DeliveryFailed) as e:
-                print("Failed to kill '{}': {}".format(pk, e.message))
+                    print('Calculation<{}> killing failed {}'.format(future[0], result))
+
 
     def calculation_cleanworkdir(self, *args):
         """

--- a/aiida/orm/implementation/general/calculation/job/__init__.py
+++ b/aiida/orm/implementation/general/calculation/job/__init__.py
@@ -1481,51 +1481,9 @@ class AbstractJobCalculation(AbstractCalculation):
         No changes of calculation status are done (they will be done later by
         the calculation manager).
 
-        .. todo: if the status is TOSUBMIT, check with some lock that it is not
-            actually being submitted at the same time in another thread.
+        .. Note: Deprecated
         """
-        # TODO: Check if we want to add a status "KILLED" or something similar.
-        from aiida.common.exceptions import (InvalidOperation,
-                                             RemoteOperationError)
-
-        old_state = self.get_state()
-
-        if (old_state == calc_states.NEW or old_state == calc_states.TOSUBMIT):
-            self._set_state(calc_states.FAILED)
-            self.logger.warning(
-                "Calculation {} killed by the user "
-                "(it was in {} state)".format(self.pk, old_state))
-            return
-
-        if old_state != calc_states.WITHSCHEDULER:
-            raise InvalidOperation("Cannot kill a calculation in {} state"
-                                   .format(old_state))
-
-        # I get the scheduler plugin class and initialize it with the correct
-        # transport
-        computer = self.get_computer()
-        t = self._get_transport()
-        s = computer.get_scheduler()
-        s.set_transport(t)
-
-        # And I call the proper kill method for the job ID of this calculation
-        with t:
-            retval = s.kill(self.get_job_id())
-
-        # Raise error is something went wrong
-        if not retval:
-            raise RemoteOperationError(
-                "An error occurred while trying to kill "
-                "calculation {} (jobid {}), see log "
-                "(maybe the calculation already finished?)"
-                    .format(self.pk, self.get_job_id()))
-        else:
-            # Do not set the state, but let the parser do its job
-            # self._set_state(calc_states.FAILED)
-            self._logger.warning(
-                "Calculation {} killed by the user "
-                "(it was {})".format(self.pk,
-                                     calc_states.WITHSCHEDULER))
+        raise NotImplementedError("deprecated method: to kill a calculation go through 'verdi calculation kill'")
 
     def _presubmit(self, folder, use_unstored_links=False):
         """

--- a/aiida/work/job_processes.py
+++ b/aiida/work/job_processes.py
@@ -188,7 +188,7 @@ class KillJob(TransportTask):
         else:
             calc._set_state(calc_states.FAILED)
             calc._set_scheduler_state(job_states.DONE)
-            calc._logger.warning(
+            calc.logger.warning(
                 "Calculation {} killed by the user "
                 "(it was {})".format(calc.pk, calc_states.WITHSCHEDULER))
 

--- a/aiida/work/job_processes.py
+++ b/aiida/work/job_processes.py
@@ -145,6 +145,7 @@ class RetrieveJob(TransportTask):
 
 
 class KillJob(TransportTask):
+
     def execute(self, transport):
         """
         Kill a calculation on the cluster.
@@ -177,21 +178,21 @@ class KillJob(TransportTask):
         scheduler.set_transport(transport)
 
         # Call the proper kill method for the job ID of this calculation
-        retval = scheduler.kill(job_id)
+        result = scheduler.kill(job_id)
 
         # Raise error if something went wrong
-        if not retval:
+        if not result:
             raise RemoteOperationError(
-                "An error occurred while trying to kill "
-                "calculation {} (jobid {}), see log "
+                "An error occurred while trying to kill calculation {} (jobid {}), see log "
                 "(maybe the calculation already finished?)".format(calc.pk, job_id))
         else:
-            # Do not set the state, but let the parser do its job
+            calc._set_state(calc_states.FAILED)
+            calc._set_scheduler_state(job_states.DONE)
             calc._logger.warning(
                 "Calculation {} killed by the user "
                 "(it was {})".format(calc.pk, calc_states.WITHSCHEDULER))
 
-        return retval
+        return result
 
 
 class Waiting(plumpy.Waiting):

--- a/aiida/work/processes.py
+++ b/aiida/work/processes.py
@@ -142,7 +142,7 @@ class Process(plumpy.Process):
         else:
             self._runner = get_runner()
 
-        load_context = load_context.copyextend(loop=self._runner.loop)
+        load_context = load_context.copyextend(loop=self._runner.loop, communicator=self._runner.communicator)
         super(Process, self).load_instance_state(saved_state, load_context)
 
         is_copy = saved_state.get('COPY', False)

--- a/requirements.txt
+++ b/requirements.txt
@@ -142,5 +142,5 @@ wcwidth==0.1.7
 Werkzeug==0.14.1
 wrapt==1.10.11
 yapf==0.19.0
--e git://github.com/muhrin/plumpy.git@7c78b11e8ef8a0a35792ba82674679c1185f63f0#egg=plumpy
+-e git://github.com/muhrin/plumpy.git@9a42c0b4105de79bff7027c6c6bb0c6f3a33b0fc#egg=plumpy
 -e git://github.com/muhrin/kiwipy.git@c9102c1d8c3a95cc49087960e4ce47754485973e#egg=kiwipy

--- a/requirements.txt
+++ b/requirements.txt
@@ -142,5 +142,5 @@ wcwidth==0.1.7
 Werkzeug==0.14.1
 wrapt==1.10.11
 yapf==0.19.0
--e git://github.com/muhrin/plumpy.git@9a42c0b4105de79bff7027c6c6bb0c6f3a33b0fc#egg=plumpy
--e git://github.com/muhrin/kiwipy.git@c9102c1d8c3a95cc49087960e4ce47754485973e#egg=kiwipy
+-e git://github.com/muhrin/plumpy.git@9e8b57096202b107014c29d848bbb939d851428d#egg=plumpy
+-e git://github.com/muhrin/kiwipy.git@07dbeac1e0a7de41638e3e212823ddd3ab63b7fb#egg=kiwipy

--- a/requirements.txt
+++ b/requirements.txt
@@ -142,5 +142,5 @@ wcwidth==0.1.7
 Werkzeug==0.14.1
 wrapt==1.10.11
 yapf==0.19.0
--e git://github.com/muhrin/plumpy.git@9e8b57096202b107014c29d848bbb939d851428d#egg=plumpy
+-e git://github.com/muhrin/plumpy.git@349471363eb880d90f888d5dc338734e85871930#egg=plumpy
 -e git://github.com/muhrin/kiwipy.git@07dbeac1e0a7de41638e3e212823ddd3ab63b7fb#egg=kiwipy


### PR DESCRIPTION
Fixes #133 

The `verdi calculation kill` command will now go through the `ProcessControlPanel` which will fire the kill request over RabbitMQ. The corresponding `JobProcess` will pick up the message, schedule a request for transport to send the kill command to the scheduler and then set the calculation state to `FAILED`. We no longer just send the kill request to the scheduler and let the daemon try and parse the calculation.