### PR TITLE
Define the 'options' of JobProcess as a PortNamespace

### DIFF
--- a/aiida/work/process_spec.py
+++ b/aiida/work/process_spec.py
@@ -2,53 +2,10 @@
 from collections import defaultdict
 
 import plumpy
-import voluptuous
 
 from aiida.common.extendeddicts import FixedFieldsAttributeDict
 from aiida.orm.data.parameter import ParameterData
 from aiida.work.ports import InputPort, PortNamespace
-
-
-class DictSchema(object):
-    def __init__(self, schema):
-        self._schema = voluptuous.Schema(schema)
-
-    def __call__(self, value):
-        """
-        Call this to validate the value against the schema.
-
-        :param value: a regular dictionary or a ParameterData instance
-        :return: tuple (success, msg).  success is True if the value is valid
-            and False otherwise, in which case msg will contain information about
-            the validation failure.
-        :rtype: tuple
-        """
-        try:
-            if isinstance(value, ParameterData):
-                value = value.get_dict()
-            self._schema(value)
-            return True, None
-        except voluptuous.Invalid as e:
-            return False, str(e)
-
-    def get_template(self):
-        return self._get_template(self._schema.schema)
-
-    def _get_template(self, dict):
-        template = type(
-            "{}Inputs".format(self.__class__.__name__),
-            (FixedFieldsAttributeDict,),
-            {'_valid_fields': dict.keys()})()
-
-        for key, value in dict.iteritems():
-            if isinstance(key, (voluptuous.Optional, voluptuous.Required)):
-                if key.default is not voluptuous.UNDEFINED:
-                    template[key.schema] = key.default
-                else:
-                    template[key.schema] = None
-            if isinstance(value, collections.Mapping):
-                template[key] = self._get_template(value)
-        return template
 
 
 class ProcessSpec(plumpy.ProcessSpec):

--- a/docs/requirements_for_rtd.txt
+++ b/docs/requirements_for_rtd.txt
@@ -70,4 +70,3 @@ tzlocal==1.5.1
 ujson==1.35
 uritools==2.1.0
 validate-email==1.3
-voluptuous==0.11.1

--- a/setup_requirements.py
+++ b/setup_requirements.py
@@ -28,7 +28,6 @@ install_requires = [
     'alembic==0.9.9',
     'ujson==1.35',
     'enum34==1.1.6',
-    'voluptuous==0.11.1',
     'aldjemy==0.8.0',
     'passlib==1.7.1',
     'validate-email==1.3',


### PR DESCRIPTION
Fixes #1526 

Originally the `options` for the JobProcess was specified as a single
non database storable `InputPort` that took a nested dictionary.
Because of this solution, the internal structure was not autocompleted
in the `ProcessBuilder`. By redefining the `options` port as a full blown
`PortNamespace` and each member within it as its own `Port`, a help string
can be defined and in the shell this can be displayed through the process
builder. Additionally, this allows the input validation to be done through
the same framework of plumpy as all the other inputs.

Since this was the last use of voluptuous, the requirement of this package
has been removed from the setup requirements