### PR TITLE
Reraise exceptions caught in submit_calc to SubmitJob TransportTask

### DIFF
--- a/aiida/daemon/execmanager.py
+++ b/aiida/daemon/execmanager.py
@@ -287,8 +287,7 @@ def submit_calc(calc, authinfo, transport=None):
                                       "calculation {}".format(calc.pk))
 
             remotedata = RemoteData(computer=computer, remote_path=workdir)
-            remotedata.add_link_from(calc, label='remote_folder',
-                                     link_type=LinkType.CREATE)
+            remotedata.add_link_from(calc, label='remote_folder', link_type=LinkType.CREATE)
             remotedata.store()
 
             job_id = s.submit_from_script(t.getcwd(), script_filename)
@@ -297,13 +296,6 @@ def submit_calc(calc, authinfo, transport=None):
             # the only ones submitting this calculations,
             # so I do not check the ModificationNotAllowed
             calc._set_state(calc_states.WITHSCHEDULER)
-            ## I do not set the state to queued; in this way, if the
-            ## daemon is down, the user sees '(unknown)' as last state
-            ## and understands that the daemon is not running.
-            # if job_tmpl.submit_as_hold:
-            #    calc._set_scheduler_state(job_states.QUEUED_HELD)
-            # else:
-            #    calc._set_scheduler_state(job_states.QUEUED)
 
             execlogger.debug("submitted calculation {} on {} with "
                              "jobid {}".format(calc.pk, computer.name, job_id),
@@ -312,18 +304,17 @@ def submit_calc(calc, authinfo, transport=None):
     except Exception as e:
         import traceback
 
-        execlogger.error(
-            "Submission of calc {} failed, check also the log file! Traceback: {}".format(
-                calc.pk, traceback.format_exc()
-            ),
-            extra=logger_extra
-        )
+        execlogger.error('Submission of calc {} failed, check also the log file! Traceback: {}'.format(
+            calc.pk, traceback.format_exc()), extra=logger_extra)
 
         try:
             calc._set_state(calc_states.SUBMISSIONFAILED)
-            return True
         except ModificationNotAllowed:
-            return False
+            execlogger.debug('failed to set state of calculation<{}> to SUBMISSIONFAILED'.format(
+                calc.pk, calc_states.SUBMISSIONFAILED), extra=logger_extra)
+            pass
+
+        raise
 
     finally:
         # close the transport, but only if it was opened within this function

--- a/aiida/work/job_processes.py
+++ b/aiida/work/job_processes.py
@@ -321,7 +321,7 @@ class Waiting(plumpy.Waiting):
             self._kill_future = None
 
     def finished(self, result):
-        self.transition_to(processes.ProcessState.FINISHED, result)
+        self.transition_to(processes.ProcessState.FINISHED, result, result is 0)
 
     def kill(self, msg=None):
         if self._kill_future is not None:

--- a/docs/requirements_for_rtd.txt
+++ b/docs/requirements_for_rtd.txt
@@ -54,7 +54,7 @@ python-mimeparse==0.1.4
 pytz==2014.10
 pyyaml
 qe-tools==1.1.0
-reentry>=1.0.3
+reentry==1.0.3
 scipy<1.0.0
 seekpath==1.8.0
 setuptools==36.6.0

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ if __name__ == '__main__':
         packages=find_packages(),
         # Don't forget to install it as well (by adding to the install_requires)
         setup_requires=[
-            'reentry >= 1.0.3',
+            'reentry == 1.0.3',
         ],
         reentry_register=True,
         entry_points={

--- a/setup_requirements.py
+++ b/setup_requirements.py
@@ -11,7 +11,7 @@
 install_requires = [
     'pip==9.0.1',
     'setuptools==36.6.0',
-    'reentry>=1.0.3',
+    'reentry==1.0.3',
     'wheel==0.29.0',
     'python-dateutil==2.6.0',
     'python-mimeparse==0.1.4',


### PR DESCRIPTION
Fixes #1363 

The old execmanager implementation of `submit_calc` would catch any
exceptions during the submit process, set the calculation state to
SUBMISSIONFAILED and return True or False. Since the exception was
not reraised, the TransportException of the SubmitJob TransportTask
of the JobProcess was not being triggered, which caused the JobProcess
to go to the next step of UpdateSchedulerState transport task which
would except because it assumes that the job was successfully
submitted. Reraising the exception in submit_calc fixes the problem.