### PR TITLE
Make the cli command decorator and validators load dbenv lazily

### DIFF
--- a/aiida/cmdline/utils/decorators.py
+++ b/aiida/cmdline/utils/decorators.py
@@ -39,11 +39,11 @@ def with_dbenv(*load_dbenv_args, **load_dbenv_kwargs):
 
         Example::
 
-            @with_dbenv
+            @with_dbenv()
             def create_my_calculation():
                 from aiida.orm import CalculationFactory  # note the local import
                 my_calc = CalculationFactory('mycalc.mycalc')
-    """
+        """
 
         @wraps(function)
         def decorated_function(*args, **kwargs):

--- a/aiida/utils/cli/__init__.py
+++ b/aiida/utils/cli/__init__.py
@@ -8,10 +8,11 @@ def command():
     Wrapped decorator for click's command decorator, which makes sure
     that the database environment is loaded
     """
-    from aiida import try_load_dbenv
-    try_load_dbenv()
+    from aiida.cmdline.utils.decorators import with_dbenv
 
-    @click.decorators.command
+    @click.command
+    @with_dbenv()
     def inner():
         func(*args, **kwargs)
+
     return inner

--- a/aiida/utils/cli/validators.py
+++ b/aiida/utils/cli/validators.py
@@ -1,8 +1,10 @@
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import 
 import click
+from aiida.cmdline.utils.decorators import with_dbenv
 
 
+@with_dbenv()
 def validate_structure(callback_kwargs, ctx, param, value):
     """
     Command line option validator for an AiiDA structure data pk. It expects
@@ -29,6 +31,8 @@ def validate_structure(callback_kwargs, ctx, param, value):
 
     return structure
 
+
+@with_dbenv()
 def validate_code(callback_kwargs, ctx, param, value):
     """
     Command line option validator for an AiiDA code. It expects a string for the value
@@ -70,6 +74,8 @@ def validate_code(callback_kwargs, ctx, param, value):
 
     return code
 
+
+@with_dbenv()
 def validate_pseudo_family(callback_kwargs, ctx, param, value):
     """
     Command line option validator for a pseudo potential family. The value should be a
@@ -91,6 +97,8 @@ def validate_pseudo_family(callback_kwargs, ctx, param, value):
 
     return value
 
+
+@with_dbenv()
 def validate_kpoint_mesh(callback_kwargs, ctx, param, value):
     """
     Command line option validator for a kpoints mesh tuple. The value should be a tuple
@@ -116,6 +124,8 @@ def validate_kpoint_mesh(callback_kwargs, ctx, param, value):
 
     return kpoints
 
+
+@with_dbenv()
 def validate_calculation(callback_kwargs, ctx, param, value):
     """
     Command line option validator for an AiiDA JobCalculation pk. It expects
@@ -157,6 +167,8 @@ def validate_calculation(callback_kwargs, ctx, param, value):
 
     return calculation
 
+
+@with_dbenv()
 def validate_group(callback_kwargs, ctx, param, value):
     """
     Command line option validator for an AiiDA Group. It expects a string for the value

--- a/docs/source/developer_guide/devel_tutorial/cmdline_plugin.rst
+++ b/docs/source/developer_guide/devel_tutorial/cmdline_plugin.rst
@@ -64,7 +64,7 @@ File ``float_cmd.py``::
    import click  # This we will use in a later step
 
    from aiida.cmdline.commands import data_cmd
-   from aiida.cmdline.dbenv_lazyloading import load_dbenv_if_not_loaded  # Will be used in a later step
+   from aiida.cmdline.utils.decorators import load_dbenv_if_not_loaded  # Will be used in a later step
 
    @data_cmd.group('yourplugin-float'):
    def float_cmd():


### PR DESCRIPTION
Fixes #1519

Since the command decorator and the validators, which are added through
the option decorators are loaded upon import, it is important to have
them load the database environment lazily, such that it is only done
when they are actually called and not already when the file they are
defined in, is simply imported.