### PR TITLE
Fixed workfunctions not RETURNING and added test

### DIFF
--- a/aiida/backends/tests/work/class_loader.py
+++ b/aiida/backends/tests/work/class_loader.py
@@ -7,9 +7,8 @@
 # For further information on the license, see the LICENSE.txt file        #
 # For further information please visit http://www.aiida.net               #
 ###########################################################################
-
 import aiida
-import aiida.work.utils as util
+from aiida.work import Process
 from aiida.backends.testbase import AiidaTestCase
 from aiida.orm.calculation.job.simpleplugins.templatereplacer import TemplatereplacerCalculation
 
@@ -17,11 +16,11 @@ from aiida.orm.calculation.job.simpleplugins.templatereplacer import Templaterep
 class TestJobProcess(AiidaTestCase):
     def setUp(self):
         super(TestJobProcess, self).setUp()
-        self.assertEquals(len(util.ProcessStack.stack()), 0)
+        self.assertIsNone(Process.current())
 
     def tearDown(self):
         super(TestJobProcess, self).tearDown()
-        self.assertEquals(len(util.ProcessStack.stack()), 0)
+        self.assertIsNone(Process.current())
 
     def test_class_loader(self):
         templatereplacer_process = aiida.work.JobProcess.build(TemplatereplacerCalculation)

--- a/aiida/backends/tests/work/job_processes.py
+++ b/aiida/backends/tests/work/job_processes.py
@@ -15,8 +15,10 @@ from aiida.orm.data.int import Int
 from aiida.orm.calculation.job.simpleplugins.templatereplacer import TemplatereplacerCalculation
 from aiida.work.persistence import ObjectLoader
 from aiida.work.job_processes import JobProcess
+from aiida.work import Process
 
 from . import utils
+
 
 class AdditionalParameterCalculation(TemplatereplacerCalculation):
     """
@@ -51,16 +53,17 @@ class AdditionalParameterCalculation(TemplatereplacerCalculation):
 
         return '{}_{}'.format('pseudo', suffix_string)
 
+
 class TestJobProcess(AiidaTestCase):
 
     def setUp(self):
         super(TestJobProcess, self).setUp()
-        self.assertEquals(len(work.ProcessStack.stack()), 0)
+        self.assertIsNone(Process.current())
         self.runner = utils.create_test_runner()
 
     def tearDown(self):
         super(TestJobProcess, self).tearDown()
-        self.assertEquals(len(work.ProcessStack.stack()), 0)
+        self.assertIsNone(Process.current())
         self.runner.close()
         self.runner = None
         work.set_runner(None)
@@ -111,16 +114,17 @@ class TestJobProcess(AiidaTestCase):
         process = TemplatereplacerCalculation.process()
         job = process(inputs)
 
+
 class TestAdditionalParameterJobProcess(AiidaTestCase):
 
     def setUp(self):
         super(TestAdditionalParameterJobProcess, self).setUp()
-        self.assertEquals(len(work.ProcessStack.stack()), 0)
+        self.assertIsNone(Process.current())
         self.runner = utils.create_test_runner()
 
     def tearDown(self):
         super(TestAdditionalParameterJobProcess, self).tearDown()
-        self.assertEquals(len(work.ProcessStack.stack()), 0)
+        self.assertIsNone(Process.current())
         self.runner.close()
         self.runner = None
         work.set_runner(None)

--- a/aiida/backends/tests/work/persistence.py
+++ b/aiida/backends/tests/work/persistence.py
@@ -12,7 +12,7 @@ import tempfile
 
 from aiida.backends.testbase import AiidaTestCase
 from aiida.work.persistence import AiiDAPersister
-import aiida.work.utils as util
+from aiida.work import Process
 from aiida.work.test_utils import DummyProcess
 from aiida import work
 
@@ -23,11 +23,11 @@ class TestProcess(AiidaTestCase):
     def setUp(self):
         super(TestProcess, self).setUp()
         work.runners.set_runner(None)
-        self.assertEquals(len(util.ProcessStack.stack()), 0)
+        self.assertIsNone(Process.current())
 
     def tearDown(self):
         super(TestProcess, self).tearDown()
-        self.assertEquals(len(util.ProcessStack.stack()), 0)
+        self.assertIsNone(Process.current())
 
     def test_save_load(self):
         process = DummyProcess()

--- a/aiida/backends/tests/work/process.py
+++ b/aiida/backends/tests/work/process.py
@@ -17,7 +17,7 @@ from aiida.orm import load_node
 from aiida.orm.data.int import Int
 from aiida.orm.data.frozendict import FrozenDict
 from aiida.orm.data.parameter import ParameterData
-from aiida.work import test_utils, utils
+from aiida.work import test_utils, Process
 
 
 class NameSpacedProcess(work.Process):
@@ -32,11 +32,11 @@ class TestProcessNamespace(AiidaTestCase):
 
     def setUp(self):
         super(TestProcessNamespace, self).setUp()
-        self.assertEquals(len(utils.ProcessStack.stack()), 0)
+        self.assertIsNone(Process.current())
 
     def tearDown(self):
         super(TestProcessNamespace, self).tearDown()
-        self.assertEquals(len(utils.ProcessStack.stack()), 0)
+        self.assertIsNone(Process.current())
 
     def test_namespaced_process(self):
         """
@@ -84,11 +84,11 @@ class TestProcess(AiidaTestCase):
     def setUp(self):
         super(TestProcess, self).setUp()
         work.runners.set_runner(None)
-        self.assertEquals(len(utils.ProcessStack.stack()), 0)
+        self.assertIsNone(Process.current())
 
     def tearDown(self):
         super(TestProcess, self).tearDown()
-        self.assertEquals(len(utils.ProcessStack.stack()), 0)
+        self.assertIsNone(Process.current())
 
     def test_process_stack(self):
         work.launch.run(ProcessStackTest)
@@ -217,7 +217,6 @@ class TestProcess(AiidaTestCase):
 class TestFunctionProcess(AiidaTestCase):
 
     def test_fixed_inputs(self):
-
         def wf(a, b, c):
             return {'a': a, 'b': b, 'c': c}
 
@@ -226,7 +225,6 @@ class TestFunctionProcess(AiidaTestCase):
         self.assertEqual(work.run(function_process_class, **inputs), inputs)
 
     def test_kwargs(self):
-
         def wf_with_kwargs(**kwargs):
             return kwargs
 

--- a/aiida/backends/tests/work/test_launch.py
+++ b/aiida/backends/tests/work/test_launch.py
@@ -11,10 +11,7 @@ from aiida.backends.testbase import AiidaTestCase
 from aiida.orm.calculation.function import FunctionCalculation
 from aiida.orm.calculation.work import WorkCalculation
 from aiida.orm.data.int import Int
-from aiida.work import utils
-from aiida.work.launch import run, run_get_node, run_get_pid
-from aiida.work.workchain import WorkChain
-from aiida.work.workfunctions import workfunction
+from aiida.work import run, run_get_node, run_get_pid, Process, WorkChain, workfunction
 
 
 @workfunction
@@ -42,14 +39,14 @@ class TestLaunchers(AiidaTestCase):
 
     def setUp(self):
         super(TestLaunchers, self).setUp()
-        self.assertEquals(len(utils.ProcessStack.stack()), 0)
+        self.assertIsNone(Process.current())
         self.a = Int(1)
         self.b = Int(2)
         self.result = 3
 
     def tearDown(self):
         super(TestLaunchers, self).tearDown()
-        self.assertEquals(len(utils.ProcessStack.stack()), 0)
+        self.assertIsNone(Process.current())
 
     def test_workfunction_run(self):
         result = run(add, a=self.a, b=self.b)
@@ -101,4 +98,3 @@ class TestLaunchers(AiidaTestCase):
         result, pid = run_get_pid(builder)
         self.assertEquals(result['result'], self.result)
         self.assertTrue(isinstance(pid, int))
-

--- a/aiida/backends/tests/work/test_process_builder.py
+++ b/aiida/backends/tests/work/test_process_builder.py
@@ -14,9 +14,7 @@ from aiida.orm.data.parameter import ParameterData
 from aiida.orm.data.bool import Bool
 from aiida.orm.data.float import Float
 from aiida.orm.data.int import Int
-#from aiida.work.process_builder import ProcessBuilder
-from aiida.work.workchain import WorkChain
-from aiida.work import utils
+from aiida.work import WorkChain, Process
 
 DEFAULT_INT = 256
 
@@ -35,14 +33,14 @@ class TestProcessBuilder(AiidaTestCase):
 
     def setUp(self):
         super(TestProcessBuilder, self).setUp()
-        self.assertEquals(len(utils.ProcessStack.stack()), 0)
+        self.assertIsNone(Process.current())
         self.calculation_class = CalculationFactory('simpleplugins.templatereplacer')
         self.process_class = self.calculation_class.process()
         self.builder = self.process_class.get_builder()
 
     def tearDown(self):
         super(TestProcessBuilder, self).tearDown()
-        self.assertEquals(len(utils.ProcessStack.stack()), 0)
+        self.assertIsNone(Process.current())
 
     def test_process_builder_attributes(self):
         """

--- a/aiida/backends/tests/work/test_process_spec.py
+++ b/aiida/backends/tests/work/test_process_spec.py
@@ -9,20 +9,19 @@
 ###########################################################################
 
 from aiida.backends.testbase import AiidaTestCase
-from aiida.work.processes import Process
-from aiida.work import utils
+from aiida.work import Process
 
 
 class TestProcessSpec(AiidaTestCase):
 
     def setUp(self):
         super(TestProcessSpec, self).setUp()
-        self.assertEquals(len(utils.ProcessStack.stack()), 0)
+        self.assertIsNone(Process.current())
         self.spec = Process.spec()
 
     def tearDown(self):
         super(TestProcessSpec, self).tearDown()
-        self.assertEquals(len(utils.ProcessStack.stack()), 0)
+        self.assertIsNone(Process.current())
 
     def test_dynamic_input(self):
         from aiida.orm import Node

--- a/aiida/backends/tests/work/work_chain.py
+++ b/aiida/backends/tests/work/work_chain.py
@@ -21,9 +21,9 @@ from aiida.orm.data.float import Float
 from aiida.orm.data.int import Int
 from aiida.orm.data.str import Str
 from aiida.utils.capturing import Capturing
-from aiida.work.utils import ProcessStack
 from aiida.workflows.wf_demo import WorkflowDemo
 from aiida import work
+from aiida.work import Process
 from aiida.work.workchain import *
 
 from . import utils
@@ -204,13 +204,13 @@ class TestWorkchain(AiidaTestCase):
 
     def setUp(self):
         super(TestWorkchain, self).setUp()
-        self.assertEquals(len(ProcessStack.stack()), 0)
+        self.assertIsNone(Process.current())
         self.runner = utils.create_test_runner()
 
     def tearDown(self):
         super(TestWorkchain, self).tearDown()
         work.set_runner(None)
-        self.assertEquals(len(ProcessStack.stack()), 0)
+        self.assertIsNone(Process.current())
 
     def test_run(self):
         A = Str('A')
@@ -555,7 +555,7 @@ class TestWorkchain(AiidaTestCase):
 class TestWorkchainWithOldWorkflows(AiidaTestCase):
     def setUp(self):
         super(TestWorkchainWithOldWorkflows, self).setUp()
-        self.assertEquals(len(ProcessStack.stack()), 0)
+        self.assertIsNone(Process.current())
         self.runner = utils.create_test_runner()
 
     def tearDown(self):
@@ -563,7 +563,7 @@ class TestWorkchainWithOldWorkflows(AiidaTestCase):
         work.set_runner(None)
         self.runner.close()
         self.runner = None
-        self.assertEquals(len(ProcessStack.stack()), 0)
+        self.assertIsNone(Process.current())
 
     def test_call_old_wf(self):
         wf = WorkflowDemo()
@@ -615,13 +615,13 @@ class TestWorkChainAbort(AiidaTestCase):
 
     def setUp(self):
         super(TestWorkChainAbort, self).setUp()
-        self.assertEquals(len(ProcessStack.stack()), 0)
+        self.assertIsNone(Process.current())
         self.runner = utils.create_test_runner()
 
     def tearDown(self):
         super(TestWorkChainAbort, self).tearDown()
         work.set_runner(None)
-        self.assertEquals(len(ProcessStack.stack()), 0)
+        self.assertIsNone(Process.current())
 
     class AbortableWorkChain(WorkChain):
         @classmethod
@@ -680,13 +680,13 @@ class TestWorkChainAbortChildren(AiidaTestCase):
 
     def setUp(self):
         super(TestWorkChainAbortChildren, self).setUp()
-        self.assertEquals(len(ProcessStack.stack()), 0)
+        self.assertIsNone(Process.current())
         self.runner = utils.create_test_runner(with_communicator=True)
 
     def tearDown(self):
         super(TestWorkChainAbortChildren, self).tearDown()
         work.set_runner(None)
-        self.assertEquals(len(ProcessStack.stack()), 0)
+        self.assertIsNone(Process.current())
 
     class SubWorkChain(WorkChain):
         @classmethod
@@ -776,13 +776,13 @@ class TestImmutableInputWorkchain(AiidaTestCase):
 
     def setUp(self):
         super(TestImmutableInputWorkchain, self).setUp()
-        self.assertEquals(len(ProcessStack.stack()), 0)
+        self.assertIsNone(Process.current())
         self.runner = utils.create_test_runner()
 
     def tearDown(self):
         super(TestImmutableInputWorkchain, self).tearDown()
         work.set_runner(None)
-        self.assertEquals(len(ProcessStack.stack()), 0)
+        self.assertIsNone(Process.current())
 
     def test_immutable_input(self):
         """
@@ -985,7 +985,7 @@ class TestWorkChainExpose(AiidaTestCase):
 
     def setUp(self):
         super(TestWorkChainExpose, self).setUp()
-        self.assertEquals(len(ProcessStack.stack()), 0)
+        self.assertIsNone(Process.current())
         self.runner = utils.create_test_runner()
 
     def tearDown(self):
@@ -993,7 +993,7 @@ class TestWorkChainExpose(AiidaTestCase):
         work.set_runner(None)
         self.runner.close()
         self.runner = None
-        self.assertEquals(len(ProcessStack.stack()), 0)
+        self.assertIsNone(Process.current())
 
     def test_expose(self):
         res = work.run(

--- a/aiida/orm/calculation/__init__.py
+++ b/aiida/orm/calculation/__init__.py
@@ -10,5 +10,7 @@
 
 from aiida.orm.implementation.calculation import Calculation, JobCalculation
 from .inline import *
+from .work import WorkCalculation
+from .function import FunctionCalculation
 
-__all__ = ['Calculation', 'JobCalculation'] + inline.__all__
+__all__ = ['Calculation', 'JobCalculation', 'WorkCalculation', 'FunctionCalculation'] + inline.__all__

--- a/aiida/work/launch.py
+++ b/aiida/work/launch.py
@@ -58,6 +58,10 @@ def run_get_node(process, *args, **inputs):
     return runner.run_get_node(process, *args, **inputs)
 
 
+# Allow user to also use run.get_node as a convenience (one less import)
+run.get_node = run_get_node
+
+
 def run_get_pid(process, *args, **inputs):
     """
     Run the process with the supplied inputs in a local runner that will block until the process is completed.

--- a/aiida/work/processes.py
+++ b/aiida/work/processes.py
@@ -368,7 +368,7 @@ class Process(plumpy.Process):
 
             value.store()
 
-            if isinstance(self.calc, WorkCalculation):
+            if utils.is_process_calc_type(self.calc):
                 value.add_link_from(self.calc, label, LinkType.RETURN)
 
     def _setup_db_record(self):

--- a/aiida/work/processes.py
+++ b/aiida/work/processes.py
@@ -368,7 +368,7 @@ class Process(plumpy.Process):
 
             value.store()
 
-            if utils.is_process_calc_type(self.calc):
+            if utils.is_work_calc_type(self.calc):
                 value.add_link_from(self.calc, label, LinkType.RETURN)
 
     def _setup_db_record(self):

--- a/aiida/work/utils.py
+++ b/aiida/work/utils.py
@@ -21,7 +21,7 @@ PROCESS_STATE_CHANGE_DESCRIPTION = 'The last time a process of type {}, changed 
 PROCESS_CALC_TYPES = (WorkCalculation, FunctionCalculation)
 
 
-def is_process_calc_type(calc_node):
+def is_work_calc_type(calc_node):
     """
     Check if the given calculation node is of the new type.
     Currently in AiiDA we have a hierarchy of 'Calculation' nodes with the following subclasses:
@@ -95,7 +95,7 @@ def set_process_state_change_timestamp(process):
 
     if isinstance(process.calc, (JobCalculation, InlineCalculation)):
         process_type = 'calculation'
-    elif is_process_calc_type(process.calc):
+    elif is_work_calc_type(process.calc):
         process_type = 'work'
     else:
         raise ValueError('unsupported calculation node type {}'.format(type(process.calc)))

--- a/aiida/work/utils.py
+++ b/aiida/work/utils.py
@@ -8,101 +8,35 @@
 # For further information please visit http://www.aiida.net               #
 ###########################################################################
 import contextlib
-from threading import local
 import tornado.ioloop
 
 from aiida.common.links import LinkType
-from aiida.orm.calculation import Calculation
+from aiida.orm.calculation import Calculation, WorkCalculation, FunctionCalculation
 from aiida.orm.data.frozendict import FrozenDict
 
-__all__ = ['ProcessStack']
+__all__ = []
 
 PROCESS_STATE_CHANGE_KEY = 'process|state_change|{}'
 PROCESS_STATE_CHANGE_DESCRIPTION = 'The last time a process of type {}, changed state'
+PROCESS_CALC_TYPES = (WorkCalculation, FunctionCalculation)
 
 
-class ProcessStack(object):
+def is_process_calc_type(calc_node):
     """
-    Keep track of the per-thread call stack of processes.
+    Check if the given calculation node is of the new type.
+    Currently in AiiDA we have a hierarchy of 'Calculation' nodes with the following subclasses:
+        1) JobCalculation
+        2) InlineCalculation
+        3) WorkCalculation
+        4) FunctionCalculation
+    1 & 2 can be considered the 'old' way of doing things, even though they are still
+    in use while 3 & 4 are the 'new' way.  In loose terms the main difference is that
+    the old way don't support RETURN and CALL links.
+
+    :param calc_node: The calculation node to test
+    :return: True if of the new type, False otherwise.
     """
-
-    _thread_local = local()
-
-    @classmethod
-    def get_active_process_id(cls):
-        """
-        Get the pid of the process at the top of the stack
-
-        :return: The pid
-        """
-        return cls.top().pid
-
-    @classmethod
-    def get_active_process_calc_node(cls):
-        """
-        Get the calculation node of the process at the top of the stack
-
-        :return: The calculation node
-        :rtype: :class:`aiida.orm.implementation.general.calculation.job.AbstractJobCalculation`
-        """
-        return cls.top().calc
-
-    @classmethod
-    def top(cls):
-        return cls.stack()[-1]
-
-    @classmethod
-    def stack(cls):
-        try:
-            return cls._thread_local.wf_stack
-        except AttributeError:
-            cls._thread_local.wf_stack = []
-            return cls._thread_local.wf_stack
-
-    @classmethod
-    def pids(cls):
-        try:
-            return cls._thread_local.pids_stack
-        except AttributeError:
-            cls._thread_local.pids_stack = []
-            return cls._thread_local.pids_stack
-
-    @classmethod
-    def push(cls, process):
-        try:
-            process._parent = cls.top()
-        except IndexError:
-            process._parent = None
-        cls.stack().append(process)
-        cls.pids().append(process.pid)
-
-    @classmethod
-    def pop(cls, process=None, pid=None):
-        """
-        Pop a process from the stack.  To make sure the stack is not corrupted
-        the process instance or pid of the calling process should be supplied
-        so we can verify that is really is top of the stack.
-
-        :param process: The process instance
-        :param pid: The process id.
-        """
-        assert process is not None or pid is not None
-        if process is not None:
-            assert process is cls.top(), \
-                "Can't pop a process that is not top of the stack"
-        elif pid is not None:
-            assert pid == cls.pids()[-1], \
-                "Can't pop a process that is not top of the stack"
-        else:
-            raise ValueError("Must supply process or pid")
-
-        process = cls.stack().pop()
-        process._parent = None
-
-        cls.pids().pop()
-
-    def __init__(self):
-        raise NotImplementedError("Can't instantiate the ProcessStack")
+    return isinstance(calc_node, PROCESS_CALC_TYPES)
 
 
 def is_workfunction(func):
@@ -155,15 +89,13 @@ def set_process_state_change_timestamp(process):
     """
     from aiida.backends.utils import set_global_setting
     from aiida.common.exceptions import UniquenessError
-    from aiida.orm.calculation.function import FunctionCalculation
     from aiida.orm.calculation.inline import InlineCalculation
     from aiida.orm.calculation.job import JobCalculation
-    from aiida.orm.calculation.work import WorkCalculation
     from aiida.utils import timezone
 
     if isinstance(process.calc, (JobCalculation, InlineCalculation)):
         process_type = 'calculation'
-    elif isinstance(process.calc, (FunctionCalculation, WorkCalculation)):
+    elif is_process_calc_type(process.calc):
         process_type = 'work'
     else:
         raise ValueError('unsupported calculation node type {}'.format(type(process.calc)))


### PR DESCRIPTION
This had been accidentally broken in a workfunctions/inline calculations
unification.  I've added a `work.utils.is_work_calc_type` that can
be used to check if a Calculation node is of the 'new' type, i.e.
supports CALL and RETURN links.