### PR TITLE
Fix problems with Processes when running multiple daemon workers

### DIFF
--- a/aiida/common/log.py
+++ b/aiida/common/log.py
@@ -83,7 +83,7 @@ LOGGING = {
                       '%(thread)d %(message)s',
         },
         'halfverbose': {
-            'format': '%(asctime)s, %(name)s: [%(levelname)s] %(message)s',
+            'format': '%(asctime)s <%(process)d> %(name)s: [%(levelname)s] %(message)s',
             'datefmt': '%m/%d/%Y %I:%M:%S %p',
         },
     },

--- a/aiida/daemon/runner.py
+++ b/aiida/daemon/runner.py
@@ -7,17 +7,17 @@
 # For further information on the license, see the LICENSE.txt file        #
 # For further information please visit http://www.aiida.net               #
 ###########################################################################
+import logging
 import signal
 from functools import partial
 
-from aiida.common.log import aiidalogger
 from aiida.common.log import configure_logging
 from aiida.daemon.client import DaemonClient
 from aiida.work.rmq import get_rmq_config
 from aiida.work import DaemonRunner, set_runner
 
 
-logger = aiidalogger.getChild(__name__)
+logger = logging.getLogger(__name__)
 
 DAEMON_LEGACY_WORKFLOW_INTERVAL = 30
 
@@ -60,7 +60,7 @@ def tick_legacy_workflows(runner, interval=DAEMON_LEGACY_WORKFLOW_INTERVAL):
     :param runner: the DaemonRunner instance to perform the callback
     :param interval: the number of seconds to wait between callbacks
     """
-    logger.info('Ticking the legacy workflows')
+    logger.debug('Ticking the legacy workflows')
     legacy_workflow_stepper()
     runner.loop.call_later(interval, partial(tick_legacy_workflows, runner))
 
@@ -73,7 +73,7 @@ def legacy_workflow_stepper():
     from aiida.daemon.timestamps import set_daemon_timestamp, get_last_daemon_timestamp
     from aiida.daemon.workflowmanager import execute_steps
 
-    logger.info('Checking for workflows to manage')
+    logger.debug('Checking for workflows to manage')
     # RUDIMENTARY way to check if this task is already running (to avoid acting
     # again and again on the same workflow steps)
     try:
@@ -87,8 +87,8 @@ def legacy_workflow_stepper():
     if not stepper_is_running:
         set_daemon_timestamp(task_name='workflow', when='start')
         # The previous wf manager stopped already -> we can run a new one
-        logger.info('Running execute_steps')
+        logger.debug('Running execute_steps')
         execute_steps()
         set_daemon_timestamp(task_name='workflow', when='stop')
     else:
-        logger.info('Execute_steps already running')
+        logger.debug('Execute_steps already running')

--- a/aiida/daemon/workflowmanager.py
+++ b/aiida/daemon/workflowmanager.py
@@ -38,7 +38,7 @@ def execute_steps():
     from aiida.orm import JobCalculation
     from aiida.orm.implementation import get_all_running_steps
  
-    logger.info("Querying the worflow DB")
+    logger.debug("Querying the worflow DB")
     
     running_steps = get_all_running_steps()
 

--- a/aiida/utils/serialize.py
+++ b/aiida/utils/serialize.py
@@ -59,7 +59,7 @@ def serialize_data(data):
     elif isinstance(data, collections.Mapping):
         return {encode_key(key): serialize_data(value) for key, value in data.iteritems()}
     elif isinstance(data, collections.Sequence) and not isinstance(data, (str, unicode)):
-        return tuple(serialize_data(value) for value in data)
+        return [serialize_data(value) for value in data]
     else:
         return data
 
@@ -78,7 +78,7 @@ def deserialize_data(data):
     elif isinstance(data, collections.Mapping):
         return {decode_key(key): deserialize_data(value) for key, value in data.iteritems()}
     elif isinstance(data, collections.Sequence) and not isinstance(data, (str, unicode)):
-        return tuple(deserialize_data(value) for value in data)
+        return [deserialize_data(value) for value in data]
     elif isinstance(data, (str, unicode)) and data.startswith(_PREFIX_VALUE_NODE):
         return load_node(uuid=data[len(_PREFIX_VALUE_NODE):])
     elif isinstance(data, (str, unicode)) and data.startswith(_PREFIX_VALUE_GROUP):

--- a/aiida/work/job_processes.py
+++ b/aiida/work/job_processes.py
@@ -166,6 +166,7 @@ class KillJob(TransportTask):
 
         if calc_state == calc_states.NEW or calc_state == calc_states.TOSUBMIT:
             calc._set_state(calc_states.FAILED)
+            calc._set_scheduler_state(job_states.DONE)
             calc.logger.warning("Calculation {} killed by the user "
                                 "(it was in {} state)".format(calc.pk, calc_state))
             return True
@@ -188,9 +189,7 @@ class KillJob(TransportTask):
         else:
             calc._set_state(calc_states.FAILED)
             calc._set_scheduler_state(job_states.DONE)
-            calc.logger.warning(
-                "Calculation {} killed by the user "
-                "(it was {})".format(calc.pk, calc_states.WITHSCHEDULER))
+            calc.logger.warning('Calculation<{}> killed by the user'.format(calc.pk))
 
         return result
 

--- a/aiida/work/persistence.py
+++ b/aiida/work/persistence.py
@@ -8,6 +8,7 @@
 # For further information please visit http://www.aiida.net               #
 ###########################################################################
 
+import logging
 import uritools
 import os.path
 import os
@@ -20,6 +21,7 @@ from aiida import orm
 from . import class_loader
 
 Bundle = plumpy.Bundle
+LOGGER = logging.getLogger(__name__)
 
 
 # If portalocker accepts my pull request to have this incorporated into the
@@ -98,6 +100,8 @@ class AiiDAPersister(plumpy.Persister):
     """
 
     def save_checkpoint(self, process, tag=None):
+        LOGGER.info('Persisting process<{}>'.format(process.pid))
+
         if tag is not None:
             raise NotImplementedError("Checkpoint tags not supported yet")
 

--- a/aiida/work/runners.py
+++ b/aiida/work/runners.py
@@ -203,6 +203,7 @@ class Runner(object):
         if self._rmq_submit:
             process = _create_process(process_class, self, input_args=args, input_kwargs=inputs)
             self.persister.save_checkpoint(process)
+            process.close()
             self.rmq.continue_process(process.pid)
             return process.calc
         else:

--- a/aiida/work/workchain.py
+++ b/aiida/work/workchain.py
@@ -165,10 +165,10 @@ class WorkChain(processes.Process):
         """
         for awaitable in self._awaitables:
             if awaitable.target == AwaitableTarget.CALCULATION:
-                fn = functools.partial(self.on_calculation_finished, awaitable)
+                fn = functools.partial(self._run_task, self.on_calculation_finished, awaitable)
                 self.runner.call_on_calculation_finish(awaitable.pk, fn)
             elif awaitable.target == AwaitableTarget.WORKFLOW:
-                fn = functools.partial(self.on_legacy_workflow_finished, awaitable)
+                fn = functools.partial(self._run_task, self.on_legacy_workflow_finished, awaitable)
                 self.runner.call_on_legacy_workflow_finish(awaitable.pk, fn)
             else:
                 assert "invalid awaitable target '{}'".format(awaitable.target)

--- a/requirements.txt
+++ b/requirements.txt
@@ -142,5 +142,5 @@ wcwidth==0.1.7
 Werkzeug==0.14.1
 wrapt==1.10.11
 yapf==0.19.0
--e git://github.com/muhrin/plumpy.git@349471363eb880d90f888d5dc338734e85871930#egg=plumpy
+-e git://github.com/muhrin/plumpy.git@d83c5365c2c84454b3f9c65a0db184b6a3c056d4#egg=plumpy
 -e git://github.com/muhrin/kiwipy.git@07dbeac1e0a7de41638e3e212823ddd3ab63b7fb#egg=kiwipy


### PR DESCRIPTION
Fixes #1332 

Includes multiple fixes that prevent that at any one point in time, multiple `DaemonRunners` have the same `Process` in memory and are therefore picking up those messages simultaneously leading to race conditions and database integrity errors.