### PR TITLE
Change the default return link label 'return' into 'result'

### DIFF
--- a/aiida/backends/tests/work/test_workfunctions.py
+++ b/aiida/backends/tests/work/test_workfunctions.py
@@ -231,6 +231,19 @@ class TestWf(AiidaTestCase):
         with self.assertRaises(AssertionError):
             submit(self.wf_return_true)
 
+    def test_default_linkname(self):
+        """
+        Verify that a workfunction that returns a single Data node, a default link label
+        will be used that can be accessed both through the getattr as through the getitem
+        method of the OutputManager of the node
+        """
+        INPUT = 1
+
+        result, node = run_get_node(self.wf_args, a=Int(INPUT))
+        self.assertEquals(node.out.result, INPUT)
+        self.assertEquals(getattr(node.out, Process.SINGLE_RETURN_LINKNAME), INPUT)
+        self.assertEquals(node.out[Process.SINGLE_RETURN_LINKNAME], INPUT)
+
     def test_simple_workflow(self):
         @workfunction
         def add(a, b):

--- a/aiida/work/processes.py
+++ b/aiida/work/processes.py
@@ -51,7 +51,7 @@ class Process(plumpy.Process):
     _spec_type = ProcessSpec
     _calc_class = WorkCalculation
 
-    SINGLE_RETURN_LINKNAME = 'return'
+    SINGLE_RETURN_LINKNAME = 'result'
 
     class SaveKeys(enum.Enum):
         """

--- a/aiida/work/workfunctions.py
+++ b/aiida/work/workfunctions.py
@@ -35,8 +35,8 @@ def workfunction(func, calc_node_class=None):
     >>> print(r)
     9
     >>> r.get_inputs_dict() # doctest: +SKIP
-    {u'return': <FunctionCalculation: uuid: ce0c63b3-1c84-4bb8-ba64-7b70a36adf34 (pk: 3567)>}
-    >>> r.get_inputs_dict()['return'].get_inputs()
+    {u'result': <FunctionCalculation: uuid: ce0c63b3-1c84-4bb8-ba64-7b70a36adf34 (pk: 3567)>}
+    >>> r.get_inputs_dict()['result'].get_inputs()
     [4, 5]
 
     """


### PR DESCRIPTION
Fixes #1570 

The 'return' keyword is protected in python, so using this as the
default link label would break the get attribute method of the
`NodeOutputManager` of the node. That is to say:

     node.out.return

would raise a syntax error. Instead we use 'result' as the default
link label for RETURN links, which does allow this notation