### PR TITLE
 Make sure that kwargs do not override existing ports in FunctionProcess 

### DIFF
--- a/aiida/backends/tests/work/test_workfunctions.py
+++ b/aiida/backends/tests/work/test_workfunctions.py
@@ -13,59 +13,224 @@ from aiida.backends.testbase import AiidaTestCase
 from aiida.orm.data.bool import get_true_node
 from aiida.orm.data.int import Int
 from aiida.orm import load_node
-from aiida.work.launch import run, run_get_node
+from aiida.orm.calculation.function import FunctionCalculation
+from aiida.work.launch import run, run_get_node, submit
 from aiida.work.processes import Process
 from aiida.work.workfunctions import workfunction
 
+DEFAULT_INT = 256
 DEFAULT_LABEL = 'Default label'
-
-@workfunction
-def simple_wf():
-    return {'result': get_true_node()}
-
-
-@workfunction
-def return_input(inp):
-    return {'result': inp}
-
-
-@workfunction
-def single_return_value():
-    return get_true_node()
-
-
-@workfunction
-def set_label_default(label=DEFAULT_LABEL):
-    assert Process.current().calc.label == DEFAULT_LABEL
-    return get_true_node()
+DEFAULT_DESCRIPTION = 'Default description'
+CUSTOM_LABEL = 'Custom label'
+CUSTOM_DESCRIPTION = 'Custom description'
 
 
 class TestWf(AiidaTestCase):
+
     def setUp(self):
         super(TestWf, self).setUp()
         self.assertEquals(len(util.ProcessStack.stack()), 0)
+
+        @workfunction
+        def wf_return_input(inp):
+            return {'result': inp}
+
+        @workfunction
+        def wf_return_true():
+            return get_true_node()
+
+        @workfunction
+        def wf_args(a):
+            return a
+
+        @workfunction
+        def wf_args_with_default(a=Int(DEFAULT_INT)):
+            return a
+
+        @workfunction
+        def wf_kwargs(**kwargs):
+            return kwargs
+
+        @workfunction
+        def wf_args_and_kwargs(a, **kwargs):
+            result = {'a': a}
+            result.update(kwargs)
+            return result
+
+        @workfunction
+        def wf_args_and_default(a, b=Int(DEFAULT_INT)):
+            return {'a': a, 'b': b}
+
+        @workfunction
+        def wf_default_label_description(a=Int(DEFAULT_INT), label=DEFAULT_LABEL, description=DEFAULT_DESCRIPTION):
+            return a
+
+        self.wf_return_input = wf_return_input
+        self.wf_return_true = wf_return_true
+        self.wf_args = wf_args
+        self.wf_args_with_default = wf_args_with_default
+        self.wf_kwargs = wf_kwargs
+        self.wf_args_and_kwargs = wf_args_and_kwargs
+        self.wf_args_and_default = wf_args_and_default
+        self.wf_default_label_description = wf_default_label_description
+
 
     def tearDown(self):
         super(TestWf, self).tearDown()
         self.assertEquals(len(util.ProcessStack.stack()), 0)
 
-    def test_blocking(self):
-        self.assertTrue(simple_wf()['result'])
-        self.assertTrue(return_input(get_true_node())['result'])
+    def test_wf_varargs(self):
+        """
+        Variadic arguments are not supported and should raise
+        """
+        with self.assertRaises(ValueError):
+            @workfunction
+            def wf_varargs(*args):
+                return get_true_node()
 
-    def test_run(self):
-        self.assertTrue(run(simple_wf)['result'])
-        self.assertTrue(run(return_input, get_true_node())['result'])
+    def test_wf_args(self):
+        """
+        Simple workfunction that defines a single positional argument
+        """
+        INPUT = 1
 
-    def test_run_and_get_node(self):
-        result, calc_node = single_return_value.run_get_node()
+        with self.assertRaises(ValueError):
+            result = self.wf_args()
+
+        result = self.wf_args(a=Int(INPUT))
+        self.assertTrue(isinstance(result, Int))
+        self.assertEquals(result, INPUT)
+
+    def test_wf_args_with_default(self):
+        """
+        Simple workfunction that defines a single argument with a default
+        """
+        INPUT = 1
+
+        result = self.wf_args_with_default()
+        self.assertTrue(isinstance(result, Int))
+        self.assertEquals(result, Int(DEFAULT_INT))
+
+        result = self.wf_args_with_default(a=Int(INPUT))
+        self.assertTrue(isinstance(result, Int))
+        self.assertEquals(result, INPUT)
+
+    def test_wf_kwargs(self):
+        """
+        Simple workfunction that defines keyword arguments
+        """
+        INPUT = {'a': Int(DEFAULT_INT)}
+
+        result = self.wf_kwargs()
+        self.assertTrue(isinstance(result, dict))
+        self.assertEquals(result, {})
+
+        result = self.wf_kwargs(**INPUT)
+        self.assertTrue(isinstance(result, dict))
+        self.assertEquals(result, INPUT)
+
+    def test_wf_args_and_kwargs(self):
+        """
+        Simple workfunction that defines a positional argument and keyword arguments
+        """
+        ARGS_INPUT = (Int(DEFAULT_INT),)
+        KWARGS_INPUT = {'b': Int(INPUT)}
+
+        result = self.wf_args_and_kwargs(*ARGS_INPUT)
+        self.assertTrue(isinstance(result, dict))
+        self.assertEquals(result, {'a': ARGS_INPUT[0]})
+
+        result = self.wf_args_and_kwargs(*ARGS_INPUT, **KWARGS_INPUT)
+        self.assertTrue(isinstance(result, dict))
+        self.assertEquals(result, {'a': ARGS_INPUT[0], 'b': Int(DEFAULT_INT)})
+
+    def test_wf_args_and_kwargs(self):
+        """
+        Simple workfunction that defines a positional argument and an argument with a default
+        """
+        INPUT = 1
+        ARGS_INPUT_DEFAULT = (Int(DEFAULT_INT),)
+        ARGS_INPUT_EXPLICIT = (Int(DEFAULT_INT), Int(INPUT))
+
+        result = self.wf_args_and_default(*ARGS_INPUT_DEFAULT)
+        self.assertTrue(isinstance(result, dict))
+        self.assertEquals(result, {'a': ARGS_INPUT_DEFAULT[0], 'b': Int(DEFAULT_INT)})
+
+        result = self.wf_args_and_default(*ARGS_INPUT_EXPLICIT)
+        self.assertTrue(isinstance(result, dict))
+        self.assertEquals(result, {'a': ARGS_INPUT_EXPLICIT[0], 'b': ARGS_INPUT_EXPLICIT[1]})
+
+    def test_wf_args_passing_kwargs(self):
+        """
+        A function that does not explicitly define kwargs, should not be able to be called with
+        keyword arguments that were not explicitly defined
+        """
+        INPUT = 1
+
+        with self.assertRaises(ValueError):
+            result = self.wf_args(a=Int(INPUT), b=Int(INPUT))
+
+    def test_wf_set_label_description(self):
+        """
+        Verify that the label and description can be set for all workfunction variants
+        """
+        result, node = self.wf_args.run_get_node(a=Int(DEFAULT_INT), label=CUSTOM_LABEL, description=CUSTOM_DESCRIPTION)
+        self.assertEquals(node.label, CUSTOM_LABEL)
+        self.assertEquals(node.description, CUSTOM_DESCRIPTION)
+
+        result, node = self.wf_args_with_default.run_get_node(label=CUSTOM_LABEL, description=CUSTOM_DESCRIPTION)
+        self.assertEquals(node.label, CUSTOM_LABEL)
+        self.assertEquals(node.description, CUSTOM_DESCRIPTION)
+
+        result, node = self.wf_kwargs.run_get_node(label=CUSTOM_LABEL, description=CUSTOM_DESCRIPTION)
+        self.assertEquals(node.label, CUSTOM_LABEL)
+        self.assertEquals(node.description, CUSTOM_DESCRIPTION)
+
+        result, node = self.wf_args_and_kwargs.run_get_node(a=Int(DEFAULT_INT), label=CUSTOM_LABEL, description=CUSTOM_DESCRIPTION)
+        self.assertEquals(node.label, CUSTOM_LABEL)
+        self.assertEquals(node.description, CUSTOM_DESCRIPTION)
+
+        result, node = self.wf_args_and_default.run_get_node(a=Int(DEFAULT_INT), label=CUSTOM_LABEL, description=CUSTOM_DESCRIPTION)
+        self.assertEquals(node.label, CUSTOM_LABEL)
+        self.assertEquals(node.description, CUSTOM_DESCRIPTION)
+
+    def test_wf_default_label_description(self):
+        """
+        Verify that a workfunction can define a default label and description but they can be overriden by the
+        user by explicitly passing them as keyword arguments
+        """
+        result, node = self.wf_default_label_description.run_get_node(a=Int(DEFAULT_INT))
+        self.assertEquals(node.label, DEFAULT_LABEL)
+        self.assertEquals(node.description, DEFAULT_DESCRIPTION)
+
+        result, node = self.wf_default_label_description.run_get_node(label=CUSTOM_LABEL, description=CUSTOM_DESCRIPTION)
+        self.assertEquals(node.label, CUSTOM_LABEL)
+        self.assertEquals(node.description, CUSTOM_DESCRIPTION)
+
+    def test_finish_status(self):
+        """
+        If a workfunction reaches the FINISHED process state, it has to have been successful
+        which means that the finish status always has to be 0
+        """
+        result, node = self.wf_args_with_default.run_get_node()
+        self.assertEquals(node.finish_status, 0)
+        self.assertEquals(node.is_finished_ok, True)
+        self.assertEquals(node.is_failed, False)
+
+    def test_launchers(self):
+        """
+        Verify that the various launchers are working
+        """
+        result = run(self.wf_return_true)
+        self.assertTrue(result)
+
+        result, node = run_get_node(self.wf_return_true)
+        self.assertTrue(result)
         self.assertEqual(result, get_true_node())
-        self.assertIsInstance(calc_node, aiida.orm.Calculation)
+        self.assertTrue(isinstance(node, FunctionCalculation))
 
-    def test_single_return_value(self):
-        result = single_return_value()
-        self.assertIsInstance(result, aiida.orm.Data)
-        self.assertEqual(result, get_true_node())
+        with self.assertRaises(AssertionError):
+            submit(self.wf_return_true)
 
     def test_simple_workflow(self):
         @workfunction
@@ -82,41 +247,14 @@ class TestWf(AiidaTestCase):
 
         result = add_mul_wf(Int(3), Int(4), Int(5))
 
-    def test_finish_status(self):
-        """
-        If a workfunction reaches the FINISHED process state, it has to have been successful
-        which means that the finish status always has to be 0
-        """
-        result, calculation = single_return_value.run_get_node()
-        self.assertEquals(calculation.finish_status, 0)
-        self.assertEquals(calculation.is_finished_ok, True)
-        self.assertEquals(calculation.is_failed, False)
-
-    def test_label_description(self):
-        label = 'Test label'
-        description = 'Test description'
-
-        result, node = simple_wf.run_get_node(label=label, description=description)
-        self.assertEqual(node.label, label)
-        self.assertEqual(node.description, description)
-
-        result = simple_wf(label=label, description=description)
-        node = result['result'].get_inputs()[0]
-        self.assertEqual(node.label, label)
-        self.assertEqual(node.description, description)
-
-    def test_override_label_default(self):
-        result, node = set_label_default.run_get_node()
-        self.assertEqual(node.label, DEFAULT_LABEL)
-
     def test_hashes(self):
-        result, w1 = run_get_node(return_input, inp=Int(2))
-        result, w2 = run_get_node(return_input, inp=Int(2))
+        result, w1 = self.wf_return_input.run_get_node(inp=Int(2))
+        result, w2 = self.wf_return_input.run_get_node(inp=Int(2))
         self.assertEqual(w1.get_hash(), w2.get_hash())
 
     def test_hashes_different(self):
-        result, w1 = run_get_node(return_input, inp=Int(2))
-        result, w2 = run_get_node(return_input, inp=Int(3))
+        result, w1 = self.wf_return_input.run_get_node(inp=Int(2))
+        result, w2 = self.wf_return_input.run_get_node(inp=Int(3))
         self.assertNotEqual(w1.get_hash(), w2.get_hash())
 
     def _check_hash_consistent(self, pid):

--- a/aiida/work/ports.py
+++ b/aiida/work/ports.py
@@ -20,6 +20,17 @@ class WithNonDb(object):
     def non_db(self):
         return self._non_db
 
+    def get_description(self):
+        """
+        Return a description of the InputPort, which will be a dictionary of its attributes
+
+        :returns: a dictionary of the stringified InputPort attributes
+        """
+        description = super(WithNonDb, self).get_description()
+        description['non_db'] = '{}'.format(self.non_db)
+
+        return description
+
 
 class InputPort(WithNonDb, ports.InputPort):
     pass

--- a/aiida/work/processes.py
+++ b/aiida/work/processes.py
@@ -393,11 +393,11 @@ class Process(plumpy.Process):
         self._add_description_and_label()
 
     def _add_description_and_label(self):
-        if self.raw_inputs:
-            description = self.raw_inputs.get('description', None)
+        if self.inputs:
+            description = self.inputs.get('description', None)
             if description is not None:
                 self._calc.description = description
-            label = self.raw_inputs.get('label', None)
+            label = self.inputs.get('label', None)
             if label is not None:
                 self._calc.label = label
 
@@ -590,15 +590,23 @@ class FunctionProcess(Process):
                 default = ()
                 if i >= first_default_pos:
                     default = defaults[i - first_default_pos]
-                spec.input(args[i], valid_type=Data, default=default)
+
+                if spec.has_input(args[i]):
+                    spec.inputs[args[i]].default = default
+                else:
+                    spec.input(args[i], valid_type=Data, default=default)
+
                 # Make sure to get rid of the argument from the keywords dict
                 kwargs.pop(args[i], None)
 
+            # Add new ports for keyword arguments if and only if they do not already exist
             for k, v in kwargs.iteritems():
-                spec.input(k)
+                if spec.has_input(k):
+                    spec.inputs[k].default = v
+                else:
+                    spec.input(k)
 
-            # If the function support kwargs then allow dynamic inputs,
-            # otherwise disallow
+            # If the function support kwargs then allow dynamic inputs, otherwise disallow
             if keywords is not None:
                 spec.inputs.dynamic = True
             else:

--- a/aiida/work/workfunctions.py
+++ b/aiida/work/workfunctions.py
@@ -35,21 +35,30 @@ def workfunction(func, calc_node_class=None):
     >>> print(r)
     9
     >>> r.get_inputs_dict() # doctest: +SKIP
-    {u'_return': <WorkCalculation: uuid: ce0c63b3-1c84-4bb8-ba64-7b70a36adf34 (pk: 3567)>}
-    >>> r.get_inputs_dict()['_return'].get_inputs()
+    {u'return': <FunctionCalculation: uuid: ce0c63b3-1c84-4bb8-ba64-7b70a36adf34 (pk: 3567)>}
+    >>> r.get_inputs_dict()['return'].get_inputs()
     [4, 5]
 
     """
+    # Build the Process class with its ProcessSpec representing this function
+    process_class = processes.FunctionProcess.build(func, calc_node_class=calc_node_class)
 
     def run_get_node(*args, **kwargs):
-        # Build up the Process representing this function
-        wf_class = processes.FunctionProcess.build(func, calc_node_class=calc_node_class, **kwargs)
-        inputs = wf_class.create_inputs(*args, **kwargs)
         # Have to create a new runner for the workfunction instead of using
         # the global because otherwise a workfunction that calls another from
         # within its scope would be blocking the event loop
         runner = runners.Runner(rmq_config=None, rmq_submit=False, enable_persistence=False)
-        proc = wf_class(inputs=inputs, runner=runner)
+        inputs = process_class.create_inputs(*args, **kwargs)
+
+        # Remove all the known inputs from the kwargs
+        for port in process_class.spec().inputs:
+            kwargs.pop(port, None)
+
+        # If any kwargs remain, the spec should be dynamic, so we raise if it isn't
+        if kwargs and not process_class.spec().inputs.dynamic:
+            raise ValueError('{} does not support keyword arguments'.format(func.__name__))
+
+        proc = process_class(inputs=inputs, runner=runner)
         return proc.execute(), proc.calc
 
     @functools.wraps(func)
@@ -57,11 +66,10 @@ def workfunction(func, calc_node_class=None):
         """
         This wrapper function is the actual function that is called.
         """
-        proc, node = run_get_node(*args, **kwargs)
-        return proc
+        result, node = run_get_node(*args, **kwargs)
+        return result
 
     wrapped_function.run_get_node = run_get_node
-
     wrapped_function._original = func
     wrapped_function._is_workfunction = True
 

--- a/docs/source/install/details/os.rst
+++ b/docs/source/install/details/os.rst
@@ -40,7 +40,7 @@ Mac OS X
 For Mac OS it is adviced to use the `Homebrew`_ package manager.
 If you have not installed Homebrew yet, you can do so with the following command:
 
-.. code-block bash::
+.. code-block:: bash
 
     /usr/bin/ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
 
@@ -48,20 +48,20 @@ If you have not installed Homebrew yet, you can do so with the following command
 
 After you have installed Homebrew, you can install the basic requirements as follows:
 
-.. code-block bash::
+.. code-block:: bash
 
     brew install git python postgresql
 
 To start the `postgres` database server, execute:
 
-.. code-block bash::
+.. code-block:: bash
 
     pg_ctl -D /usr/local/var/postgres start
 
 For a more detailed description of database requirements and usage see the :ref:`database<database>` section.
 Installing the RabbitMQ message broke through Homebrew is as easy as:
 
-.. code-block bash::
+.. code-block:: bash
 
     brew install rabbitmq
 


### PR DESCRIPTION
Fixes #1494 

The `FunctionProcess` inherits the `ProcessSpec` from `Process` which already
defines some input ports such as `label` and `description`. In the build
method of the `FunctionProcess` it creates additional ports dynamically
based on the passed args and kwargs of the function. These were overriding
any existing ports with default parameters. For the case of the `label`
and `description` ports, overriding with the defaults, meant losing the
correct `valid_type` and `non_db` attribute values. This in turn caused
setting the `label` and `description` for a workfunction to except during
the creation of the database record.