### PR TITLE
Docs: add section on how to monitor launched  workfunctions and workchains

### DIFF
--- a/docs/source/concepts/processes.rst
+++ b/docs/source/concepts/processes.rst
@@ -8,6 +8,11 @@ Anything that runs in AiiDA is an instance of :py:class:`~aiida.work.processes.P
 
 ISSUE#1131
 
+.. _process_state:
+
+The process state
+=================
+
 
 
 .. _process_builder:


### PR DESCRIPTION
Fixes #1129 

Gives a short explanation of the four main analysis tools

 * verdi work list
 * verdi work report
 * verdi work status
 * verdi calculation show