### PR TITLE
Adding readthedocs YAML config file

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,0 +1,14 @@
+# Configuration for readthedocs
+
+# Important: we need to disable all unneeded formats. 
+# Note that HTML and JSON are always built: 
+# https://docs.readthedocs.io/en/latest/yaml-config.html#formats 
+# Especially, the 'htmlzip' format takes a LOT of memory and causes
+# the build to fail - see our issue #1472:
+# https://github.com/aiidateam/aiida_core/issues/1472
+formats: []
+
+## For now I don't specify any other parameter, that is 
+## currently setup in the web page of Read the Docs.
+## For other parameters see
+## https://docs.readthedocs.io/en/latest/yaml-config.html


### PR DESCRIPTION
At the moment we just configure the formats,
in particular disabling the htmlzip format, that was
causing a lot of memory usage and, as a consequence,
the builds to fail, see #1472

This should close #1472 if it  works as expected