### PR TITLE
Remove scipy from the requirements

### DIFF
--- a/docs/requirements_for_rtd.txt
+++ b/docs/requirements_for_rtd.txt
@@ -57,7 +57,6 @@ python-mimeparse==1.6.0
 pytz==2018.4
 qe-tools==1.1.0
 reentry==1.2.0
-scipy==1.0.1
 seekpath==1.8.1
 singledispatch >= 3.4.0.3
 six==1.11.0

--- a/setup_requirements.py
+++ b/setup_requirements.py
@@ -44,7 +44,6 @@ install_requires = [
     'pycrypto==2.6.1',
     'pika==0.11.2',
     'ipython<6.0',  # Version of ipython non enforced, because some still prefer version 4 rather than the latest
-    'scipy==1.0.1',
     'plumpy==0.10.1',
     'circus==0.14.0',
     'tornado==4.5.3',  # As of 2018/03/06 Tornado released v5.0 which breaks circus 0.14.0


### PR DESCRIPTION
The requirement was added with an upper bound on October 27 2017
when scipy v1.0.0 was released, but it was broken. Therefore we had
to fix the upper bound but now scipy v1.0.1 is out and we can remove
it. Especially since having it as a requirement was failing the builds
on readthedocs due to it running out of memory