### PR TITLE
Add migration to drop obsolete kombu tables and daemon timestamps

### DIFF
--- a/aiida/backends/djsite/db/migrations/0011_delete_kombu_tables.py
+++ b/aiida/backends/djsite/db/migrations/0011_delete_kombu_tables.py
@@ -1,0 +1,37 @@
+# -*- coding: utf-8 -*-
+###########################################################################
+# Copyright (c), The AiiDA team. All rights reserved.                     #
+# This file is part of the AiiDA code.                                    #
+#                                                                         #
+# The code is hosted on GitHub at https://github.com/aiidateam/aiida_core #
+# For further information on the license, see the LICENSE.txt file        #
+# For further information please visit http://www.aiida.net               #
+###########################################################################
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+from aiida.backends.djsite.db.migrations import update_schema_version
+
+
+SCHEMA_VERSION = "1.0.11"
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('db', '0010_process_type'),
+    ]
+
+    operations = [
+        migrations.RunSQL("""
+            DROP TABLE IF EXISTS kombu_message;
+            DROP TABLE IF EXISTS kombu_queue;
+            DELETE FROM db_dbsetting WHERE key = 'daemon|user';
+            DELETE FROM db_dbsetting WHERE key = 'daemon|task_stop|retriever';
+            DELETE FROM db_dbsetting WHERE key = 'daemon|task_start|retriever';
+            DELETE FROM db_dbsetting WHERE key = 'daemon|task_stop|updater';
+            DELETE FROM db_dbsetting WHERE key = 'daemon|task_start|updater';
+            DELETE FROM db_dbsetting WHERE key = 'daemon|task_stop|submitter';
+            DELETE FROM db_dbsetting WHERE key = 'daemon|task_start|submitter';
+        """),
+        update_schema_version(SCHEMA_VERSION)
+    ]

--- a/aiida/backends/djsite/db/migrations/__init__.py
+++ b/aiida/backends/djsite/db/migrations/__init__.py
@@ -9,7 +9,7 @@
 ###########################################################################
 
 
-LATEST_MIGRATION = '0010_process_type'
+LATEST_MIGRATION = '0011_delete_kombu_tables'
 
 
 def _update_schema_version(version, apps, schema_editor):

--- a/aiida/backends/sqlalchemy/migrations/versions/0aebbeab274d_base_data_plugin_type_string.py
+++ b/aiida/backends/sqlalchemy/migrations/versions/0aebbeab274d_base_data_plugin_type_string.py
@@ -1,4 +1,4 @@
-"""base_data_plugin_type_string
+"""Correct the type string for the base data types
 
 Revision ID: 0aebbeab274d
 Revises: 35d4ee9a1b0e

--- a/aiida/backends/sqlalchemy/migrations/versions/f9a69de76a9a_delete_kombu_tables.py
+++ b/aiida/backends/sqlalchemy/migrations/versions/f9a69de76a9a_delete_kombu_tables.py
@@ -1,0 +1,40 @@
+"""Delete the kombu tables that were used by the old Celery based daemon and the obsolete related timestamps
+
+Revision ID: f9a69de76a9a
+Revises: 6c629c886f84
+Create Date: 2018-05-10 15:07:59.235950
+
+"""
+from alembic import op
+from sqlalchemy.sql import text
+
+
+# revision identifiers, used by Alembic.
+revision = 'f9a69de76a9a'
+down_revision = '6c629c886f84'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    conn = op.get_bind()
+
+    # Drop the kombu tables and delete the old timestamps and user related to the daemon in the DbSetting table
+    statement = text("""
+            DROP TABLE IF EXISTS kombu_message;
+            DROP TABLE IF EXISTS kombu_queue;
+            DROP SEQUENCE IF EXISTS message_id_sequence;
+            DROP SEQUENCE IF EXISTS queue_id_sequence;
+            DELETE FROM db_dbsetting WHERE key = 'daemon|user';
+            DELETE FROM db_dbsetting WHERE key = 'daemon|task_stop|retriever';
+            DELETE FROM db_dbsetting WHERE key = 'daemon|task_start|retriever';
+            DELETE FROM db_dbsetting WHERE key = 'daemon|task_stop|updater';
+            DELETE FROM db_dbsetting WHERE key = 'daemon|task_start|updater';
+            DELETE FROM db_dbsetting WHERE key = 'daemon|task_stop|submitter';
+            DELETE FROM db_dbsetting WHERE key = 'daemon|task_start|submitter';
+    """)
+    conn.execute(statement)
+
+
+def downgrade():
+    print 'There is no downgrade for the deletion of the kombu tables and the daemon timestamps'


### PR DESCRIPTION
Fixes #1277 

Note: I wonder if this is also a good time to get rid of the `DbLock` table and related lock manager classes? As far as I can gather none of it is actually being used

The changes in the daemon to make it event based, have gotten rid
of Celery, the daemon task timestamps and the concept of the daemon
user. This commit adds the migrations for both backends to delete
the corresponding tables and entries in the DbSetting table from
the database. Since this is a lossy migration, there is no downgrade
of the migration possible and, by extension, available