### PR TITLE
Do not allow the copy or deepcopy of Node, except for Data 

### DIFF
--- a/aiida/backends/tests/calculation_node.py
+++ b/aiida/backends/tests/calculation_node.py
@@ -49,19 +49,6 @@ class TestCalcNode(AiidaTestCase):
         self.assertEquals(calculation.is_finished_ok, False)
         self.assertEquals(calculation.is_failed, False)
 
-    def test_calculation_updatable_not_copied(self):
-        """
-        Check that updatable attributes of Calculation are not copied
-        """
-        a = Calculation()
-        a._set_attr(Calculation.PROCESS_STATE_KEY, self.stateval)
-        a.store()
-        b = a.copy()
-
-        # updatable attributes are not copied
-        with self.assertRaises(AttributeError):
-            b.get_attr(Calculation.PROCESS_STATE_KEY)
-
     def test_calculation_updatable_attribute(self):
         """
         Check that updatable attributes and only those can be mutated for a stored but unsealed Calculation

--- a/aiida/backends/tests/dataclasses.py
+++ b/aiida/backends/tests/dataclasses.py
@@ -2156,8 +2156,8 @@ class TestStructureDataLock(AiidaTestCase):
         _ = a.is_alloy()
         _ = a.has_vacancies()
 
-        b = a.copy()
-        # I check that I can edit after copy
+        b = a.clone()
+        # I check that clone returned an unstored copy and so can be altered
         b.append_site(s)
         b.clear_sites()
         # I check that the original did not change
@@ -2220,9 +2220,9 @@ class TestStructureDataReload(AiidaTestCase):
             self.assertAlmostEqual(b.sites[1].position[i], 1.)
 
 
-    def test_copy(self):
+    def test_clone(self):
         """
-        Start from a StructureData object, copy it and see if it is preserved
+        Start from a StructureData object, clone it and see if it is preserved
         """
         from aiida.orm.data.structure import StructureData
 
@@ -2234,7 +2234,7 @@ class TestStructureDataReload(AiidaTestCase):
         a.append_atom(position=(0., 0., 0.), symbols=['Ba'])
         a.append_atom(position=(1., 1., 1.), symbols=['Ti'])
 
-        b = a.copy()
+        b = a.clone()
 
         for i in range(3):
             for j in range(3):
@@ -2252,8 +2252,8 @@ class TestStructureDataReload(AiidaTestCase):
 
         a.store()
 
-        # Copy after store()
-        c = a.copy()
+        # Clone after store()
+        c = a.clone()
         for i in range(3):
             for j in range(3):
                 self.assertAlmostEqual(cell[i][j], c.cell[i][j])

--- a/aiida/backends/tests/nodes.py
+++ b/aiida/backends/tests/nodes.py
@@ -10,20 +10,35 @@
 # pylint: disable=too-many-lines,invalid-name,protected-access
 # pylint: disable=missing-docstring,too-many-locals,too-many-statements
 # pylint: disable=too-many-public-methods
+import copy
 import unittest
 from sqlalchemy.exc import StatementError
 
 from aiida.backends.testbase import AiidaTestCase
 from aiida.common.exceptions import ModificationNotAllowed, UniquenessError
 from aiida.common.links import LinkType
-from aiida.common import caching
 from aiida.orm.calculation import Calculation
-from aiida.orm.code import Code
 from aiida.orm.data import Data
 from aiida.orm.node import Node
 from aiida.orm.utils import load_node
 from aiida.utils.capturing import Capturing
 from aiida.utils.delete_nodes import delete_nodes
+
+
+class TestNodeCopyDeepcopy(AiidaTestCase):
+    """Test that calling copy and deepcopy on a Node does the right thing."""
+
+    def test_copy_not_supported(self):
+        """Copying a base Node instance is not supported."""
+        node = Node()
+        with self.assertRaises(NotImplementedError):
+            clone = copy.copy(node)
+
+    def test_copy_not_supported(self):
+        """Deep copying a base Node instance is not supported."""
+        node = Node()
+        with self.assertRaises(NotImplementedError):
+            clone = copy.deepcopy(node)
 
 
 class TestNodeHashing(AiidaTestCase):
@@ -543,10 +558,10 @@ class TestNodeBasic(AiidaTestCase):
 
         self.assertEquals(date_to_compare, retrieved)
 
-    def test_attributes_on_copy(self):
+    def test_attributes_on_clone(self):
         import copy
 
-        a = Node()
+        a = Data()
         attrs_to_set = {
             'none': None,
             'bool': self.boolval,
@@ -562,20 +577,8 @@ class TestNodeBasic(AiidaTestCase):
         for k, v in attrs_to_set.iteritems():
             a._set_attr(k, v)
 
-        a.store()
-
-        # I now set extras
-        extras_to_set = {
-            'bool': 'some non-boolean value',
-            'some_other_name': 987
-        }
-        all_extras = dict(_aiida_hash=AnyValue(), **extras_to_set)
-
-        for k, v in extras_to_set.iteritems():
-            a.set_extra(k, v)
-
-            # I make a copy
-        b = a.copy()
+        # Create a copy
+        b = copy.deepcopy(a)
         # I modify an attribute and add a new one; I mirror it in the dictionary
         # for later checking
         b_expected_attributes = copy.deepcopy(attrs_to_set)
@@ -585,8 +588,7 @@ class TestNodeBasic(AiidaTestCase):
         b_expected_attributes['new'] = 'cvb'
 
         # I check before storing that the attributes are ok
-        self.assertEquals({k: v
-                           for k, v in b.iterattrs()}, b_expected_attributes)
+        self.assertEquals({k: v for k, v in b.iterattrs()}, b_expected_attributes)
         # Note that during copy, I do not copy the extras!
         self.assertEquals({k: v for k, v in b.iterextras()}, {})
 
@@ -596,20 +598,17 @@ class TestNodeBasic(AiidaTestCase):
         b.set_extra('meta', 'textofext')
         b_expected_extras = {'meta': 'textofext', '_aiida_hash': AnyValue()}
 
-        # Now I check for the attributes
-        # First I check that nothing has changed
+        # Now I check that the attributes of the original node have not changed
         self.assertEquals({k: v for k, v in a.iterattrs()}, attrs_to_set)
-        self.assertEquals({k: v for k, v in a.iterextras()}, all_extras)
 
         # I check then on the 'b' copy
-        self.assertEquals({k: v
-                           for k, v in b.iterattrs()}, b_expected_attributes)
+        self.assertEquals({k: v for k, v in b.iterattrs()}, b_expected_attributes)
         self.assertEquals({k: v for k, v in b.iterextras()}, b_expected_extras)
 
     def test_files(self):
         import tempfile
 
-        a = Node()
+        a = Data()
 
         file_content = 'some text ABCDE'
         file_content_different = 'other values 12345'
@@ -627,7 +626,7 @@ class TestNodeBasic(AiidaTestCase):
         with open(a.get_abs_path('file2.txt')) as f:
             self.assertEquals(f.read(), file_content)
 
-        b = a.copy()
+        b = a.clone()
         self.assertNotEquals(a.uuid, b.uuid)
 
         # Check that the content is there
@@ -638,7 +637,7 @@ class TestNodeBasic(AiidaTestCase):
         with open(b.get_abs_path('file2.txt')) as f:
             self.assertEquals(f.read(), file_content)
 
-        # I overwrite a file and create a new one in the copy only
+        # I overwrite a file and create a new one in the clone only
         with tempfile.NamedTemporaryFile() as f:
             f.write(file_content_different)
             f.flush()
@@ -666,9 +665,9 @@ class TestNodeBasic(AiidaTestCase):
         # so I recheck
         a.store()
 
-        # I now copy after storing
-        c = a.copy()
-        # I overwrite a file and create a new one in the copy only
+        # I now clone after storing
+        c = a.clone()
+        # I overwrite a file and create a new one in the clone only
         with tempfile.NamedTemporaryFile() as f:
             f.write(file_content_different)
             f.flush()
@@ -702,7 +701,7 @@ class TestNodeBasic(AiidaTestCase):
         import random
         import string
 
-        a = Node()
+        a = Data()
 
         # Since Node uses the same method of Folder(),
         # for this test I create a test folder by hand
@@ -747,8 +746,8 @@ class TestNodeBasic(AiidaTestCase):
         with self.assertRaises(ValueError):
             a.get_folder_list('..')
 
-        # copy into a new node
-        b = a.copy()
+        # clone into a new node
+        b = a.clone()
         self.assertNotEquals(a.uuid, b.uuid)
 
         # Check that the content is there
@@ -811,7 +810,7 @@ class TestNodeBasic(AiidaTestCase):
         a.store()
 
         # I now copy after storing
-        c = a.copy()
+        c = a.clone()
         # I overwrite a file, create a new one and remove a directory
         # in the copy only
         with tempfile.NamedTemporaryFile() as f:

--- a/aiida/backends/tests/orm/mixins.py
+++ b/aiida/backends/tests/orm/mixins.py
@@ -1,16 +1,20 @@
 # -*- coding: utf-8 -*-
 from aiida.backends.testbase import AiidaTestCase
+from aiida.orm.mixins import Sealable
 
 
 class TestSealable(AiidaTestCase):
 
-    def test_copy_not_include_updatable_attrs(self):
-    	"""
-    	Verify that a node with an updatable attribute, e.g. 'sealed' from the
-    	Sealable mixin, can be copied successfully
-    	"""
-    	from aiida.orm.calculation.job import JobCalculation
+    def test_change_updatable_attrs_after_store(self):
+        """
+        Verify that a Sealable node can alter updatable attributes even after storing
+        """
+        from aiida.orm.calculation.job import JobCalculation
 
-    	job = JobCalculation()
-    	job.seal()
-    	job.copy(include_updatable_attrs=False)
+        resources = {'num_machines': 1, 'num_mpiprocs_per_machine': 1}
+        job = JobCalculation(computer=self.computer, resources=resources)
+        job.store()
+
+        for attr in JobCalculation._updatable_attributes:
+            if attr != Sealable.SEALED_KEY:
+                job._set_attr(attr, 'a')

--- a/aiida/orm/data/__init__.py
+++ b/aiida/orm/data/__init__.py
@@ -66,6 +66,9 @@ class Data(Node):
 
         :returns: an unstored clone of this Data node
         """
+        if self.is_stored:
+            raise NotImplementedError('deep copying a stored Data node is not supported, use Data.clone() instead')
+
         return self.clone()
 
     def clone(self):

--- a/aiida/orm/data/__init__.py
+++ b/aiida/orm/data/__init__.py
@@ -56,11 +56,42 @@ class Data(Node):
     # Example: {'dat': 'dat_multicolumn'}
     _custom_export_format_replacements = {}
 
+    def __copy__(self):
+        """Copying a Data node is not supported, use copy.deepcopy or call Data.clone()."""
+        raise NotImplementedError('copying a Data node is not supported, use copy.deepcopy')
+
+    def __deepcopy__(self, memo):
+        """
+        Create a clone of the Data node by pipiong through to the clone method and return the result.
+
+        :returns: an unstored clone of this Data node
+        """
+        return self.clone()
+
+    def clone(self):
+        """
+        Create a clone of the Data node.
+
+        :returns: an unstored clone of this Data node
+        """
+        clone = self.__class__()
+        clone.dbnode.dbcomputer = self._dbnode.dbcomputer
+        clone.dbnode.type = self._dbnode.type
+        clone.label = self.label
+        clone.description = self.description
+
+        for key, value in self.iterattrs():
+            clone._set_attr(key, value)
+
+        for path in self.get_folder_list():
+            clone.add_path(self.get_abs_path(path), path)
+
+        return clone
+
     @property
     def source(self):
         """
-        Gets the dictionary describing the source of Data object. Possible
-        fields:
+        Gets the dictionary describing the source of Data object. Possible fields:
 
         * **db_name**: name of the source database.
         * **db_uri**: URI of the source database.
@@ -69,12 +100,10 @@ class Data(Node):
         * **version**: version of the object's source.
         * **extras**: a dictionary with other fields for source description.
         * **source_md5**: MD5 checksum of object's source.
-        * **description**: human-readable free form description of the
-            object's source.
+        * **description**: human-readable free form description of the object's source.
         * **license**: a string with a type of license.
 
-        .. note:: some limitations for setting the data source exist, see
-            ``_validate`` method.
+        .. note:: some limitations for setting the data source exist, see ``_validate`` method.
 
         :return: dictionary describing the source of Data object.
         """
@@ -86,8 +115,7 @@ class Data(Node):
         Sets the dictionary describing the source of Data object.
 
         :raise KeyError: if dictionary contains unknown field.
-        :raise ValueError: if supplied source description is not a
-            dictionary.
+        :raise ValueError: if supplied source description is not a dictionary.
         """
         if not isinstance(source, dict):
             raise ValueError("Source must be supplied as a dictionary")

--- a/aiida/orm/implementation/django/node.py
+++ b/aiida/orm/implementation/django/node.py
@@ -28,6 +28,7 @@ from . import user as users
 
 
 class Node(AbstractNode):
+
     @classmethod
     def get_subclass_from_uuid(cls, uuid):
         from aiida.backends.djsite.db.models import DbNode
@@ -486,23 +487,6 @@ class Node(AbstractNode):
         # Note: I have to reload the object (to have the right values in memory,
         # otherwise I only get the Django Field F object as a result!
         self._dbnode = DbNode.objects.get(pk=self._dbnode.pk)
-
-    def copy(self, **kwargs):
-        newobject = self.__class__()
-        newobject._dbnode.type = self._dbnode.type  # Inherit type
-        newobject.label = self.label  # Inherit label
-        # TODO: add to the description the fact that this was a copy?
-        newobject.description = self.description  # Inherit description
-        newobject._dbnode.dbcomputer = self._dbnode.dbcomputer  # Inherit computer
-
-        for k, v in self.iterattrs():
-            if k != Sealable.SEALED_KEY:
-                newobject._set_attr(k, v)
-
-        for path in self.get_folder_list():
-            newobject.add_path(self.get_abs_path(path), path)
-
-        return newobject
 
     @property
     def uuid(self):

--- a/aiida/orm/implementation/general/node.py
+++ b/aiida/orm/implementation/general/node.py
@@ -306,6 +306,14 @@ class AbstractNode(object):
 
         return "uuid: {} (pk: {})".format(self.uuid, self.pk)
 
+    def __copy__(self):
+        """Copying a Node is not supported in general, but only for the Data sub class."""
+        raise NotImplementedError('copying a base Node is not supported')
+
+    def __deepcopy__(self, memo):
+        """Deep copying a Node is not supported in general, but only for the Data sub class."""
+        raise NotImplementedError('deep copying a base Node is not supported')
+
     @property
     def backend(self):
         return self._backend
@@ -1376,21 +1384,6 @@ class AbstractNode(object):
         """
         pass
 
-    @abstractmethod
-    def copy(self, **kwargs):
-        """
-        Return a copy of the current object to work with, not stored yet.
-
-        This is a completely new entry in the DB, with its own UUID.
-        Works both on stored instances and with not-stored ones.
-
-        Copies files and attributes, but not the extras.
-        Does not store the Node to allow modification of attributes.
-
-        :return: an object copy
-        """
-        pass
-
     @property
     @abstractmethod
     def uuid(self):
@@ -1705,12 +1698,18 @@ class AbstractNode(object):
         return self
 
     def _store_from_cache(self, cache_node, with_transaction):
-        new_node = cache_node.copy(include_updatable_attrs=True)
-        inputlinks_cache = self._inputlinks_cache
-        # "impersonate" the copied node by getting all its attributes
-        self.__dict__ = new_node.__dict__
-        # restore the input links
-        self._inputlinks_cache = inputlinks_cache
+        from aiida.orm.mixins import Sealable
+        assert self.type == cache_node.type
+
+        self.label = cache_node.label
+        self.description = cache_node.description
+
+        for key, value in cache_node.iterattrs():
+            if key != Sealable.SEALED_KEY:
+                self._set_attr(key, value)
+
+        for path in cache_node.get_folder_list():
+            self.add_path(cache_node.get_abs_path(path), path)
 
         # Make sure the node doesn't have any RETURN links
         if cache_node.get_outputs(link_type=LinkType.RETURN):
@@ -1720,10 +1719,9 @@ class AbstractNode(object):
         self.set_extra('_aiida_cached_from', cache_node.uuid)
 
     def _add_outputs_from_cache(self, cache_node):
-        # add CREATE links
-        output_mapping = {}
+        # Add CREATE links
         for linkname, out_node in cache_node.get_outputs(also_labels=True, link_type=LinkType.CREATE):
-            new_node = out_node.copy(include_updatable_attrs=True).store()
+            new_node = out_node.clone().store()
             new_node.add_link_from(self, label=linkname, link_type=LinkType.CREATE)
 
     @abstractmethod

--- a/aiida/orm/implementation/sqlalchemy/node.py
+++ b/aiida/orm/implementation/sqlalchemy/node.py
@@ -541,25 +541,6 @@ class Node(AbstractNode):
             session.rollback()
             raise
 
-    def copy(self, **kwargs):
-        # Make sure we have the latest version from the database
-        self._ensure_model_uptodate()
-        newobject = self.__class__()
-        newobject._dbnode.type = self._dbnode.type  # Inherit type
-        newobject._dbnode.label = self._dbnode.label  # Inherit label
-        # TODO: add to the description the fact that this was a copy?
-        newobject._dbnode.description = self._dbnode.description  # Inherit description
-        newobject._dbnode.dbcomputer = self._dbnode.dbcomputer  # Inherit computer
-
-        for k, v in self.iterattrs():
-            if k != Sealable.SEALED_KEY:
-                newobject._set_attr(k, v)
-
-        for path in self.get_folder_list():
-            newobject.add_path(self.get_abs_path(path), path)
-
-        return newobject
-
     @property
     def pk(self):
         return self._dbnode.id

--- a/aiida/orm/mixins.py
+++ b/aiida/orm/mixins.py
@@ -205,26 +205,3 @@ class Sealable(object):
             raise ModificationNotAllowed('Cannot change the immutable attributes of a stored node')
 
         super(Sealable, self)._del_attr(key, stored_check=False)
-
-    @override
-    def copy(self, include_updatable_attrs=False):
-        """
-        Create a copy of the node minus the updatable attributes if include_updatable_attrs is False
-        """
-        clone = super(Sealable, self).copy()
-
-        if include_updatable_attrs is False:
-            for key, value in clone._iter_updatable_attributes():
-                clone._del_attr(key)
-
-        return clone
-
-    def _iter_updatable_attributes(self):
-        """
-        Iterate over the updatable attributes and yield key value pairs
-        """
-        for key in list(self._updatable_attributes):
-            try:
-                yield (key, self.get_attr(key))
-            except AttributeError:
-                pass

--- a/aiida/work/job_processes.py
+++ b/aiida/work/job_processes.py
@@ -161,10 +161,7 @@ class KillJob(TransportTask):
         calc_state = calc.get_state()
 
         if calc_state == calc_states.NEW or calc_state == calc_states.TOSUBMIT:
-            calc._set_state(calc_states.FAILED)
-            calc._set_scheduler_state(job_states.DONE)
-            calc.logger.warning("Calculation {} killed by the user "
-                                "(it was in {} state)".format(calc.pk, calc_state))
+            calc.logger.warning("Calculation {} killed by the user (it was in {} state)".format(calc.pk, calc_state))
             return True
 
         if calc_state != calc_states.WITHSCHEDULER:
@@ -183,8 +180,6 @@ class KillJob(TransportTask):
                 "An error occurred while trying to kill calculation {} (jobid {}), see log "
                 "(maybe the calculation already finished?)".format(calc.pk, job_id))
         else:
-            calc._set_state(calc_states.FAILED)
-            calc._set_scheduler_state(job_states.DONE)
             calc.logger.warning('Calculation<{}> killed by the user'.format(calc.pk))
 
         return result
@@ -429,6 +424,20 @@ class JobProcess(processes.Process):
         return states_map
 
     # region Process overrides
+    @override
+    def on_excepted(self):
+        """The Process excepted so we set the calculation and scheduler state."""
+        super(JobProcess, self).on_excepted()
+        self.calc._set_state(calc_states.FAILED)
+        self.calc._set_scheduler_state(job_states.DONE)
+
+    @override
+    def on_killed(self):
+        """The Process was killed so we set the calculation and scheduler state."""
+        super(JobProcess, self).on_excepted()
+        self.calc._set_state(calc_states.FAILED)
+        self.calc._set_scheduler_state(job_states.DONE)
+
     @override
     def update_outputs(self):
         # DO NOT REMOVE:

--- a/aiida/work/processes.py
+++ b/aiida/work/processes.py
@@ -267,7 +267,7 @@ class Process(plumpy.Process):
             self.calc._set_exit_status(result.status)
             self.calc._set_exit_message(result.message)
         else:
-            raise ValueError('the result should be an integer, ExitCode or None, got {}'.format(type(result)))
+            raise ValueError('the result should be an integer, ExitCode or None, got {} {} {}'.format(type(result), result, self.pid))
 
     @override
     def on_output_emitting(self, output_port, value):

--- a/docs/source/developer_guide/internals.rst
+++ b/docs/source/developer_guide/internals.rst
@@ -54,8 +54,6 @@ General purpose methods
 
 - :py:meth:`~aiida.orm.implementation.general.node.AbstractNode._increment_version_number_db`: increment the version number of the node on the DB. This happens when adding an ``attribute`` or an ``extra`` to the node. This method should not be called by the users.
 
-- :py:meth:`~aiida.orm.implementation.general.node.AbstractNode.copy` returns a not stored copy of the node with new UUID that can be edited directly.
-
 - :py:meth:`~aiida.orm.implementation.general.node.AbstractNode.uuid` returns the universally unique identifier (UUID) of the node.
 
 - :py:meth:`~aiida.orm.implementation.general.node.AbstractNode.pk` returns the principal key (ID) of the node.


### PR DESCRIPTION
Fixes #1699

We explicitly disallow calling the functions copy and deepcopy
from the python copy module on a Node instance. The reason is that
the behavior of this for a Calculation node, with respect to what
should be returned and how this would affect the graph, is not clear.
Rather, to clone a Calculation, the caching mechanism should be
used or a new ProcessBuilder could be generated from a completed
Process that would recreate the necessary inputs that could then
easily be relaunched.

For Data nodes, the behavior can be defined a bit better. Therefore
we allow to call deepcopy on a Data node, which will call the internal
clone method, which will return an identical, but unstored, clone of
the original Data node. The clone will have no links and a newly
generated UUID.