### PR TITLE
Avoid using print to write to stdout from verdi commands but use click.echo

### DIFF
--- a/docs/source/work/index.rst
+++ b/docs/source/work/index.rst
@@ -67,7 +67,7 @@ Now, let's try making a slightly more complex workflow by composing workfunction
 >>> r = prod_sum(Int(2), Int(3), Int(4))
 >>>
 >>> from aiida.utils.ascii_vis import draw_parents
->>> draw_parents(r, dist=4) # doctest: +SKIP
+>>> print draw_parents(r, dist=4) # doctest: +SKIP
                        /-4 [3582]
 -- /20 [3588]prod [3587]
                       |                  /-2 [3581]
@@ -185,7 +185,7 @@ To run the workflow locally we call
 >>> res = ProdSum.run(a=Int(2), b=Int(3), c=Int(4))
 >>> print res
 {'result': 20}
->>> draw_parents(res['result']) # doctest: +SKIP
+>>> print draw_parents(res['result']) # doctest: +SKIP
                           /-2 [3594]
                          |
 -- /20 [3598]ProdSum [3597]-3 [3596]


### PR DESCRIPTION
Fixes #1436 

In this example, the `verdi work status` command was calling a library
function from ascii_vis to return a graph, but the function itself
called print. When this output was piped, print would attempt to encode
the output to ASCII, but since the output contained unicode characters
an exception was thrown. Instead, we should always use click.echo, which
can deal with these situations. Likewise, library functions should at
best return formatted strings, but never call print directly.