### PR TITLE
Fix the problem with socket filename size limitation for circus IPC protocol

### DIFF
--- a/aiida/backends/tests/__init__.py
+++ b/aiida/backends/tests/__init__.py
@@ -50,6 +50,7 @@ db_test_list = {
         'restapi': ['aiida.backends.tests.restapi'],
         'computer': ['aiida.backends.tests.computer'],
         'examplehelpers': ['aiida.backends.tests.example_helpers'],
+        'daemon.client': ['aiida.backends.tests.daemon.test_client'],
         'orm.data.frozendict': ['aiida.backends.tests.orm.data.frozendict'],
         'orm.log': ['aiida.backends.tests.orm.log'],
         'orm.utils': ['aiida.backends.tests.orm.utils'],

--- a/aiida/backends/tests/daemon/test_client.py
+++ b/aiida/backends/tests/daemon/test_client.py
@@ -1,0 +1,27 @@
+# -*- coding: utf-8 -*-
+import zmq
+from aiida.backends.testbase import AiidaTestCase
+from aiida.daemon.client import DaemonClient
+
+
+class TestBackendLog(AiidaTestCase):
+
+    def test_ipc_socket_file_length_limit(self):
+        """
+        The maximum length of socket filepaths is often limited by the operating system.
+        For MacOS it is limited to 103 bytes, versus 107 bytes on Unix. This limit is
+        exposed by the Zmq library which is used by Circus library that is used to
+        daemonize the daemon runners. This test verifies that the three endpoints used
+        for the Circus client have a filepath that does not exceed that path limit.
+
+        See issue #1317 and pull request #1403 for the discussion
+        """
+        daemon_client = DaemonClient()
+
+        controller_endpoint = daemon_client.get_controller_endpoint()
+        pubsub_endpoint = daemon_client.get_pubsub_endpoint()
+        stats_endpoint = daemon_client.get_stats_endpoint()
+
+        self.assertTrue(len(controller_endpoint) <= zmq.IPC_PATH_MAX_LEN)
+        self.assertTrue(len(pubsub_endpoint) <= zmq.IPC_PATH_MAX_LEN)
+        self.assertTrue(len(stats_endpoint) <= zmq.IPC_PATH_MAX_LEN)

--- a/aiida/common/profile.py
+++ b/aiida/common/profile.py
@@ -14,9 +14,10 @@ DAEMON_PID_FILE_TEMPLATE = os.path.join(CONFIG_DIR, DAEMON_DIR, 'aiida-{}.pid')
 CIRCUS_LOG_FILE_TEMPLATE = os.path.join(CONFIG_DIR, DAEMON_LOG_DIR, 'circus-{}.log')
 DAEMON_LOG_FILE_TEMPLATE = os.path.join(CONFIG_DIR, DAEMON_LOG_DIR, 'aiida-{}.log')
 CIRCUS_PORT_FILE_TEMPLATE = os.path.join(CONFIG_DIR, DAEMON_DIR, 'circus-{}.port')
-CIRCUS_CONTROLLER_SOCKET_TEMPLATE = os.path.join(CONFIG_DIR, DAEMON_DIR, 'circus-{}.controller.socket')
-CIRCUS_PUBSUB_SOCKET_TEMPLATE = os.path.join(CONFIG_DIR, DAEMON_DIR, 'circus-{}.pubsub.socket')
-CIRCUS_STATS_SOCKET_TEMPLATE = os.path.join(CONFIG_DIR, DAEMON_DIR, 'circus-{}.stats.socket') 
+CIRCUS_SOCKET_FILE_TEMPATE = os.path.join(CONFIG_DIR, DAEMON_DIR, 'circus-{}.sockets')
+CIRCUS_CONTROLLER_SOCKET_TEMPLATE = 'circus-{}.controller.sock'
+CIRCUS_PUBSUB_SOCKET_TEMPLATE = 'circus-{}.pubsub.sock'
+CIRCUS_STATS_SOCKET_TEMPLATE = 'circus-{}.stats.sock'
 
 
 def get_current_profile_name():
@@ -54,9 +55,12 @@ class ProfileConfig(object):
             self.profile_config = setup.get_profile_config(profile_name)
 
     @property
+    def profile_uuid(self):
+        return self.profile_config[setup.PROFILE_UUID_KEY]
+
+    @property
     def rmq_prefix(self):
-    	profile_uuid = self.profile_config[setup.PROFILE_UUID_KEY]
-        return self._RMQ_PREFIX.format(uuid=profile_uuid)
+        return self._RMQ_PREFIX.format(uuid=self.profile_uuid)
 
     @property
     def filepaths(self):
@@ -66,9 +70,10 @@ class ProfileConfig(object):
                 'pid': CIRCUS_PID_FILE_TEMPLATE.format(self.profile_name),
                 'port': CIRCUS_PORT_FILE_TEMPLATE.format(self.profile_name),
                 'socket': {
-                    'controller': CIRCUS_CONTROLLER_SOCKET_TEMPLATE.format(self.profile_name),
-                    'pubsub': CIRCUS_PUBSUB_SOCKET_TEMPLATE.format(self.profile_name),
-                    'stats': CIRCUS_STATS_SOCKET_TEMPLATE.format(self.profile_name),
+                    'file': CIRCUS_SOCKET_FILE_TEMPATE.format(self.profile_name),
+                    'controller': CIRCUS_CONTROLLER_SOCKET_TEMPLATE.format(self.profile_uuid[:16]),
+                    'pubsub': CIRCUS_PUBSUB_SOCKET_TEMPLATE.format(self.profile_uuid[:16]),
+                    'stats': CIRCUS_STATS_SOCKET_TEMPLATE.format(self.profile_uuid[:16]),
                 }
             },
             'daemon': {

--- a/aiida/common/profile.py
+++ b/aiida/common/profile.py
@@ -15,9 +15,9 @@ CIRCUS_LOG_FILE_TEMPLATE = os.path.join(CONFIG_DIR, DAEMON_LOG_DIR, 'circus-{}.l
 DAEMON_LOG_FILE_TEMPLATE = os.path.join(CONFIG_DIR, DAEMON_LOG_DIR, 'aiida-{}.log')
 CIRCUS_PORT_FILE_TEMPLATE = os.path.join(CONFIG_DIR, DAEMON_DIR, 'circus-{}.port')
 CIRCUS_SOCKET_FILE_TEMPATE = os.path.join(CONFIG_DIR, DAEMON_DIR, 'circus-{}.sockets')
-CIRCUS_CONTROLLER_SOCKET_TEMPLATE = 'circus-{}.controller.sock'
-CIRCUS_PUBSUB_SOCKET_TEMPLATE = 'circus-{}.pubsub.sock'
-CIRCUS_STATS_SOCKET_TEMPLATE = 'circus-{}.stats.sock'
+CIRCUS_CONTROLLER_SOCKET_TEMPLATE = 'circus.c.sock'
+CIRCUS_PUBSUB_SOCKET_TEMPLATE = 'circus.p.sock'
+CIRCUS_STATS_SOCKET_TEMPLATE = 'circus.s.sock'
 
 
 def get_current_profile_name():
@@ -71,9 +71,9 @@ class ProfileConfig(object):
                 'port': CIRCUS_PORT_FILE_TEMPLATE.format(self.profile_name),
                 'socket': {
                     'file': CIRCUS_SOCKET_FILE_TEMPATE.format(self.profile_name),
-                    'controller': CIRCUS_CONTROLLER_SOCKET_TEMPLATE.format(self.profile_uuid[:16]),
-                    'pubsub': CIRCUS_PUBSUB_SOCKET_TEMPLATE.format(self.profile_uuid[:16]),
-                    'stats': CIRCUS_STATS_SOCKET_TEMPLATE.format(self.profile_uuid[:16]),
+                    'controller': CIRCUS_CONTROLLER_SOCKET_TEMPLATE,
+                    'pubsub': CIRCUS_PUBSUB_SOCKET_TEMPLATE,
+                    'stats': CIRCUS_STATS_SOCKET_TEMPLATE,
                 }
             },
             'daemon': {


### PR DESCRIPTION
Fixes #1317 

Currently, we are using the IPC protocol as the default for the daemon to
communicate with the endpoints of the circus controller. The sockets used
to be stored in the AiiDA config folder, however, UNIX has a built in byte
limit of 107 on socket filenames and given that the config folder can be
nested arbitrarily deeply, this limit was easily exceeded. The solution is
to store them in a temporary directory. This solution should always avoid the
limit comfortably but adds slightly more complexity. A temporary folder is
generated by the OS and is only accesible by the user who created it, so
the security is guaranteed here, which is what the IPC protocol was supposed
to solve in the first place over the TCP protocol.