### PR TITLE
Use the exc_info passed to on_except to format a stack trace

### DIFF
--- a/aiida/work/processes.py
+++ b/aiida/work/processes.py
@@ -238,7 +238,7 @@ class Process(plumpy.Process):
         Log the exception by calling the report method with formatted stack trace from exception info object
         """
         super(Process, self).on_except(exc_info)
-        self.report(traceback.format_exc())
+        self.report(''.join(traceback.format_exception(*exc_info)))
 
     @override
     def on_finish(self, result, successful):


### PR DESCRIPTION
Fixes #1477 

Calling traceback.format_exc() will use sys.exc_info() to retrieve
a exception info object to format a stacktrace, but this will be
None at this point. Rather we should use the exc_info passed as an
argument to exc_info