### PR TITLE
fix exit codes

### DIFF
--- a/aiida/cmdline/utils/echo.py
+++ b/aiida/cmdline/utils/echo.py
@@ -89,7 +89,7 @@ def echo_critical(message, bold=False, nl=True):
     """
     click.secho('Critical: ', fg='red', bold=True, nl=False, err=True)
     click.secho(message, bold=bold, nl=nl, err=True)
-    sys.exit(ExitCode.CRITICAL)
+    sys.exit(ExitCode.CRITICAL.value)
 
 
 #pylint: disable=redefined-builtin
@@ -109,4 +109,4 @@ def echo_deprecated(message, bold=False, nl=True, exit=False):
     click.secho(message, bold=bold, nl=nl, err=True)
 
     if exit:
-        sys.exit(ExitCode.DEPRECATED)
+        sys.exit(ExitCode.DEPRECATED.value)


### PR DESCRIPTION
Fixes #1654 

@giovannipizzi Since we are using this enum elsewhere as well, we stuck with it (meaning we have to use `.value`).
I could move to an  `IntEnum` if you like.