### PR TITLE
Setting timeout for Jenkins builds

### DIFF
--- a/.jenkins-data/Jenkinsfile
+++ b/.jenkins-data/Jenkinsfile
@@ -190,6 +190,11 @@ pipeline {
             }
         } 
     } 
+    options {
+        // we do not want the whole run to hang forever - 
+ 	// we set a total timeout of 1 hour
+        timeout(time: 60, unit: 'MINUTES')
+    }
 }
 
 


### PR DESCRIPTION
This set a total build timeout of 1 hour to avoid
infinite builds in case e.g. there is an input prompt
or some other strange condition.

To see if there is a way to improve the timeout as it works
on Travis: timeout since the last output was produced.