### PR TITLE
Respect the AttributeDict in serializing and deserializing

### DIFF
--- a/aiida/utils/serialize.py
+++ b/aiida/utils/serialize.py
@@ -1,7 +1,9 @@
 # -*- coding: utf-8 -*-
 import collections
 from ast import literal_eval
+from aiida.common.extendeddicts import AttributeDict
 from aiida.orm import Group, Node, load_group, load_node
+
 
 _PREFIX_KEY_TUPLE = 'tuple():'
 _PREFIX_VALUE_NODE = 'aiida_node:'
@@ -52,6 +54,8 @@ def serialize_data(data):
         return '{}{}'.format(_PREFIX_VALUE_NODE, data.uuid)
     elif isinstance(data, Group):
         return '{}{}'.format(_PREFIX_VALUE_GROUP, data.uuid)
+    elif isinstance(data, AttributeDict):
+        return AttributeDict({encode_key(key): serialize_data(value) for key, value in data.iteritems()})
     elif isinstance(data, collections.Mapping):
         return {encode_key(key): serialize_data(value) for key, value in data.iteritems()}
     elif isinstance(data, collections.Sequence) and not isinstance(data, (str, unicode)):
@@ -69,7 +73,9 @@ def deserialize_data(data):
     :param data: serialized data
     :return: the deserialized data with keys decoded and node instances loaded from UUID's
     """
-    if isinstance(data, collections.Mapping):
+    if isinstance(data, AttributeDict):
+        return AttributeDict({decode_key(key): deserialize_data(value) for key, value in data.iteritems()})
+    elif isinstance(data, collections.Mapping):
         return {decode_key(key): deserialize_data(value) for key, value in data.iteritems()}
     elif isinstance(data, collections.Sequence) and not isinstance(data, (str, unicode)):
         return tuple(deserialize_data(value) for value in data)


### PR DESCRIPTION
Fixes #1329 

When an AttributeDict was stored in the context of a workchain, the
serialized version was turned into a plain dictionary. Add a special
case for AttributeDict to keep the properties of the Mapping