### PR TITLE
[WIP] plugin fixtures: return testrunner result

### DIFF
--- a/.travis-data/test_plugin_testcase.py
+++ b/.travis-data/test_plugin_testcase.py
@@ -108,4 +108,7 @@ class PluginTestCase2(PluginTestCase):
 if __name__ == '__main__':
     MODULE = sys.modules[__name__]
     SUITE = unittest.defaultTestLoader.loadTestsFromModule(MODULE)
-    TestRunner().run(SUITE, backend=determine_backend())
+    RESULT = TestRunner().run(SUITE, backend=determine_backend())
+
+    EXIT_CODE = int(not RESULT.wasSuccessful())
+    sys.exit(EXIT_CODE)

--- a/aiida/utils/fixtures.py
+++ b/aiida/utils/fixtures.py
@@ -469,4 +469,4 @@ class TestRunner(unittest.runner.TextTestRunner):
         with Capturing():
             with fixture_manager() as manager:
                 manager.backend = backend
-                super(TestRunner, self).run(suite)
+                return super(TestRunner, self).run(suite)


### PR DESCRIPTION
This is needed in order e.g. to fail on travis, when tests don't pass.