### PR TITLE
add code coverage reports

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,4 @@
+coverage:
+  precision: 2
+  round: down
+  range: "30...100"

--- a/.coveragerc
+++ b/.coveragerc
@@ -1,6 +1,6 @@
 [run]
-data_file = coverage/.coverage
 source = aiida
+data_file = coverage/.coverage
 omit = *test*,*/migrations/*
 
 [html]

--- a/.coveragerc
+++ b/.coveragerc
@@ -1,6 +1,5 @@
 [run]
 source = aiida
-data_file = coverage/.coverage
 omit = *test*,*/migrations/*
 
 [html]

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 *.pyc
 *~
+*.swp
 *.project
 *.pydevproject
 .settings
@@ -13,7 +14,3 @@
 /.idea/
 *.egg-info
 .eggs
-
-# files created by coverage
-*\,cover
-coverage/

--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,6 @@
 /.idea/
 *.egg-info
 .eggs
+
+# produced by coverage.py
+.coverage

--- a/.travis-data/test_daemon.py
+++ b/.travis-data/test_daemon.py
@@ -11,6 +11,7 @@ import os
 import subprocess
 import sys
 import time
+
 from aiida.common.exceptions import NotExistent
 from aiida.orm import DataFactory
 from aiida.orm.data.base import Int

--- a/.travis.yml
+++ b/.travis.yml
@@ -63,5 +63,9 @@ before_script:
 
 script: .travis-data/test_script.sh
 
+after_success:
+  # upload coverage report to codecov.io
+  - if [ "$TEST_TYPE" == "tests" ]; then codecov; fi
+
 git:
   depth: 3

--- a/coverage/.gitignore
+++ b/coverage/.gitignore
@@ -1,3 +1,2 @@
-# files created by coverage
-.coverage
+# created by coverage
 html/

--- a/coverage/.gitignore
+++ b/coverage/.gitignore
@@ -1,0 +1,3 @@
+# files created by coverage
+.coverage
+html/

--- a/docs/requirements_for_rtd.txt
+++ b/docs/requirements_for_rtd.txt
@@ -24,6 +24,7 @@ chainmap
 click-plugins
 click-spinner
 click==6.7
+codecov
 coverage==4.5.1
 django-extensions==1.5.0
 django==1.7.11

--- a/docs/requirements_for_rtd.txt
+++ b/docs/requirements_for_rtd.txt
@@ -24,6 +24,7 @@ chainmap
 click-plugins
 click-spinner
 click==6.7
+coverage==4.5.1
 django-extensions==1.5.0
 django==1.7.11
 docutils==0.13.1

--- a/setup_requirements.py
+++ b/setup_requirements.py
@@ -130,7 +130,8 @@ extras_require = {
         'mock==2.0.0',
         'pgtest==1.1.0',
         'sqlalchemy-diff==0.1.3',
-        'coverage==4.5.1'
+        'coverage==4.5.1',
+        'codecov'
     ],
     'dev_precommit': [
         'pre-commit==1.3.0',

--- a/setup_requirements.py
+++ b/setup_requirements.py
@@ -129,7 +129,8 @@ extras_require = {
     'testing': [
         'mock==2.0.0',
         'pgtest==1.1.0',
-        'sqlalchemy-diff==0.1.3'
+        'sqlalchemy-diff==0.1.3',
+        'coverage==4.5.1'
     ],
     'dev_precommit': [
         'pre-commit==1.3.0',


### PR DESCRIPTION
Fix #1412 

This PR
 * runs coverage tests on travis (combining output of all tests that are run)
 * uploads the coverage reports to coverage.io
 * Automatic coverage info will be shown upon every new commit

I propose to not to enforce any automatic rules on coverage for the moment - let's first see whether there are any glitches.
Of course, everybody is encouraged to take this information into account when approving pull requests.