### PR TITLE
Add util function get_strict_version

### DIFF
--- a/aiida/__init__.py
+++ b/aiida/__init__.py
@@ -8,13 +8,14 @@
 # For further information please visit http://www.aiida.net               #
 ###########################################################################
 import warnings
+from distutils.version import StrictVersion
+
 from aiida.common.log import configure_logging
 from aiida.common.setup import get_property
 
 __copyright__ = u"Copyright (c), This file is part of the AiiDA platform. For further information please visit http://www.aiida.net/. All rights reserved."
 __license__ = "MIT license, see LICENSE.txt file."
 __version__ = "1.0.0a1"
-__version__ = "0.12.1"
 __authors__ = "The AiiDA team."
 __paper__ = """G. Pizzi, A. Cepellotti, R. Sabatini, N. Marzari, and B. Kozinsky, "AiiDA: automated interactive infrastructure and database for computational science", Comp. Mat. Sci 111, 218-230 (2016); http://dx.doi.org/10.1016/j.commatsci.2015.09.013 - http://www.aiida.net."""
 __paper_short__ = """G. Pizzi et al., Comp. Mat. Sci 111, 218 (2016)."""
@@ -27,6 +28,7 @@ if get_property("warnings.showdeprecations"):
     # in Python 2.7 it is suppressed by default
     warnings.simplefilter('default', DeprecationWarning)
 
+
 def try_load_dbenv(*argc, **argv):
     """
     Run `load_dbenv` unless the dbenv has already been loaded.
@@ -35,6 +37,7 @@ def try_load_dbenv(*argc, **argv):
         load_dbenv(*argc, **argv)
         return True
     return False
+
 
 def load_dbenv(*argc, **argv):
     """
@@ -52,9 +55,20 @@ def is_dbenv_loaded(*argc, **argv):
     return is_dbenv_loaded(*argc, **argv)
 
 
+def get_strict_version():
+    """
+    Return a distutils StrictVersion instance with the current distribution version
+
+    :returns: StrictVersion instance with the current version
+    """
+    return StrictVersion(__version__)
+
+
 def get_version():
     """
-    Very simple function to get a string with the version number.
+    Return the current distribution version
+
+    :returns: a string with the current version
     """
     return __version__
 
@@ -71,6 +85,7 @@ If you use AiiDA for publication purposes, please cite:
 {}
 """.format(__version__, __paper__)
 
+
 def get_file_header(comment_char="# "):
     """
     Get a string to be put as header of files created with AiiDA;
@@ -80,4 +95,4 @@ def get_file_header(comment_char="# "):
     :return: a (multiline) string
     """
     lines = _get_raw_file_header().splitlines()
-    return "\n".join("{}{}".format(comment_char, line) for line in lines)
+    return '\n'.join('{}{}'.format(comment_char, line) for line in lines)

--- a/aiida/__init__.py
+++ b/aiida/__init__.py
@@ -8,7 +8,6 @@
 # For further information please visit http://www.aiida.net               #
 ###########################################################################
 import warnings
-from distutils.version import StrictVersion
 
 from aiida.common.log import configure_logging
 from aiida.common.setup import get_property
@@ -61,6 +60,7 @@ def get_strict_version():
 
     :returns: StrictVersion instance with the current version
     """
+    from distutils.version import StrictVersion
     return StrictVersion(__version__)
 
 


### PR DESCRIPTION
Fixes #1685 

The utility function `aiida.get_strict_version` will return a StrictVersion
instance from `distutils.version` with the current version of the package.