### PR TITLE
Update reentry to v1.2.0 for release branch

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -41,7 +41,7 @@
       )$
 
 - repo: local
-  hooks: 
+  hooks:
   - id: rtd-requirements
     name: Requirements for RTD
     entry: python ./docs/update_req_for_rtd.py --pre-commit
@@ -51,6 +51,19 @@
         setup_requirements.py|
         docs/requirements_for_rtd.txt|
         docs/update_req_for_rtd.py|
+      )$
+    pass_filenames: false
+
+- repo: local
+  hooks:
+  - id: pyproject
+    name: Validating pyproject.toml
+    entry: python ./utils/validate_pyproject.py
+    language: system
+    files: >-
+      (?x)^(
+        setup_requirements.py|
+        utils/validate_pyproject|
       )$
     pass_filenames: false
 

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -8,3 +8,4 @@ include fastentrypoints.py
 include setup_requirements.py
 include AUTHORS.txt
 include CHANGELOG.md
+include pyproject.toml

--- a/docs/requirements_for_rtd.txt
+++ b/docs/requirements_for_rtd.txt
@@ -44,7 +44,6 @@ paramiko==2.4.0
 passlib==1.7.1
 pathlib2==2.3.0
 pgtest==1.1.0
-pip==9.0.1
 plumpy==0.7.12
 portalocker==1.1.0
 psutil==5.4.0
@@ -60,7 +59,6 @@ qe-tools==1.1.0
 reentry==1.2.0
 scipy<1.0.0
 seekpath==1.8.0
-setuptools==36.6.0
 singledispatch >= 3.4.0.3
 six==1.11.0
 spglib==1.9.10.1
@@ -73,4 +71,3 @@ ujson==1.35
 uritools==1.0.2
 validate-email==1.3
 voluptuous==0.8.11
-wheel==0.29.0

--- a/docs/requirements_for_rtd.txt
+++ b/docs/requirements_for_rtd.txt
@@ -57,7 +57,7 @@ python-mimeparse==0.1.4
 pytz==2014.10
 pyyaml
 qe-tools==1.1.0
-reentry == 1.1.2
+reentry==1.2.0
 scipy<1.0.0
 seekpath==1.8.0
 setuptools==36.6.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+# Minimum requirements for the build system to execute.
+requires = ["setuptools", "wheel", "reentry==1.2.0"]

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ import fastentrypoints
 import re
 from os import path
 from setuptools import setup, find_packages
-from setup_requirements import install_requires, extras_require, REENTRY_PINNED
+from setup_requirements import install_requires, extras_require
 
 
 if __name__ == '__main__':
@@ -39,10 +39,7 @@ if __name__ == '__main__':
         install_requires=install_requires,
         extras_require=extras_require,
         packages=find_packages(),
-        # Don't forget to install it as well (by adding to the install_requires)
-        setup_requires=[
-            REENTRY_PINNED,
-        ],
+        # Don't forget to install it as well (by adding to the install_requires
         reentry_register=True,
         entry_points={
             'console_scripts': [

--- a/setup.py
+++ b/setup.py
@@ -9,10 +9,11 @@
 ###########################################################################
 import fastentrypoints
 import re
+import sys
+from distutils.version import StrictVersion
 from os import path
 from setuptools import setup, find_packages
 from setup_requirements import install_requires, extras_require
-
 
 if __name__ == '__main__':
     # Get the version number
@@ -21,6 +22,21 @@ if __name__ == '__main__':
     with open(fname) as aiida_init:
         match_expr = "__version__[^'\"]+(['\"])([^'\"]+)"
         aiida_version = re.search(match_expr, aiida_init.read()).group(2).strip()
+
+    # Ensure that pip is installed and the version is at least 10.0.0, which is required for the build process
+    try:
+        import pip
+    except ImportError:
+        print 'Could not import pip, which is required for installation'
+        sys.exit(1)
+
+    PIP_REQUIRED_VERSION = '10.0.0'
+    required_version = StrictVersion(PIP_REQUIRED_VERSION)
+    installed_version = StrictVersion(pip.__version__)
+
+    if installed_version < required_version:
+        print 'The installation requires pip>={}, whereas currently {} is installed'.format(required_version, installed_version)
+        sys.exit(1)
 
     bin_folder = path.join(aiida_folder, 'bin')
     setup(

--- a/setup_requirements.py
+++ b/setup_requirements.py
@@ -10,10 +10,7 @@
 # Requirements for core AiiDA functionalities
 
 install_requires = [
-    'pip==9.0.1',
-    'setuptools==36.6.0',
     'reentry==1.2.0',
-    'wheel==0.29.0',
     'python-dateutil==2.6.0',
     'python-mimeparse==0.1.4',
     'django==1.7.11',  # upgrade to Django 1.9 does prevent AiiDA functioning

--- a/setup_requirements.py
+++ b/setup_requirements.py
@@ -8,12 +8,11 @@
 # For further information please visit http://www.aiida.net               #
 ###########################################################################
 # Requirements for core AiiDA functionalities
-REENTRY_PINNED = 'reentry == 1.1.2'
 
 install_requires = [
     'pip==9.0.1',
     'setuptools==36.6.0',
-    REENTRY_PINNED,
+    'reentry==1.2.0',
     'wheel==0.29.0',
     'python-dateutil==2.6.0',
     'python-mimeparse==0.1.4',

--- a/setup_requirements.py
+++ b/setup_requirements.py
@@ -133,7 +133,8 @@ extras_require = {
         'pre-commit==1.3.0',
         'yapf==0.19.0',
         'prospector==0.12.7',
-        'pylint==1.7.4'
+        'pylint==1.7.4',
+        'toml'
     ]
 }
 

--- a/utils/validate_pyproject.py
+++ b/utils/validate_pyproject.py
@@ -3,20 +3,21 @@
 import click
 import os
 import sys
+import toml
 
 @click.command()
 def validate_pyproject():
     """
     Ensure that the version of reentry in setup_requirements.py and pyproject.toml are identical
     """
-    import setup_requirements
-    import toml
-
     filename_pyproject = 'pyproject.toml'
     filename_requirements = 'setup_requirements.py'
 
     dir_path = os.path.dirname(os.path.realpath(__file__))
     toml_file = os.path.join(dir_path, os.pardir, filename_pyproject)
+    sys.path.append(os.path.join(dir_path, os.pardir))
+
+    import setup_requirements
 
     reentry_requirement = None
 

--- a/utils/validate_pyproject.py
+++ b/utils/validate_pyproject.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+import click
+import os
+import sys
+
+@click.command()
+def validate_pyproject():
+    """
+    Ensure that the version of reentry in setup_requirements.py and pyproject.toml are identical
+    """
+    import setup_requirements
+    import toml
+
+    filename_pyproject = 'pyproject.toml'
+    filename_requirements = 'setup_requirements.py'
+
+    dir_path = os.path.dirname(os.path.realpath(__file__))
+    toml_file = os.path.join(dir_path, os.pardir, filename_pyproject)
+
+    reentry_requirement = None
+
+    for requirement in setup_requirements.install_requires:
+        if 'reentry' in requirement:
+            reentry_requirement = requirement
+            break
+
+    if reentry_requirement is None:
+        click.echo('Could not find the reentry requirement in {}'.format(filename_requirements), err=True)
+        sys.exit(1)
+
+    try:
+        with open(toml_file, 'r') as handle:
+            toml_string = handle.read()
+    except IOError as exception:
+        click.echo('Could not read the required file: {}'.format(toml_file), err=True)
+        sys.exit(1)
+
+    try:
+        parsed_toml = toml.loads(toml_string)
+    except Exception as exception:
+        click.echo('Could not parse {}: {}'.format(toml_file, exception), err=True)
+        sys.exit(1)
+
+    try:
+        pyproject_toml_requires = parsed_toml['build-system']['requires']
+    except KeyError as exception:
+        click.echo('Could not retrieve the build-system requires list from {}'.format(toml_file), err=True)
+        sys.exit(1)
+
+    if reentry_requirement not in pyproject_toml_requires:
+        click.echo('Reentry requirement from {} {} is not mirrored in {}'.format(
+            filename_requirements, reentry_requirement, toml_file), err=True)
+        sys.exit(1)
+
+
+if __name__ == '__main__':
+    validate_pyproject()  # pylint: disable=no-value-for-parameter


### PR DESCRIPTION
Fixes #1429 

Update reentry to v1.2.0 which fixes the issue with entry points not being registered.
This currently contains the alpha release `v1.2.0a9`, but once it is confirmed to work
in all relevant environments and branches the actual version `v1.2.0` will be released
and I will update this PR with the actual release