### PR TITLE
Make sphinxext tests appear in the coverage report

### DIFF
--- a/.travis-data/test_script.sh
+++ b/.travis-data/test_script.sh
@@ -5,7 +5,7 @@ set -ev
 
 case "$TEST_TYPE" in
     docs)
-        # Compile the docs (HTML format); 
+        # Compile the docs (HTML format);
         # -C change to 'docs' directory before doing anything
         # -n to warn about all missing references
         # -W to convert warnings in errors
@@ -28,11 +28,11 @@ case "$TEST_TYPE" in
         # Run the daemon tests using docker
         # Note: This is not a typo, the profile is called ${TEST_AIIDA_BACKEND}
         coverage run -a $VERDI -p ${TEST_AIIDA_BACKEND} run ${DATA_DIR}/test_daemon.py
+
+        # run the sphinxext tests
+        pytest --cov aiida --cov-append -vv aiida/sphinxext/tests
         ;;
     pre-commit)
         pre-commit run --all-files || ( git status --short ; git diff ; exit 1 )
-        ;;
-    sphinxext)
-        py.test -vv aiida/sphinxext/tests
         ;;
 esac

--- a/.travis.yml
+++ b/.travis.yml
@@ -49,7 +49,6 @@ env:
 ## also when building the docs
 ## because otherwise the code would complain. Also, I need latex.
 - TEST_TYPE="pre-commit"
-- TEST_AIIDA_BACKEND=django TEST_TYPE="sphinxext"
 - TEST_AIIDA_BACKEND=django TEST_TYPE="docs"
 - TEST_AIIDA_BACKEND=django TEST_TYPE="tests"
 - TEST_AIIDA_BACKEND=sqlalchemy TEST_TYPE="tests"

--- a/docs/requirements_for_rtd.txt
+++ b/docs/requirements_for_rtd.txt
@@ -49,6 +49,8 @@ psutil==5.4.0
 pycrypto==2.6.1
 pymatgen==4.5.3
 pyparsing==2.1.10
+pytest
+pytest-cov
 python-dateutil==2.6.0
 python-memcached==1.58
 python-mimeparse==0.1.4

--- a/setup_requirements.py
+++ b/setup_requirements.py
@@ -126,7 +126,8 @@ extras_require = {
         'toml'
     ],
     'dev_sphinxext': [
-        'pytest'
+        'pytest',
+        'pytest-cov',
     ]
 }
 
@@ -145,4 +146,4 @@ extras_require['dev_sphinxext'] += extras_require['docs']
 #    the requirements (and there is no easy way on our side to fix a specific
 #    installation order of dependencies)
 
-extras_require['testing'] += extras_require['rest'] + extras_require['atomic_tools']
+extras_require['testing'] += extras_require['rest'] + extras_require['atomic_tools'] + extras_require['dev_sphinxext']


### PR DESCRIPTION
Adds coverage reporting for the sphinxext tests. While I was at it, I also made them part of the "regular" tests, because I'm not sure if they really warrant having an entirely separate Travis build. That could easily be reverted, though.