### PR TITLE
Implement the LazyChoice param type for click-based verdi commands

### DIFF
--- a/aiida/cmdline/commands/calculation.py
+++ b/aiida/cmdline/commands/calculation.py
@@ -10,8 +10,6 @@
 import os
 import sys
 
-from plumpy import ProcessState
-
 from aiida.backends.utils import load_dbenv, is_dbenv_loaded
 from aiida.cmdline import delayed_load_node as load_node
 from aiida.cmdline.baseclass import VerdiCommandWithSubcommands
@@ -136,6 +134,9 @@ class Calculation(VerdiCommandWithSubcommands):
             load_dbenv()
 
         import argparse
+        from plumpy import ProcessState
+
+        from aiida.common.datastructures import calc_states
         from aiida.cmdline.utils.common import print_last_process_state_change
         from aiida.common.datastructures import calc_states
         from aiida.common.setup import get_property

--- a/aiida/daemon/client.py
+++ b/aiida/daemon/client.py
@@ -6,9 +6,6 @@ import socket
 import sys
 import tempfile
 
-from circus.client import CircusClient
-from circus.exc import CallError
-
 from aiida.common.profile import ProfileConfig
 from aiida.common.setup import get_property
 from aiida.utils.which import which
@@ -289,6 +286,7 @@ class DaemonClient(ProfileConfig):
 
         :return: CircucClient instance
         """
+        from circus.client import CircusClient
         return CircusClient(endpoint=self.get_controller_endpoint(), timeout=self._DAEMON_TIMEOUT)
 
     def call_client(self, command):
@@ -301,6 +299,8 @@ class DaemonClient(ProfileConfig):
         :param command: command to call the circus client with
         :return: the result of the circus client call
         """
+        from circus.exc import CallError
+
         if not self.get_daemon_pid():
             return {'status': self.DAEMON_ERROR_NOT_RUNNING}
 

--- a/aiida/utils/cli/types.py
+++ b/aiida/utils/cli/types.py
@@ -1,0 +1,18 @@
+from click import Choice
+
+
+class LazyChoice(Choice):
+    """
+    This is a subclass of click's Choice ParamType that evaluates the set of choices
+    lazily. This is useful if the choices set requires an import that is slow. Using
+    the vanilla click.Choice will call this on import which will slow down verdi and
+    its autocomplete. This type will generate the choices set lazily through the
+    choices property
+    """
+
+    def __init__(self, callable):
+        self.callable = callable
+
+    @property
+    def choices(self):
+        return self.callable()

--- a/docs/source/nitpick-exceptions
+++ b/docs/source/nitpick-exceptions
@@ -91,6 +91,7 @@ py:class  abc.ABCMeta
 
 py:class  click.core.Option
 py:class  click.types.ParamType
+py:class  click.types.Choice
 
 py:class  distutils.version.Version
 


### PR DESCRIPTION
Fixes #376 

The click based verdi commands use decorators to define the options
and arguments of the command. These are executed at import time.
In general we attempt to put all the heavy imports within the body
of the commands, to keep verdi and its autocomplete fast and responsive.
However, sometimes those options require data that needs a heavy import.
An example is the choices for the process state of the `verdi work list`
command, which require the import of ProcessState from plumpy, which
was slowing everything down.

The LazyChoice allows to pass a callable instead of a list, such that
the import will only be called at runtime when the command is ran.