### PR TITLE
Make plugin data classes work again

### DIFF
--- a/aiida/cmdline/commands/data.py
+++ b/aiida/cmdline/commands/data.py
@@ -18,7 +18,7 @@ from aiida.cmdline.baseclass import (
 from aiida.cmdline.commands.node import _Label, _Description
 from aiida.common.exceptions import MultipleObjectsError
 from aiida.cmdline.commands import verdi
-from aiida.plugins.entry_point import get_entry_point_names
+from aiida.plugins.entry_point import get_entry_point_names, get_entry_point
 
 
 class Data(VerdiCommandRouter):
@@ -46,9 +46,14 @@ class Data(VerdiCommandRouter):
             'remote': _Remote,
             'description': _Description,
         }
-        for entry_point_name in get_entry_point_names('aiida.cmdline.data'):
+        entry_point_group = 'aiida.cmdline.data'
+        for entry_point_name in get_entry_point_names(entry_point_group):
+            # Important! I need to load the entry point group in memory,
+            # so click will see it and add the extension of the data command
+            # to the known subgroups.
+            plugin = get_entry_point(entry_point_group, entry_point_name)
+            plugin.load()
             self.routed_subcommands[entry_point_name] = verdi
-
 
 class Listable(object):
     """


### PR DESCRIPTION
The bug appeared after 0.12.0 in the current develop branch.

This fixes #1516 (verdi data subcommands defined in plugins weren't working anymore)