### PR TITLE
Shield subprocesses from signal

### DIFF
--- a/aiida/control/postgres.py
+++ b/aiida/control/postgres.py
@@ -323,7 +323,7 @@ def _pg_execute_sh(command, user='postgres', **kwargs):
     from aiida.common.utils import escape_for_bash
     psql_cmd = ['psql {options} -tc {}'.format(escape_for_bash(command), options=options)]
     sudo_su_psql = sudo_cmd + su_cmd + psql_cmd
-    result = subprocess.check_output(sudo_su_psql, preexec_fn=os.setpgrp, **kwargs)
+    result = subprocess.check_output(sudo_su_psql, preexec_fn=os.setsid, **kwargs)
 
     if isinstance(result, str):
         result = result.strip().split('\n')

--- a/aiida/control/postgres.py
+++ b/aiida/control/postgres.py
@@ -20,8 +20,8 @@ try:
 except ImportError:
     import subprocess
 
-import click
 import os
+import click
 
 _CREATE_USER_COMMAND = 'CREATE USER "{}" WITH PASSWORD \'{}\''
 _DROP_USER_COMMAND = 'DROP USER "{}"'

--- a/aiida/control/postgres.py
+++ b/aiida/control/postgres.py
@@ -21,6 +21,7 @@ except ImportError:
     import subprocess
 
 import click
+import os
 
 _CREATE_USER_COMMAND = 'CREATE USER "{}" WITH PASSWORD \'{}\''
 _DROP_USER_COMMAND = 'DROP USER "{}"'
@@ -322,7 +323,7 @@ def _pg_execute_sh(command, user='postgres', **kwargs):
     from aiida.common.utils import escape_for_bash
     psql_cmd = ['psql {options} -tc {}'.format(escape_for_bash(command), options=options)]
     sudo_su_psql = sudo_cmd + su_cmd + psql_cmd
-    result = subprocess.check_output(sudo_su_psql, **kwargs)
+    result = subprocess.check_output(sudo_su_psql, preexec_fn=os.setpgrp, **kwargs)
 
     if isinstance(result, str):
         result = result.strip().split('\n')

--- a/aiida/transport/plugins/local.py
+++ b/aiida/transport/plugins/local.py
@@ -176,7 +176,7 @@ class LocalTransport(Transport):
         Create a folder (directory) named path.
 
         :param path: name of the folder to create
-        :param ignore_existing: if True, does not give any error if the 
+        :param ignore_existing: if True, does not give any error if the
                 directory already exists
 
         :raise OSError: If the directory already exists.
@@ -362,7 +362,7 @@ class LocalTransport(Transport):
     def rmtree(self, path):
         """
         Remove tree as rm -r would do
-        
+
         :param path: a string to path
         """
         the_path = os.path.join(self.curdir, path)
@@ -593,7 +593,7 @@ class LocalTransport(Transport):
         :param source: path to local file
         :param destination: path to remote file
         :param dereference: follow symbolic links. Default = False
-        
+
         :raise ValueError: if 'remote' source or destination is not valid
         :raise OSError: if source does not exist
         """
@@ -692,8 +692,11 @@ class LocalTransport(Transport):
         job to finish, use exec_command_wait.
         Otherwise, to end the process, use the proc.wait() method.
 
+        The subprocess is set to have a different process group than the
+        main process, so that it is shielded from signals sent to the parent.
+
         :param command: the command to execute
-        
+
         :return: a tuple with (stdin, stdout, stderr, proc),
             where stdin, stdout and stderr behave as file-like objects,
             proc is the process object as returned by the
@@ -705,16 +708,18 @@ class LocalTransport(Transport):
             stdin=subprocess.PIPE,
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
-            cwd=self.getcwd())
+            cwd=self.getcwd(),
+            preexec_fn=os.setpgrp,
+        )
         return proc.stdin, proc.stdout, proc.stderr, proc
 
     def exec_command_wait(self, command, stdin=None):
         """
         Executes the specified command and waits for it to finish.
-        
+
         :param command: the command to execute
 
-        :return: a tuple with (return_value, stdout, stderr) where stdout and 
+        :return: a tuple with (return_value, stdout, stderr) where stdout and
                  stderr are strings.
         """
         local_stdin, local_stdout, local_stderr, local_proc = self._exec_command_internal(command)
@@ -762,7 +767,7 @@ class LocalTransport(Transport):
     def rename(self, src, dst):
         """
         Rename a file or folder from oldpath to newpath.
-        
+
         :param str oldpath: existing name of the file or folder
         :param str newpath: new name for the file or folder
 
@@ -782,9 +787,9 @@ class LocalTransport(Transport):
 
     def symlink(self, remotesource, remotedestination):
         """
-        Create a symbolic link between the remote source and the remote 
+        Create a symbolic link between the remote source and the remote
         destination
-        
+
         :param remotesource: remote source. Can contain a pattern.
         :param remotedestination: remote destination
         """

--- a/aiida/transport/plugins/local.py
+++ b/aiida/transport/plugins/local.py
@@ -709,7 +709,7 @@ class LocalTransport(Transport):
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
             cwd=self.getcwd(),
-            preexec_fn=os.setpgrp,
+            preexec_fn=os.setsid,
         )
         return proc.stdin, proc.stdout, proc.stderr, proc
 

--- a/aiida/transport/plugins/ssh.py
+++ b/aiida/transport/plugins/ssh.py
@@ -20,6 +20,8 @@ from aiida.common.utils import escape_for_bash
 from aiida.transport.util import FileAttribute
 from aiida.common import aiidalogger
 
+__all__ = ["parse_sshconfig", "convert_to_bool", "SshTransport"]
+
 
 # TODO : callback functions in paramiko are currently not used much and probably broken
 def parse_sshconfig(computername):
@@ -405,7 +407,7 @@ class SshTransport(aiida.transport.Transport):
         :param key_policy: (optional, default = paramiko.RejectPolicy())
            the policy to use for unknown keys
 
-        Other parameters valid for the ssh connect function (see the 
+        Other parameters valid for the ssh connect function (see the
         self._valid_connect_params list) are passed to the connect
         function (as port, username, password, ...); taken from the
         accepted paramiko.SSHClient.connect() params.

--- a/aiida/transport/plugins/ssh.py
+++ b/aiida/transport/plugins/ssh.py
@@ -1414,5 +1414,5 @@ class _DetachedProxyCommand(paramiko.ProxyCommand):
         from subprocess import Popen, PIPE
         from shlex import split as shlsplit
         self.cmd = shlsplit(command_line)
-        self.process = Popen(self.cmd, stdin=PIPE, stdout=PIPE, stderr=PIPE, bufsize=0, preexec_fn=os.setpgrp)
+        self.process = Popen(self.cmd, stdin=PIPE, stdout=PIPE, stderr=PIPE, bufsize=0, preexec_fn=os.setsid)
         self.timeout = None

--- a/aiida/transport/plugins/ssh.py
+++ b/aiida/transport/plugins/ssh.py
@@ -188,7 +188,7 @@ class SshTransport(aiida.transport.Transport):
     def _get_timeout_suggestion_string(cls, computer):
         """
         Return a suggestion for the specific field.
-        
+
         Provide 60s as a default timeout for connections.
         """
         config = parse_sshconfig(computer.hostname)
@@ -398,7 +398,7 @@ class SshTransport(aiida.transport.Transport):
     def __init__(self, machine, **kwargs):
         """
         Initialize the SshTransport class.
-        
+
         :param machine: the machine to connect to
         :param load_system_host_keys: (optional, default False)
            if False, do not load the system host keys
@@ -447,11 +447,11 @@ class SshTransport(aiida.transport.Transport):
     def open(self):
         """
         Open a SSHClient to the machine possibly using the parameters given
-        in the __init__. 
-        
+        in the __init__.
+
         Also opens a sftp channel, ready to be used.
         The current working directory is set explicitly, so it is not None.
-        
+
         :raise InvalidOperation: if the channel is already open
         """
         from aiida.common.exceptions import InvalidOperation
@@ -484,9 +484,9 @@ class SshTransport(aiida.transport.Transport):
     def close(self):
         """
         Close the SFTP channel, and the SSHClient.
-        
+
         :todo: correctly manage exceptions
-        
+
         :raise InvalidOperation: if the channel is already open
         """
         from aiida.common.exceptions import InvalidOperation
@@ -533,7 +533,7 @@ class SshTransport(aiida.transport.Transport):
     def chdir(self, path):
         """
         Change directory of the SFTP session. Emulated internally by
-        paramiko. 
+        paramiko.
 
         Differently from paramiko, if you pass None to chdir, nothing
         happens and the cwd is unchanged.
@@ -900,7 +900,7 @@ class SshTransport(aiida.transport.Transport):
         :param remotepath: a remote path
         :param localpath: an (absolute) local path
         :param dereference: follow symbolic links.
-            Default = True (default behaviour in paramiko). 
+            Default = True (default behaviour in paramiko).
             False is not implemented.
         :param overwrite: if True overwrites files and folders.
             Default = False
@@ -997,8 +997,8 @@ class SshTransport(aiida.transport.Transport):
 
         :param remotepath: a remote path
         :param localpath: an (absolute) local path
-        :param dereference: follow symbolic links. 
-            Default = True (default behaviour in paramiko). 
+        :param dereference: follow symbolic links.
+            Default = True (default behaviour in paramiko).
             False is not implemented.
         :param  overwrite: if True overwrites files and folders.
             Default = False
@@ -1061,8 +1061,8 @@ class SshTransport(aiida.transport.Transport):
         """
         Copy a file from remote source to remote destination
         Redirects to copy().
-        
-        :param remotesource: 
+
+        :param remotesource:
         :param remotedestination:
         :param dereference:
         :param pattern:
@@ -1263,10 +1263,10 @@ class SshTransport(aiida.transport.Transport):
                 stderr on the same buffer (i.e., stdout).
                 Note: If combine_stderr is True, stderr will always be empty.
         :param bufsize: same meaning of the one used by paramiko.
-        
+
         :return: a tuple with (stdin, stdout, stderr, channel),
             where stdin, stdout and stderr behave as file-like objects,
-            plus the methods provided by paramiko, and channel is a 
+            plus the methods provided by paramiko, and channel is a
             paramiko.Channel object.
         """
         channel = self.sshclient.get_transport().open_session()
@@ -1292,7 +1292,7 @@ class SshTransport(aiida.transport.Transport):
     def exec_command_wait(self, command, stdin=None, combine_stderr=False, bufsize=-1):
         """
         Executes the specified command and waits for it to finish.
-        
+
         :param command: the command to execute
         :param stdin: (optional,default=None) can be a string or a
                    file-like object.
@@ -1324,11 +1324,11 @@ class SshTransport(aiida.transport.Transport):
         ssh_stdin.flush()
         ssh_stdin.channel.shutdown_write()
 
-        output_text = stdout.read()
-
-        # I get the return code (blocking, but in principle I waited above)
+        # I get the return code (blocking)
         retval = channel.recv_exit_status()
 
+        # needs to be after 'recv_exit_status', otherwise it might hang
+        output_text = stdout.read()
         stderr_text = stderr.read()
 
         return retval, output_text, stderr_text
@@ -1367,10 +1367,10 @@ class SshTransport(aiida.transport.Transport):
 
     def symlink(self, remotesource, remotedestination):
         """
-        Create a symbolic link between the remote source and the remote 
+        Create a symbolic link between the remote source and the remote
         destination.
-        
-        :param remotesource: remote source. Can contain a pattern. 
+
+        :param remotesource: remote source. Can contain a pattern.
         :param remotedestination: remote destination
         """
         # paramiko gives some errors if path is starting with '.'

--- a/docs/source/developer_guide/developers.rst
+++ b/docs/source/developer_guide/developers.rst
@@ -516,11 +516,11 @@ While the AiiDA daemon is running, interrupt signals (``SIGINT`` and ``SIGTERM``
 
     signal.signal(signal.SIGINT, print_foo)
 
-You should be aware of this while developing code which runs in the daemon. In particular, it's important when creating subprocesses. When a signal is sent, the whole process group receives that signal. As a result, the subprocess can be killed even though the Python main process captures the signal. This can be avoided by creating a new process group for the subprocess, meaning that it will not receive the signal. To do this, you need to pass ``preexec_fn=os.setpgrp`` to the ``subprocess`` function:
+You should be aware of this while developing code which runs in the daemon. In particular, it's important when creating subprocesses. When a signal is sent, the whole process group receives that signal. As a result, the subprocess can be killed even though the Python main process captures the signal. This can be avoided by creating a new process group for the subprocess, meaning that it will not receive the signal. To do this, you need to pass ``preexec_fn=os.setsid`` to the ``subprocess`` function:
 
 .. code:: python
 
     import os
     import subprocess
 
-    print(subprocess.check_output('sleep 3; echo bar', preexec_fn=os.setpgrp))
+    print(subprocess.check_output('sleep 3; echo bar', preexec_fn=os.setsid))


### PR DESCRIPTION
Fixes #1335. 

Shields subprocesses from receiving signals by moving them to a different process group. For the SSH transport, this only affects the ``ProxyCommand``, because otherwise paramiko doesn't need subprocesses, in which case the regular Python signal handler works (guess who uses a proxycommand :smile:).

Right now it's solved a bit ugly by subclassing ``paramiko.ProxyCommand`` -- I can try what the the paramiko maintainers think about a PR that would allow passing keyword arguments to the ``Popen``, but anyway that would probably be a long time before it's in a release.

**Note:** This does _not_ fix the ``CLASS_LOADER`` issue discussed further down in #1335, just the original issue. 
