### PR TITLE
Various fixes to prevent RMQ channel and connection from closing

### DIFF
--- a/aiida/work/runners.py
+++ b/aiida/work/runners.py
@@ -238,14 +238,15 @@ class Runner(object):
         finally:
             runner.close()
 
-    def _setup_rmq(self, url, prefix=None, testing_mode=False):
+    def _setup_rmq(self, url, prefix=None, task_prefetch_count=None, testing_mode=False):
         self._rmq_connector = plumpy.rmq.RmqConnector(amqp_url=url, loop=self._loop)
 
         self._rmq_communicator = plumpy.rmq.RmqCommunicator(
             self._rmq_connector,
             exchange_name=rmq.get_message_exchange_name(prefix),
             task_queue=rmq.get_launch_queue_name(prefix),
-            testing_mode=testing_mode
+            testing_mode=testing_mode,
+            task_prefetch_count=task_prefetch_count
         )
 
         self._rmq = rmq.ProcessControlPanel(
@@ -280,8 +281,8 @@ class DaemonRunner(Runner):
         kwargs['rmq_submit'] = True
         super(DaemonRunner, self).__init__(*args, **kwargs)
 
-    def _setup_rmq(self, url, prefix=None, testing_mode=False):
-        super(DaemonRunner, self)._setup_rmq(url, prefix, testing_mode)
+    def _setup_rmq(self, url, prefix=None, task_prefetch_count=None, testing_mode=False):
+        super(DaemonRunner, self)._setup_rmq(url, prefix, task_prefetch_count, testing_mode)
 
         # Create a context for loading new processes
         load_context = plumpy.LoadContext(runner=self)

--- a/requirements.txt
+++ b/requirements.txt
@@ -143,4 +143,4 @@ Werkzeug==0.14.1
 wrapt==1.10.11
 yapf==0.19.0
 -e git://github.com/muhrin/plumpy.git@4a4b3a49520e3450d49e29b74cc2eb18782c5dd4#egg=plumpy
--e git://github.com/muhrin/kiwipy.git@3ab98fe840d731224571da29df8f155bf6f0d3b8#egg=kiwipy
+-e git://github.com/muhrin/kiwipy.git@561d0a8b97b2a8923e9d85b4cd1c39f0dbe9d182#egg=kiwipy


### PR DESCRIPTION
Fixes #1366 

All subscribers to a specific queue of RabbitMQ get a heartbeat with
a default timeout of 60 seconds. If the heartbeat callback is not actioned
before the timeout expires, RabbitMQ is going to assume that the subscriber
died and is going to close its connection. Combined with the unlimited task
prefetch count that we set for the `DaemonRunner`, it could take all the tasks
it wanted and it could easily lead to the situation where it would be to busy
to action the heartbeat callback and the connection would be closed. After
which all the tasks that the runner had, would fall over as soon as they tried
to communicate with RabbitMQ. To deal with this situation, a few things have
been changed in kiwipy, plumpy and aiida-core.

 * The default queue heartbeat timeout has been set to 600 seconds
 * The task prefetch count has been limited to 20
 * The `auto_delete` from the messages and tasks queues have been removed
 * The expiry time of the task queue has been set to one week
 * The expiry time of the message queue has been set to one minute

These measures should limit the chance that the heartbeat timeout is reached,
causing the connection to be closed. Additionally, changes have been added to
cancel the current tasks of a runner, when the connection does get closed.
The change of the auto_delete and the increased expiry times of the queues
should prevent that existing tasks get deleted too soon by RabbitMQ when the
daemon is shutdown.