### PR TITLE
Clean up the launch free functions and methods of Runner class

### DIFF
--- a/aiida/backends/tests/__init__.py
+++ b/aiida/backends/tests/__init__.py
@@ -57,6 +57,7 @@ db_test_list = {
         'work.class_loader': ['aiida.backends.tests.work.class_loader'],
         'work.daemon': ['aiida.backends.tests.work.daemon'],
         'work.futures': ['aiida.backends.tests.work.test_futures'],
+        'work.launch': ['aiida.backends.tests.work.test_launch'],
         'work.persistence': ['aiida.backends.tests.work.persistence'],
         'work.process': ['aiida.backends.tests.work.process'],
         'work.process_builder': ['aiida.backends.tests.work.test_process_builder'],

--- a/aiida/backends/tests/work/test_launch.py
+++ b/aiida/backends/tests/work/test_launch.py
@@ -1,0 +1,104 @@
+# -*- coding: utf-8 -*-
+###########################################################################
+# Copyright (c), The AiiDA team. All rights reserved.                     #
+# This file is part of the AiiDA code.                                    #
+#                                                                         #
+# The code is hosted on GitHub at https://github.com/aiidateam/aiida_core #
+# For further information on the license, see the LICENSE.txt file        #
+# For further information please visit http://www.aiida.net               #
+###########################################################################
+from aiida.backends.testbase import AiidaTestCase
+from aiida.orm.calculation.function import FunctionCalculation
+from aiida.orm.calculation.work import WorkCalculation
+from aiida.orm.data.int import Int
+from aiida.work import utils
+from aiida.work.launch import run, run_get_node, run_get_pid
+from aiida.work.workchain import WorkChain
+from aiida.work.workfunctions import workfunction
+
+
+@workfunction
+def add(a, b):
+    return a + b
+
+
+class AddWorkChain(WorkChain):
+
+    @classmethod
+    def define(cls, spec):
+        super(AddWorkChain, cls).define(spec)
+        spec.input('a', valid_type=Int)
+        spec.input('b', valid_type=Int)
+        spec.outline(
+            cls.add
+        )
+        spec.output('result', valid_type=Int)
+
+    def add(self):
+        self.out('result', self.inputs.a + self.inputs.b)
+
+
+class TestLaunchers(AiidaTestCase):
+
+    def setUp(self):
+        super(TestLaunchers, self).setUp()
+        self.assertEquals(len(utils.ProcessStack.stack()), 0)
+        self.a = Int(1)
+        self.b = Int(2)
+        self.result = 3
+
+    def tearDown(self):
+        super(TestLaunchers, self).tearDown()
+        self.assertEquals(len(utils.ProcessStack.stack()), 0)
+
+    def test_workfunction_run(self):
+        result = run(add, a=self.a, b=self.b)
+        self.assertEquals(result, self.result)
+
+    def test_workfunction_run_get_node(self):
+        result, node = run_get_node(add, a=self.a, b=self.b)
+        self.assertEquals(result, self.result)
+        self.assertTrue(isinstance(node, FunctionCalculation))
+
+    def test_workfunction_run_get_pid(self):
+        result, pid = run_get_pid(add, a=self.a, b=self.b)
+        self.assertEquals(result, self.result)
+        self.assertTrue(isinstance(pid, int))
+
+    def test_workchain_run(self):
+        result = run(AddWorkChain, a=self.a, b=self.b)
+        self.assertEquals(result['result'], self.result)
+
+    def test_workchain_run_get_node(self):
+        result, node = run_get_node(AddWorkChain, a=self.a, b=self.b)
+        self.assertEquals(result['result'], self.result)
+        self.assertTrue(isinstance(node, WorkCalculation))
+
+    def test_workchain_run_get_pid(self):
+        result, pid = run_get_pid(AddWorkChain, a=self.a, b=self.b)
+        self.assertEquals(result['result'], self.result)
+        self.assertTrue(isinstance(pid, int))
+
+    def test_workchain_builder_run(self):
+        builder = AddWorkChain.get_builder()
+        builder.a = self.a
+        builder.b = self.b
+        result = run(builder)
+        self.assertEquals(result['result'], self.result)
+
+    def test_workchain_builder_run_get_node(self):
+        builder = AddWorkChain.get_builder()
+        builder.a = self.a
+        builder.b = self.b
+        result, node = run_get_node(builder)
+        self.assertEquals(result['result'], self.result)
+        self.assertTrue(isinstance(node, WorkCalculation))
+
+    def test_workchain_builder_run_get_pid(self):
+        builder = AddWorkChain.get_builder()
+        builder.a = self.a
+        builder.b = self.b
+        result, pid = run_get_pid(builder)
+        self.assertEquals(result['result'], self.result)
+        self.assertTrue(isinstance(pid, int))
+


### PR DESCRIPTION
Fixes #1399 

The code was duplicated in the run function and its derivatives even
though aside from the return value, the implementation and functionality
should be the same. Deduplicated the implementation and added tests for
all the run based functions for a workfunction, workchain and the builder
of a workchain