### PR TITLE
make prompts yellow (and add help for invalid args to prompts)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,6 +27,7 @@
         aiida/cmdline/commands/restapi.py|
         aiida/cmdline/commands/workflow.py|
         aiida/cmdline/options/types/legacy_workflow.py|
+        aiida/cmdline/options/interactive.py|
         aiida/cmdline/params/types/path.py|
         aiida/cmdline/utils/multi_line_input.py|
         aiida/cmdline/utils/test_multiline.py|
@@ -73,6 +74,7 @@
         aiida/cmdline/commands/restapi.py|
         aiida/cmdline/commands/workflow.py|
         aiida/cmdline/options/types/legacy_workflow.py|
+        aiida/cmdline/options/interactive.py|
         aiida/cmdline/params/types/path.py|
         aiida/cmdline/utils/multi_line_input.py|
         aiida/cmdline/utils/test_multiline.py|

--- a/aiida/cmdline/params/options/interactive.py
+++ b/aiida/cmdline/params/options/interactive.py
@@ -157,6 +157,9 @@ class InteractiveOption(ConditionalOption):
 
     def simple_prompt_loop(self, ctx, param, value):
         """prompt until successful conversion. dispatch control sequences"""
+        if not hasattr(ctx, 'prompt_loop_info_printed'):
+            echo.echo_info('enter "?" for help')
+            ctx.prompt_loop_info_printed = True
         while 1:
             # prompt
             value = self.prompt_func(ctx)

--- a/aiida/cmdline/params/options/interactive.py
+++ b/aiida/cmdline/params/options/interactive.py
@@ -106,7 +106,7 @@ class InteractiveOption(ConditionalOption):
         """prompt function with args set"""
         return click.prompt(
             click.style(self._prompt, fg=self.PROMPT_COLOR),
-            prompt_suffix = click.style(': ', fg=self.PROMPT_COLOR),
+            prompt_suffix=click.style(': ', fg=self.PROMPT_COLOR),
             default=self._get_default(ctx),
             hide_input=self.hide_input,
             confirmation_prompt=self.confirmation_prompt)

--- a/aiida/cmdline/params/options/test_interactive.py
+++ b/aiida/cmdline/params/options/test_interactive.py
@@ -80,7 +80,7 @@ class InteractiveOptionTest(unittest.TestCase):
         result = runner.invoke(cmd, [], input='?\nTEST\n')
         expected = "Opt: ?\n\tExpecting text\nOpt: TEST\nTEST\n"
         self.assertIsNone(result.exception)
-        self.assertEqual(result.output, expected)
+        self.assertIn(expected, result.output)
 
     def test_prompt_help_custom(self):
         """
@@ -92,7 +92,7 @@ class InteractiveOptionTest(unittest.TestCase):
         result = runner.invoke(cmd, [], input='?\nTEST\n')
         expected = "Opt: ?\n\tPlease enter some text\nOpt: TEST\nTEST\n"
         self.assertIsNone(result.exception)
-        self.assertEqual(result.output, expected)
+        self.assertIn(expected, result.output)
 
     def test_prompt_simple(self):
         """
@@ -107,7 +107,7 @@ class InteractiveOptionTest(unittest.TestCase):
             expected = 'Opt: \nOpt: ?\n\thelp msg\n'
             expected += self.prompt_output(cli_input, output)
             self.assertIsNone(result.exception)
-            self.assertEqual(result.output, expected)
+            self.assertIn(expected, result.output)
 
     def strip_line(self, text):
         """returns text without the last line"""
@@ -123,10 +123,10 @@ class InteractiveOptionTest(unittest.TestCase):
             cmd = self.simple_command(type=ptype, help='help msg')
             runner = CliRunner()
             result = runner.invoke(cmd, [], input='\n?\n{}\n'.format(cli_input))
-            expected_beginning = 'Opt: \nOpt: ?\n\thelp msg\n'
-            expected_beginning += self.strip_line(self.prompt_output(cli_input))
+            expected_output = 'Opt: \nOpt: ?\n\thelp msg\n'
+            expected_output += self.strip_line(self.prompt_output(cli_input))
             self.assertIsNone(result.exception)
-            self.assertTrue(result.output.startswith(expected_beginning))
+            self.assertIn(expected_output, result.output)
 
     def test_default_value_prompt(self):
         """
@@ -277,7 +277,8 @@ class InteractiveOptionTest(unittest.TestCase):
         cmd = self.simple_command(callback=self.user_callback, type=Only42IntParamType())
         result = self.runner.invoke(cmd, [], input='23\n42\n')
         self.assertIsNone(result.exception)
-        self.assertIn('Opt: 23\nType validation: invalid', result.output)
+        self.assertIn('Opt: 23\n', result.output)
+        self.assertIn('Type validation: invalid', result.output)
         self.assertIn('Opt: 42\n42\n', result.output)
 
     def test_after_callback_default_noninteractive(self):

--- a/aiida/cmdline/params/options/test_interactive.py
+++ b/aiida/cmdline/params/options/test_interactive.py
@@ -56,7 +56,7 @@ class InteractiveOptionTest(unittest.TestCase):
         result = runner.invoke(cmd, [], input='TEST\n')
         expected = self.prompt_output('TEST')
         self.assertIsNone(result.exception)
-        self.assertEqual(result.output, expected)
+        self.assertIn(expected, result.output)
 
     def test_prompt_empty_input(self):
         """
@@ -68,7 +68,7 @@ class InteractiveOptionTest(unittest.TestCase):
         result = runner.invoke(cmd, [], input='\nTEST\n')
         expected = "Opt: \nOpt: TEST\nTEST\n"
         self.assertIsNone(result.exception)
-        self.assertEqual(result.output, expected)
+        self.assertIn(expected, result.output)
 
     def test_prompt_help_default(self):
         """
@@ -78,9 +78,13 @@ class InteractiveOptionTest(unittest.TestCase):
         cmd = self.simple_command(type=str)
         runner = CliRunner()
         result = runner.invoke(cmd, [], input='?\nTEST\n')
-        expected = "Opt: ?\n\tExpecting text\nOpt: TEST\nTEST\n"
+        expected_1 = 'Opt: ?\n'
+        expected_2 = 'Expecting text\n'
+        expected_3 = 'Opt: TEST\nTEST\n'
         self.assertIsNone(result.exception)
-        self.assertIn(expected, result.output)
+        self.assertIn(expected_1, result.output)
+        self.assertIn(expected_2, result.output)
+        self.assertIn(expected_3, result.output)
 
     def test_prompt_help_custom(self):
         """
@@ -90,9 +94,13 @@ class InteractiveOptionTest(unittest.TestCase):
         cmd = self.simple_command(type=str, help='Please enter some text')
         runner = CliRunner()
         result = runner.invoke(cmd, [], input='?\nTEST\n')
-        expected = "Opt: ?\n\tPlease enter some text\nOpt: TEST\nTEST\n"
+        expected_1 = 'Opt: ?\n'
+        expected_2 = 'Please enter some text\n'
+        expected_3 = 'Opt: TEST\nTEST\n'
         self.assertIsNone(result.exception)
-        self.assertIn(expected, result.output)
+        self.assertIn(expected_1, result.output)
+        self.assertIn(expected_2, result.output)
+        self.assertIn(expected_3, result.output)
 
     def test_prompt_simple(self):
         """
@@ -104,10 +112,12 @@ class InteractiveOptionTest(unittest.TestCase):
             cmd = self.simple_command(type=ptype, help='help msg')
             runner = CliRunner()
             result = runner.invoke(cmd, [], input='\n?\n{}\n'.format(cli_input))
-            expected = 'Opt: \nOpt: ?\n\thelp msg\n'
-            expected += self.prompt_output(cli_input, output)
+            expected_1 = 'Opt: \nOpt: ?\n'
+            expected_2 = 'help msg\n'
+            expected_2 += self.prompt_output(cli_input, output)
             self.assertIsNone(result.exception)
-            self.assertIn(expected, result.output)
+            self.assertIn(expected_1, result.output)
+            self.assertIn(expected_2, result.output)
 
     def strip_line(self, text):
         """returns text without the last line"""
@@ -123,10 +133,12 @@ class InteractiveOptionTest(unittest.TestCase):
             cmd = self.simple_command(type=ptype, help='help msg')
             runner = CliRunner()
             result = runner.invoke(cmd, [], input='\n?\n{}\n'.format(cli_input))
-            expected_output = 'Opt: \nOpt: ?\n\thelp msg\n'
-            expected_output += self.strip_line(self.prompt_output(cli_input))
+            expected_1 = 'Opt: \nOpt: ?\n'
+            expected_2 = 'help msg\n'
+            expected_2 += self.strip_line(self.prompt_output(cli_input))
             self.assertIsNone(result.exception)
-            self.assertIn(expected_output, result.output)
+            self.assertIn(expected_1, result.output)
+            self.assertIn(expected_2, result.output)
 
     def test_default_value_prompt(self):
         """
@@ -139,12 +151,12 @@ class InteractiveOptionTest(unittest.TestCase):
         returns.append(result)
         expected = 'Opt [default]: \ndefault\n'
         self.assertIsNone(result.exception)
-        self.assertEqual(result.output, expected)
+        self.assertIn(expected, result.output)
         result = self.runner.invoke(cmd, [], input='TEST\n')
         returns.append(result)
         expected = 'Opt [default]: TEST\nTEST\n'
         self.assertIsNone(result.exception)
-        self.assertEqual(result.output, expected)
+        self.assertIn(expected, result.output)
         return returns
 
     def test_default_value_empty_opt(self):
@@ -308,8 +320,9 @@ class InteractiveOptionTest(unittest.TestCase):
         """Test that default="" allows to pass an empty cli option."""
         cmd = self.simple_command(default="", type=str)
         result = self.runner.invoke(cmd, input='\n')
+        expected = 'Opt []: \n\n'
         self.assertIsNone(result.exception)
-        self.assertEqual(result.output, 'Opt []: \n\n')
+        self.assertIn(expected, result.output)
 
     def test_default_empty_noninteractive(self):
         """Test that empty_ok=True allows to pass an empty cli option also in non interactive mode."""
@@ -331,8 +344,9 @@ class InteractiveOptionTest(unittest.TestCase):
     def test_not_required_interactive(self):
         cmd = self.simple_command(required=False)
         result = self.runner.invoke(cmd, input='value\n')
+        expected = 'Opt: value\nvalue\n'
         self.assertIsNone(result.exception)
-        self.assertEqual(result.output, 'Opt: value\nvalue\n')
+        self.assertIn(expected, result.output)
 
     def test_not_required_noninteractive_default(self):
         cmd = self.simple_command(required=False, default='')
@@ -343,5 +357,6 @@ class InteractiveOptionTest(unittest.TestCase):
     def test_not_required_interactive_default(self):
         cmd = self.simple_command(required=False, default='')
         result = self.runner.invoke(cmd, input='\nnot needed\n')
+        expected = 'Opt []: \n\n'
         self.assertIsNone(result.exception)
-        self.assertEqual(result.output, 'Opt []: \n\n')
+        self.assertIn(expected, result.output)


### PR DESCRIPTION
Addresses part of #1683 

Addressed:
 * use `echo.echo_error` for validation errors in prompt loop
 * use `echo.echo_info` for help messages in prompt loop
 * display help msg on validation error in prompt loop
 * color prompt
 * display help message before starting to prompt for InteractiveOptions