### PR TITLE
Save and load the parsed inputs from the persisted state

### DIFF
--- a/aiida/utils/serialize.py
+++ b/aiida/utils/serialize.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 import collections
 from ast import literal_eval
+from plumpy.utils import AttributesFrozendict
 from aiida.common.extendeddicts import AttributeDict
 from aiida.orm import Group, Node, load_group, load_node
 
@@ -56,6 +57,8 @@ def serialize_data(data):
         return '{}{}'.format(_PREFIX_VALUE_GROUP, data.uuid)
     elif isinstance(data, AttributeDict):
         return AttributeDict({encode_key(key): serialize_data(value) for key, value in data.iteritems()})
+    elif isinstance(data, AttributesFrozendict):
+        return AttributesFrozendict({encode_key(key): serialize_data(value) for key, value in data.iteritems()})
     elif isinstance(data, collections.Mapping):
         return {encode_key(key): serialize_data(value) for key, value in data.iteritems()}
     elif isinstance(data, collections.Sequence) and not isinstance(data, (str, unicode)):
@@ -75,6 +78,8 @@ def deserialize_data(data):
     """
     if isinstance(data, AttributeDict):
         return AttributeDict({decode_key(key): deserialize_data(value) for key, value in data.iteritems()})
+    elif isinstance(data, AttributesFrozendict):
+        return AttributesFrozendict({decode_key(key): deserialize_data(value) for key, value in data.iteritems()})
     elif isinstance(data, collections.Mapping):
         return {decode_key(key): deserialize_data(value) for key, value in data.iteritems()}
     elif isinstance(data, collections.Sequence) and not isinstance(data, (str, unicode)):

--- a/requirements.txt
+++ b/requirements.txt
@@ -142,5 +142,5 @@ wcwidth==0.1.7
 Werkzeug==0.14.1
 wrapt==1.10.11
 yapf==0.19.0
--e git://github.com/muhrin/plumpy.git@2b628c331c286347fdd7ab12911ae82ad2146033#egg=plumpy
+-e git://github.com/muhrin/plumpy.git@6fffb7ffc967b8655a21f192f4311d782bafe6d3#egg=plumpy
 -e git://github.com/muhrin/kiwipy.git@3ab98fe840d731224571da29df8f155bf6f0d3b8#egg=kiwipy


### PR DESCRIPTION
Fixes #1361 

This is an issue in plumpy that was also fixed there.
The parsed inputs of a Process, which is returned by calling self.inputs,
were being rebuilt from the raw inputs everytime the process was loaded
from a persisted state. This meant that inputs that were not explicitly
passed by the user and were populated with the defaults specified by the
port, were being recreated upon reloading the instance. However, they
should have been the ones that were created when the process was created
the first time around. Therefore we persist the parsed inputs to the saved
state and reload them instead of recreating them with `create_input_args`