### PR TITLE
Issue 1079 bash login shell

### DIFF
--- a/.travis-data/code-setup-input.txt
+++ b/.travis-data/code-setup-input.txt
@@ -3,6 +3,6 @@ simple script that doubles a number and sleeps for a given number of seconds
 False
 simpleplugins.templatereplacer
 torquessh
-/usr/local/bin/doubler.sh
+/usr/local/bin/d"o'ub ler.sh
 
 

--- a/.travis-data/torquessh-doubler/Dockerfile
+++ b/.travis-data/torquessh-doubler/Dockerfile
@@ -4,7 +4,7 @@ MAINTAINER AiiDA Team <info@aiida.net>
 # Use baseimage-docker's init system.
 CMD ["/sbin/my_init"]
 
-# Install required packages
 COPY doubler.sh /usr/local/bin/
 
-
+# Use messed-up filename to test quoting robustness
+RUN mv /usr/local/bin/doubler.sh /usr/local/bin/d\"o\'ub\ ler.sh

--- a/.travis-data/torquessh-doubler/README.md
+++ b/.travis-data/torquessh-doubler/README.md
@@ -3,3 +3,8 @@
 This folder contains an example of an extension of the torquessh-base image,
 where we add a very basic script to double a number.
 This is meant to be a very lightweight 'code' to test daemon functionality.
+
+# Notes
+
+Inside the docker image, we use a filename including single quotes, double
+quotes and spaces in order to test the robustness of AiiDA's escaping routines.


### PR DESCRIPTION
fixes #1079 , helps with https://github.com/marvel-nccr/quantum-mobile/issues/66

use login shell to execute all remote SSH commands

This has the advantage that all commands will be executed in the same
environment as seen by a user loggin in onto the machine
(e.g. on most UNIX systems, .profile will be sourced for login shells,
while it won't be sourced for non-login shells).

Additionally, calling `bash -l -c '<cmd>'` instead of `<cmd>`
means that the bash shell will be used, independent of the default
shell on the system.
This is advantageous on systems, where bash is not the default shell
(since our remote commands work only in bash).

Also
* rename doubler code: adding a space, single quote and double quote to check robustness of escaping mechanism in AiiDA