### PR TITLE
Fix logic to decide if processes are cached

### DIFF
--- a/aiida/work/processes.py
+++ b/aiida/work/processes.py
@@ -277,7 +277,7 @@ class Process(plumpy.Process):
         self._setup_db_record()
         if self.inputs.store_provenance:
             try:
-                self.calc.store_all(use_cache=self._use_cache_enabled())
+                self.calc.store_all()
                 if self.calc.is_finished_ok:
                     self._state = ProcessState.FINISHED
                     for name, value in self.calc.get_outputs_dict(link_type=LinkType.RETURN).items():
@@ -428,17 +428,6 @@ class Process(plumpy.Process):
         else:
             assert (port is None) or (isinstance(port, InputPort) and port.non_db)
             return []
-
-    def _use_cache_enabled(self):
-        # First priority: inputs
-        try:
-            return self._parsed_inputs['_use_cache']
-        # Second priority: config
-        except KeyError:
-            return (
-                caching.get_use_cache(type(self)) or
-                caching.get_use_cache(type(self._calc))
-            )
 
 
     def exposed_inputs(self, process_class, namespace=None, agglomerate=True):


### PR DESCRIPTION
...by removing it. Since the ``_use_cache`` cannot be passed to new-style processes (maybe we want to re-introduce that?), we can just let the lower-level ``store`` method check if a particular node type needs to be cached.

The check for _both_ ``type(self)`` and ``type(self._calc)`` created a bug where calculation cannot be explicitly switched off for a particular calculation if it is enabled by default, because the process would always return true.