### PR TITLE
fix badly scaled image in docs

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -6,7 +6,6 @@
 .. figure:: images/AiiDA_transparent_logo.png
     :width: 250px
     :align: center
-    :height: 100px
 
     Automated Interactive Infrastructure and Database for Computational Science
 


### PR DESCRIPTION
on read the docs, the aiida logo was incorrectly scaled
http://aiida-core.readthedocs.io/en/latest/

The issue does not appear on the locally built docs (for some reason, the browser discards the height setting there).