### PR TITLE
Enable use of tuple in QueryBuilder.append for all ORM classes

### DIFF
--- a/aiida/backends/tests/query.py
+++ b/aiida/backends/tests/query.py
@@ -83,6 +83,7 @@ class TestQueryBuilder(AiidaTestCase):
             self.assertEqual(clstype, Data._plugin_type_string)
             self.assertEqual(query_type_string, Data._query_type_string)
 
+
     def test_simple_query_1(self):
         """
         Testing a simple query
@@ -442,10 +443,14 @@ class TestQueryHelp(AiidaTestCase):
         from aiida.orm.data.parameter import ParameterData
         from aiida.orm.data import Data
         from aiida.orm.querybuilder import QueryBuilder
+        from aiida.orm.group import Group
+        from aiida.orm.computer import Computer
+        g = Group(name='helloworld').store()
         for cls in (StructureData, ParameterData, Data):
             obj = cls()
             obj._set_attr('foo-qh2', 'bar')
             obj.store()
+            g.add_nodes(obj)
 
         for cls, expected_count, subclassing in (
                 (StructureData, 1, True),
@@ -469,6 +474,17 @@ class TestQueryHelp(AiidaTestCase):
                 sorted([uuid for uuid, in qb.all()]),
                 sorted([uuid for uuid, in qb_new.all()]))
 
+        qb = QueryBuilder().append(Group, filters={'name':'helloworld'})
+        self.assertEqual(qb.count(), 1)
+
+        qb = QueryBuilder().append((Group,), filters={'name':'helloworld'})
+        self.assertEqual(qb.count(), 1)
+
+        qb = QueryBuilder().append(Computer,)
+        self.assertEqual(qb.count(), 1)
+
+        qb = QueryBuilder().append(cls=(Computer,))
+        self.assertEqual(qb.count(), 1)
 
             
 class TestQueryBuilderCornerCases(AiidaTestCase):

--- a/aiida/orm/querybuilder.py
+++ b/aiida/orm/querybuilder.py
@@ -641,15 +641,18 @@ class QueryBuilder(object):
         try:
             self._filters[tag] = {}
             # I have to add a filter on column type.
-            # This so far only is necessary for AiidaNodes
-            # GROUPS?
-            if query_type_string is not None:
+            # This so far only is necessary for AiidaNodes not for groups.
+            # Now here there is the issue that for everything else,
+            # the query_type_string is either None (e.g. if Group was passed)
+            # or a list of None (if (Group, ) was passed.
+            # Here we have to only call the function _add_type_filter essentially if it makes sense to
+            # For now that is only nodes, and it is hardcoded. In the future (e.g. we subclass group)
+            # this has to be added
+            if ormclass == self._impl.Node:
                 plugin_type_string = ormclasstype
-                #~ print plugin_type_string
                 self._add_type_filter(tag, query_type_string, plugin_type_string, subclassing)
             # The order has to be first _add_type_filter and then add_filter.
             # If the user adds a query on the type column, it overwrites what I did
-
             # if the user specified a filter, add it:
             if filters is not None:
                 self.add_filter(tag, filters)


### PR DESCRIPTION
Issue #1398 was fixed in a previous commit to allow adding a tuple of classes to the `QueryBuilder`
through the `append` method, but it did not work for all ORM classes e.g. `Group`.
This commit fixes the problem and enables the new approach for all ORM classes.