### PR TITLE
add echo_deprecated function

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,6 +14,7 @@
         aiida/cmdline/utils/multi_line_input.py|
         aiida/cmdline/utils/test_multiline.py|
         aiida/cmdline/utils/templates.py|
+        aiida/cmdline/utils/echo.py|
         docs/update_req_for_rtd.py| # a|b -> match a OR b
         .ci/test_setup.py|
         aiida/transport/.*.py|
@@ -39,6 +40,10 @@
         aiida/control/.*.py|
         aiida/cmdline/tests/.*.py|
         aiida/cmdline/commands/daemon.py|
+        aiida/cmdline/utils/multi_line_input.py|
+        aiida/cmdline/utils/test_multiline.py|
+        aiida/cmdline/utils/templates.py|
+        aiida/cmdline/utils/echo.py|
         docs/update_req_for_rtd.py|
         .ci/test_setup.py|
         .ci/test_plugin_testcase.py|

--- a/aiida/cmdline/commands/rehash.py
+++ b/aiida/cmdline/commands/rehash.py
@@ -53,4 +53,5 @@ def rehash(nodes, entry_point):
             echo.echo('.', nl=False)
         node.rehash()
 
-    echo.echo_success('{} nodes re-hashed'.format(i + 1), prefix='\n')
+    echo.echo('')
+    echo.echo_success('{} nodes re-hashed'.format(i + 1))

--- a/aiida/cmdline/commands/work.py
+++ b/aiida/cmdline/commands/work.py
@@ -418,7 +418,8 @@ def plugins(entry_point):
             for entry_point in entry_points:
                 echo.echo("* {}".format(entry_point))
 
-            echo.echo_info('Pass the entry point as an argument to display detailed information', prefix='\n')
+            echo.echo('')
+            echo.echo_info('Pass the entry point as an argument to display detailed information')
         else:
             echo.echo_error('No workflow plugins found')
 

--- a/aiida/cmdline/utils/echo.py
+++ b/aiida/cmdline/utils/echo.py
@@ -1,108 +1,122 @@
 # -*- coding: utf-8 -*-
+""" Convenience functions for printing output from verdi commands """
+import enum
 import sys
 import click
 
 
-def echo(message, bold=False, prefix=None, nl=True):
+#pylint: disable=too-few-public-methods
+class ExitCode(enum.Enum):
+    """Exit codes for the verdi command line."""
+    CRITICAL = 1
+    DEPRECATED = 80
+    UNKNOWN = 99
+
+
+#pylint: disable=invalid-name
+def echo(message, bold=False, nl=True):
     """
     Print a normal message through click's echo function to stdout
 
     :param message: the string representing the message to print
     :param bold: whether to print the message in bold
-    :param prefix: an optional string that will be printed before the message
     :param nl: whether to print a newline at the end of the message
     """
-    if prefix is not None:
-        click.secho(prefix)
-
     click.secho(message, bold=bold, nl=nl)
 
 
-def echo_info(message, bold=False, prefix=None, nl=True):
+def echo_info(message, bold=False, nl=True):
     """
     Print an info message through click's echo function to stdout, prefixed with 'Info:'
 
     :param message: the string representing the message to print
     :param bold: whether to print the message in bold
-    :param prefix: an optional string that will be printed before the message. Note that it does not automatically
-        include a newline character
     :param nl: whether to print a newline at the end of the message
     """
-    if prefix is not None:
-        click.secho(prefix, nl=False)
-
     click.secho('Info: ', fg='blue', bold=True, nl=False)
     click.secho(message, bold=bold, nl=nl)
 
 
-def echo_success(message, bold=False, prefix=None, nl=True):
+def echo_success(message, bold=False, nl=True):
     """
     Print a success message through click's echo function to stdout, prefixed with 'Success:'
 
     :param message: the string representing the message to print
     :param bold: whether to print the message in bold
-    :param prefix: an optional string that will be printed before the message. Note that it does not automatically
         include a newline character
     :param nl: whether to print a newline at the end of the message
     """
-    if prefix is not None:
-        click.secho(prefix, nl=False)
-
     click.secho('Success: ', fg='green', bold=True, nl=False)
     click.secho(message, bold=bold, nl=nl)
 
 
-def echo_warning(message, bold=False, prefix=None, nl=True):
+def echo_warning(message, bold=False, nl=True):
     """
     Print a warning message through click's echo function to stdout, prefixed with 'Warning:'
 
     :param message: the string representing the message to print
     :param bold: whether to print the message in bold
-    :param prefix: an optional string that will be printed before the message. Note that it does not automatically
-        include a newline character
     :param nl: whether to print a newline at the end of the message
     """
-    if prefix is not None:
-        click.secho(prefix, nl=False)
-
     click.secho('Warning: ', fg='yellow', bold=True, nl=False)
     click.secho(message, bold=bold, nl=nl)
 
 
-def echo_error(message, bold=False, prefix=None, nl=True):
+def echo_error(message, bold=False, nl=True):
     """
     Print an error message through click's echo function to stdout, prefixed with 'Error:'
 
     :param message: the string representing the message to print
     :param bold: whether to print the message in bold
-    :param prefix: an optional string that will be printed before the message. Note that it does not automatically
-        include a newline character
     :param nl: whether to print a newline at the end of the message
     """
-    if prefix is not None:
-        click.secho(prefix, nl=False)
-
     click.secho('Error: ', fg='red', bold=True, nl=False, err=True)
     click.secho(message, bold=bold, nl=nl, err=True)
 
 
-def echo_critical(message, bold=False, prefix=None, nl=True, exit_status=1):
+def echo_exit(message, bold=False, nl=True, exit_status=ExitCode.UNKNOWN, exit_label='EXIT: '):
+    """
+    Print error message through click's echo function to stdout, prefixed with
+    exit_label and then calls sys.exit with the given exit_status.
+
+    :param message: the string representing the message to print
+    :param bold: whether to print the message in bold
+    :param nl: whether to print a newline at the end of the message
+    :param exit_status: the integer to pass to the sys.exit() call
+    :param exit_label: the prefix for the error message
+    """
+    click.secho(exit_label, fg='red', bold=True, nl=False, err=True)
+    click.secho(message, bold=bold, nl=nl, err=True)
+    sys.exit(exit_status)
+
+
+def echo_critical(message, bold=False, nl=True):
     """
     Print an error message through click's echo function to stdout, prefixed with 'Critical:'
-    and then calls sys.exit with the give exit_status. This should be used to print messages for errors
-    that cannot be recovered from and so the script should be directly terminated with a non-zero exit
+    and then calls sys.exit with the given exit_status.
+
+    This should be used to print messages for errors that cannot be recovered
+    from and so the script should be directly terminated with a non-zero exit
     status to indicate that the command failed
 
     :param message: the string representing the message to print
     :param bold: whether to print the message in bold
-    :param prefix: an optional string that will be printed before the message. Note that it does not automatically
-        include a newline character
     :param nl: whether to print a newline at the end of the message
     :param exit_status: the integer to pass to the sys.exit() call
     """
-    if prefix is not None:
-        click.secho(prefix, nl=False)
+    echo_exit(message=message, bold=bold, nl=nl, exit_status=ExitCode.CRITICAL, exit_label='Critical: ')
 
-    click.secho('Critical: ', fg='red', bold=True, nl=False, err=True)
-    click.secho(message, bold=bold, nl=nl, err=True)
-    sys.exit(exit_status)
+
+def echo_deprecated(message, bold=False, nl=True):
+    """
+    Print an error message through click's echo function to stdout, prefixed with 'Deprecated:'
+    and then calls sys.exit with the given exit_status.
+
+    This should be used to indicate deprecated commands.
+
+    :param message: the string representing the message to print
+    :param bold: whether to print the message in bold
+    :param nl: whether to print a newline at the end of the message
+    :param exit_status: the integer to pass to the sys.exit() call
+    """
+    echo_exit(message=message, bold=bold, nl=nl, exit_status=ExitCode.DEPRECATED, exit_label='Deprecated: ')

--- a/aiida/cmdline/utils/echo.py
+++ b/aiida/cmdline/utils/echo.py
@@ -74,7 +74,7 @@ def echo_error(message, bold=False, nl=True):
     click.secho(message, bold=bold, nl=nl, err=True)
 
 
-def echo_exit(message, bold=False, nl=True, exit_status=ExitCode.UNKNOWN, exit_label='EXIT: '):
+def echo_exit(message, bold=False, nl=True, exit_status=ExitCode.UNKNOWN, exit_label='Exit: '):
     """
     Print error message through click's echo function to stdout, prefixed with
     exit_label and then calls sys.exit with the given exit_status.
@@ -102,7 +102,6 @@ def echo_critical(message, bold=False, nl=True):
     :param message: the string representing the message to print
     :param bold: whether to print the message in bold
     :param nl: whether to print a newline at the end of the message
-    :param exit_status: the integer to pass to the sys.exit() call
     """
     echo_exit(message=message, bold=bold, nl=nl, exit_status=ExitCode.CRITICAL, exit_label='Critical: ')
 
@@ -117,6 +116,5 @@ def echo_deprecated(message, bold=False, nl=True):
     :param message: the string representing the message to print
     :param bold: whether to print the message in bold
     :param nl: whether to print a newline at the end of the message
-    :param exit_status: the integer to pass to the sys.exit() call
     """
     echo_exit(message=message, bold=bold, nl=nl, exit_status=ExitCode.DEPRECATED, exit_label='Deprecated: ')

--- a/aiida/cmdline/utils/echo.py
+++ b/aiida/cmdline/utils/echo.py
@@ -74,22 +74,6 @@ def echo_error(message, bold=False, nl=True):
     click.secho(message, bold=bold, nl=nl, err=True)
 
 
-def echo_exit(message, bold=False, nl=True, exit_status=ExitCode.UNKNOWN, exit_label='Exit: '):
-    """
-    Print error message through click's echo function to stdout, prefixed with
-    exit_label and then calls sys.exit with the given exit_status.
-
-    :param message: the string representing the message to print
-    :param bold: whether to print the message in bold
-    :param nl: whether to print a newline at the end of the message
-    :param exit_status: the integer to pass to the sys.exit() call
-    :param exit_label: the prefix for the error message
-    """
-    click.secho(exit_label, fg='red', bold=True, nl=False, err=True)
-    click.secho(message, bold=bold, nl=nl, err=True)
-    sys.exit(exit_status)
-
-
 def echo_critical(message, bold=False, nl=True):
     """
     Print an error message through click's echo function to stdout, prefixed with 'Critical:'
@@ -103,10 +87,13 @@ def echo_critical(message, bold=False, nl=True):
     :param bold: whether to print the message in bold
     :param nl: whether to print a newline at the end of the message
     """
-    echo_exit(message=message, bold=bold, nl=nl, exit_status=ExitCode.CRITICAL, exit_label='Critical: ')
+    click.secho('Critical: ', fg='red', bold=True, nl=False, err=True)
+    click.secho(message, bold=bold, nl=nl, err=True)
+    sys.exit(ExitCode.CRITICAL)
 
 
-def echo_deprecated(message, bold=False, nl=True):
+#pylint: disable=redefined-builtin
+def echo_deprecated(message, bold=False, nl=True, exit=False):
     """
     Print an error message through click's echo function to stdout, prefixed with 'Deprecated:'
     and then calls sys.exit with the given exit_status.
@@ -116,5 +103,10 @@ def echo_deprecated(message, bold=False, nl=True):
     :param message: the string representing the message to print
     :param bold: whether to print the message in bold
     :param nl: whether to print a newline at the end of the message
+    :param exit: whether to exit after printing the message
     """
-    echo_exit(message=message, bold=bold, nl=nl, exit_status=ExitCode.DEPRECATED, exit_label='Deprecated: ')
+    click.secho('Deprecated: ', fg='red', bold=True, nl=False, err=True)
+    click.secho(message, bold=bold, nl=nl, err=True)
+
+    if exit:
+        sys.exit(ExitCode.DEPRECATED)

--- a/aiida/cmdline/utils/multi_line_input.py
+++ b/aiida/cmdline/utils/multi_line_input.py
@@ -11,10 +11,10 @@ def edit_pre_post(pre=None, post=None, summary=None):
     execution scripts for both codes and computers
     """
     from aiida.cmdline.utils.templates import env
-    t = env.get_template('prepost.bash.tpl')
+    template = env.get_template('prepost.bash.tpl')
     summary = summary or {}
     summary = {k: v for k, v in summary.iteritems() if v}
-    content = t.render(default_pre=pre or '', default_post=post or '', summary=summary)
+    content = template.render(default_pre=pre or '', default_post=post or '', summary=summary)
     mlinput = click.edit(content, extension='.bash')
     if mlinput:
         import re
@@ -30,8 +30,8 @@ def edit_comment(old_cmt=''):
     call up an editor to edit comments to nodes in the database
     """
     from aiida.cmdline.utils.templates import env
-    t = env.get_template('new_cmt.txt.tpl')
-    content = t.render(old_comment=old_cmt)
+    template = env.get_template('new_cmt.txt.tpl')
+    content = template.render(old_comment=old_cmt)
     mlinput = click.edit(content, extension='.txt')
     if mlinput:
         import re

--- a/aiida/cmdline/utils/templates.py
+++ b/aiida/cmdline/utils/templates.py
@@ -1,3 +1,5 @@
+"""Templates for input/output of verdi commands."""
 from jinja2 import Environment, PackageLoader
 
+#pylint: disable=invalid-name
 env = Environment(loader=PackageLoader('aiida', 'cmdline/templates'))

--- a/aiida/cmdline/utils/test_multiline.py
+++ b/aiida/cmdline/utils/test_multiline.py
@@ -2,7 +2,6 @@
 import os
 import unittest
 
-import click
 from click.testing import CliRunner
 
 from aiida.cmdline.utils.multi_line_input import edit_pre_post, edit_comment


### PR DESCRIPTION
 * add cmdline.utils.echo.echo_deprecated
 * add standard error codes
 * remove 'prefix' option from the echo commands