### PR TITLE
Added back the last daemon status update

### DIFF
--- a/aiida/daemon/timestamps.py
+++ b/aiida/daemon/timestamps.py
@@ -12,7 +12,6 @@ from pytz import UTC
 from aiida.backends import settings
 from aiida.backends.profile import BACKEND_DJANGO, BACKEND_SQLA
 
-
 if settings.BACKEND == BACKEND_DJANGO:
     from aiida.backends.djsite.globalsettings import set_global_setting, get_global_setting
 elif settings.BACKEND == BACKEND_SQLA:
@@ -20,12 +19,11 @@ elif settings.BACKEND == BACKEND_SQLA:
 else:
     raise Exception("Unkown backend {}".format(settings.BACKEND))
 
-
 celery_tasks = {
-        'submitter': 'submitter',
-        'updater': 'updater',
-        'retriever': 'retriever',
-        'workflow': 'workflow_stepper',
+    'submitter': 'submitter',
+    'updater': 'updater',
+    'retriever': 'retriever',
+    'workflow': 'workflow_stepper',
 }
 
 
@@ -102,17 +100,17 @@ def set_daemon_timestamp(task_name, when):
                          "celery_tasks dictionary")
 
     set_global_setting(
-            'daemon|task_{}|{}'.format(when, actual_task_name),
-            timezone.datetime.now(tz=UTC),
-            description=(
-                    "The last time the daemon {} to run the "
-                    "task '{}' ({})"
-                    "".format(
-                            verb,
-                            task_name,
-                            actual_task_name
-                    )
+        'daemon|task_{}|{}'.format(when, actual_task_name),
+        timezone.datetime.now(tz=UTC),
+        description=(
+            "The last time the daemon {} to run the "
+            "task '{}' ({})"
+            "".format(
+                verb,
+                task_name,
+                actual_task_name
             )
+        )
     )
 
 
@@ -137,8 +135,6 @@ def get_last_daemon_timestamp(task_name, when='stop'):
                          "celery_tasks dictionary".format(task_name))
 
     try:
-        return get_global_setting('daemon|task_{}|{}'.format(when,
-                                                             actual_task_name))
+        return get_global_setting('daemon|task_{}|{}'.format(when, actual_task_name))
     except KeyError:  # No such global setting found
         return None
-

--- a/aiida/orm/backend.py
+++ b/aiida/orm/backend.py
@@ -44,7 +44,7 @@ def construct_backend(backend_type=None):
 
 class Backend(object):
     """
-    The public interface that defines a backend factory that creates backend
+    The public interface that defines a backend factory that creates backendQ
     specific concrete objects.
     """
     __metaclass__ = ABCMeta

--- a/aiida/work/job_processes.py
+++ b/aiida/work/job_processes.py
@@ -12,7 +12,6 @@ import sys
 import tempfile
 import tornado.gen
 from voluptuous import Any
-from functools import partial
 
 import plumpy
 from plumpy.ports import PortNamespace
@@ -21,6 +20,7 @@ from aiida.common.exceptions import (InvalidOperation, RemoteOperationError)
 from aiida.common import exceptions
 from aiida.common.lang import override
 from aiida.daemon import execmanager
+from aiida.daemon.timestamps import set_daemon_timestamp
 from aiida.orm.calculation.job import JobCalculation
 from aiida.orm.calculation.job import JobCalculationFinishStatus
 from aiida.scheduler.datastructures import job_states
@@ -425,6 +425,10 @@ class JobProcess(processes.Process):
     @override
     def get_or_create_db_record(self):
         return self._calc_class()
+
+    def on_entered(self, from_state):
+        super(JobProcess, self).on_entered(from_state)
+        set_daemon_timestamp('updater', 'stop')
 
     @override
     def _setup_db_record(self):


### PR DESCRIPTION
Fixes #1501 

This was no longer changing in verdi calculation list because the old
daemon has been replaced by an event based daemon.

To give some of this functionality back we now set the global settings
timestamp every time a job calculation saves a checkpoint.  Note, there
is a consequences of this that may appear to be surprising:

The 'daemon' timestamp will be updated even if the JobProcess is ran
in the local interpreter.

I feel this is acceptable but if we feel it is misleading perhaps we can
change the string printed to better reflect what this timestamp means.