### PR TITLE
run sphinx-apidoc on rtd

### DIFF
--- a/aiida/common/setup.py
+++ b/aiida/common/setup.py
@@ -132,8 +132,11 @@ def store_config(confs):
 
     :param confs: the dictionary to store.
     """
-    import json
+    from aiida.backends.settings import IN_RT_DOC_MODE
+    if IN_RT_DOC_MODE:
+        return
 
+    import json
     aiida_dir = os.path.expanduser(AIIDA_CONFIG_FOLDER)
     conf_file = os.path.join(aiida_dir, CONFIG_FNAME)
     old_umask = os.umask(DEFAULT_UMASK)

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -6,15 +6,9 @@
 SPHINXBUILD   = sphinx-build
 PAPER         =
 BUILDDIR      = build
-
+ 
 # Added for sphinx-apidoc
-SPHINXAPIDOC  = sphinx-apidoc
 APIDOCDIR     = source/apidoc
-PACKAGEDIR    = ../aiida
-ALLAPIDOCOPTS = -o $(APIDOCDIR) $(PACKAGEDIR) --private --force --no-headings
-ALLAPIDOCOPTS += --module-first --no-toc --maxdepth 4
-# See https://stackoverflow.com/a/30144019
-AUTOMODULE_OPTIONS = 'members,special-members,private-members,undoc-members,show-inheritance'
 
 # Internal variables.
 PAPEROPT_a4     = -D latex_paper_size=a4
@@ -25,18 +19,13 @@ I18NSPHINXOPTS  = $(PAPEROPT_$(PAPER)) $(SPHINXOPTS) source
 
 .PHONY: help clean html dirhtml singlehtml pickle json htmlhelp qthelp devhelp epub latex latexpdf text man changes linkcheck doctest gettext all default
 
-default: apidoc
+default:
 	$(SPHINXBUILD) -b html -nW $(ALLSPHINXOPTS) $(BUILDDIR)/html
 
-all: apidoc html
-
-# Added for sphinx-apidoc
-apidoc:
-	SPHINX_APIDOC_OPTIONS=$(AUTOMODULE_OPTIONS) $(SPHINXAPIDOC) $(ALLAPIDOCOPTS)
+all: html
 
 help:
 	@echo "Please use \`make <target>' where <target> is one of"
-	@echo "  apidoc     to auto-generate .rst files for API documentation"
 	@echo "  html       to make standalone HTML files"
 	@echo "  dirhtml    to make HTML files named index.html in directories"
 	@echo "  singlehtml to make a single large HTML file"

--- a/docs/requirements_for_rtd.txt
+++ b/docs/requirements_for_rtd.txt
@@ -1,18 +1,11 @@
 Flask-Cache==0.13.1
-Flask-Cache==0.13.1
-Flask-Cors==3.0.1
 Flask-Cors==3.0.1
 Flask-HTTPAuth==3.2.0
-Flask-HTTPAuth==3.2.0
-Flask-RESTful==0.3.6
 Flask-RESTful==0.3.6
 Flask-SQLAlchemy==2.1
-Flask-SQLAlchemy==2.1
-Flask==0.10.1
 Flask==0.10.1
 Jinja2==2.9.5
 MarkupSafe==0.23
-Pattern==2.6
 Pattern==2.6
 PyCifRW==4.2.1
 PyMySQL==0.7.9
@@ -27,6 +20,7 @@ anyjson==0.3.3
 ase==3.12.0
 billiard==3.3.0.23
 celery==3.1.25
+chainmap
 click-plugins
 click-spinner
 click==6.7
@@ -37,12 +31,9 @@ ecdsa==0.13
 enum34==1.1.6
 ete3==3.0.0b35
 flask-marshmallow==0.7.0
-flask-marshmallow==0.7.0
 future==0.16.0
 ipython<6.0
 itsdangerous==0.24
-itsdangerous==0.24
-marshmallow-sqlalchemy==0.10.0
 marshmallow-sqlalchemy==0.10.0
 meld3==1.0.0
 mock==2.0.0
@@ -58,9 +49,7 @@ psutil==5.4.0
 pycrypto==2.6.1
 pymatgen==4.5.3
 pyparsing==2.1.10
-pyparsing==2.1.10
 python-dateutil==2.6.0
-python-memcached==1.58
 python-memcached==1.58
 python-mimeparse==0.1.4
 pytz==2014.10
@@ -70,11 +59,11 @@ reentry==1.0.2
 scipy<1.0.0
 seekpath==1.8.0
 setuptools==36.6.0
+singledispatch >= 3.4.0.3
 six==1.11.0
 spglib==1.9.10.1
 sphinx-rtd-theme==0.2.5b2
 sqlalchemy-diff==0.1.3
-sqlalchemy-migrate==0.10.0
 sqlalchemy-migrate==0.10.0
 tabulate==0.7.5
 tzlocal==1.3

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -263,6 +263,48 @@ else:
     settings.AIIDADB_PROFILE = "default"
 
 
+def run_apidoc(_):
+    """Runs sphinx-apidoc when building the documentation.
+
+    Needs to be done in conf.py in order to include the APIdoc in the
+    build on readthedocs.
+
+    See also https://github.com/rtfd/readthedocs.org/issues/1139
+    """
+    source_dir = os.path.abspath(os.path.dirname(__file__))
+    apidoc_dir = os.path.join(source_dir, 'apidoc')
+    package_dir = os.path.join(source_dir, os.pardir, os.pardir, 'aiida')
+
+    # In #1139, they suggest the route below, but for me this ended up
+    # calling sphinx-build, not sphinx-apidoc
+    #from sphinx.apidoc import main
+    #main([None, '-e', '-o', apidoc_dir, package_dir, '--force'])
+
+    import subprocess
+    cmd_path = 'sphinx-apidoc'
+    if hasattr(sys, 'real_prefix'):  # Check to see if we are in a virtualenv
+        # If we are, assemble the path manually
+        cmd_path = os.path.abspath(os.path.join(sys.prefix, 'bin', 'sphinx-apidoc'))
+
+    options = [
+        '-o', apidoc_dir, package_dir,
+        '--private',
+        '--force',
+        '--no-headings',
+        '--module-first',
+        '--no-toc',
+        '--maxdepth', '4',
+    ]
+
+    # See https://stackoverflow.com/a/30144019
+    env = os.environ.copy()
+    env["SPHINX_APIDOC_OPTIONS"] = 'members,special-members,private-members,undoc-members,show-inheritance'
+    subprocess.check_call([cmd_path] + options, env=env)
+
+def setup(app):
+    app.connect('builder-inited', run_apidoc)
+
+
 # -- Options for manual page output --------------------------------------------
 
 # One entry per manual page. List of tuples

--- a/docs/update_req_for_rtd.py
+++ b/docs/update_req_for_rtd.py
@@ -21,36 +21,32 @@ import click
 @click.option('--pre-commit', is_flag=True)
 def update_req_for_rtd(pre_commit):
     """Update the separate requirements file for Read the Docs"""
-    sys.path.append(
-        os.path.join(os.path.split(os.path.abspath(__file__))[0], os.pardir))
+    docs_dir = os.path.abspath(os.path.dirname(__file__))
+    sys.path.append(os.path.join(docs_dir, os.pardir))
 
     import setup_requirements
 
-    req_for_rtd_lines = list(setup_requirements.extras_require['docs'] +
-                             setup_requirements.extras_require['rest'] +
-                             setup_requirements.extras_require['testing'])
-
-    required_packages = list(setup_requirements.install_requires)
-    for package in required_packages:
-        # To avoid that it requires also the postgres libraries
-        if package.startswith('psycopg2'):
-            continue
-
-        req_for_rtd_lines.append(package)
-
-    req_for_rtd = "\n".join(sorted(req_for_rtd_lines))
+    reqs = set(setup_requirements.extras_require['docs'] +
+               setup_requirements.extras_require['rest'] +
+               setup_requirements.extras_require['testing'] +
+               setup_requirements.extras_require[':python_version < "3"'] +
+               # To avoid that it requires also the postgres libraries
+               [
+                   p for p in setup_requirements.install_requires
+                   if not p.startswith('psycopg2')
+               ])
+    reqs_str = "\n".join(sorted(reqs))
 
     basename = 'requirements_for_rtd.txt'
 
     # pylint: disable=bad-continuation
-    with open(
-            os.path.join(os.path.split(os.path.abspath(__file__))[0], basename),
-            'w') as requirements_file:
-        requirements_file.write(req_for_rtd)
+    with open(os.path.join(docs_dir, basename), 'w') as reqs_file:
+        reqs_file.write(reqs_str)
 
     click.echo("File '{}' written.".format(basename))
+
     if pre_commit:
-        msg = 'some requirements for Read the Docs have changed, {}'
+        msg = 'Some requirements for Read the Docs have changed, {}'
         local_help = 'please add the changes and commit again'
         travis_help = 'please run aiida/docs/update_req_for_rtd.py locally and commit the changes it makes'
         help_msg = msg.format(

--- a/setup_requirements.py
+++ b/setup_requirements.py
@@ -71,7 +71,7 @@ install_requires = [
 
 extras_require = {
     # Requirements for Python 2 only
-    ':python_version < "3"': ['chainmap', 'pathlib2', 'singledispatch >= 3.4.0.3'],
+    ':python_version < "3"': ['chainmap', 'singledispatch >= 3.4.0.3'],
     # Requirements for ssh transport with authentification through Kerberos
     # token
     # N. B.: you need to install first libffi and MIT kerberos GSSAPI including header files.


### PR DESCRIPTION
Rebased #1352 on top of `release_v0.12.0`
 * add chainmap dependency to rtd
 * remove duplicates in rtd requirements
 * make run_apidoc less OS dependent
 * fix pathlib dependency
 * fix aiida.settings warning (unable to write config file)