### PR TITLE
ZipFile: set allowZip64=True as the default.

### DIFF
--- a/aiida/cmdline/commands/exportfile.py
+++ b/aiida/cmdline/commands/exportfile.py
@@ -203,7 +203,7 @@ def migrate(file_input, file_output, force, silent, archive_format):
 
         if archive_format == 'zip' or archive_format == 'zip-uncompressed':
             compression = zipfile.ZIP_DEFLATED if archive_format == 'zip' else zipfile.ZIP_STORED
-            with zipfile.ZipFile(file_output, mode='w', compression=compression) as archive:
+            with zipfile.ZipFile(file_output, mode='w', compression=compression, allowZip64=True) as archive:
                 src = folder.abspath
                 for dirpath, dirnames, filenames in os.walk(src):
                     relpath = os.path.relpath(dirpath, src)

--- a/aiida/common/archive.py
+++ b/aiida/common/archive.py
@@ -25,7 +25,7 @@ def extract_zip(infile, folder, nodes_export_subfolder="nodes",
         print "READING DATA AND METADATA..."
 
     try:
-        with zipfile.ZipFile(infile, "r") as zip:
+        with zipfile.ZipFile(infile, "r", allowZip64=True) as zip:
 
             zip.extract(path=folder.abspath,
                    member='metadata.json')

--- a/aiida/orm/importexport.py
+++ b/aiida/orm/importexport.py
@@ -2056,7 +2056,7 @@ class ZipFolder(object):
     set _zipfile to None, ...)
     """
     def __init__(self, zipfolder_or_fname, mode=None, subfolder='.',
-                  use_compression=True):
+                  use_compression=True, allowZip64=True):
         """
         :param zipfolder_or_fname: either another ZipFolder instance,
           of which you want to get a subfolder, or a filename to create.
@@ -2082,7 +2082,8 @@ class ZipFolder(object):
             else:
                 compression = zipfile.ZIP_STORED
             self._zipfile = zipfile.ZipFile(zipfolder_or_fname, mode=the_mode,
-                                            compression=compression)
+                                            compression=compression,
+                                            allowZip64=allowZip64)
             self._pwd = subfolder
         else:
             if mode is not None:


### PR DESCRIPTION
Solves the issue #1617 (exporting large databases)

According to my tests enabling the flag allowZip64=True does not change the time to create a zip archive. For more details see #1617 