### PR TITLE
 Fix verdi export create when specifying computers

### DIFF
--- a/aiida/cmdline/commands/exportfile.py
+++ b/aiida/cmdline/commands/exportfile.py
@@ -10,12 +10,15 @@
 import click
 from aiida.cmdline.commands import verdi, export
 from aiida.cmdline.baseclass import VerdiCommandWithSubcommands
+from aiida.utils.cli.options import MultipleValueOption
+
 
 CONTEXT_SETTINGS = dict(help_option_names=['-h', '--help'])
 
 
 class DanglingLinkError(Exception):
     pass
+
 
 class Export(VerdiCommandWithSubcommands):
     """
@@ -33,13 +36,13 @@ class Export(VerdiCommandWithSubcommands):
 
 @export.command('create', context_settings=CONTEXT_SETTINGS)
 @click.argument('outfile', type=click.Path())
-@click.option('-n', '--nodes', multiple=True, type=int,
+@click.option('-n', '--nodes', cls=MultipleValueOption, type=int,
     help='Export the given nodes by pk')
-@click.option('-c', '--computers', multiple=True, type=int,
+@click.option('-c', '--computers', cls=MultipleValueOption, type=int,
     help='Export the given computers by pk')
-@click.option('-G', '--groups', multiple=True, type=int,
+@click.option('-G', '--groups', cls=MultipleValueOption, type=int,
     help='Export the given groups by pk')
-@click.option('-g', '--group_names', multiple=True, type=str,
+@click.option('-g', '--group_names', cls=MultipleValueOption, type=str,
     help='Export the given groups by group name')
 @click.option('-P', '--no-parents', is_flag=True, default=False,
     help='Store only the nodes that are explicitly given, without exporting the parents')
@@ -59,7 +62,7 @@ def create(outfile, computers, groups, nodes, group_names, no_parents, no_calc_o
     from aiida.orm.querybuilder import QueryBuilder
     from aiida.orm.importexport import export, export_zip
 
-    node_id_set = set(nodes)
+    node_id_set = set(nodes or [])
     group_dict = dict()
 
     if group_names:

--- a/aiida/orm/importexport.py
+++ b/aiida/orm/importexport.py
@@ -103,8 +103,7 @@ entity_names_to_sqla_schema = {
     NODE_ENTITY_NAME: "aiida.backends.sqlalchemy.models.node.DbNode",
     LINK_ENTITY_NAME: "aiida.backends.sqlalchemy.models.node.DbLink",
     GROUP_ENTITY_NAME: "aiida.backends.sqlalchemy.models.group.DbGroup",
-    COMPUTER_ENTITY_NAME:
-        "aiida.backends.sqlalchemy.models.computer.DbComputer",
+    COMPUTER_ENTITY_NAME: "aiida.backends.sqlalchemy.models.computer.DbComputer",
     USER_ENTITY_NAME: "aiida.backends.sqlalchemy.models.user.DbUser"
 }
 
@@ -1684,6 +1683,7 @@ def export_tree(what, folder, also_parents=True, also_calc_outputs=True,
 
     given_node_entry_ids = set()
     given_group_entry_ids = set()
+    given_computer_entry_ids = set()
 
     # I store a list of the actual dbnodes
     for entry in what:
@@ -1696,6 +1696,8 @@ def export_tree(what, folder, also_parents=True, also_calc_outputs=True,
             given_group_entry_ids.add(entry.pk)
         elif entry_entity_name == NODE_ENTITY_NAME:
             given_node_entry_ids.add(entry.pk)
+        elif entry_entity_name == COMPUTER_ENTITY_NAME:
+            given_computer_entry_ids.add(entry.pk)
         else:
             raise ValueError("I was given {}, which is not a DbNode or DbGroup instance".format(entry))
 
@@ -1737,6 +1739,8 @@ def export_tree(what, folder, also_parents=True, also_calc_outputs=True,
         given_entities.append(GROUP_ENTITY_NAME)
     if len(given_node_entry_ids) > 0:
         given_entities.append(NODE_ENTITY_NAME)
+    if len(given_computer_entry_ids) > 0:
+        given_entities.append(COMPUTER_ENTITY_NAME)
 
     entries_to_add = dict()
     for given_entity in given_entities:
@@ -1754,9 +1758,12 @@ def export_tree(what, folder, also_parents=True, also_calc_outputs=True,
             project_cols.append(nprop)
 
         # Getting the ids that correspond to the right entity
-        entry_ids_to_add = (given_node_entry_ids
-                            if (given_entity == NODE_ENTITY_NAME)
-                            else given_group_entry_ids)
+        if given_entity == GROUP_ENTITY_NAME:
+            entry_ids_to_add = given_group_entry_ids
+        elif given_entity == NODE_ENTITY_NAME:
+            entry_ids_to_add = given_node_entry_ids
+        elif given_entity == COMPUTER_ENTITY_NAME:
+            entry_ids_to_add = given_computer_entry_ids
 
         qb = QueryBuilder()
         qb.append(entity_names_to_entities[given_entity],

--- a/aiida/utils/cli/options.py
+++ b/aiida/utils/cli/options.py
@@ -4,6 +4,75 @@ import click
 from . import validators
 
 
+class MultipleValueParamType(click.ParamType):
+
+    def __init__(self, param_type):
+        super(MultipleValueParamType, self).__init__()
+        self._param_type = param_type
+        self.name = param_type.__name__.upper()
+
+    def convert(self, value, param, ctx):
+        try:
+            return tuple([self._param_type(entry) for entry in value])
+        except ValueError:
+            self.fail('could not convert {} into type {}'.format(value, self._param_type))
+
+
+class MultipleValueOption(click.Option):
+    """
+    An option that can handle multiple values with a single flag. For example::
+
+        @click.option('-n', '--nodes', cls=MultipleValueOption)
+
+    Will be able to parse the following::
+
+        --nodes 10 15 12
+
+    This is better than the builtin ``multiple=True`` keyword for click's option which forces the user to specify
+    the option flag for each value, which gets inpractical for long lists of values
+    """
+
+    def __init__(self, *args, **kwargs):
+        param_type = kwargs.pop('type', None)
+
+        if param_type is not None:
+            kwargs['type'] = MultipleValueParamType(param_type)
+
+        super(MultipleValueOption, self).__init__(*args, **kwargs)
+        self._previous_parser_process = None
+        self._eat_all_parser = None
+
+    def add_to_parser(self, parser, ctx):
+        result = super(MultipleValueOption, self).add_to_parser(parser, ctx)
+
+        def parser_process(value, state):
+            ENDOPTS = '--'
+            done = False
+            value = [value]
+
+            # Grab everything up to the next option or endopts symbol
+            while state.rargs and not done:
+                for prefix in self._eat_all_parser.prefixes:
+                    if state.rargs[0].startswith(prefix) or state.rargs[0] == ENDOPTS:
+                        done = True
+                if not done:
+                    value.append(state.rargs.pop(0))
+
+            value = tuple(value)
+
+            self._previous_parser_process(value, state)
+
+        for name in self.opts:
+            our_parser = parser._long_opt.get(name) or parser._short_opt.get(name)
+            if our_parser:
+                self._eat_all_parser = our_parser
+                self._previous_parser_process = our_parser.process
+                our_parser.process = parser_process
+                break
+
+        return result
+
+
 class overridable_option(object):
     """
     Wrapper around click option that allows to store the name

--- a/docs/source/nitpick-exceptions
+++ b/docs/source/nitpick-exceptions
@@ -89,6 +89,9 @@ py:obj None
 # as types or rtypes without actually being imported
 py:class  abc.ABCMeta
 
+py:class  click.core.Option
+py:class  click.types.ParamType
+
 py:class  distutils.version.Version
 
 py:class  docutils.parsers.rst.Directive


### PR DESCRIPTION
Fixes #1033 

Only passing computers to `verdi export create` was not supported by `export` and hence broken.
I added the necessary logic to make computers exportable.

Additionally, I fixed the parsing of the `verdi export create` command.
Click does support multiple values for an option through the `multiple` keyword
of the option constructor, however, this requires the user to repeat the flag
for each value, i.e.:

    --nodes 1 --nodes 2 --nodes 15

For big lists, this is impractical and untenable. Also it is not very intuitive and users were using it the way below, which would throw cryptic errors. Therefore we introduce a custom
`MultiValueOption` that instead supports the following notation:

    --nodes 1 2 15

Since these options are greedy, they can clash with cli commands that also take
arguments. If the greedy option is used, the argument will be mistaken for another
option value. In this case, the `MultiValueOption` respects the endopts marker '--'
that is the standard for POSIX command line interfaces. Anything after this marker
will be considered as arguments by the parser.