### PR TITLE
Fix incompatibilities between dependency requirements

### DIFF
--- a/aiida/orm/data/cif.py
+++ b/aiida/orm/data/cif.py
@@ -484,6 +484,11 @@ class CifData(SinglefileData):
             self._get_folder_pathsubfolder.open(self.filename), **kwargs)
 
     def set_ase(self, aseatoms):
+        """
+        Set the contents of the CifData starting from an ASE atoms object
+
+        :param aseatoms: the ASE atoms object
+        """
         import tempfile
         cif = cif_from_ase(aseatoms)
         with tempfile.NamedTemporaryFile() as f:

--- a/docs/requirements_for_rtd.txt
+++ b/docs/requirements_for_rtd.txt
@@ -64,7 +64,7 @@ six==1.11.0
 spglib==1.9.10.1
 sphinx-rtd-theme==0.2.5b2
 sqlalchemy-diff==0.1.3
-sqlalchemy-migrate==0.10.0
+sqlalchemy-migrate==0.11.0
 tabulate==0.7.5
 tzlocal==1.3
 ujson==1.35

--- a/setup_requirements.py
+++ b/setup_requirements.py
@@ -86,7 +86,7 @@ extras_require = {
         'pyparsing==2.1.10',
         'Pattern==2.6',
         'Flask-SQLAlchemy==2.1',
-        'sqlalchemy-migrate==0.10.0',
+        'sqlalchemy-migrate==0.11.0',
         'marshmallow-sqlalchemy==0.10.0',
         'flask-marshmallow==0.7.0',
         'itsdangerous==0.24',
@@ -133,7 +133,7 @@ extras_require = {
         'pre-commit==1.3.0',
         'yapf==0.19.0',
         'prospector==0.12.7',
-        'pylint==1.7.4',
+        'pylint==1.8.4',
         'toml'
     ]
 }


### PR DESCRIPTION
The older pinned versions of `sqlalchemy-migrate` and `pylint` caused
dependency requirement inconsistencies for the `pbr` and `pylint-django`
indirect dependencies