### PR TITLE
update reentry requirement to version 1.1.1

### DIFF
--- a/docs/requirements_for_rtd.txt
+++ b/docs/requirements_for_rtd.txt
@@ -55,7 +55,7 @@ python-mimeparse==0.1.4
 pytz==2014.10
 pyyaml
 qe-tools==1.1.0
-reentry==1.0.2
+reentry==1.1.1
 scipy<1.0.0
 seekpath==1.8.0
 setuptools==36.6.0

--- a/docs/requirements_for_rtd.txt
+++ b/docs/requirements_for_rtd.txt
@@ -55,7 +55,7 @@ python-mimeparse==0.1.4
 pytz==2014.10
 pyyaml
 qe-tools==1.1.0
-reentry==1.1.1
+reentry == 1.1.2
 scipy<1.0.0
 seekpath==1.8.0
 setuptools==36.6.0

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ if __name__ == '__main__':
         packages=find_packages(),
         # Don't forget to install it as well (by adding to the install_requires)
         setup_requires=[
-            'reentry >= 1.0.2',
+            'reentry == 1.1.1',
         ],
         reentry_register=True,
         entry_points={

--- a/setup.py
+++ b/setup.py
@@ -11,9 +11,7 @@ import fastentrypoints
 import re
 from os import path
 from setuptools import setup, find_packages
-from setup_requirements import install_requires, extras_require
-
-
+from setup_requirements import install_requires, extras_require, REENTRY_PINNED
 
 
 if __name__ == '__main__':
@@ -43,7 +41,7 @@ if __name__ == '__main__':
         packages=find_packages(),
         # Don't forget to install it as well (by adding to the install_requires)
         setup_requires=[
-            'reentry == 1.1.1',
+            REENTRY_PINNED,
         ],
         reentry_register=True,
         entry_points={

--- a/setup_requirements.py
+++ b/setup_requirements.py
@@ -11,7 +11,7 @@
 install_requires = [
     'pip==9.0.1',
     'setuptools==36.6.0',
-    'reentry==1.0.2',
+    'reentry==1.1.1',
     'wheel==0.29.0',
     'python-dateutil==2.6.0',
     'python-mimeparse==0.1.4',

--- a/setup_requirements.py
+++ b/setup_requirements.py
@@ -8,10 +8,12 @@
 # For further information please visit http://www.aiida.net               #
 ###########################################################################
 # Requirements for core AiiDA functionalities
+REENTRY_PINNED = 'reentry == 1.1.2'
+
 install_requires = [
     'pip==9.0.1',
     'setuptools==36.6.0',
-    'reentry==1.1.1',
+    REENTRY_PINNED,
     'wheel==0.29.0',
     'python-dateutil==2.6.0',
     'python-mimeparse==0.1.4',


### PR DESCRIPTION
* version 1.1.1 fixes a bug that happened during setup
* `install_requires` and `setup_requires` now both pin to exact version 1.1.1