### PR TITLE
Load plugin commands lazily in a click.Group subclass

### DIFF
--- a/aiida/cmdline/baseclass.py
+++ b/aiida/cmdline/baseclass.py
@@ -137,17 +137,24 @@ class VerdiCommandRouter(VerdiCommand):
         sys.exit(1)
 
     def run(self, *args):
+        """Run a subcommand, can be a VerdiCommand or a click.Command"""
         try:
-            the_class = self.routed_subcommands[args[0]]
-            the_class._custom_command_name = "{} {}".format(
+            cmd_or_class = self.routed_subcommands[args[0]]
+            cmd_or_class._custom_command_name = "{} {}".format(
                 self.get_full_command_name(with_exec_name=False), args[0])
-            function_to_call = the_class().run
+            if isinstance(cmd_or_class, click.Command):
+                function_to_call = cmd_or_class
+            else:
+                function_to_call = cmd_or_class().run
         except IndexError:
             function_to_call = self.no_subcommand
         except KeyError:
             function_to_call = self.invalid_subcommand
 
-        function_to_call(*args[1:])
+        if isinstance(function_to_call, click.Command):
+            function_to_call()
+        else:
+            function_to_call(*args[1:])
 
     def complete(self, subargs_idx, subargs):
         """

--- a/aiida/cmdline/commands/__init__.py
+++ b/aiida/cmdline/commands/__init__.py
@@ -9,6 +9,8 @@
 ###########################################################################
 import click
 
+from aiida.cmdline.utils.pluginable import Pluginable
+
 
 def click_subcmd_complete(cmd_group):
     """Create a subcommand completion function for a click command group."""
@@ -69,8 +71,9 @@ def user():
 def node():
     pass
 
-@verdi.group('data')
+@verdi.group('data', entry_point_group='aiida.cmdline.data', cls=Pluginable)
 def data_cmd():
+    """Verdi data interface for plugin commands."""
     pass
 
 

--- a/aiida/cmdline/commands/data.py
+++ b/aiida/cmdline/commands/data.py
@@ -1090,7 +1090,7 @@ class _Structure(VerdiCommandWithSubcommands,
         from aiida.orm.data.structure import StructureData
 
         super(_Structure, self).__init__()
-        
+
         self.dataclass = StructureData
         self.valid_subcommands = {
             'show': (self.show, self.complete_none),
@@ -1250,9 +1250,9 @@ class _Structure(VerdiCommandWithSubcommands,
     def _show_vesta(self, exec_name, structure_list):
         """
         Plugin for VESTA
-        This VESTA plugin was added by Yue-Wen FANG and Abel Carreras 
+        This VESTA plugin was added by Yue-Wen FANG and Abel Carreras
         at Kyoto University in the group of Prof. Isao Tanaka's lab
-        
+
         """
         import tempfile, subprocess
 

--- a/aiida/cmdline/commands/data.py
+++ b/aiida/cmdline/commands/data.py
@@ -18,7 +18,7 @@ from aiida.cmdline.baseclass import (
 from aiida.cmdline.commands.node import _Label, _Description
 from aiida.common.exceptions import MultipleObjectsError
 from aiida.cmdline.commands import verdi
-from aiida.plugins.entry_point import get_entry_point_names, get_entry_point
+from aiida.plugins.entry_point import get_entry_point_names
 
 
 class Data(VerdiCommandRouter):
@@ -48,11 +48,6 @@ class Data(VerdiCommandRouter):
         }
         entry_point_group = 'aiida.cmdline.data'
         for entry_point_name in get_entry_point_names(entry_point_group):
-            # Important! I need to load the entry point group in memory,
-            # so click will see it and add the extension of the data command
-            # to the known subgroups.
-            plugin = get_entry_point(entry_point_group, entry_point_name)
-            plugin.load()
             self.routed_subcommands[entry_point_name] = verdi
 
 class Listable(object):

--- a/aiida/cmdline/utils/pluginable.py
+++ b/aiida/cmdline/utils/pluginable.py
@@ -1,0 +1,24 @@
+"""Plugin aware click command Group."""
+import click
+
+from aiida.plugins.entry_point import load_entry_point, get_entry_point_names, MissingEntryPointError
+
+class Pluginable(click.Group):
+    """A click command group that finds and loads unloaded plugin commands lazily."""
+
+    def __init__(self, *args, **kwargs):
+        """Initialize with entry point group."""
+        self._entry_point_group = kwargs.pop('entry_point_group')
+        super(Pluginable, self).__init__(*args, **kwargs)
+
+    def list_commands(self, ctx):
+        subcommands = super(Pluginable, self).list_commands()
+        subcommands.extend(get_entry_point_names(self._entry_point_group))
+
+    def get_command(self, ctx, name):
+        command = None
+        try:
+            command = load_entry_point(self._entry_point_group, name)
+        except MissingEntryPointError:
+            command = super(Pluginable, self).get_command(ctx, name)
+        return command

--- a/aiida/cmdline/utils/pluginable.py
+++ b/aiida/cmdline/utils/pluginable.py
@@ -4,7 +4,7 @@ import click
 from aiida.plugins.entry_point import load_entry_point, get_entry_point_names, MissingEntryPointError
 
 class Pluginable(click.Group):
-    """A click command group that finds and loads unloaded plugin commands lazily."""
+    """A click command group that finds and loads plugin commands lazily."""
 
     def __init__(self, *args, **kwargs):
         """Initialize with entry point group."""
@@ -12,10 +12,12 @@ class Pluginable(click.Group):
         super(Pluginable, self).__init__(*args, **kwargs)
 
     def list_commands(self, ctx):
+        """Add entry point names of available plugins to the command list."""
         subcommands = super(Pluginable, self).list_commands()
         subcommands.extend(get_entry_point_names(self._entry_point_group))
 
     def get_command(self, ctx, name):
+        """Try to load a subcommand from entry points, else defer to super."""
         command = None
         try:
             command = load_entry_point(self._entry_point_group, name)

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -387,7 +387,7 @@ epub_copyright = copyright
 
 # Warnings to ignore when using the -n (nitpicky) option
 # We should ignore any python built-in exception, for instance
-nitpick_ignore = []
+nitpick_ignore = [('py:class', 'click.Group'), ('py:class', 'click.core.Group')]
 
 for line in open('nitpick-exceptions'):
     if line.strip() == "" or line.startswith("#"):

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -387,7 +387,7 @@ epub_copyright = copyright
 
 # Warnings to ignore when using the -n (nitpicky) option
 # We should ignore any python built-in exception, for instance
-nitpick_ignore = [('py:class', 'click.Group'), ('py:class', 'click.core.Group')]
+nitpick_ignore = []
 
 for line in open('nitpick-exceptions'):
     if line.strip() == "" or line.startswith("#"):

--- a/docs/source/nitpick-exceptions
+++ b/docs/source/nitpick-exceptions
@@ -92,6 +92,7 @@ py:class  abc.ABCMeta
 py:class  click.core.Option
 py:class  click.types.ParamType
 py:class  click.types.Choice
+py:class  click.core.Group
 
 py:class  distutils.version.Version
 


### PR DESCRIPTION
Currently the plugin commands for `verdi data` are loaded within `aiida.cmdline.commands.data`, while adding plugin command names to the list of subcommands. If the plugins are not loaded, the plugin commands will not be found. This behaviour is not intuitive and therefore not future proof, and means all plugins have to be imported, not only the one that will be used.

The correct place for this is a subclass of click.Group (analog to  http://click.pocoo.org/6/commands/#custom-multi-commands in the click documentation). This way only the subcommand to be used must be loaded (imported).

This pull request introduces such a class, which can also be reused for all verdi commands that should have plugins in the future.