### PR TITLE
Ensure that WorkChain._do_step return None, int or ExitCode

### DIFF
--- a/aiida/backends/tests/work/work_chain.py
+++ b/aiida/backends/tests/work/work_chain.py
@@ -1133,3 +1133,21 @@ class TestWorkChainExpose(AiidaTestCase):
                 'sub.sub.sub_2.b': Float(1.2), 'sub.sub.sub_2.sub_3.c': Bool(False)
             }
         )
+
+
+class TestWorkChainReturnDict(AiidaTestCase):
+
+    class PointlessWorkChain(WorkChain):
+
+        @classmethod
+        def define(cls, spec):
+            super(TestWorkChainReturnDict.PointlessWorkChain, cls).define(spec)
+            spec.outline(cls.return_dict)
+
+        def return_dict(self):
+            """Only return a dictionary, which should be allowed, even though it accomplishes nothing."""
+            return {}
+
+    def test_run_pointless_workchain(self):
+        """Running the pointless workchain should not incur any exceptions"""
+        result = work.run(TestWorkChainReturnDict.PointlessWorkChain)


### PR DESCRIPTION
Fixes #1693 

In the case where the return value of the stepper was not of type
None, int or ExitCode, yet the stepper considered itself to be finished,
for example when the last step was executed, the return value of the
stepper would be returned, which could have any type. However, the
result of _do_step should only be an exit status, i.e. int or ExitCode.
To fix this, we explicitly check the return value of the stepper and
convert any type other than int or ExitCode to None.