### PR TITLE
Fix minor bug in delete_nodes utility due to typo

### DIFF
--- a/aiida/utils/delete_nodes.py
+++ b/aiida/utils/delete_nodes.py
@@ -99,17 +99,17 @@ def delete_nodes(pks, follow_calls=False, follow_returns=False,
 
     if not disable_checks:
         called_qb = QueryBuilder()
-        called_qb.append(Calculation, filters={'id':{'!in':pks_set_to_delete}}, project='id')
+        called_qb.append(Calculation, filters={'id': {'!in': pks_set_to_delete}}, project='id')
         called_qb.append(Calculation, project='type', edge_project='label',
-                filters={'id':{'in':pks_set_to_delete}},
-                edge_filters={'type':{'==': LinkType.CALL.value}})
+                filters={'id': {'in': pks_set_to_delete}},
+                edge_filters={'type': {'==': LinkType.CALL.value}})
         caller_to_called2delete = called_qb.all()
 
         if verbosity > 0 and caller_to_called2delete:
             calculation_pks_losing_called = set(zip(*caller_to_called2delete)[0])
             print "\n{} calculation{} {} lose at least one called instance".format(
                     len(calculation_pks_losing_called),
-                    's' if len(calculation_pks_losing_created) > 1 else '',
+                    's' if len(calculation_pks_losing_called) > 1 else '',
                     'would' if dry_run else 'will')
             if verbosity > 1:
                 print "These are the calculations that {} lose a called instance:".format('would' if dry_run else 'will')
@@ -117,9 +117,9 @@ def delete_nodes(pks, follow_calls=False, follow_returns=False,
                     print '  ', load_node(calc_losing_called_pk)
 
         created_qb = QueryBuilder()
-        created_qb.append(Calculation, filters={'id':{'!in':pks_set_to_delete}}, project='id')
+        created_qb.append(Calculation, filters={'id':{'!in': pks_set_to_delete}}, project='id')
         created_qb.append(Data, project='type', edge_project='label',
-                filters={'id':{'in':pks_set_to_delete}},
+                filters={'id':{'in': pks_set_to_delete}},
                 edge_filters={'type':{'==':LinkType.CREATE.value}})
 
         creator_to_created2delete = created_qb.all()


### PR DESCRIPTION
Fixes #1563 

Added a test that would have caught this bug. For this it was
necessary to set the verbosity to 2, because the bug was only
triggered in the branches of code for high verbosity. Additionally,
the tests created a simple graph of base Node instances, which
means that the logic involving Calculation nodes and CALL links
was not hit. The new test explicitly creates Calculation nodes with
CALL links to test this case