### PR TITLE
Implement the `submit_test` functionality for the ProcessBuilder

### DIFF
--- a/aiida/orm/implementation/general/calculation/job/__init__.py
+++ b/aiida/orm/implementation/general/calculation/job/__init__.py
@@ -1778,18 +1778,15 @@ class AbstractJobCalculation(AbstractCalculation):
 
     def submit_test(self, folder=None, subfolder_name=None):
         """
-        Test submission, creating the files in a local folder.
+        Run a test submission by creating the files that would be generated for the real calculation in a local folder,
+        without actually storing the calculation nor the input nodes. This functionality therefore also does not
+        require any of the inputs nodes to be stored yet.
 
-        :note: this submit_test function does not require any node
-            (neither the calculation nor the input links) to be stored yet.
-
-        :param folder: A Folder object, within which each calculation files
-            are created; if not passed, a subfolder 'submit_test' of the current
-            folder is used.
-        :param subfolder_name: the name of the subfolder to use for this
-            calculation (within Folder). If not passed, a unique string
-            starting with the date and time in the format ``yymmdd-HHMMSS-``
-            is used.
+        :param folder: a Folder object, within which to create the calculation files. By default a folder
+            will be created in the current working directory
+        :param subfolder_name: the name of the subfolder to use within the directory of the ``folder`` object. By
+            default a unique string will be generated based on the current datetime with the format ``yymmdd-``
+            followed by an auto incrementing index
         """
         import os
         import errno

--- a/aiida/utils/serialize.py
+++ b/aiida/utils/serialize.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 import collections
+import uuid
 from ast import literal_eval
 from plumpy.utils import AttributesFrozendict
 from aiida.common.extendeddicts import AttributeDict
@@ -9,6 +10,7 @@ from aiida.orm import Group, Node, load_group, load_node
 _PREFIX_KEY_TUPLE = 'tuple():'
 _PREFIX_VALUE_NODE = 'aiida_node:'
 _PREFIX_VALUE_GROUP = 'aiida_group:'
+_PREFIX_VALUE_UUID = 'aiida_uuid:'
 
 
 def encode_key(key):
@@ -55,6 +57,8 @@ def serialize_data(data):
         return '{}{}'.format(_PREFIX_VALUE_NODE, data.uuid)
     elif isinstance(data, Group):
         return '{}{}'.format(_PREFIX_VALUE_GROUP, data.uuid)
+    elif isinstance(data, uuid.UUID):
+        return '{}{}'.format(_PREFIX_VALUE_UUID, data)
     elif isinstance(data, AttributeDict):
         return AttributeDict({encode_key(key): serialize_data(value) for key, value in data.iteritems()})
     elif isinstance(data, AttributesFrozendict):
@@ -88,5 +92,7 @@ def deserialize_data(data):
         return load_node(uuid=data[len(_PREFIX_VALUE_NODE):])
     elif isinstance(data, (str, unicode)) and data.startswith(_PREFIX_VALUE_GROUP):
         return load_group(uuid=data[len(_PREFIX_VALUE_GROUP):])
+    elif isinstance(data, (str, unicode)) and data.startswith(_PREFIX_VALUE_UUID):
+        return uuid.UUID(data[len(_PREFIX_VALUE_UUID):])
     else:
         return data

--- a/aiida/work/job_processes.py
+++ b/aiida/work/job_processes.py
@@ -24,6 +24,7 @@ from aiida.daemon import execmanager
 from aiida.orm.calculation.job import JobCalculation
 from aiida.orm.calculation.job import JobCalculationFinishStatus
 from aiida.scheduler.datastructures import job_states
+from aiida.work.process_builder import JobProcessBuilder
 from aiida.work.process_spec import DictSchema
 
 from . import persistence
@@ -341,6 +342,10 @@ class JobProcess(processes.Process):
     OPTIONS_INPUT_LABEL = 'options'
 
     _calc_class = None
+
+    @classmethod
+    def get_builder(cls):
+        return JobProcessBuilder(cls)
 
     @classmethod
     def build(cls, calc_class):

--- a/aiida/work/process_builder.py
+++ b/aiida/work/process_builder.py
@@ -2,7 +2,7 @@
 from aiida.common.extendeddicts import AttributeDict, FixedFieldsAttributeDict
 from aiida.work.ports import PortNamespace
 
-__all__ = ['ProcessBuilder', 'ProcessBuilderInputDict']
+__all__ = ['ProcessBuilder', 'JobProcessBuilder', 'ProcessBuilderInputDict']
 
 
 class ProcessBuilderInput(object):
@@ -81,3 +81,27 @@ class ProcessBuilder(ProcessBuilderInputDict):
         self._process_class = process_class
         self._process_spec = self._process_class.spec()
         super(ProcessBuilder, self).__init__(port_namespace=self._process_spec.inputs)
+
+
+class JobProcessBuilder(ProcessBuilder):
+
+    def __dir__(self):
+        return super(JobProcessBuilder, self).__dir__() + ['submit_test']
+
+    def submit_test(self, folder=None, subfolder_name=None):
+        """
+        Run a test submission by creating the files that would be generated for the real calculation in a local folder,
+        without actually storing the calculation nor the input nodes. This functionality therefore also does not
+        require any of the inputs nodes to be stored yet.
+
+        :param folder: a Folder object, within which to create the calculation files. By default a folder
+            will be created in the current working directory
+        :param subfolder_name: the name of the subfolder to use within the directory of the ``folder`` object. By
+            default a unique string will be generated based on the current datetime with the format ``yymmdd-``
+            followed by an auto incrementing index
+        """
+        inputs = self._todict()
+        inputs['store_provenance'] = False
+        process = self._process_class(inputs=inputs)
+
+        return process._calc.submit_test(folder, subfolder_name)

--- a/docs/source/concepts/processes.rst
+++ b/docs/source/concepts/processes.rst
@@ -170,3 +170,14 @@ Launching the process
 When all the inputs have been defined for the builder, it can be used to actually launch the ``Process``.
 The ``ProcessBuilder`` can be launched by passing it to the free functions ``run`` and ``submit`` from the ``aiida.work.launch`` module, just as you would do a normal process.
 For more details please refer to the :ref:`process builder section <running_workflows_process_builder>` in the section of the documentation on :ref:`running workflows <running_workflows>`.
+
+Submit test
+-----------
+The ``ProcessBuilder`` of a ``JobCalculation`` has one additional feature.
+It has the method :py:meth:`~aiida.work.process_builder.JobProcessBuilder.submit_test()`.
+When this method is called, provided that the inputs are valid, a directory will be created locally with all the inputs files and scripts that would be created if the builder were to be submitted for real.
+This gives you a chance to inspect the generated files before actually sending them to the remote computer.
+This action also will not create an actual calculation node in the database, nor do the input nodes have to be stored, allowing you to check that everything is correct without polluting the database.
+
+By default the method will create a folder ``submit_test`` in the current working directory and within it a directory with an automatically generated unique name, each time the method is called.
+The method takes two optional arguments ``folder`` and ``subfolder_name``, to change the base folder and the name of the test directory, respectively.


### PR DESCRIPTION
Fixes #1149 

This was the last remaining item to be done on the checklist of #1149 .

The `JobProcess` overrides the `get_builder` method to return a subclass
of the `ProcessBuilder`, the `JobProcessBuilder` which has an additional
method called `submit_test`. This method will call through to the same
method of the `JobCalculation` class, which will create a folder in the
current working directory with the input files and scripts as they would
have been created on the remote computer, were the builder have been
submitted for real. This gives the user a chance to inspect the generated
files without having to store the calculation or inputs nodes and actually
submitting the job to the remote.