### PR TITLE
 Add filtering on process state and finish status to verdi [calculation|work] list 

### DIFF
--- a/aiida/cmdline/commands/calculation.py
+++ b/aiida/cmdline/commands/calculation.py
@@ -384,12 +384,12 @@ class Calculation(VerdiCommandWithSubcommands):
         else:
             plugins = get_entry_point_names('aiida.calculations')
             if plugins:
-                print("## Pass as a further parameter one (or more) "
-                      "plugin names to get more details on a given plugin.")
+                print('Registered calculation entry points:')
                 for plugin in plugins:
-                    print "* {}".format(plugin)
+                    print '* {}'.format(plugin)
+                print("\nPass the entry point as an argument to display detailed information")
             else:
-                print "## No calculation plugins found"
+                print 'No calculation plugins found'
 
     def calculation_inputcat(self, *args):
         """

--- a/aiida/cmdline/commands/calculation.py
+++ b/aiida/cmdline/commands/calculation.py
@@ -10,6 +10,8 @@
 import os
 import sys
 
+from plumpy import ProcessState
+
 from aiida.backends.utils import load_dbenv, is_dbenv_loaded
 from aiida.cmdline import delayed_load_node as load_node
 from aiida.cmdline.baseclass import VerdiCommandWithSubcommands
@@ -170,6 +172,12 @@ class Calculation(VerdiCommandWithSubcommands):
                             dest='all_states', action='store_true',
                             help="Overwrite manual set of states if present, and look for calculations in every possible state")
         parser.set_defaults(all_states=False)
+        parser.add_argument('-S', '--process-state', choices=([e.value for e in ProcessState]),
+                            help='Only include entries with this process state')
+        parser.add_argument('-f', '--finish-status', type=int,
+                            help='Only include entries with this finish status')
+        parser.add_argument('-n', '--failed', dest='failed', action='store_true',
+                            help='Only include entries that are failed, i.e. whose finish status is non-zero')
         parser.add_argument('-A', '--all-users',
                             dest='all_users', action='store_true',
                             help="Show calculations for all users, rather than only for the current user")
@@ -203,6 +211,25 @@ class Calculation(VerdiCommandWithSubcommands):
         if parsed_args.all_states:
             parsed_args.states = None
 
+        PROCESS_STATE_KEY = 'attributes.{}'.format(C.PROCESS_STATE_KEY)
+        FINISH_STATUS_KEY = 'attributes.{}'.format(C.FINISH_STATUS_KEY)
+
+        filters = {}
+
+        if parsed_args.process_state:
+            parsed_args.states = None
+            filters[PROCESS_STATE_KEY] = {'==': parsed_args.process_state}
+
+        if parsed_args.failed:
+            parsed_args.states = None
+            filters[PROCESS_STATE_KEY] = {'==': ProcessState.FINISHED.value}
+            filters[FINISH_STATUS_KEY] = {'!==': 0}
+
+        if parsed_args.finish_status:
+            parsed_args.states = None
+            filters[PROCESS_STATE_KEY] = {'==': ProcessState.FINISHED.value}
+            filters[FINISH_STATUS_KEY] = {'==': parsed_args.finish_status}
+
         C._list_calculations(
             states=parsed_args.states,
             past_days=parsed_args.past_days,
@@ -214,6 +241,7 @@ class Calculation(VerdiCommandWithSubcommands):
             # with_scheduler_state=parsed_args.with_scheduler_state,
             order_by=parsed_args.order_by,
             limit=parsed_args.limit,
+            filters=filters,
             projections=parsed_args.project,
         )
 

--- a/aiida/cmdline/commands/work.py
+++ b/aiida/cmdline/commands/work.py
@@ -426,9 +426,9 @@ def plugins(entry_point):
             click.echo('Registered workflow entry points:')
             for entry_point in entry_points:
                 click.echo("* {}".format(entry_point))
-            click.echo("\nPass the entry point of a workflow as an argument to display detailed information")
+            click.echo("\nPass the entry point as an argument to display detailed information")
         else:
-            click.echo("# No workflows found")
+            click.echo("No workflow plugins found")
 
 
 @work.command('watch', context_settings=CONTEXT_SETTINGS)

--- a/aiida/cmdline/commands/work.py
+++ b/aiida/cmdline/commands/work.py
@@ -11,24 +11,19 @@ import click
 import logging
 from functools import partial
 from tabulate import tabulate
+from plumpy import ProcessState
 
 from aiida.cmdline.baseclass import VerdiCommandWithSubcommands
 from aiida.cmdline.commands import work, verdi
+from aiida.common.log import LOG_LEVELS
 from aiida.utils.ascii_vis import print_tree_descending
 
 
 CONTEXT_SETTINGS = dict(help_option_names=['-h', '--help'])
 
-LIST_CMDLINE_PROJECT_CHOICES = ['pk', 'uuid', 'ctime', 'mtime', 'state', 'process_state', 'finish_status', 'sealed', 'process_label', 'label', 'description']
+LIST_CMDLINE_PROJECT_CHOICES = ('pk', 'uuid', 'ctime', 'mtime', 'state', 'process_state', 'finish_status', 'sealed', 'process_label', 'label', 'description')
 LIST_CMDLINE_PROJECT_DEFAULT = ('pk', 'ctime', 'state', 'process_label')
-
-LOG_LEVEL_MAPPING = {
-    levelname: i for levelname, i in [
-    (logging.getLevelName(i), i) for i in range(logging.CRITICAL + 1)
-]
-    if not levelname.startswith('Level')
-}
-LOG_LEVELS = LOG_LEVEL_MAPPING.keys()
+LIST_CMDLINE_PROCESS_STATE_CHOICES = ([e.value for e in ProcessState])
 
 
 class Work(VerdiCommandWithSubcommands):
@@ -70,24 +65,36 @@ class Work(VerdiCommandWithSubcommands):
 
 @work.command('list', context_settings=CONTEXT_SETTINGS)
 @click.option(
-    '-p', '--past-days', type=int, default=1,
-    help='add a filter to show only work calculations created in the past N days'
+    '-p', '--past-days', type=int, default=1, metavar='N',
+    help='Only include entries created in the past N days'
 )
 @click.option(
     '-a', '--all-states', 'all_states', is_flag=True,
-    help='return all work calculations regardless of their process state'
+    help='Include all entries, regardless of process state'
+)
+@click.option(
+    '-S', '--process-state', type=click.Choice(LIST_CMDLINE_PROCESS_STATE_CHOICES),
+    help='Only include entries with this process state'
+)
+@click.option(
+    '-f', '--finish_status', type=click.INT,
+    help='Only include entries with this finish status'
+)
+@click.option(
+    '-n', '--failed', is_flag=True,
+    help='Only include entries that are failed, i.e. whose finish status is non-zero'
 )
 @click.option(
     '-l', '--limit', type=int, default=None,
-    help='limit the final result set to this size'
+    help='Limit the number of entries to display'
 )
 @click.option(
     '-P', '--project', type=click.Choice(LIST_CMDLINE_PROJECT_CHOICES), default=LIST_CMDLINE_PROJECT_DEFAULT,
-    multiple=True, help='define the list of properties to show'
+    multiple=True, help='Define the list of properties to show'
 )
-def do_list(past_days, all_states, limit, project):
+def do_list(past_days, all_states, process_state, finish_status, failed, limit, project):
     """
-    Return a list of running workflows on screen
+    Return a list of work calculations that are still running
     """
     from aiida.backends.utils import load_dbenv, is_dbenv_loaded
     if not is_dbenv_loaded():
@@ -97,7 +104,6 @@ def do_list(past_days, all_states, limit, project):
     from aiida.orm.mixins import Sealable
     from aiida.orm.calculation import Calculation
     from aiida.utils import timezone
-    from aiida.work.processes import ProcessState
 
     SEALED_KEY = 'attributes.{}'.format(Sealable.SEALED_KEY)
     PROCESS_LABEL_KEY = 'attributes.{}'.format(Calculation.PROCESS_LABEL_KEY)
@@ -154,6 +160,17 @@ def do_list(past_days, all_states, limit, project):
     if not all_states:
         filters[PROCESS_STATE_KEY] = {'!in': TERMINAL_STATES}
 
+    if process_state:
+        filters[PROCESS_STATE_KEY] = {'==': process_state}
+
+    if failed:
+        filters[PROCESS_STATE_KEY] = {'==': ProcessState.FINISHED.value}
+        filters[FINISH_STATUS_KEY] = {'!==': 0}
+
+    if finish_status:
+        filters[PROCESS_STATE_KEY] = {'==': ProcessState.FINISHED.value}
+        filters[FINISH_STATUS_KEY] = {'==': finish_status}
+
     query = _build_query(
         limit=limit,
         projections=projection_attribute_map.values(),
@@ -179,6 +196,7 @@ def do_list(past_days, all_states, limit, project):
     tabulated = tabulate(table, headers=projection_labels)
 
     click.echo(tabulated)
+    click.echo('\nTotal results: {}\n'.format(len(table)))
 
 
 @work.command('report', context_settings=CONTEXT_SETTINGS)
@@ -190,7 +208,7 @@ def do_list(past_days, all_states, limit, project):
     help='Set the number of spaces to indent each level by'
 )
 @click.option(
-    '-l', '--levelname', type=click.Choice(LOG_LEVELS), default='REPORT',
+    '-l', '--levelname', type=click.Choice(LOG_LEVELS.keys()), default='REPORT',
     help='Filter the results by name of the log level'
 )
 @click.option(
@@ -223,7 +241,7 @@ def report(pk, levelname, order_by, indent_size, max_depth):
         entries = backend.log.find(filter_by=filters)
         entries = [
             entry for entry in entries
-            if LOG_LEVEL_MAPPING[entry.levelname] >= LOG_LEVEL_MAPPING[levelname]
+            if LOG_LEVELS[entry.levelname] >= LOG_LEVELS[levelname]
         ]
         return [(_, depth) for _ in entries]
 

--- a/aiida/cmdline/utils/common.py
+++ b/aiida/cmdline/utils/common.py
@@ -44,6 +44,7 @@ def print_node_summary(node):
 
     :params node: a Node instance
     """
+    table_headers = ['Property', 'Value']
     table = []
     table.append(['type', node.__class__.__name__])
     table.append(['pk', str(node.pk)])
@@ -52,6 +53,17 @@ def print_node_summary(node):
     table.append(['description', node.description])
     table.append(['ctime', node.ctime])
     table.append(['mtime', node.mtime])
+
+    from plumpy import ProcessState
+    try:
+        table.append(['process state', ProcessState(node.process_state)])
+    except AttributeError:
+        pass
+
+    try:
+        table.append(['finish status', node.finish_status])
+    except AttributeError:
+        pass
 
     try:
         computer = node.get_computer()
@@ -68,7 +80,7 @@ def print_node_summary(node):
         if code is not None:
             table.append(['code', code.label])
 
-    print(tabulate(table))
+    print(tabulate(table, headers=table_headers))
 
 
 def print_node_info(node, print_summary=True):

--- a/aiida/common/log.py
+++ b/aiida/common/log.py
@@ -23,6 +23,7 @@ logging.addLevelName(LOG_LEVEL_REPORT, 'REPORT')
 
 # Convenience dictionary of available log level names and their log level integer
 LOG_LEVELS = {
+    logging.getLevelName(logging.NOTSET): logging.NOTSET,
     logging.getLevelName(logging.DEBUG): logging.DEBUG,
     logging.getLevelName(logging.INFO): logging.INFO,
     logging.getLevelName(LOG_LEVEL_REPORT): LOG_LEVEL_REPORT,

--- a/aiida/orm/implementation/general/calculation/job/__init__.py
+++ b/aiida/orm/implementation/general/calculation/job/__init__.py
@@ -944,7 +944,7 @@ class AbstractJobCalculation(AbstractCalculation):
             cls, states=None, past_days=None, group=None,
             group_pk=None, all_users=False, pks=tuple(),
             relative_ctime=True, with_scheduler_state=False,
-            order_by=None, limit=None,
+            order_by=None, limit=None, filters=None,
             projections=('pk', 'state', 'ctime', 'sched', 'computer', 'type')
     ):
         """
@@ -969,6 +969,7 @@ class AbstractJobCalculation(AbstractCalculation):
             value of the ``past_days`` option.")
         :param relative_ctime: if true, prints the creation time relative from now.
                                (like 2days ago). Default = True
+        :param filters: a dictionary of filters to be passed to the QueryBuilder query
         :param all_users: if True, list calculation belonging to all users.
                            Default = False
 
@@ -1018,7 +1019,10 @@ class AbstractJobCalculation(AbstractCalculation):
 
         print(cls._get_last_daemon_check_string(now))
 
-        calculation_filters = {}
+        if filters is None:
+            calculation_filters = {}
+        else:
+            calculation_filters = filters
 
         # filter for calculation pks:
         if pks:

--- a/aiida/plugins/entry_point.py
+++ b/aiida/plugins/entry_point.py
@@ -68,7 +68,7 @@ def get_entry_point_names(group, sort=True):
     entry_point_names = [ep.name for ep in get_entry_points(group)]
 
     if sort is True:
-        sorted(entry_point_names)
+        entry_point_names.sort()
 
     return entry_point_names
 


### PR DESCRIPTION
Fixes #1355 

Added new filtering options to `verdi work list` and `verdi calculation list`

 * -S Filter for specific process state
 * -f Filter for specific finish status
 * -n Filter for non-zero finish status, i.e. failed calculations

Also synchronized and cleaned up the `verdi calculation plugins` and `verdi work plugins` commands.
Additionally, made the node count optional with the `-C` flag in the `verdi group list` command. The
node count makes the command very slow for groups with many nodes and is often not always required information for the user
