### PR TITLE
Migrate verdi node

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,6 +9,7 @@
         aiida/control/.*.py|        # must match the whole path, therefore
         aiida/cmdline/tests/.*.py|  # the .*.py (.* matches everything)
         aiida/cmdline/commands/daemon.py|
+        aiida/cmdline/commands/node.py|
         aiida/cmdline/params/.*.py|
         aiida/cmdline/optiontypes/.*.py|
         aiida/cmdline/utils/multi_line_input.py|
@@ -40,6 +41,7 @@
         aiida/control/.*.py|
         aiida/cmdline/tests/.*.py|
         aiida/cmdline/commands/daemon.py|
+        aiida/cmdline/commands/node.py|
         aiida/cmdline/utils/multi_line_input.py|
         aiida/cmdline/utils/test_multiline.py|
         aiida/cmdline/utils/templates.py|

--- a/aiida/backends/tests/__init__.py
+++ b/aiida/backends/tests/__init__.py
@@ -62,6 +62,7 @@ db_test_list = {
         'cmdline.params.types.node': ['aiida.backends.tests.cmdline.params.types.test_node'],
         'cmdline.params.types.plugin': ['aiida.backends.tests.cmdline.params.types.test_plugin'],
         'cmdline.commands.code': ['aiida.backends.tests.cmdline.commands.test_code'],
+        'cmdline.commands.node': ['aiida.backends.tests.cmdline.commands.test_node'],
         'daemon.client': ['aiida.backends.tests.daemon.test_client'],
         'orm.data.frozendict': ['aiida.backends.tests.orm.data.frozendict'],
         'orm.log': ['aiida.backends.tests.orm.log'],

--- a/aiida/backends/tests/cmdline/commands/test_node.py
+++ b/aiida/backends/tests/cmdline/commands/test_node.py
@@ -5,7 +5,7 @@ from click.testing import CliRunner
 
 from aiida.backends.testbase import AiidaTestCase
 from aiida.common.links import LinkType
-from aiida.cmdline.commands.node import node_delete, show, tree
+from aiida.cmdline.commands.node import node_delete, show, tree, repo_ls
 
 class TestVerdiNode(AiidaTestCase):
 
@@ -86,4 +86,12 @@ class TestVerdiNode(AiidaTestCase):
         self.assertTrue(str(nodes['outp3'].pk) in result.output)
         self.assertTrue(str(nodes['in2'].pk) not in result.output)
 
+    def test_node_repo_ls(self):
+        nodes = self.nodes
+        options = [str(nodes['in1'].pk)]
+        result = self.runner.invoke(repo_ls, options)
+        self.assertIsNone(result.exception)
 
+        options = [str(nodes['in1'].pk), 'non-existent-path']
+        result = self.runner.invoke(repo_ls, options)
+        self.assertIsNotNone(result.exception)

--- a/aiida/backends/tests/cmdline/commands/test_node.py
+++ b/aiida/backends/tests/cmdline/commands/test_node.py
@@ -5,7 +5,7 @@ from click.testing import CliRunner
 
 from aiida.backends.testbase import AiidaTestCase
 from aiida.common.links import LinkType
-from aiida.cmdline.commands.node import node_delete
+from aiida.cmdline.commands.node import node_delete, show
 
 class TestVerdiNode(AiidaTestCase):
 
@@ -65,11 +65,16 @@ class TestVerdiNode(AiidaTestCase):
         See also backends/tests/nodes.py."""
         nodes = self.nodes
         options = [str(nodes['in1'].pk), '-v', '--non-interactive']
-        result = self.runner.invoke(node_delete, options, input=user_input)
+        result = self.runner.invoke(node_delete, options)
         self.assertIsNone(result.exception)
 
-        for label in ['in1', 'wf', 'slave1', 'outp1', 'outp3']:
-            node = nodes[label]
-            self.assertTrue(str(node.uuid) in result.output, "Node {} should be deleted".format(label))
+    def test_node_show(self):
+        nodes = self.nodes
+        options = [str(nodes['in1'].pk), '--print-groups']
+        result = self.runner.invoke(show, options)
+        self.assertIsNone(result.exception)
+
+        self.assertTrue(str(nodes['in1'].uuid) in result.output)
+
 
 

--- a/aiida/backends/tests/cmdline/commands/test_node.py
+++ b/aiida/backends/tests/cmdline/commands/test_node.py
@@ -53,7 +53,6 @@ class TestVerdiNode(AiidaTestCase):
         options = [str(nodes['in1'].pk), '-v']
         user_input = '\n'.join(['Y'])
         result = self.runner.invoke(node_delete, options, input=user_input)
-        import pdb; pdb.set_trace()
         self.assertIsNone(result.exception)
 
         for label in ['in1', 'wf', 'slave1', 'outp1', 'outp3']:

--- a/aiida/backends/tests/cmdline/commands/test_node.py
+++ b/aiida/backends/tests/cmdline/commands/test_node.py
@@ -48,7 +48,7 @@ class TestVerdiNode(AiidaTestCase):
     def test_node_delete(self):
         """Test it deletes nodes down the provenance.
         
-        See alo backends/tests/nodes.py."""
+        See also backends/tests/nodes.py."""
         nodes = self.nodes
         options = [str(nodes['in1'].pk), '-v']
         user_input = '\n'.join(['Y'])
@@ -58,4 +58,18 @@ class TestVerdiNode(AiidaTestCase):
         for label in ['in1', 'wf', 'slave1', 'outp1', 'outp3']:
             node = nodes[label]
             self.assertTrue(str(node.uuid) in result.output, "Node {} should be deleted".format(label))
+
+    def test_node_delete_non_interactive(self):
+        """Test it deletes nodes down the provenance.
+        
+        See also backends/tests/nodes.py."""
+        nodes = self.nodes
+        options = [str(nodes['in1'].pk), '-v', '--non-interactive']
+        result = self.runner.invoke(node_delete, options, input=user_input)
+        self.assertIsNone(result.exception)
+
+        for label in ['in1', 'wf', 'slave1', 'outp1', 'outp3']:
+            node = nodes[label]
+            self.assertTrue(str(node.uuid) in result.output, "Node {} should be deleted".format(label))
+
 

--- a/aiida/backends/tests/cmdline/commands/test_node.py
+++ b/aiida/backends/tests/cmdline/commands/test_node.py
@@ -5,7 +5,7 @@ from click.testing import CliRunner
 
 from aiida.backends.testbase import AiidaTestCase
 from aiida.common.links import LinkType
-from aiida.cmdline.commands.node import node_delete, show, tree, repo_ls, repo_cat
+from aiida.cmdline.commands.node import node_delete, node_label, node_description, show, tree, repo_ls, repo_cat
 
 class TestVerdiNode(AiidaTestCase):
 
@@ -71,7 +71,30 @@ class TestVerdiNode(AiidaTestCase):
 
         self.assertTrue(str(nodes['in1'].uuid) in result.output)
         self.assertTrue(str(nodes['outp3'].pk) in result.output)
-        self.assertTrue(str(nodes['in2'].pk) not in result.output)
+        self.assertTrue(str(nodes['in2'].uuid) not in result.output)
+
+    def test_node_label(self):
+        node = self.nodes['in1']
+        label = u"my label"
+        node.label = label
+        node.store()
+        
+        options = [str(node.pk), '--raw']
+        result = self.runner.invoke(node_label, options)
+        self.assertIsNone(result.exception)
+        self.assertEquals(result.output, label+'\n')
+
+    def test_node_description(self):
+        node = self.nodes['in1']
+        description = u"my desc\nover two lines"
+        node.description = description
+        node.store()
+        
+        options = [str(node.pk), '--raw']
+        result = self.runner.invoke(node_description, options)
+        self.assertIsNone(result.exception)
+        self.assertEquals(result.output, description+'\n')
+
 
 class TestVerdiNodeRepo(AiidaTestCase):
 

--- a/aiida/backends/tests/cmdline/commands/test_node.py
+++ b/aiida/backends/tests/cmdline/commands/test_node.py
@@ -79,10 +79,21 @@ class TestVerdiNode(AiidaTestCase):
         node.label = label
         node.store()
         
+        # read existing label
         options = [str(node.pk), '--raw']
         result = self.runner.invoke(node_label, options)
         self.assertIsNone(result.exception)
         self.assertEquals(result.output, label+'\n')
+
+        # set new label
+        new_label = "my new label"
+        options = [str(node.pk), '--label', new_label, '--force']
+        result = self.runner.invoke(node_label, options)
+        self.assertIsNone(result.exception)
+
+        from aiida.orm import load_node
+        updated_node = load_node(node.pk)
+        self.assertEquals(updated_node.label, new_label)
 
     def test_node_description(self):
         node = self.nodes['in1']

--- a/aiida/backends/tests/cmdline/commands/test_node.py
+++ b/aiida/backends/tests/cmdline/commands/test_node.py
@@ -5,7 +5,7 @@ from click.testing import CliRunner
 
 from aiida.backends.testbase import AiidaTestCase
 from aiida.common.links import LinkType
-from aiida.cmdline.commands.node import node_delete, show
+from aiida.cmdline.commands.node import node_delete, show, tree
 
 class TestVerdiNode(AiidaTestCase):
 
@@ -76,5 +76,14 @@ class TestVerdiNode(AiidaTestCase):
 
         self.assertTrue(str(nodes['in1'].uuid) in result.output)
 
+    def test_node_tree(self):
+        nodes = self.nodes
+        options = [str(nodes['in1'].pk), '-d', 3]
+        result = self.runner.invoke(tree, options)
+        self.assertIsNone(result.exception)
+
+        self.assertTrue(str(nodes['in1'].uuid) in result.output)
+        self.assertTrue(str(nodes['outp3'].pk) in result.output)
+        self.assertTrue(str(nodes['in2'].pk) not in result.output)
 
 

--- a/aiida/backends/tests/cmdline/commands/test_node.py
+++ b/aiida/backends/tests/cmdline/commands/test_node.py
@@ -1,0 +1,62 @@
+import os
+import subprocess as sp
+import click
+from click.testing import CliRunner
+
+from aiida.backends.testbase import AiidaTestCase
+from aiida.common.links import LinkType
+from aiida.cmdline.commands.node import node_delete
+
+class TestVerdiNode(AiidaTestCase):
+
+    node_labels = ('in1', 'in2', 'wf', 'slave1', 'slave2', 'outp1', 'outp2', 'outp3', 'outp4')
+
+    @classmethod
+    def setUpClass(cls):
+        super(TestVerdiNode, cls).setUpClass()
+        from aiida.orm import Computer
+        new_comp = Computer(name='comp',
+                                hostname='localhost',
+                                transport_type='local',
+                                scheduler_type='direct',
+                                workdir='/tmp/aiida')
+        new_comp.store()
+
+
+
+    def setUp(self):
+        """Sets up a few nodes to play around with."""
+        from aiida.orm import Node
+
+        nodes = { key : Node().store() for key in self.node_labels }
+
+        nodes['wf'].add_link_from(nodes['in1'], link_type=LinkType.INPUT)
+        nodes['slave1'].add_link_from(nodes['in1'], link_type=LinkType.INPUT)
+        nodes['slave1'].add_link_from(nodes['in2'], link_type=LinkType.INPUT)
+        nodes['slave2'].add_link_from(nodes['in2'], link_type=LinkType.INPUT)
+        nodes['slave1'].add_link_from(nodes['wf'], link_type=LinkType.CALL)
+        nodes['slave2'].add_link_from(nodes['wf'], link_type=LinkType.CALL)
+        nodes['outp1'].add_link_from(nodes['slave1'], link_type=LinkType.CREATE)
+        nodes['outp2'].add_link_from(nodes['slave2'], link_type=LinkType.CREATE)
+        nodes['outp2'].add_link_from(nodes['wf'], link_type=LinkType.RETURN)
+        nodes['outp3'].add_link_from(nodes['wf'], link_type=LinkType.CREATE)
+        nodes['outp4'].add_link_from(nodes['wf'], link_type=LinkType.RETURN)
+        self.nodes = nodes
+
+        self.runner = CliRunner()
+
+    def test_node_delete(self):
+        """Test it deletes nodes down the provenance.
+        
+        See alo backends/tests/nodes.py."""
+        nodes = self.nodes
+        options = [str(nodes['in1'].pk), '-v']
+        user_input = '\n'.join(['Y'])
+        result = self.runner.invoke(node_delete, options, input=user_input)
+        import pdb; pdb.set_trace()
+        self.assertIsNone(result.exception)
+
+        for label in ['in1', 'wf', 'slave1', 'outp1', 'outp3']:
+            node = nodes[label]
+            self.assertTrue(str(node.uuid) in result.output, "Node {} should be deleted".format(label))
+

--- a/aiida/cmdline/baseclass.py
+++ b/aiida/cmdline/baseclass.py
@@ -238,7 +238,10 @@ class VerdiCommandWithSubcommands(VerdiCommand):
         except KeyError:
             function_to_call = self.invalid_subcommand
 
-        function_to_call(*args[1:])
+        if isinstance(function_to_call, click.Command):
+            function_to_call()
+        else:
+            function_to_call(*args[1:])
 
     def complete(self, subargs_idx, subargs):
         if subargs_idx == 0:

--- a/aiida/cmdline/commands/__init__.py
+++ b/aiida/cmdline/commands/__init__.py
@@ -114,6 +114,11 @@ def verdi_import(ctx):
 def verdi_node(ctx):
     pass
 
+@verdi_node.group('repo')
+@click.pass_context
+def verdi_node_repo(ctx):
+    pass
+
 @verdi.group('profile')
 @click.pass_context
 def verdi_profile(ctx):

--- a/aiida/cmdline/commands/node.py
+++ b/aiida/cmdline/commands/node.py
@@ -321,12 +321,11 @@ def print_node_info(node, print_groups=False):
 @click.option('-c', '--follow-calls', is_flag=True, help='follow call links downwards when deleting')
 # Commenting also the option for follow returns. This is dangerous for the inexperienced user.
 #@click.option('-r', '--follow-returns', is_flag=True, help='follow return links downwards when deleting')
-@click.option('-f', '--force', is_flag=True, help='delete without user confirmation')
 @click.option('-n', '--dry-run', is_flag=True, help='dry run, does not delete')
 @click.option('-v', '--verbose', is_flag=True, help='print individual nodes marked for deletion.')
 @options.NON_INTERACTIVE()
 @with_dbenv()
-def node_delete(nodes, follow_calls, force, dry_run, verbose, non_interactive):
+def node_delete(nodes, follow_calls, dry_run, verbose, non_interactive):
     """
     Deletes a node and everything that originates from it.
     """
@@ -343,9 +342,8 @@ def node_delete(nodes, follow_calls, force, dry_run, verbose, non_interactive):
 
     node_pks_to_delete = [ node.pk for node in nodes ]
 
-    delete_nodes(node_pks_to_delete,
-            follow_calls=follow_calls,
-            dry_run=dry_run, verbosity=verbosity)
+    delete_nodes(node_pks_to_delete, follow_calls=follow_calls,
+            dry_run=dry_run, verbosity=verbosity, force=non_interactive)
 
 
 class _Tree(VerdiCommand):

--- a/aiida/cmdline/commands/node.py
+++ b/aiida/cmdline/commands/node.py
@@ -7,23 +7,20 @@
 # For further information on the license, see the LICENSE.txt file        #
 # For further information please visit http://www.aiida.net               #
 ###########################################################################
+""""
+Manipulating and printing information of nodes.
+"""
 import sys
 import click
 
 from aiida.backends.utils import load_dbenv, is_dbenv_loaded
 from aiida.cmdline import delayed_load_node as load_node
-from aiida.cmdline.baseclass import VerdiCommand
-from aiida.cmdline.baseclass import (
-    VerdiCommandRouter, VerdiCommandWithSubcommands)
+from aiida.cmdline.baseclass import (VerdiCommandRouter, VerdiCommandWithSubcommands)
 from aiida.cmdline.commands import verdi, verdi_node, verdi_node_repo
 
 from aiida.cmdline.utils import echo
 from aiida.cmdline.utils.decorators import with_dbenv
 from aiida.cmdline.params import options, arguments
-
-
-
-
 
 
 class Node(VerdiCommandRouter):
@@ -60,6 +57,7 @@ class _Repo(VerdiCommandWithSubcommands):
         """
         A dictionary with valid commands and functions to be called.
         """
+        super(_Repo, self).__init__()
         self.valid_subcommands = {
             'ls': (verdi, self.complete_none),
             'cat': (verdi, self.complete_none),
@@ -69,22 +67,21 @@ class _Repo(VerdiCommandWithSubcommands):
 @verdi_node_repo.command('cat')
 @arguments.NODE()
 @click.argument('relative_path', type=str)
-@click.option('-c', '--color', 'color', flag_value=True,
-              help="Use different color for folders and files.")
 @with_dbenv()
-def repo_cat(node, relative_path, color):
-     """Output the content of a file in the repository folder."""
-     try:
-         cat_repo_files(node, relative_path)
-     except ValueError as e:
-         echo.echo_critical(e.message)
-     except IOError as e:
-         import errno
-         # Ignore Broken pipe errors, re-raise everything else
-         if e.errno == errno.EPIPE:
-             pass
-         else:
-             echo.echo_critical(e.message)
+def repo_cat(node, relative_path):
+    """Output the content of a file in the repository folder."""
+    try:
+        cat_repo_files(node, relative_path)
+    except ValueError as exc:
+        echo.echo_critical(exc.message)
+    except IOError as exc:
+        import errno
+        # Ignore Broken pipe errors, re-raise everything else
+        if exc.errno == errno.EPIPE:
+            pass
+        else:
+            echo.echo_critical(exc.message)
+
 
 def cat_repo_files(node, path):
     """
@@ -97,16 +94,16 @@ def cat_repo_files(node, path):
     """
     import os
 
-    f = node.folder
+    fldr = node.folder
 
     is_dir = False
     parts = path.split(os.path.sep)
     # except the last item
     for item in parts[:-1]:
-        f = f.get_subfolder(item)
+        fldr = fldr.get_subfolder(item)
     if parts:
-        if f.isdir(parts[-1]):
-            f = f.get_subfolder(parts[-1])
+        if fldr.isdir(parts[-1]):
+            fldr = fldr.get_subfolder(parts[-1])
             is_dir = True
         else:
             fname = parts[-1]
@@ -114,35 +111,33 @@ def cat_repo_files(node, path):
         is_dir = True
 
     if is_dir:
-        if not f.isdir('.'):
-            raise ValueError(
-                "No directory '{}' in the repo".format(path))
+        if not fldr.isdir('.'):
+            raise ValueError("No directory '{}' in the repo".format(path))
         else:
             raise ValueError("'{}' is a directory".format(path))
     else:
-        if not f.isfile(fname):
-            raise ValueError(
-                "No file '{}' in the repo".format(path))
+        if not fldr.isfile(fname):
+            raise ValueError("No file '{}' in the repo".format(path))
 
-        absfname = f.get_abs_path(fname)
-        with open(absfname) as f:
-            for l in f:
-                sys.stdout.write(l)
+        absfname = fldr.get_abs_path(fname)
+        with open(absfname) as repofile:
+            for line in repofile:
+                sys.stdout.write(line)
 
 
 @verdi_node_repo.command('ls')
 @arguments.NODE()
 @click.argument('relative_path', type=str, default='.')
-@click.option('-c', '--color', 'color', flag_value=True,
-              help="Use different color for folders and files.")
+@click.option('-c', '--color', 'color', flag_value=True, help="Use different color for folders and files.")
 @with_dbenv()
 def repo_ls(node, relative_path, color):
-     """List files in the repository folder."""
+    """List files in the repository folder."""
 
-     try:
-         list_repo_files(node, relative_path, color)
-     except ValueError as e:
-         echo.critical(e.message)
+    try:
+        list_repo_files(node, relative_path, color)
+    except ValueError as exc:
+        echo.echo_critical(exc.message)
+
 
 def list_repo_files(node, path, color):
     """
@@ -156,16 +151,16 @@ def list_repo_files(node, path, color):
     """
     import os
 
-    f = node.folder
+    fldr = node.folder
 
     is_dir = False
     parts = path.split(os.path.sep)
     # except the last item
     for item in parts[:-1]:
-        f = f.get_subfolder(item)
+        fldr = fldr.get_subfolder(item)
     if parts:
-        if f.isdir(parts[-1]):
-            f = f.get_subfolder(parts[-1])
+        if fldr.isdir(parts[-1]):
+            fldr = fldr.get_subfolder(parts[-1])
             is_dir = True
         else:
             fname = parts[-1]
@@ -173,48 +168,45 @@ def list_repo_files(node, path, color):
         is_dir = True
 
     if is_dir:
-        if not f.isdir('.'):
-            raise ValueError(
-                "{}: No such file or directory in the repo".format(path))
+        if not fldr.isdir('.'):
+            raise ValueError("{}: No such file or directory in the repo".format(path))
 
-        for elem, elem_is_file in sorted(f.get_content_list(only_paths=False)):
+        for elem, elem_is_file in sorted(fldr.get_content_list(only_paths=False)):
             if elem_is_file or not color:
                 print elem
             else:
                 # BOLD("1;") and color 34=blue
-                outstr = "\x1b[1;{color_id}m{elem}\x1b[0m".format(color_id=34,
-                                                                  elem=elem)
+                outstr = "\x1b[1;{color_id}m{elem}\x1b[0m".format(color_id=34, elem=elem)
                 print outstr
     else:
-        if not f.isfile(fname):
-            raise ValueError(
-                "{}: No such file or directory in the repo".format(path))
+        if not fldr.isfile(fname):
+            raise ValueError("{}: No such file or directory in the repo".format(path))
 
         print fname
 
 
 @verdi_node.command('show')
 @arguments.NODES()
-@click.option('--print-groups', 'print_groups', flag_value=True,
-              help="Show groups containing the nodes.")
+@click.option('--print-groups', 'print_groups', flag_value=True, help="Show groups containing the nodes.")
 @with_dbenv()
 def show(nodes, print_groups):
+    """Show generic information on node(s)."""
     from aiida.cmdline.utils.common import print_node_info
     for node in nodes:
-        ###TODO
-        #Add a check here on the node type, otherwise it might try to access attributes such as code which are not necessarily there
-        #####
+        # pylint: disable=fixme
+        #TODO: Add a check here on the node type, otherwise it might try to access
+        # attributes such as code which are not necessarily there
         print_node_info(node)
 
         if print_groups:
             from aiida.orm.querybuilder import QueryBuilder
             from aiida.orm.group import Group
-            from aiida.orm.node import Node
+            from aiida.orm.node import Node  # pylint: disable=redefined-outer-name
 
+            # pylint: disable=invalid-name
             qb = QueryBuilder()
             qb.append(Node, tag='node', filters={'id': {'==': node.pk}})
-            qb.append(Group, tag='groups', group_of='node',
-                      project=['id', 'name'])
+            qb.append(Group, tag='groups', group_of='node', project=['id', 'name'])
 
             echo.echo("#### GROUPS:")
 
@@ -223,8 +215,7 @@ def show(nodes, print_groups):
             else:
                 res = qb.iterdict()
                 for gr in res:
-                    gr_specs = "{} {}".format(gr['groups']['name'],
-                                              gr['groups']['id'])
+                    gr_specs = "{} {}".format(gr['groups']['name'], gr['groups']['id'])
                     echo.echo(gr_specs)
 
 
@@ -242,11 +233,13 @@ def tree(nodes, depth):
         if len(nodes) > 1:
             echo.echo("")
 
+
 class NodeTreePrinter(object):
     """Utility functions for printing node trees."""
 
     @classmethod
     def print_node_tree(cls, node, max_depth, follow_links=None):
+        """Top-level function for printing node tree."""
         from aiida.cmdline.utils.common import print_node_summary
         from ete3 import Tree
         print_node_summary(node)
@@ -254,27 +247,26 @@ class NodeTreePrinter(object):
         tree_string = \
             "({});".format(cls._build_tree(node, max_depth=max_depth,
                                             follow_links=follow_links))
-        t = Tree(tree_string, format=1)
-        echo.echo(t.get_ascii(show_internal=True))
+        tmp = Tree(tree_string, format=1)
+        echo.echo(tmp.get_ascii(show_internal=True))
 
-    @classmethod
-    def _ctime(cls, nodelab):
+    @staticmethod
+    def _ctime(nodelab):
         return nodelab[1].ctime
 
     @classmethod
-    def _build_tree(cls, node, label_type=None, show_pk=True, max_depth=None,
-                    follow_links=None, depth=0):
+    def _build_tree(cls, node, show_pk=True, max_depth=None, follow_links=None, depth=0):
+        """Return string with tree."""
         if max_depth is not None and depth > max_depth:
-            return
+            return None
 
         children = []
+        # pylint: disable=unused-variable
         for label, child \
                 in sorted(node.get_outputs(also_labels=True,
                                            link_type=follow_links),
                           key=cls._ctime):
-            child_str = cls._build_tree(
-                child, label, show_pk, follow_links=follow_links,
-                max_depth=max_depth, depth=depth + 1)
+            child_str = cls._build_tree(child, show_pk, follow_links=follow_links, max_depth=max_depth, depth=depth + 1)
             if child_str:
                 children.append(child_str)
 
@@ -299,7 +291,8 @@ class NodeTreePrinter(object):
 @click.option('-c', '--follow-calls', is_flag=True, help='follow call links downwards when deleting')
 # Commenting also the option for follow returns. This is dangerous for the inexperienced user.
 #@click.option('-r', '--follow-returns', is_flag=True, help='follow return links downwards when deleting')
-@click.option('-n', '--dry-run', is_flag=True, help='dry run, does not delete')
+@click.option(
+    '-n', '--dry-run', is_flag=True, help='dry run, does not delete')
 @click.option('-v', '--verbose', is_flag=True, help='print individual nodes marked for deletion.')
 @options.NON_INTERACTIVE()
 @with_dbenv()
@@ -318,11 +311,10 @@ def node_delete(nodes, follow_calls, dry_run, verbose, non_interactive):
     elif verbose:
         verbosity = 2
 
-    node_pks_to_delete = [ node.pk for node in nodes ]
+    node_pks_to_delete = [node.pk for node in nodes]
 
-    delete_nodes(node_pks_to_delete, follow_calls=follow_calls,
-            dry_run=dry_run, verbosity=verbosity, force=non_interactive)
-
+    delete_nodes(
+        node_pks_to_delete, follow_calls=follow_calls, dry_run=dry_run, verbosity=verbosity, force=non_interactive)
 
 
 # the classes _Label and _Description are written here,
@@ -330,102 +322,106 @@ def node_delete(nodes, follow_calls, dry_run, verbose, non_interactive):
 # in fact, I don't want to allow the possibility of changing labels or
 # descriptions of codes, for that there is a separate command
 
+
 class _Label(VerdiCommandWithSubcommands):
     """
     See or modify the label of one or more set of nodes
     """
 
     def __init__(self, node_subclass='data'):
+        super(_Label, self).__init__()
         self._node_subclass = node_subclass
         if self._node_subclass not in ['calculation', 'data']:
             raise ValueError("Class must be loaded with a valid node_subclass")
 
-    def _node_class_ok(self, n):
+    def _node_class_ok(self, node):
+        """Check whether node class is recognized."""
         from aiida.orm import Calculation as OrmCalculation
         from aiida.orm import Data as OrmData
 
         if self._node_subclass == 'calculation':
-            return isinstance(n, OrmCalculation)
+            return isinstance(node, OrmCalculation)
         elif self._node_subclass == 'data':
-            return isinstance(n, OrmData)
+            return isinstance(node, OrmData)
         else:
             raise ValueError("node_subclass not recognized")
 
+    # pylint: disable=too-many-branches
     def run(self, *args):
         if not is_dbenv_loaded():
             load_dbenv()
         import argparse
         from aiida.cmdline import wait_for_confirmation
 
-        parser = argparse.ArgumentParser(prog=self.get_full_command_name(),
-                                         description="See/modify the labels of Nodes.")
+        parser = argparse.ArgumentParser(
+            prog=self.get_full_command_name(), description="See/modify the labels of Nodes.")
         # display parameters
-        parser.add_argument('-r', '--raw', action='store_true', default=False,
-                            help="Display only the labels, without the pk.")
+        parser.add_argument(
+            '-r', '--raw', action='store_true', default=False, help="Display only the labels, without the pk.")
         # pks
-        parser.add_argument('pks', type=int, nargs='+',
-                            help="a list of nodes to show.")
+        parser.add_argument('pks', type=int, nargs='+', help="a list of nodes to show.")
         # parameters for label modification
-        parser.add_argument('-s', '--set', action='store_true', default=False,
-                            help="If present, set a new label, otherwise only "
-                                 "show the labels.")
-        parser.add_argument('-f', '--force', action='store_true',
-                            default=False,
-                            help="Force the reset of the label.")
-        parser.add_argument('-l', '--label', type=str, default=None,
-                            help="The new label to be set on the node. Note: "
-                                 "pass it between quotes.")
+        parser.add_argument(
+            '-s',
+            '--set',
+            action='store_true',
+            default=False,
+            help="If present, set a new label, otherwise only "
+            "show the labels.")
+        parser.add_argument('-f', '--force', action='store_true', default=False, help="Force the reset of the label.")
+        parser.add_argument(
+            '-l',
+            '--label',
+            type=str,
+            default=None,
+            help="The new label to be set on the node. Note: "
+            "pass it between quotes.")
 
         parsed_args = parser.parse_args(args)
         raw = parsed_args.raw
+        # pylint: disable=invalid-name
         pks = parsed_args.pks
 
         if not parsed_args.set:
             for pk in pks:
-                n = load_node(pk)
-                if not self._node_class_ok(n):
-                    print "Node {} is not a subclass of {}. Exiting...".format(
-                        pk,
-                        self._node_subclass)
+                node = load_node(pk)
+                if not self._node_class_ok(node):
+                    print "Node {} is not a subclass of {}. Exiting...".format(pk, self._node_subclass)
                     sys.exit(1)
                 if raw:
-                    print '"{}"'.format(n.label)
+                    print '"{}"'.format(node.label)
                 else:
-                    if not n.label:
+                    if not node.label:
                         print 'Node {}, label: n.a.'.format(pk)
                     else:
-                        print 'Node {}, label: "{}"'.format(pk, n.label)
+                        print 'Node {}, label: "{}"'.format(pk, node.label)
         else:
             if len(pks) > 1:
-                sys.stderr.write("More than one node found to set one label"
-                                 ". Exiting...\n")
+                sys.stderr.write("More than one node found to set one label" ". Exiting...\n")
                 sys.exit(1)
             else:
                 pk = pks[0]
 
             new_label = parsed_args.label
             if new_label is None:
-                sys.stderr.write("A new label is required"
-                                 ". Exiting...\n")
+                sys.stderr.write("A new label is required" ". Exiting...\n")
                 sys.exit(1)
 
-            n = load_node(pk)
+            node = load_node(pk)
 
-            if not self._node_class_ok(n):
-                print "Node {} is not a subclass of {}. Exiting...".format(pk,
-                                                                           self._node_subclass)
+            if not self._node_class_ok(node):
+                print "Node {} is not a subclass of {}. Exiting...".format(pk, self._node_subclass)
                 sys.exit(1)
 
-            old_label = n.label
+            old_label = node.label
             if not parsed_args.force:
                 sys.stderr.write("Current label is: {}\n".format(old_label))
                 sys.stderr.write("New label is: {}\n".format(new_label))
-                sys.stderr.write("Are you sure you want to reset the label? "
-                                 "[Y/N] ")
+                sys.stderr.write("Are you sure you want to reset the label? " "[Y/N] ")
                 if not wait_for_confirmation():
                     sys.exit(0)
 
-            n.label = new_label
+            node.label = new_label
 
 
 class _Description(VerdiCommandWithSubcommands):
@@ -434,58 +430,73 @@ class _Description(VerdiCommandWithSubcommands):
     """
 
     def __init__(self, node_subclass='data'):
+        super(_Description, self).__init__()
         self._node_subclass = node_subclass
         if self._node_subclass not in ['calculation', 'data']:
             raise ValueError("Class must be loaded with a valid node_subclass")
 
-    def _node_class_ok(self, n):
+    def _node_class_ok(self, node):
+        """Check whether node class is recognized."""
         from aiida.orm import Calculation as OrmCalculation
         from aiida.orm import Data as OrmData
 
         if self._node_subclass == 'calculation':
-            return isinstance(n, OrmCalculation)
+            return isinstance(node, OrmCalculation)
         elif self._node_subclass == 'data':
-            return isinstance(n, OrmData)
+            return isinstance(node, OrmData)
         else:
             raise ValueError("node_subclass not recognized")
 
+    # pylint: disable=too-many-statements,too-many-branches
     def run(self, *args):
         if not is_dbenv_loaded():
             load_dbenv()
         import argparse
         from aiida.cmdline import wait_for_confirmation
 
-        parser = argparse.ArgumentParser(prog=self.get_full_command_name(),
-                                         description="See description of Nodes. If no node "
-                                                     "description or label is found, prints n.a.")
+        parser = argparse.ArgumentParser(
+            prog=self.get_full_command_name(),
+            description="See description of Nodes. If no node "
+            "description or label is found, prints n.a.")
 
         # parameters for display
-        parser.add_argument('-n', '--no-labels', action='store_false',
-                            default=True,
-                            help="Don't show the labels.")
-        parser.add_argument('-r', '--raw', action='store_true', default=False,
-                            help="If set, prints only the description without "
-                                 "pks or labels.")
+        parser.add_argument('-n', '--no-labels', action='store_false', default=True, help="Don't show the labels.")
+        parser.add_argument(
+            '-r',
+            '--raw',
+            action='store_true',
+            default=False,
+            help="If set, prints only the description without "
+            "pks or labels.")
         # pks
-        parser.add_argument('pks', type=int, nargs='+',
-                            help="a list of node pks to show.")
+        parser.add_argument('pks', type=int, nargs='+', help="a list of node pks to show.")
         # parameters for description modifications
-        parser.add_argument('-s', '--set', action='store_true', default=False,
-                            help="If present, set a new label, otherwise only "
-                                 "show the labels.")
-        parser.add_argument('-a', '--add-to-description', action='store_true',
-                            default=False,
-                            help="If -s, the string passed in -d is appended "
-                                 "to the current description.")
-        parser.add_argument('-f', '--force', action='store_true',
-                            default=False,
-                            help="Force the reset of the description.")
-        parser.add_argument('-d', '--description', type=str,
-                            help="The new description to be set on the node. "
-                                 "Note: pass it between quotes.")
+        parser.add_argument(
+            '-s',
+            '--set',
+            action='store_true',
+            default=False,
+            help="If present, set a new label, otherwise only "
+            "show the labels.")
+        parser.add_argument(
+            '-a',
+            '--add-to-description',
+            action='store_true',
+            default=False,
+            help="If -s, the string passed in -d is appended "
+            "to the current description.")
+        parser.add_argument(
+            '-f', '--force', action='store_true', default=False, help="Force the reset of the description.")
+        parser.add_argument(
+            '-d',
+            '--description',
+            type=str,
+            help="The new description to be set on the node. "
+            "Note: pass it between quotes.")
 
         parsed_args = parser.parse_args(args)
 
+        # pylint: disable=invalid-name
         pks = parsed_args.pks
 
         if not parsed_args.set:
@@ -494,36 +505,31 @@ class _Description(VerdiCommandWithSubcommands):
                 n = load_node(pk)
 
                 if not self._node_class_ok(n):
-                    print "Node {} is not a subclass of {}. Exiting...".format(
-                        pk,
-                        self._node_subclass)
-                    sys.exit(1)
+                    echo.echo_critical("Node {} is not a subclass of {}. Exiting...".format(pk, self._node_subclass))
 
                 label = n.label
                 description = n.description
 
                 if parsed_args.raw:
-                    print '"{}"'.format(n.description)
-                    print ""
+                    echo.echo('"{}"'.format(n.description))
+                    echo.echo("")
 
                 else:
-                    print "Node pk: {}".format(pk)
+                    echo.echo("Node pk: {}".format(pk))
                     if also_labels:
                         if label:
-                            print 'Label: "{}"'.format(label)
+                            echo.echo('Label: "{}"'.format(label))
                         else:
-                            print 'Label: n.a.'
+                            echo.echo('Label: n.a.')
                     if description:
-                        print 'Description: "{}"'.format(description)
+                        echo.echo('Description: "{}"'.format(description))
                     else:
-                        print 'Description: n.a.'
-                    print ""
+                        echo.echo('Description: n.a.')
+                    echo.echo("")
         else:
             # check that only one pk is present
             if len(pks) > 1:
-                sys.stderr.write(
-                    "More than one node found to set one description"
-                    ". Exiting...\n")
+                sys.stderr.write("More than one node found to set one description" ". Exiting...\n")
                 sys.exit(1)
             else:
                 pk = pks[0]
@@ -536,20 +542,13 @@ class _Description(VerdiCommandWithSubcommands):
             if not parsed_args.add_to_description:
                 n = load_node(pk)
                 if not self._node_class_ok(n):
-                    print "Node {} is not a subclass of {}. Exiting...".format(
-                        pk,
-                        self._node_subclass)
-                    sys.exit(1)
+                    echo.echo_critical("Node {} is not a subclass of {}. Exiting...".format(pk, self._node_subclass))
 
                 old_description = n.description
                 if not parsed_args.force:
-                    sys.stderr.write(
-                        "Current description is: {}\n".format(old_description))
-                    sys.stderr.write(
-                        "New description is: {}\n".format(new_description))
-                    sys.stderr.write(
-                        "Are you sure you want to reset the description? "
-                        "[Y/N] ")
+                    sys.stderr.write("Current description is: {}\n".format(old_description))
+                    sys.stderr.write("New description is: {}\n".format(new_description))
+                    sys.stderr.write("Are you sure you want to reset the description? " "[Y/N] ")
                     if not wait_for_confirmation():
                         sys.exit(0)
 
@@ -558,10 +557,7 @@ class _Description(VerdiCommandWithSubcommands):
             else:
                 n = load_node(pk)
                 if not self._node_class_ok(n):
-                    print "Node {} is not a subclass of {}. Exiting...".format(
-                        pk,
-                        self._node_subclass)
-                    sys.exit(1)
+                    echo.echo_critical("Node {} is not a subclass of {}. Exiting...".format(pk, self._node_subclass))
 
                 old_description = n.description
                 new_description = old_description + "\n" + new_description

--- a/aiida/cmdline/commands/node.py
+++ b/aiida/cmdline/commands/node.py
@@ -323,7 +323,7 @@ def print_node_info(node, print_groups=False):
 #@click.option('-r', '--follow-returns', is_flag=True, help='follow return links downwards when deleting')
 @click.option('-f', '--force', is_flag=True, help='delete without user confirmation')
 @click.option('-n', '--dry-run', is_flag=True, help='dry run, does not delete')
-@click.option('-v', '--verbose', help='print individual nodes marked for deletion.')
+@click.option('-v', '--verbose', is_flag=True, help='print individual nodes marked for deletion.')
 @options.NON_INTERACTIVE()
 @with_dbenv()
 def node_delete(nodes, follow_calls, force, dry_run, verbose, non_interactive):

--- a/aiida/cmdline/commands/node.py
+++ b/aiida/cmdline/commands/node.py
@@ -12,6 +12,7 @@ Manipulating and printing information of nodes.
 """
 import sys
 import click
+import tabulate
 
 from aiida.backends.utils import load_dbenv, is_dbenv_loaded
 from aiida.cmdline import delayed_load_node as load_node
@@ -42,6 +43,8 @@ class Node(VerdiCommandRouter):
             'show': verdi,
             'tree': verdi,
             'delete': verdi,
+            'label': verdi,
+            'description': verdi,
         }
 
 
@@ -183,6 +186,74 @@ def list_repo_files(node, path, color):
             raise ValueError("{}: No such file or directory in the repo".format(path))
 
         print fname
+
+
+@verdi_node.command('label')
+@arguments.NODES()
+@options.LABEL(help='Set LABEL as the new label for all NODES')
+@options.RAW(help='Display only the labels, no extra information')
+@options.FORCE()
+@with_dbenv()
+def node_label(nodes, label, raw, force):
+    """View or set the labels of one or more nodes."""
+    table = []
+
+    if label is None:
+        for node in nodes:
+
+            if raw:
+                table.append([node.label])
+            else:
+                table.append([node.pk, node.label])
+
+        if raw:
+            echo.echo(tabulate.tabulate(table, tablefmt='plain'))
+        else:
+            echo.echo(tabulate.tabulate(table, headers=['ID', 'Label']))
+
+    else:
+        if not force:
+            warning = 'Are you sure you want to set the label for {} nodes?'.format(len(nodes))
+            click.confirm(warning, abort=True)
+
+        for node in nodes:
+            node.label = label
+
+        echo.echo_success("Set label '{}' for {} nodes".format(label, len(nodes)))
+
+
+@verdi_node.command('description')
+@arguments.NODES()
+@options.DESCRIPTION(help='Set DESCRIPTION as the new description for all NODES')
+@options.RAW(help='Display only descriptions, no extra information')
+@options.FORCE()
+@with_dbenv()
+def node_description(nodes, description, force, raw):
+    """View or set the descriptions of one or more nodes."""
+    table = []
+
+    if description is None:
+        for node in nodes:
+
+            if raw:
+                table.append([node.description])
+            else:
+                table.append([node.pk, node.description])
+
+        if raw:
+            echo.echo(tabulate.tabulate(table, tablefmt='plain'))
+        else:
+            echo.echo(tabulate.tabulate(table, headers=['ID', 'Description']))
+
+    else:
+        if not force:
+            warning = 'Are you sure you want to set the description for  {} nodes?'.format(len(nodes))
+            click.confirm(warning, abort=True)
+
+        for node in nodes:
+            node.description = description
+
+        echo.echo_success("Set description for {} nodes".format(len(nodes)))
 
 
 @verdi_node.command('show')


### PR DESCRIPTION
Migrating `verdi node` commands to click

 * migrate `verdi node delete`
 * migrate `verdi node show`
 * migrate `verdi node tree`
 * migrate `verdi node repo ls`
 * migrate `verdi node repo cat`
 * add `verdi node label`
 * add `verdi node description`
 * add at least one unit test per command
 * add corresponding file to `pre-commit`

Comments:
There are still two classes `_Label` and `_Description` that I haven't deleted
```
# the classes _Label and _Description are written here,
# but in fact they are called by the verdi calculation or verdi data
# in fact, I don't want to allow the possibility of changing labels or
# descriptions of codes, for that there is a separate command
```
The `verdi node label` and `verdi node description` commands now replace this functionality,
and the two classes `_Label` and `_Description` can be deleted once the migration of the `verdi calculation` and `verdi data` commands are migrated.