### PR TITLE
Ensure that getters of ProcessBuilder return actual values

### DIFF
--- a/aiida/backends/tests/work/test_process_builder.py
+++ b/aiida/backends/tests/work/test_process_builder.py
@@ -18,13 +18,17 @@ from aiida.work.process_builder import ProcessBuilder
 from aiida.work.workchain import WorkChain
 from aiida.work import utils
 
+DEFAULT_INT = 256
+
+
 class TestWorkChain(WorkChain):
     @classmethod
     def define(cls, spec):
         super(TestWorkChain, cls).define(spec)
-        spec.input('a', valid_type=Int)
-        spec.input('b', valid_type=Float)
-        spec.input('c.d', valid_type=Bool)
+        spec.input('a', valid_type=Int, help='A pointless integer')
+        spec.input('b', valid_type=Float, help='A pointless float')
+        spec.input('c.d', valid_type=Bool, help='A pointless boolean')
+        spec.input('e', valid_type=Int, default=Int(DEFAULT_INT))
 
 
 class TestProcessBuilder(AiidaTestCase):
@@ -60,20 +64,49 @@ class TestProcessBuilder(AiidaTestCase):
         self.assertEquals(self.builder.label, label)
         self.assertEquals(self.builder.description, description)
 
-    def test_test_workchain(self):
+    def test_workchain(self):
         """
-        Verify that the attributes of the TestWorkChain can be set.
+        Verify that the attributes of the TestWorkChain can be set but defaults are not there
         """
         builder = TestWorkChain.get_builder()
         builder.a = Int(2)
         builder.b = Float(2.3)
         builder.c.d = Bool(True)
-        self.assertEquals(builder._todict(), {'a': Int(2), 'b': Float(2.3), 'c': {'d': Bool(True)}})
+        self.assertEquals(builder, {'a': Int(2), 'b': Float(2.3), 'c': {'d': Bool(True)}})
 
     def test_invalid_setattr_raises(self):
         """
-        Verify that __setattr__ cannot be called on a ProcessBuilderInput.
+        Verify that __setattr__ cannot be called on a terminal Port
         """
         builder = TestWorkChain.get_builder()
         with self.assertRaises(AttributeError):
             builder.a.b = 3
+
+    def test_dynamic_getters_value(self):
+        """
+        Verify that getters will return the actual value
+        """
+        builder = TestWorkChain.get_builder()
+        builder.a = Int(2)
+        builder.b = Float(2.3)
+        builder.c.d = Bool(True)
+
+        # Verify that the correct type is returned by the getter
+        self.assertTrue(isinstance(builder.a, Int))
+        self.assertTrue(isinstance(builder.b, Float))
+        self.assertTrue(isinstance(builder.c.d, Bool))
+
+        # Verify that the correct value is returned by the getter
+        self.assertEquals(builder.a, Int(2))
+        self.assertEquals(builder.b, Float(2.3))
+        self.assertEquals(builder.c.d, Bool(True))
+
+    def test_dynamic_getters_doc_string(self):
+        """
+        Verify that getters have the correct docstring
+        """
+        builder = TestWorkChain.get_builder()
+        self.assertEquals(builder.__class__.a.__doc__, str(TestWorkChain.spec().inputs['a']))
+        self.assertEquals(builder.__class__.b.__doc__, str(TestWorkChain.spec().inputs['b']))
+        self.assertEquals(builder.__class__.c.__doc__, str(TestWorkChain.spec().inputs['c']))
+        self.assertEquals(builder.c.__class__.d.__doc__, str(TestWorkChain.spec().inputs['c']['d']))

--- a/aiida/work/runners.py
+++ b/aiida/work/runners.py
@@ -165,7 +165,7 @@ class Runner(object):
         if isinstance(process, ProcessBuilder):
             builder = process
             process_class = builder._process_class
-            inputs.update(builder._todict())
+            inputs.update(**builder)
         elif issubclass(process, JobCalculation):
             process_class = process.process()
         elif issubclass(process, Process):


### PR DESCRIPTION
Fixes #1495 

The old solution returned an instance of `ProcessBuilderDictionaryInput`
which means that simple things like value comparisons were broken. The
user would always expect to get the actual value that is stored under
the attribute and not some proxy. To solve this problem while still
maintaining the dynamic creation of doc strings and support for the
nested `PortNamespace`, we turn the `ProcessBuilderInputDict` into a
simple `ProcessBuilderNamespace` that is essentially a mapping. Upon
instantiating it will dynamically create the getter and setter properties
based on the ports of the process spec of the process.