### PR TITLE
Remove the explicit dependency upper limit for scipy

### DIFF
--- a/docs/requirements_for_rtd.txt
+++ b/docs/requirements_for_rtd.txt
@@ -57,7 +57,6 @@ pytz==2014.10
 pyyaml
 qe-tools==1.1.0
 reentry==1.2.0
-scipy<1.0.0
 seekpath==1.8.0
 singledispatch >= 3.4.0.3
 six==1.11.0

--- a/setup_requirements.py
+++ b/setup_requirements.py
@@ -63,8 +63,7 @@ install_requires = [
     'pycrypto==2.6.1',
     # Requirements for verdi shell (version of ipython non enforced, because
     # there are people who still prefer version 4 rather than the latest)
-    'ipython<6.0',
-    'scipy<1.0.0'  # At this moment the install of 1.0.0 release is broken
+    'ipython<6.0'
 ]
 
 extras_require = {


### PR DESCRIPTION
This was introduced when scipy 1.0.0 was released which broke the
build. Now that 1.0.1 is available, which fixes that issue, the
upper bound and explicit dependency is no longer needed.