### PR TITLE
Implement the Exit exception to allow setting finish status for workfunctions

### DIFF
--- a/aiida/work/__init__.py
+++ b/aiida/work/__init__.py
@@ -10,6 +10,7 @@
 
 from plumpy import Bundle
 from plumpy import ProcessState
+from .exceptions import *
 from .futures import *
 from .launch import *
 from .job_processes import *
@@ -21,7 +22,7 @@ from .utils import *
 from .workfunctions import *
 from .workchain import *
 
-__all__ = (processes.__all__ + runners.__all__ + utils.__all__ +
+__all__ = (exceptions.__all__ + processes.__all__ + runners.__all__ + utils.__all__ +
            workchain.__all__ + launch.__all__ + workfunctions.__all__ +
            ['ProcessState'] + job_processes.__all__ +
            rmq.__all__ + futures.__all__ + persistence.__all__)

--- a/aiida/work/exceptions.py
+++ b/aiida/work/exceptions.py
@@ -1,0 +1,23 @@
+# -*- coding: utf-8 -*-
+
+__all__ = ['Exit']
+
+
+class Exit(Exception):
+    """
+    This can be raised from within a workfunction to tell it to exit immediately, but as opposed to all other
+    exceptions will not cause the workflow engine to mark the workfunction as excepted. Rather it will take
+    the exit code set for the exception and set that as the finish status of the workfunction.
+    """
+
+    def __init__(self, exit_code=0):
+        """
+        Construct the exception with a given exit code
+
+        :param exit_code: the integer exit code, default is 0
+        """
+        self._exit_code = exit_code
+
+    @property
+    def exit_code(self):
+        return self._exit_code

--- a/aiida/work/processes.py
+++ b/aiida/work/processes.py
@@ -31,6 +31,7 @@ from aiida.orm.calculation.function import FunctionCalculation
 from aiida.orm.calculation.work import WorkCalculation
 from aiida.orm.data import Data
 from aiida.utils.serialize import serialize_data, deserialize_data
+from aiida.work.exceptions import Exit
 from aiida.work.ports import InputPort, PortNamespace
 from aiida.work.process_spec import ProcessSpec
 from aiida.work.process_builder import ProcessBuilder
@@ -686,18 +687,23 @@ class FunctionProcess(Process):
             except ValueError:
                 kwargs[name] = value
 
-        result = self._func(*args, **kwargs)
-        if result is not None:
-            if isinstance(result, Data):
-                self.out(self.SINGLE_RETURN_LINKNAME, result)
-            elif isinstance(result, collections.Mapping):
-                for name, value in result.iteritems():
-                    self.out(name, value)
-            else:
-                raise TypeError(
-                    "Workfunction returned unsupported type '{}'\n"
-                    "Must be a Data type or a Mapping of {{string: Data}}".
-                        format(result.__class__))
+        try:
+            result = self._func(*args, **kwargs)
+        except Exit as exception:
+            finish_status = exception.exit_code
+        else:
+            finish_status = 0
 
-        # Execution successful so we return exit code (finish status) 0
-        return 0
+            if result is not None:
+                if isinstance(result, Data):
+                    self.out(self.SINGLE_RETURN_LINKNAME, result)
+                elif isinstance(result, collections.Mapping):
+                    for name, value in result.iteritems():
+                        self.out(name, value)
+                else:
+                    raise TypeError(
+                        "Workfunction returned unsupported type '{}'\n"
+                        "Must be a Data type or a Mapping of {{string: Data}}".
+                            format(result.__class__))
+
+        return finish_status

--- a/aiida/work/workfunctions.py
+++ b/aiida/work/workfunctions.py
@@ -11,7 +11,6 @@
 This file provides very simple workflows for testing purposes.
 Do not delete, otherwise 'verdi developertest' will stop to work.
 """
-
 import functools
 from . import processes
 from . import runners

--- a/docs/source/concepts/workflows.rst
+++ b/docs/source/concepts/workflows.rst
@@ -754,6 +754,23 @@ As already noted in the :ref:`report<reporting>` section, the report messages of
 The finish status, however, is a perfect way.
 The parent workchain can easily request the finish status of the child workchain through the ``finish_status`` property, and based on its value determine how to continue.
 
+Workfunction exit codes
+^^^^^^^^^^^^^^^^^^^^^^^
+The method of setting the finish status for a ``WorkChain`` as explained in the previous section, by simply returning an integer from any of the outline steps, will not work of course for workfunctions, as there you can only return once and the return value has to be a database storable type.
+To still be able to mark a workfunction as ``failed'' by letting it finish nominally, but setting a non-zero finish status, we provide a special exception class :py:class:`~aiida.work.exceptions.Exit`.
+This exception can be constructed with an integer, to denote the desired finish status and when raised from a workfunction, workflow engine will mark the node as ``Finished`` and set the finish status to the value of the exception.
+Consider the following example:
+
+.. code:: python
+
+    @workfunction
+    def exiting_workfunction():
+        from aiida.work import Exit
+        raise Exit(418)
+
+The execution of the workfunction will be immediately terminated as soon as the exception is raised and the finish status will be set to ``418`` in this example.
+Since no output nodes are returned, the ``FunctionCalculation`` node will have no outputs.
+
 Modular workflow design
 -----------------------
 When creating complex workflows, it is a good idea to split them up into smaller, modular parts.


### PR DESCRIPTION
Fix #1630 

There was no method yet to exit from a workfunction and specify an exit code
that should be used to set the finish status of the corresponding node.
However, this is an important feature to have. Here we choose to implement
a specific exception, aiida.common.exceptions.Exit, which will be treated
differently from all other exceptions by the workflow engine. When this is
raised, as opposed to marking the workfunction as EXCEPTED, the exit code
is retrieved from the exception class and is set as the finish status on the
node of the workfunction.