### PR TITLE
Effectuate save_checkpoint directly in on_entered instead of scheduling

### DIFF
--- a/aiida/backends/tests/work/persistence.py
+++ b/aiida/backends/tests/work/persistence.py
@@ -56,7 +56,6 @@ class TestAiiDAPersister(AiidaTestCase):
 
     def test_delete_checkpoint(self):
         process = DummyProcess()
-        self.assertEquals(process.calc.checkpoint, None)
 
         self.persister.save_checkpoint(process)
         self.assertTrue(isinstance(process.calc.checkpoint, basestring))

--- a/aiida/backends/tests/work/process.py
+++ b/aiida/backends/tests/work/process.py
@@ -20,6 +20,14 @@ from aiida.orm.data.parameter import ParameterData
 from aiida.work import test_utils, utils
 
 
+class NameSpacedProcess(work.Process):
+
+    @classmethod
+    def define(cls, spec):
+        super(NameSpacedProcess, cls).define(spec)
+        spec.input('some.name.space.a', valid_type=Int)
+
+
 class TestProcessNamespace(AiidaTestCase):
 
     def setUp(self):
@@ -35,14 +43,6 @@ class TestProcessNamespace(AiidaTestCase):
         Test that inputs in nested namespaces are properly validated and the link labels
         are properly formatted by connecting the namespaces with underscores
         """
-
-        class NameSpacedProcess(work.Process):
-
-            @classmethod
-            def define(cls, spec):
-                super(NameSpacedProcess, cls).define(spec)
-                spec.input('some.name.space.a', valid_type=Int)
-
         proc = NameSpacedProcess(inputs={'some': {'name': {'space': {'a': Int(5)}}}})
 
         # Test that the namespaced inputs are AttributesFrozenDicts

--- a/aiida/work/processes.py
+++ b/aiida/work/processes.py
@@ -212,8 +212,8 @@ class Process(plumpy.Process):
     def on_entered(self, from_state):
         super(Process, self).on_entered(from_state)
         self.update_node_state(self._state)
-        if self._enable_persistence and not self._state.is_terminal() and not self._state.label == ProcessState.CREATED:
-            self.call_soon(self.runner.persister.save_checkpoint, self)
+        if self._enable_persistence and not self._state.is_terminal():
+            self.runner.persister.save_checkpoint(self)
 
     @override
     def on_terminated(self):


### PR DESCRIPTION
Fixes #1473 

Scheduling the `save_checkpoint` call with a `call_soon` would lead to
the call being effectuated after the process already reached a terminal
state and being sealed, triggering a `ModificationNotAllowed` exception,
which in turn lead to the forbidden `FINISHED` -> `EXCEPTED` transition.
Calling `save_checkpoint` directly in `on_entered` prevents this problem.