### PR TITLE
Fix bug in the copy method of Sealable nodes

### DIFF
--- a/aiida/backends/tests/__init__.py
+++ b/aiida/backends/tests/__init__.py
@@ -53,6 +53,7 @@ db_test_list = {
         'daemon.client': ['aiida.backends.tests.daemon.test_client'],
         'orm.data.frozendict': ['aiida.backends.tests.orm.data.frozendict'],
         'orm.log': ['aiida.backends.tests.orm.log'],
+        'orm.mixins': ['aiida.backends.tests.orm.mixins'],
         'orm.utils': ['aiida.backends.tests.orm.utils'],
         'work.class_loader': ['aiida.backends.tests.work.class_loader'],
         'work.daemon': ['aiida.backends.tests.work.daemon'],

--- a/aiida/backends/tests/orm/mixins.py
+++ b/aiida/backends/tests/orm/mixins.py
@@ -1,0 +1,16 @@
+# -*- coding: utf-8 -*-
+from aiida.backends.testbase import AiidaTestCase
+
+
+class TestSealable(AiidaTestCase):
+
+    def test_copy_not_include_updatable_attrs(self):
+    	"""
+    	Verify that a node with an updatable attribute, e.g. 'sealed' from the
+    	Sealable mixin, can be copied successfully
+    	"""
+    	from aiida.orm.calculation.job import JobCalculation
+
+    	job = JobCalculation()
+    	job.seal()
+    	job.copy(include_updatable_attrs=False)

--- a/aiida/orm/mixins.py
+++ b/aiida/orm/mixins.py
@@ -214,7 +214,7 @@ class Sealable(object):
         clone = super(Sealable, self).copy()
 
         if include_updatable_attrs is False:
-            for key, value in self._iter_updatable_attributes():
+            for key, value in clone._iter_updatable_attributes():
                 clone._del_attr(key)
 
         return clone


### PR DESCRIPTION
Fixes #1549 

The copy method of the base Node class was copying over all the
attributes, except for the sealed key. Subsequently, the copy
implementation of the `Sealable` mixin was deleting the updatable
attributes from the clone, by iterating over the attributes of
the original node. This would trigger an exception, because even
though the original node has the sealed attribute, it was excluded
in the `Node.copy()` implementation and so calling `_del_attr` on it
would raise. By iterating over the attributes of the clone node, the
problem is fixed.

Note however, that the base node implementation should really have
no knowledge whatsoever of the `Sealable` mixin and its sealed key.
However, removing it now leads to other problems, because by copying
it there, we can no longer delete the attributes afterwards, because
it will hit the `ModificationNotAllowed` exception, due to the sealed
attribute being present.