### PR TITLE
Fix bug that circumvented check whether the daemon is running

### DIFF
--- a/aiida/cmdline/utils/decorators.py
+++ b/aiida/cmdline/utils/decorators.py
@@ -115,7 +115,7 @@ def only_if_daemon_pid(function):
 
         daemon_client = DaemonClient()
 
-        if not daemon_client.get_daemon_pid:
+        if not daemon_client.get_daemon_pid():
             click.echo('The daemon is not running')
             sys.exit(0)
 


### PR DESCRIPTION
Fixes #1484 

The bug was in the decorator `only_if_daemon_pid` because the property
`get_daemon_pid` was changed to a method in a previous commit. As a result
the conditional was never hit and some commands that depended on the daemon
running such as `incr`, `decr` and `restart` were executing even if the
daemon was not running.