### PR TITLE
pretty print config.json

### DIFF
--- a/aiida/common/setup.py
+++ b/aiida/common/setup.py
@@ -142,7 +142,7 @@ def store_config(confs):
     old_umask = os.umask(DEFAULT_UMASK)
     try:
         with open(conf_file, "w") as json_file:
-            json.dump(confs, json_file)
+            json.dump(confs, json_file, indent=2)
     finally:
         os.umask(old_umask)
 


### PR DESCRIPTION
Why have a human-readable config.json, when one could also make it
completely unreadable, right?