### PR TITLE
Check whether checkpoint is None before calling yaml.load

### DIFF
--- a/aiida/orm/implementation/general/calculation/__init__.py
+++ b/aiida/orm/implementation/general/calculation/__init__.py
@@ -311,7 +311,7 @@ class AbstractCalculation(Sealable):
         """
         Return the checkpoint bundle set for the Calculation
 
-        :returns: checkpoint bundle
+        :returns: checkpoint bundle if it exists, None otherwise
         """
         return self.get_attr(self.CHECKPOINT_KEY, None)
 

--- a/aiida/work/persistence.py
+++ b/aiida/work/persistence.py
@@ -107,7 +107,7 @@ class AiiDAPersister(plumpy.Persister):
         LOGGER.info('Persisting process<{}>'.format(process.pid))
 
         if tag is not None:
-            raise NotImplementedError("Checkpoint tags not supported yet")
+            raise NotImplementedError('Checkpoint tags not supported yet')
 
         loader = class_loader.CLASS_LOADER
 
@@ -121,14 +121,16 @@ class AiiDAPersister(plumpy.Persister):
 
     def load_checkpoint(self, pid, tag=None):
         if tag is not None:
-            raise NotImplementedError("Checkpoint tags not supported yet")
+            raise NotImplementedError('Checkpoint tags not supported yet')
 
-        calc = orm.load_node(pid)
-        try:
-            bundle = yaml.load(calc.checkpoint)
-            return bundle
-        except ValueError:
-            raise PersistenceError("Calculation node '{}' does not have a saved checkpoint")
+        calculation = orm.load_node(pid)
+        checkpoint = calculation.checkpoint
+
+        if checkpoint is None:
+            raise PersistenceError('Calculation<{}> does not have a saved checkpoint'.format(calculation.pk))
+
+        bundle = yaml.load(checkpoint)
+        return bundle
 
     def get_checkpoints(self):
         """


### PR DESCRIPTION
Fixes #1367 

The calculation is not guaranteed to have a checkpoint attribute
set, in which case the checkpoint property will return None. We
check for this value and raise `PersistenceError` if that is the case