### PR TITLE
Serialize the context of a WorkChain before persisting

### DIFF
--- a/aiida/utils/serialize.py
+++ b/aiida/utils/serialize.py
@@ -1,0 +1,87 @@
+# -*- coding: utf-8 -*-
+import collections
+from ast import literal_eval
+from aiida.common.extendeddicts import AttributeDict
+from aiida.orm import Group, Node, load_group, load_node
+
+
+_PREFIX_KEY_TUPLE = 'tuple():'
+_PREFIX_VALUE_NODE = 'aiida_node:'
+_PREFIX_VALUE_GROUP = 'aiida_group:'
+
+
+def encode_key(key):
+    """
+    Helper function for the serialize_data function which may need to serialize a
+    dictionary that uses tuples as keys. This function will encode the tuple into
+    a string such that it is JSON serializable
+
+    :param key: the key to encode
+    :return: the encoded key
+    """
+    if isinstance(key, tuple):
+        return '{}{}'.format(_PREFIX_KEY_TUPLE, key)
+    else:
+        return key
+
+
+def decode_key(key):
+    """
+    Helper function for the deserialize_data function which can undo the key encoding
+    of tuple keys done by the encode_key function
+
+    :param key: the key to decode
+    :return: the decoded key
+    """
+    if key.startswith(_PREFIX_KEY_TUPLE):
+        return literal_eval(key[len(_PREFIX_KEY_TUPLE):])
+    else:
+        return key
+
+
+def serialize_data(data):
+    """
+    Serialize a value or collection that may potentially contain AiiDA nodes, which
+    will be serialized to their UUID. Keys encountered in any mappings, such as a dictionary,
+    will also be encoded if necessary. An example is where tuples are used as keys in the
+    pseudo potential input dictionaries. These operations will ensure that the returned data is
+    JSON serializable.
+
+    :param data: a single value or collection
+    :return: the serialized data with the same internal structure
+    """
+    if isinstance(data, Node):
+        return '{}{}'.format(_PREFIX_VALUE_NODE, data.uuid)
+    elif isinstance(data, Group):
+        return '{}{}'.format(_PREFIX_VALUE_GROUP, data.uuid)
+    elif isinstance(data, AttributeDict):
+        return AttributeDict({encode_key(key): serialize_data(value) for key, value in data.iteritems()})
+    elif isinstance(data, collections.Mapping):
+        return {encode_key(key): serialize_data(value) for key, value in data.iteritems()}
+    elif isinstance(data, collections.Sequence) and not isinstance(data, (str, unicode)):
+        return [serialize_data(value) for value in data]
+    else:
+        return data
+
+
+def deserialize_data(data):
+    """
+    Deserialize a single value or a collection that may contain serialized AiiDA nodes. This is
+    essentially the inverse operation of serialize_data which will reload node instances from
+    the serialized UUID data. Encoded tuples that are used as dictionary keys will be decoded.
+
+    :param data: serialized data
+    :return: the deserialized data with keys decoded and node instances loaded from UUID's
+    """
+    if isinstance(data, AttributeDict):
+        return AttributeDict({decode_key(key): deserialize_data(value) for key, value in data.iteritems()})
+    elif isinstance(data, collections.Mapping):
+        return {decode_key(key): deserialize_data(value) for key, value in data.iteritems()}
+    elif isinstance(data, collections.Sequence) and not isinstance(data, (str, unicode)):
+        return [deserialize_data(value) for value in data]
+    elif isinstance(data, (str, unicode)) and data.startswith(_PREFIX_VALUE_NODE):
+        return load_node(uuid=data[len(_PREFIX_VALUE_NODE):])
+    elif isinstance(data, (str, unicode)) and data.startswith(_PREFIX_VALUE_GROUP):
+        return load_group(uuid=data[len(_PREFIX_VALUE_GROUP):])
+    else:
+        return data

--- a/aiida/work/persistence.py
+++ b/aiida/work/persistence.py
@@ -16,6 +16,7 @@ import os.path
 import plum.persistence.pickle_persistence
 from plum.process import Process
 from aiida.common.lang import override
+from aiida.utils.serialize import serialize_data, deserialize_data
 from aiida.work.defaults import class_loader
 
 import glob
@@ -397,9 +398,13 @@ class Persistence(plum.persistence.pickle_persistence.PicklePersistence):
     def load_checkpoint_from_file_object(self, file_object):
         cp = pickle.load(file_object)
 
-        inputs = cp[Process.BundleKeys.INPUTS.value]
+        inputs = cp[Process.BundleKeys.INPUTS_RAW.value]
         if inputs:
-            cp[Process.BundleKeys.INPUTS.value] = self._load_nodes_from(inputs)
+            cp[Process.BundleKeys.INPUTS_RAW.value] = deserialize_data(inputs)
+
+        inputs = cp[Process.BundleKeys.INPUTS_PARSED.value]
+        if inputs:
+            cp[Process.BundleKeys.INPUTS_PARSED.value] = deserialize_data(inputs)
 
         cp.set_class_loader(class_loader)
         return cp
@@ -412,50 +417,15 @@ class Persistence(plum.persistence.pickle_persistence.PicklePersistence):
     def create_bundle(self, process):
         bundle = Bundle()
         process.save_instance_state(bundle)
-        inputs = bundle[Process.BundleKeys.INPUTS.value]
+        inputs = bundle[Process.BundleKeys.INPUTS_RAW.value]
         if inputs:
-            bundle[Process.BundleKeys.INPUTS.value] = self._convert_to_ids(inputs)
+            bundle[Process.BundleKeys.INPUTS_RAW.value] = serialize_data(inputs)
+
+        inputs = bundle[Process.BundleKeys.INPUTS_PARSED.value]
+        if inputs:
+            bundle[Process.BundleKeys.INPUTS_PARSED.value] = serialize_data(inputs)
 
         return bundle
-
-    def _convert_to_ids(self, nodes):
-        from aiida.orm import Node
-
-        input_ids = {}
-        for label, node in nodes.iteritems():
-            if node is None:
-                continue
-            elif isinstance(node, Node):
-                if node.is_stored:
-                    input_ids[label] = node.pk
-                else:
-                    # Try using the UUID, but there's probably no chance of
-                    # being abel to recover the node from this if not stored
-                    # (for the time being)
-                    input_ids[label] = node.uuid
-            elif isinstance(node, collections.Mapping):
-                input_ids[label] = self._convert_to_ids(node)
-
-        return input_ids
-
-    def _load_nodes_from(self, pks_mapping):
-        """
-        Take a dictionary of of {label: pk} or nested dictionary i.e.
-        {label: {label: pk}} and convert to the equivalent dictionary but
-        with nodes instead of the ids.
-
-        :param pks_mapping: The dictionary of node pks.
-        :return: A dictionary with the loaded nodes.
-        """
-        from aiida.orm import load_node
-
-        nodes = {}
-        for label, pk in pks_mapping.iteritems():
-            if isinstance(pk, collections.Mapping):
-                nodes[label] = self._load_nodes_from(pk)
-            else:
-                nodes[label] = load_node(pk=pk)
-        return nodes
 
     def _clear(self, fileobj):
         """

--- a/docs/requirements_for_rtd.txt
+++ b/docs/requirements_for_rtd.txt
@@ -52,7 +52,7 @@ passlib==1.7.1
 pathlib2==2.3.0
 pgtest==1.1.0
 pip==9.0.1
-plumpy==0.7.11
+plumpy==0.7.12
 portalocker==1.1.0
 psutil==5.4.0
 pycrypto==2.6.1

--- a/setup_requirements.py
+++ b/setup_requirements.py
@@ -41,7 +41,7 @@ install_requires = [
     'psutil==5.4.0',
     'meld3==1.0.0',
     'numpy==1.12.0',
-    'plumpy==0.7.11',
+    'plumpy==0.7.12',
     'portalocker==1.1.0',
     'SQLAlchemy==1.0.19',  # upgrade to SQLalchemy 1.1.5 does break tests, see #465
     'SQLAlchemy-Utils==0.33.0',


### PR DESCRIPTION
Fixes #1353 and fixes #1291 by extension

This was the underlying issue that was causing the `aiida-quantumespresso` workflows to fail with `SqlAlchemy` on `develop`. The fact that it worked on Django was a lucky coincidence.

The user is free to populate the context with `Node` instances, which
means that if the `WorkChain` needs to be persisted that the nodes
need to be serialized. Since the nodes are not necessarily stored
upon calling `save_instance_state`, we also store them if they were
not yet stored. We also use this opportunity to replace the ad hoc
serialization in the pickle persister and use the new more complete
serializer and deserializer.

- [x] Add new plumpy release as dependency (awaiting release)