### PR TITLE
Add warning about environment variables to LocalTransport docstring.

### DIFF
--- a/aiida/transport/plugins/local.py
+++ b/aiida/transport/plugins/local.py
@@ -27,7 +27,12 @@ from aiida.common import aiidalogger
 
 class LocalTransport(Transport):
     """
-    Support copy and command execution on the same host on which AiiDA is running via direct file copy and execution commands.
+    Support copy and command execution on the same host on which AiiDA is running via direct file copy and
+    execution commands.
+
+    Note that the environment variables are copied from the submitting process, so you might need to clean it
+    with a ``prepend_text``. For example, the AiiDA daemon sets a ``PYTHONPATH``, so you might want to add
+    ``unset PYTHONPATH`` if you plan on running calculations that use Python.
     """
     # There are no valid parameters for the local transport
     _valid_auth_params = []


### PR DESCRIPTION
Fixes #1420. The user-facing documentation for the local transport is in the initial setup, where I don't think we want to put this specific issue. For lack of a better place I just put it in the docstring, which means users can find it when searching the documentation.