### PR TITLE
Make the daemon client timeout configurable through property table

### DIFF
--- a/aiida/common/setup.py
+++ b/aiida/common/setup.py
@@ -58,6 +58,9 @@ aiidadb_backend_value_django = 'django'
 # differentiate them from non-testing ones.
 TEST_KEYWORD = 'test_'
 
+# Default timeout in seconds for circus client calls
+DEFAULT_DAEMON_TIMEOUT = 20
+
 
 def get_aiida_dir():
     return os.path.expanduser(AIIDA_CONFIG_FOLDER)
@@ -767,6 +770,12 @@ class _NoDefaultValue(object):
 # 4. The default value, if no setting is found
 # 5. A list of valid values, or None if no such list makes sense
 _property_table = {
+    "daemon.timeout": (
+        "daemon_timeout",
+        "int",
+        "The timeout in seconds for calls to the circus client",
+        DEFAULT_DAEMON_TIMEOUT,
+        None),
     "verdishell.modules": (
         "modules_for_verdi_shell",
         "string",

--- a/aiida/daemon/client.py
+++ b/aiida/daemon/client.py
@@ -10,6 +10,7 @@ from circus.client import CircusClient
 from circus.exc import CallError
 
 from aiida.common.profile import ProfileConfig
+from aiida.common.setup import get_property
 
 
 VERDI_BIN = os.path.abspath(os.path.join(sys.executable, '../verdi'))
@@ -37,7 +38,12 @@ class DaemonClient(ProfileConfig):
     _DAEMON_NAME = 'aiida-{name}'
     _DEFAULT_LOGLEVEL = 'INFO'
     _ENDPOINT_PROTOCOL = ControllerProtocol.IPC
-    _SOCKET_DIRECTORY = None
+
+
+    def __init__(self, profile_name=None):
+        super(DaemonClient, self).__init__(profile_name)
+        self._SOCKET_DIRECTORY = None
+        self._DAEMON_TIMEOUT = get_property('daemon.timeout')
 
     @property
     def daemon_name(self):
@@ -279,7 +285,7 @@ class DaemonClient(ProfileConfig):
 
         :return: CircucClient instance
         """
-        return CircusClient(endpoint=self.get_controller_endpoint(), timeout=3.)
+        return CircusClient(endpoint=self.get_controller_endpoint(), timeout=self._DAEMON_TIMEOUT)
 
     def call_client(self, command):
         """


### PR DESCRIPTION
Fixes #1408 

When the daemon is particularly busy it might not always respond
directly and with a short timeout interval the client call will
fail. In this case a larger timeout value is preferable. Here
we make it config wide configurable and set the default to 20
seconds