### PR TITLE
Fix cached calculations excepting

### DIFF
--- a/.travis-data/test_daemon.py
+++ b/.travis-data/test_daemon.py
@@ -203,7 +203,7 @@ def run_calculation(code, counter, inputval):
     """
     process, inputs, expected_result = create_calculation_process(code=code, inputval=inputval)
     result, calc = run_get_node(process, **inputs)
-    print "[{}] ran calculation {}, pk={}".format(counter, node.uuid, node.pk)
+    print "[{}] ran calculation {}, pk={}".format(counter, calc.uuid, calc.pk)
     return calc, expected_result
 
 def create_calculation_process(code, inputval):

--- a/aiida/work/job_processes.py
+++ b/aiida/work/job_processes.py
@@ -477,7 +477,9 @@ class JobProcess(processes.Process):
         """
         calc_state = self.calc.get_state()
 
-        if calc_state != calc_states.NEW:
+        if calc_state == calc_states.FINISHED:
+            return 0
+        elif calc_state != calc_states.NEW:
             raise exceptions.InvalidOperation(
                 'Cannot submit a calculation not in {} state (the current state is {})'.format(
                     calc_states.NEW, calc_state


### PR DESCRIPTION
Fixes #1364. Blocked because it's based on ~#1405~ and ~#1406~.

In ``JobProcess.run``, checks if the calculation state is ``FINISHED`` and returns 0 (success) if that's the case.

This is tested by launching calculations with ``run_get_pid`` while ``enable_caching`` is active in the daemon tests.