### PR TITLE
Remove old daemon timestamps and replace with process state change

### DIFF
--- a/aiida/backends/djsite/globalsettings.py
+++ b/aiida/backends/djsite/globalsettings.py
@@ -11,22 +11,24 @@
 Functions to manage the global settings stored in the DB (in the DbSettings
 table.
 """
-
+from django.db import IntegrityError
+from aiida.common.exceptions import UniquenessError
 
 
 def set_global_setting(key, value, description=None):
     """
-    Set a global setting in the DbSetting table (therefore, stored at the DB
-    level).
+    Set a global setting in the DbSetting table (therefore, stored at the DB level).
     """
     from aiida.backends.djsite.db.models import DbSetting
 
     # Before storing, validate the key
     DbSetting.validate_key(key)
 
-    # This also saves in the DB    
-    DbSetting.set_value(key, value,
-                        other_attribs={"description": description})
+    # This also saves in the DB
+    try:
+        DbSetting.set_value(key, value, other_attribs={"description": description})
+    except IntegrityError as exception:
+        raise UniquenessError(exception)
 
 
 def del_global_setting(key):

--- a/aiida/backends/utils.py
+++ b/aiida/backends/utils.py
@@ -168,18 +168,18 @@ def get_global_setting(key):
         from aiida.backends.sqlalchemy.globalsettings import get_global_setting
     else:
         raise Exception("unknown backend {}".format(settings.BACKEND))
+
     return get_global_setting(key)
 
 
 def get_global_setting_description(key):
     if settings.BACKEND == BACKEND_DJANGO:
-        from aiida.backends.djsite.globalsettings import (
-            get_global_setting_description)
+        from aiida.backends.djsite.globalsettings import get_global_setting_description
     elif settings.BACKEND == BACKEND_SQLA:
-        from aiida.backends.sqlalchemy.globalsettings import (
-            get_global_setting_description)
+        from aiida.backends.sqlalchemy.globalsettings import get_global_setting_description
     else:
         raise Exception("unknown backend {}".format(settings.BACKEND))
+
     return get_global_setting_description(key)
 
 

--- a/aiida/cmdline/commands/calculation.py
+++ b/aiida/cmdline/commands/calculation.py
@@ -201,6 +201,9 @@ class Calculation(VerdiCommandWithSubcommands):
                             default=get_property('verdishell.calculation_list'),
                             help="Define the list of properties to show"
                         )
+        parser.add_argument('-r', '--raw', dest='raw', action='store_true',
+            help='Only print the query result, without any headers, footers or other additional information'
+        )
 
         args = list(args)
         parsed_args = parser.parse_args(args)
@@ -238,14 +241,15 @@ class Calculation(VerdiCommandWithSubcommands):
             group=parsed_args.group,
             group_pk=parsed_args.group_pk,
             relative_ctime=parsed_args.relative_ctime,
-            # with_scheduler_state=parsed_args.with_scheduler_state,
             order_by=parsed_args.order_by,
             limit=parsed_args.limit,
             filters=filters,
             projections=parsed_args.project,
+            raw=parsed_args.raw,
         )
 
-        print_last_process_state_change(process_type='calculation')
+        if not parsed_args.raw:
+            print_last_process_state_change(process_type='calculation')
 
 
     def calculation_res(self, *args):

--- a/aiida/cmdline/commands/calculation.py
+++ b/aiida/cmdline/commands/calculation.py
@@ -136,7 +136,7 @@ class Calculation(VerdiCommandWithSubcommands):
             load_dbenv()
 
         import argparse
-        from aiida.cmdline.utils.daemon import print_last_process_state_change
+        from aiida.cmdline.utils.common import print_last_process_state_change
         from aiida.common.datastructures import calc_states
         from aiida.common.setup import get_property
         from aiida.orm.calculation.job import JobCalculation as C

--- a/aiida/cmdline/commands/calculation.py
+++ b/aiida/cmdline/commands/calculation.py
@@ -135,11 +135,11 @@ class Calculation(VerdiCommandWithSubcommands):
         if not is_dbenv_loaded():
             load_dbenv()
 
-        from aiida.common.datastructures import calc_states
-
         import argparse
-        from aiida.orm.calculation.job import JobCalculation as C
+        from aiida.cmdline.utils.daemon import print_last_process_state_change
+        from aiida.common.datastructures import calc_states
         from aiida.common.setup import get_property
+        from aiida.orm.calculation.job import JobCalculation as C
 
         parser = argparse.ArgumentParser(
             prog=self.get_full_command_name(),
@@ -244,6 +244,9 @@ class Calculation(VerdiCommandWithSubcommands):
             filters=filters,
             projections=parsed_args.project,
         )
+
+        print_last_process_state_change(process_type='calculation')
+
 
     def calculation_res(self, *args):
         """

--- a/aiida/cmdline/commands/work.py
+++ b/aiida/cmdline/commands/work.py
@@ -102,7 +102,7 @@ def do_list(past_days, all_states, process_state, finish_status, failed, limit, 
     if not is_dbenv_loaded():
         load_dbenv()
 
-    from aiida.cmdline.utils.daemon import print_last_process_state_change
+    from aiida.cmdline.utils.common import print_last_process_state_change
     from aiida.common.utils import str_timedelta
     from aiida.orm.mixins import Sealable
     from aiida.orm.calculation import Calculation

--- a/aiida/cmdline/commands/work.py
+++ b/aiida/cmdline/commands/work.py
@@ -98,6 +98,7 @@ def do_list(past_days, all_states, process_state, finish_status, failed, limit, 
     if not is_dbenv_loaded():
         load_dbenv()
 
+    from aiida.cmdline.utils.daemon import print_last_process_state_change
     from aiida.common.utils import str_timedelta
     from aiida.orm.mixins import Sealable
     from aiida.orm.calculation import Calculation
@@ -198,6 +199,8 @@ def do_list(past_days, all_states, process_state, finish_status, failed, limit, 
 
     click.echo(tabulated)
     click.echo('\nTotal results: {}\n'.format(len(table)))
+
+    print_last_process_state_change(process_type='work')
 
 
 @work.command('report', context_settings=CONTEXT_SETTINGS)

--- a/aiida/cmdline/commands/work.py
+++ b/aiida/cmdline/commands/work.py
@@ -90,7 +90,11 @@ class Work(VerdiCommandWithSubcommands):
     '-P', '--project', type=click.Choice(LIST_CMDLINE_PROJECT_CHOICES), default=LIST_CMDLINE_PROJECT_DEFAULT,
     multiple=True, help='Define the list of properties to show'
 )
-def do_list(past_days, all_states, process_state, finish_status, failed, limit, project):
+@click.option(
+    '-r', '--raw', is_flag=True,
+    help='Only print the query result, without any headers, footers or other additional information'
+)
+def do_list(past_days, all_states, process_state, finish_status, failed, limit, project, raw):
     """
     Return a list of work calculations that are still running
     """
@@ -195,12 +199,15 @@ def do_list(past_days, all_states, process_state, finish_status, failed, limit, 
     # Since we sorted by descending creation time, we revert the list to print the most recent entries last
     projection_labels = list(map(lambda p: projection_label_map[p], project))
     table = table[::-1]
-    tabulated = tabulate(table, headers=projection_labels)
 
-    click.echo(tabulated)
-    click.echo('\nTotal results: {}\n'.format(len(table)))
-
-    print_last_process_state_change(process_type='work')
+    if raw:
+        tabulated = tabulate(table, tablefmt='plain')
+        click.echo(tabulated)
+    else:
+        tabulated = tabulate(table, headers=projection_labels)
+        click.echo(tabulated)
+        click.echo('\nTotal results: {}\n'.format(len(table)))
+        print_last_process_state_change(process_type='work')
 
 
 @work.command('report', context_settings=CONTEXT_SETTINGS)

--- a/aiida/cmdline/utils/daemon.py
+++ b/aiida/cmdline/utils/daemon.py
@@ -74,30 +74,3 @@ def get_daemon_status(client):
                 'Use verdi daemon [incr | decr] [num] to increase / decrease the amount of workers')
 
     return template.format(**info)
-
-
-def print_last_process_state_change(process_type='calculation'):
-    """
-    Print the last time that a process of the specified type has changed its state.
-    This function will also print a warning if the daemon is not running.
-
-    :param process_type: the process type for which to get the latest state change timestamp.
-        Valid process types are either 'calculation' or 'work'.
-    """
-    from aiida.cmdline.utils.echo import echo_info, echo_warning
-    from aiida.daemon.client import DaemonClient
-    from aiida.utils import timezone
-    from aiida.common.utils import str_timedelta
-    from aiida.work.utils import get_process_state_change_timestamp
-
-    client = DaemonClient()
-
-    timestamp = get_process_state_change_timestamp(process_type)
-    timedelta = timezone.delta(timestamp, timezone.now())
-    formatted = timezone.localtime(timestamp).strftime('at %H:%M:%S on %Y-%m-%d')
-    relative = str_timedelta(timedelta, negative_to_zero=True, max_num_fields=1)
-
-    echo_info('last time an entry changed state: {} ({})'.format(relative, formatted))
-
-    if not client.is_daemon_running:
-        echo_warning('the daemon is not running', bold=True)

--- a/aiida/cmdline/utils/echo.py
+++ b/aiida/cmdline/utils/echo.py
@@ -1,0 +1,35 @@
+# -*- coding: utf-8 -*-
+import click
+
+
+def echo_info(message, bold=False):
+    """
+    Print an info message through click's echo function to stdout, prefixed with 'Info:'
+
+    :param message: the string representing the message to print
+    :param bold: whether to print the message in bold
+    """
+    click.secho('Info: ', fg='blue', bold=True, nl=False)
+    click.secho(message, bold=bold)
+
+
+def echo_warning(message, bold=False):
+    """
+    Print a warning message through click's echo function to stdout, prefixed with 'Warning:'
+
+    :param message: the string representing the message to print
+    :param bold: whether to print the message in bold
+    """
+    click.secho('Warning: ', fg='yellow', bold=True, nl=False)
+    click.secho(message, bold=bold)
+
+
+def echo_error(message, bold=False):
+    """
+    Print an error message through click's echo function to stdout, prefixed with 'Error:'
+
+    :param message: the string representing the message to print
+    :param bold: whether to print the message in bold
+    """
+    click.secho('Error: ', fg='red', bold=True, nl=False)
+    click.secho(message, bold=bold)

--- a/aiida/daemon/runner.py
+++ b/aiida/daemon/runner.py
@@ -70,25 +70,25 @@ def legacy_workflow_stepper():
     Function to tick the legacy workflows
     """
     from datetime import timedelta
-    from aiida.daemon.timestamps import set_daemon_timestamp, get_last_daemon_timestamp
+    from aiida.daemon.timestamps import set_timestamp_workflow_stepper, get_timestamp_workflow_stepper
     from aiida.daemon.workflowmanager import execute_steps
 
     logger.debug('Checking for workflows to manage')
     # RUDIMENTARY way to check if this task is already running (to avoid acting
     # again and again on the same workflow steps)
     try:
-        stepper_is_running = (get_last_daemon_timestamp('workflow', when='stop')
-                              - get_last_daemon_timestamp('workflow', when='start')) <= timedelta(0)
+        stepper_is_running = (get_timestamp_workflow_stepper(when='stop')
+                              - get_timestamp_workflow_stepper(when='start')) <= timedelta(0)
     except TypeError:
         # When some timestamps are None (undefined)
-        stepper_is_running = (get_last_daemon_timestamp('workflow', when='stop')
-                              is None and get_last_daemon_timestamp('workflow', when='start') is not None)
+        stepper_is_running = (get_timestamp_workflow_stepper(when='stop')
+                              is None and get_timestamp_workflow_stepper(when='start') is not None)
 
     if not stepper_is_running:
-        set_daemon_timestamp(task_name='workflow', when='start')
         # The previous wf manager stopped already -> we can run a new one
+        set_timestamp_workflow_stepper(when='start')
         logger.debug('Running execute_steps')
         execute_steps()
-        set_daemon_timestamp(task_name='workflow', when='stop')
+        set_timestamp_workflow_stepper(when='stop')
     else:
         logger.debug('Execute_steps already running')

--- a/aiida/daemon/timestamps.py
+++ b/aiida/daemon/timestamps.py
@@ -7,86 +7,17 @@
 # For further information on the license, see the LICENSE.txt file        #
 # For further information please visit http://www.aiida.net               #
 ###########################################################################
-from pytz import UTC
-
-from aiida.backends import settings
-from aiida.backends.profile import BACKEND_DJANGO, BACKEND_SQLA
+from aiida.backends.utils import set_global_setting, get_global_setting
+from aiida.utils import timezone
 
 
-if settings.BACKEND == BACKEND_DJANGO:
-    from aiida.backends.djsite.globalsettings import set_global_setting, get_global_setting
-elif settings.BACKEND == BACKEND_SQLA:
-    from aiida.backends.sqlalchemy.globalsettings import set_global_setting, get_global_setting
-else:
-    raise Exception("Unkown backend {}".format(settings.BACKEND))
-
-
-celery_tasks = {
-        'submitter': 'submitter',
-        'updater': 'updater',
-        'retriever': 'retriever',
-        'workflow': 'workflow_stepper',
-}
-
-
-def get_most_recent_daemon_timestamp():
+def set_timestamp_workflow_stepper(when):
     """
-    Try to detect any last timestamp left by the daemon, for instance
-    to get a hint on whether the daemon is running or not.
+    Store the current timestamp in the DbSettings for the workflow_stepper task
 
-    :return:  a datetime.datetime object with the most recent time.
-      Return None if no information is found in the DB.
+    :param when: can either be 'start' or 'stop', to set when the task started or stopped
     """
-    import datetime
-    # I go low-level here
-    if settings.BACKEND == BACKEND_DJANGO:
-        from aiida.backends.djsite.db.models import DbSetting
-        daemon_timestamps = DbSetting.objects.filter(key__startswith='daemon|task_')
-        timestamps = []
-        for timestamp_setting in daemon_timestamps:
-            timestamp = timestamp_setting.getvalue()
-            if isinstance(timestamp, datetime.datetime):
-                timestamps.append(timestamp)
-
-        if timestamps:
-            # The most recent timestamp
-
-            return max(timestamps)
-        else:
-            return None
-
-    elif settings.BACKEND == BACKEND_SQLA:
-        from aiida.backends.sqlalchemy.models.settings import DbSetting
-        from aiida.backends.sqlalchemy import get_scoped_session
-        session = get_scoped_session()
-
-        from sqlalchemy import func
-        from pytz import utc
-        from sqlalchemy.dialects.postgresql import TIMESTAMP
-
-        maxtimestamp, = session.query(
-            func.max(DbSetting.val[()].cast(TIMESTAMP))).filter(
-            DbSetting.key.like("daemon|task%")).first()
-
-        if maxtimestamp is None:
-            return None
-        else:
-            return utc.localize(maxtimestamp)
-
-
-def set_daemon_timestamp(task_name, when):
-    """
-    Set in the DB the current time associated with the given task;
-    this is used to store a timestamp to know when the daemon run for the last
-    time.
-
-    :param task_name: the task for which we want to set the timestamp
-      It has to be one of the keys of the
-      ``aiida.backends.djsite.settings.settings.djcelery_tasks`` dictionary.
-    :param when: can either be 'start' (to call when the task started) or
-      'stop' (to call when the task ended)
-    """
-    from aiida.utils import timezone
+    task = 'workflow_stepper'
 
     if when == 'start':
         verb = 'started'
@@ -95,50 +26,24 @@ def set_daemon_timestamp(task_name, when):
     else:
         raise ValueError("the 'when' parameter can only be 'start' or 'stop'")
 
-    try:
-        actual_task_name = celery_tasks[task_name]
-    except KeyError:
-        raise ValueError("Unknown value for 'task_name', not found in the "
-                         "celery_tasks dictionary")
-
     set_global_setting(
-            'daemon|task_{}|{}'.format(when, actual_task_name),
-            timezone.datetime.now(tz=UTC),
-            description=(
-                    "The last time the daemon {} to run the "
-                    "task '{}' ({})"
-                    "".format(
-                            verb,
-                            task_name,
-                            actual_task_name
-                    )
-            )
+        'daemon|task_{}|{}'.format(when, task), timezone.datetime.now(),
+        description=(
+            "The last time the daemon {} to run the task '{}'".format(verb, task)
+        )
     )
 
 
-def get_last_daemon_timestamp(task_name, when='stop'):
+def get_timestamp_workflow_stepper(when='stop'):
     """
-    Return the last time stored in the DB that the daemon executed the given
-    task.
+    Return the timestamp stored in the DbSettings table for the workflow_stepper task
 
-    :param task_name: the task for which we want the information.
-      It has to be one of the keys of the
-      ``celery_tasks`` dictionary.
-    :param when: can either be 'start' (to know when the task started) or
-      'stop' (to know when the task ended)
-
-    :return: a datetime.datetime object. Return None if no information is
-      found in the DB.
+    :param when: can either be 'start' or 'stop', to get when the task started or stopped
+    :return: a datetime.datetime object. Return None if no information is found in the DB.
     """
+    task = 'workflow_stepper'
+
     try:
-        actual_task_name = celery_tasks[task_name]
+        return get_global_setting('daemon|task_{}|{}'.format(when, task))
     except KeyError:
-        raise ValueError("Unknown value for '{}', not found in the "
-                         "celery_tasks dictionary".format(task_name))
-
-    try:
-        return get_global_setting('daemon|task_{}|{}'.format(when,
-                                                             actual_task_name))
-    except KeyError:  # No such global setting found
         return None
-

--- a/aiida/orm/implementation/general/calculation/job/__init__.py
+++ b/aiida/orm/implementation/general/calculation/job/__init__.py
@@ -1018,8 +1018,6 @@ class AbstractJobCalculation(AbstractCalculation):
             assert isinstance(limit, int), \
                 "Limit (set to {}) has to be an integer or None".format(limit)
 
-        print(cls._get_last_daemon_check_string(now))
-
         if filters is None:
             calculation_filters = {}
         else:
@@ -1119,46 +1117,6 @@ class AbstractJobCalculation(AbstractCalculation):
                 break
 
         print("\nTotal results: {}\n".format(counter))
-
-    @classmethod
-    def _get_last_daemon_check_string(cls, since):
-        """
-        Get a string showing the how long it has been since the daemon was
-        last ticked relative to a particular timepoint.
-
-        :param since: The timepoint to get the last check time since.
-        :return: A string indicating the elapsed period, or an information
-          message.
-        """
-        from aiida.daemon.timestamps import get_last_daemon_timestamp
-
-        # get the last daemon check:
-        try:
-            last_daemon_check = \
-                get_last_daemon_timestamp('updater', when='stop')
-        except ValueError:
-            last_check_string = (
-                "# Last daemon state_updater check: "
-                "(Error while retrieving the information)"
-            )
-        else:
-            if last_daemon_check is None:
-                last_check_string = "# Last daemon state_updater check: (Never)"
-            else:
-                last_check_string = (
-                    "# Last daemon state_updater check: "
-                    "{} ({})".format(
-                        str_timedelta(
-                            timezone.delta(last_daemon_check, since),
-                            negative_to_zero=True
-                        ),
-                        timezone.localtime(
-                            last_daemon_check
-                        ).strftime("at %H:%M:%S on %Y-%m-%d")
-                    )
-                )
-
-        return last_check_string
 
     @classmethod
     def _get_calculation_info_row(cls, res, projections, times_since=None):

--- a/aiida/orm/implementation/general/calculation/job/__init__.py
+++ b/aiida/orm/implementation/general/calculation/job/__init__.py
@@ -943,7 +943,7 @@ class AbstractJobCalculation(AbstractCalculation):
             group_pk=None, all_users=False, pks=tuple(),
             relative_ctime=True, with_scheduler_state=False,
             order_by=None, limit=None, filters=None,
-            projections=('pk', 'state', 'ctime', 'sched', 'computer', 'type')
+            projections=('pk', 'state', 'ctime', 'sched', 'computer', 'type'), raw=False
     ):
         """
         Print a description of the AiiDA calculations.
@@ -970,6 +970,8 @@ class AbstractJobCalculation(AbstractCalculation):
         :param filters: a dictionary of filters to be passed to the QueryBuilder query
         :param all_users: if True, list calculation belonging to all users.
                            Default = False
+        :param raw: Only print the query result, without any headers, footers
+            or other additional information
 
         :return: a string with description of calculations.
         """
@@ -1110,13 +1112,20 @@ class AbstractJobCalculation(AbstractCalculation):
 
                     counter += 1
 
-                print(tabulate(calc_list_data, headers=calc_list_header))
+                if raw:
+                    print(tabulate(calc_list_data, tablefmt='plain'))
+                else:
+                    print(tabulate(calc_list_data, headers=calc_list_header))
 
             except StopIteration:
-                print(tabulate(calc_list_data, headers=calc_list_header))
+                if raw:
+                    print(tabulate(calc_list_data, tablefmt='plain'))
+                else:
+                    print(tabulate(calc_list_data, headers=calc_list_header))
                 break
 
-        print("\nTotal results: {}\n".format(counter))
+        if not raw:
+            print("\nTotal results: {}\n".format(counter))
 
     @classmethod
     def _get_calculation_info_row(cls, res, projections, times_since=None):

--- a/aiida/work/processes.py
+++ b/aiida/work/processes.py
@@ -215,6 +215,9 @@ class Process(plumpy.Process):
         if self._enable_persistence and not self._state.is_terminal():
             self.runner.persister.save_checkpoint(self)
 
+        # Update the latest process state change timestamp
+        utils.set_process_state_change_timestamp(self)
+
     @override
     def on_terminated(self):
         """
@@ -225,8 +228,8 @@ class Process(plumpy.Process):
             try:
                 self.runner.persister.delete_checkpoint(self.pid)
             except BaseException as e:
-                self.logger.warning("Failed to delete checkpoint: {}\n{}".format(
-                    e, traceback.format_exc()))
+                self.logger.warning("Failed to delete checkpoint: {}\n{}".format(e, traceback.format_exc()))
+
         try:
             self.calc.seal()
         except exceptions.ModificationNotAllowed:


### PR DESCRIPTION
Fixes #1501 and replaces PR #1504 

With the changes to the daemon from a task based celery app, to an event based runner, the old daemon task timestamps that were written to the global `DbSettings` table are no longer relevant. Except for the `workflow_stepper`, which is still being used by the ticker of the legacy workflows. We remove the old daemon task timestamp setter and getter and leave only an explicit version for the `workflow_stepper`. In addition we now add a new timestamp triggered in the `Process.on_entered` hook, to record the last time a process changed its state, split between processes of type `calculation` and `work`. These timestamps are then used by `verdi calculation list` and `verdi work list` respectively, to print a line at the bottom of the query results stating the last time a process of their category changed its state. It will also print a warning when the daemon is not running. A new option `-r/--raw` allows to suppress this information along with all other table formatting such as headers and footers