### PR TITLE
Add unique constraints on UUID column of Node database model

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -31,6 +31,7 @@
         aiida/backends/djsite/db/migrations/__init__.py|
         aiida/backends/djsite/db/models.py|
         aiida/backends/djsite/db/subtests/djangomigrations.py|
+        aiida/backends/djsite/db/subtests/migrations.py|
         aiida/backends/djsite/db/subtests/generic.py|
         aiida/backends/djsite/db/subtests/__init__.py|
         aiida/backends/djsite/db/subtests/nodes.py|

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,6 +27,7 @@
         aiida/backends/djsite/db/migrations/0011_delete_kombu_tables.py|
         aiida/backends/djsite/db/migrations/0012_drop_dblock.py|
         aiida/backends/djsite/db/migrations/0013_django_1_8.py|
+        aiida/backends/djsite/db/migrations/0014_add_node_uuid_unique_constraint.py|
         aiida/backends/djsite/db/migrations/__init__.py|
         aiida/backends/djsite/db/models.py|
         aiida/backends/djsite/db/subtests/djangomigrations.py|
@@ -67,6 +68,7 @@
         aiida/backends/sqlalchemy/migrations/versions/a6048f0ffca8_update_linktypes.py|
         aiida/backends/sqlalchemy/migrations/versions/e15ef2630a1b_initial_schema.py|
         aiida/backends/sqlalchemy/migrations/versions/f9a69de76a9a_delete_kombu_tables.py|
+        aiida/backends/sqlalchemy/migrations/versions/62fe0d36de90_add_node_uuid_unique_constraint.py|
         aiida/backends/sqlalchemy/models/authinfo.py|
         aiida/backends/sqlalchemy/models/base.py|
         aiida/backends/sqlalchemy/models/comment.py|

--- a/aiida/backends/djsite/db/migrations/0001_initial.py
+++ b/aiida/backends/djsite/db/migrations/0001_initial.py
@@ -8,19 +8,19 @@
 # For further information please visit http://www.aiida.net               #
 ###########################################################################
 from __future__ import unicode_literals
-
 from __future__ import absolute_import
+
 from django.db import models, migrations
 import django.db.models.deletion
 import django.utils.timezone
 from django.conf import settings
 import django_extensions.db.fields
 
-from aiida.backends.djsite.db.migrations import update_schema_version
+from aiida.backends.djsite.db.migrations import upgrade_schema_version
 
 
-
-SCHEMA_VERSION = "1.0.1"
+REVISION = '1.0.1'
+DOWN_REVISION = '1.0.0'
 
 
 class Migration(migrations.Migration):
@@ -456,5 +456,5 @@ class Migration(migrations.Migration):
             name='dbattribute',
             unique_together=set([('dbnode', 'key')]),
         ),
-        update_schema_version(SCHEMA_VERSION)
+        upgrade_schema_version(REVISION, DOWN_REVISION)
     ]

--- a/aiida/backends/djsite/db/migrations/0002_db_state_change.py
+++ b/aiida/backends/djsite/db/migrations/0002_db_state_change.py
@@ -8,14 +8,15 @@
 # For further information please visit http://www.aiida.net               #
 ###########################################################################
 from __future__ import unicode_literals
-
 from __future__ import absolute_import
+
 from django.db import models, migrations
 
-from aiida.backends.djsite.db.migrations import update_schema_version
+from aiida.backends.djsite.db.migrations import upgrade_schema_version
 
 
-SCHEMA_VERSION = "1.0.2"
+REVISION = '1.0.2'
+DOWN_REVISION = '1.0.1'
 
 
 def fix_calc_states(apps, schema_editor):
@@ -60,5 +61,5 @@ class Migration(migrations.Migration):
         ),
         # Fix up any calculation states that had one of the removed states
         migrations.RunPython(fix_calc_states),
-        update_schema_version(SCHEMA_VERSION)
+        upgrade_schema_version(REVISION, DOWN_REVISION)
     ]

--- a/aiida/backends/djsite/db/migrations/0003_add_link_type.py
+++ b/aiida/backends/djsite/db/migrations/0003_add_link_type.py
@@ -8,15 +8,15 @@
 # For further information please visit http://www.aiida.net               #
 ###########################################################################
 from __future__ import unicode_literals
-
 from __future__ import absolute_import
+
 from django.db import models, migrations
 import aiida.utils.timezone
-from aiida.backends.djsite.db.migrations import update_schema_version
+from aiida.backends.djsite.db.migrations import upgrade_schema_version
 
 
-
-SCHEMA_VERSION = "1.0.3"
+REVISION = '1.0.3'
+DOWN_REVISION = '1.0.2'
 
 
 class Migration(migrations.Migration):
@@ -96,5 +96,5 @@ class Migration(migrations.Migration):
             name='dblink',
             unique_together=set([]),
         ),
-        update_schema_version(SCHEMA_VERSION)
+        upgrade_schema_version(REVISION, DOWN_REVISION)
     ]

--- a/aiida/backends/djsite/db/migrations/0004_add_daemon_and_uuid_indices.py
+++ b/aiida/backends/djsite/db/migrations/0004_add_daemon_and_uuid_indices.py
@@ -8,15 +8,16 @@
 # For further information please visit http://www.aiida.net               #
 ###########################################################################
 from __future__ import unicode_literals
-
 from __future__ import absolute_import
+
 import django_extensions.db.fields
 from django.db import migrations
 
-from aiida.backends.djsite.db.migrations import update_schema_version
+from aiida.backends.djsite.db.migrations import upgrade_schema_version
 
 
-SCHEMA_VERSION = "1.0.4"
+REVISION = '1.0.4'
+DOWN_REVISION = '1.0.3'
 
 
 class Migration(migrations.Migration):
@@ -44,5 +45,5 @@ class Migration(migrations.Migration):
                                                         blank=True),
             preserve_default=True,
         ),
-        update_schema_version(SCHEMA_VERSION)
+        upgrade_schema_version(REVISION, DOWN_REVISION)
     ]

--- a/aiida/backends/djsite/db/migrations/0005_add_cmtime_indices.py
+++ b/aiida/backends/djsite/db/migrations/0005_add_cmtime_indices.py
@@ -8,14 +8,15 @@
 # For further information please visit http://www.aiida.net               #
 ###########################################################################
 from __future__ import unicode_literals
-
 from __future__ import absolute_import
+
 from django.db import models, migrations
 import aiida.utils.timezone
-from aiida.backends.djsite.db.migrations import update_schema_version
+from aiida.backends.djsite.db.migrations import upgrade_schema_version
 
 
-SCHEMA_VERSION = "1.0.5"
+REVISION = '1.0.5'
+DOWN_REVISION = '1.0.4'
 
 
 class Migration(migrations.Migration):
@@ -37,5 +38,5 @@ class Migration(migrations.Migration):
             field=models.DateTimeField(auto_now=True, db_index=True),
             preserve_default=True,
         ),
-        update_schema_version(SCHEMA_VERSION)
+        upgrade_schema_version(REVISION, DOWN_REVISION)
     ]

--- a/aiida/backends/djsite/db/migrations/0006_delete_dbpath.py
+++ b/aiida/backends/djsite/db/migrations/0006_delete_dbpath.py
@@ -8,13 +8,15 @@
 # For further information please visit http://www.aiida.net               #
 ###########################################################################
 from __future__ import unicode_literals
-
 from __future__ import absolute_import
-from django.db import models, migrations
-from aiida.backends.djsite.db.migrations import update_schema_version
+
+from django.db import migrations
+from aiida.backends.djsite.db.migrations import upgrade_schema_version
 
 
-SCHEMA_VERSION = "1.0.6"
+REVISION = '1.0.6'
+DOWN_REVISION = '1.0.5'
+
 
 class Migration(migrations.Migration):
 
@@ -42,6 +44,6 @@ class Migration(migrations.Migration):
             DROP TRIGGER IF EXISTS autoupdate_tc ON db_dblink;
             DROP FUNCTION IF EXISTS update_tc();
         """),
-        update_schema_version(SCHEMA_VERSION)
+        upgrade_schema_version(REVISION, DOWN_REVISION)
 
     ]

--- a/aiida/backends/djsite/db/migrations/0007_update_linktypes.py
+++ b/aiida/backends/djsite/db/migrations/0007_update_linktypes.py
@@ -8,13 +8,15 @@
 # For further information please visit http://www.aiida.net               #
 ###########################################################################
 from __future__ import unicode_literals
-
 from __future__ import absolute_import
-from django.db import models, migrations
-from aiida.backends.djsite.db.migrations import update_schema_version
+
+from django.db import migrations
+from aiida.backends.djsite.db.migrations import upgrade_schema_version
 
 
-SCHEMA_VERSION = "1.0.7"
+REVISION = '1.0.8'
+DOWN_REVISION = '1.0.7'
+
 
 class Migration(migrations.Migration):
 
@@ -126,6 +128,6 @@ class Migration(migrations.Migration):
                     AND ( db_dblink_1.type = null  OR db_dblink_1.type = '')
             );
         """),
-        update_schema_version(SCHEMA_VERSION)
+        upgrade_schema_version(REVISION, DOWN_REVISION)
 
     ]

--- a/aiida/backends/djsite/db/migrations/0008_code_hidden_to_extra.py
+++ b/aiida/backends/djsite/db/migrations/0008_code_hidden_to_extra.py
@@ -8,13 +8,15 @@
 # For further information please visit http://www.aiida.net               #
 ###########################################################################
 from __future__ import unicode_literals
-
 from __future__ import absolute_import
-from django.db import models, migrations
-from aiida.backends.djsite.db.migrations import update_schema_version
+
+from django.db import migrations
+from aiida.backends.djsite.db.migrations import upgrade_schema_version
 
 
-SCHEMA_VERSION = "1.0.8"
+REVISION = '1.0.8'
+DOWN_REVISION = '1.0.7'
+
 
 class Migration(migrations.Migration):
 
@@ -46,5 +48,5 @@ class Migration(migrations.Migration):
                 WHERE db_dbattribute.key = 'hidden' AND db_dbnode.type = 'code.Code.'
             );
         """),
-        update_schema_version(SCHEMA_VERSION)
+        upgrade_schema_version(REVISION, DOWN_REVISION)
     ]

--- a/aiida/backends/djsite/db/migrations/0009_base_data_plugin_type_string.py
+++ b/aiida/backends/djsite/db/migrations/0009_base_data_plugin_type_string.py
@@ -8,13 +8,15 @@
 # For further information please visit http://www.aiida.net               #
 ###########################################################################
 from __future__ import unicode_literals
-
 from __future__ import absolute_import
-from django.db import models, migrations
-from aiida.backends.djsite.db.migrations import update_schema_version
+
+from django.db import migrations
+from aiida.backends.djsite.db.migrations import upgrade_schema_version
 
 
-SCHEMA_VERSION = "1.0.9"
+REVISION = '1.0.9'
+DOWN_REVISION = '1.0.8'
+
 
 class Migration(migrations.Migration):
 
@@ -33,5 +35,5 @@ class Migration(migrations.Migration):
             UPDATE db_dbnode SET type = 'data.str.Str.' WHERE type = 'data.base.Str.';
             UPDATE db_dbnode SET type = 'data.list.List.' WHERE type = 'data.base.List.';
         """),
-        update_schema_version(SCHEMA_VERSION)
+        upgrade_schema_version(REVISION, DOWN_REVISION)
     ]

--- a/aiida/backends/djsite/db/migrations/0010_process_type.py
+++ b/aiida/backends/djsite/db/migrations/0010_process_type.py
@@ -8,13 +8,15 @@
 # For further information please visit http://www.aiida.net               #
 ###########################################################################
 from __future__ import unicode_literals
-
 from __future__ import absolute_import
+
 from django.db import models, migrations
-from aiida.backends.djsite.db.migrations import update_schema_version
+from aiida.backends.djsite.db.migrations import upgrade_schema_version
 
 
-SCHEMA_VERSION = "1.0.10"
+REVISION = '1.0.10'
+DOWN_REVISION = '1.0.9'
+
 
 class Migration(migrations.Migration):
 
@@ -28,5 +30,5 @@ class Migration(migrations.Migration):
             name='process_type',
             field=models.CharField(max_length=255, db_index=True, null=True)
         ),
-        update_schema_version(SCHEMA_VERSION)
+        upgrade_schema_version(REVISION, DOWN_REVISION)
     ]

--- a/aiida/backends/djsite/db/migrations/0011_delete_kombu_tables.py
+++ b/aiida/backends/djsite/db/migrations/0011_delete_kombu_tables.py
@@ -8,13 +8,15 @@
 # For further information please visit http://www.aiida.net               #
 ###########################################################################
 from __future__ import unicode_literals
-
 from __future__ import absolute_import
-from django.db import models, migrations
-from aiida.backends.djsite.db.migrations import update_schema_version
+
+from django.db import migrations
+from aiida.backends.djsite.db.migrations import upgrade_schema_version
 
 
-SCHEMA_VERSION = "1.0.11"
+REVISION = '1.0.11'
+DOWN_REVISION = '1.0.10'
+
 
 class Migration(migrations.Migration):
 
@@ -34,5 +36,5 @@ class Migration(migrations.Migration):
             DELETE FROM db_dbsetting WHERE key = 'daemon|task_stop|submitter';
             DELETE FROM db_dbsetting WHERE key = 'daemon|task_start|submitter';
         """),
-        update_schema_version(SCHEMA_VERSION)
+        upgrade_schema_version(REVISION, DOWN_REVISION)
     ]

--- a/aiida/backends/djsite/db/migrations/0012_drop_dblock.py
+++ b/aiida/backends/djsite/db/migrations/0012_drop_dblock.py
@@ -11,10 +11,11 @@ from __future__ import unicode_literals
 from __future__ import absolute_import
 
 from django.db import migrations
-from aiida.backends.djsite.db.migrations import update_schema_version
+from aiida.backends.djsite.db.migrations import upgrade_schema_version
 
 
-SCHEMA_VERSION = "1.0.12"
+REVISION = '1.0.12'
+DOWN_REVISION = '1.0.11'
 
 
 class Migration(migrations.Migration):
@@ -27,5 +28,5 @@ class Migration(migrations.Migration):
         migrations.DeleteModel(
             name='DbLock',
         ),
-        update_schema_version(SCHEMA_VERSION)
+        upgrade_schema_version(REVISION, DOWN_REVISION)
     ]

--- a/aiida/backends/djsite/db/migrations/0013_django_1_8.py
+++ b/aiida/backends/djsite/db/migrations/0013_django_1_8.py
@@ -8,8 +8,8 @@
 # For further information please visit http://www.aiida.net               #
 ###########################################################################
 from __future__ import unicode_literals
-
 from __future__ import absolute_import
+
 from django.db import models, migrations
 from aiida.backends.djsite.db.migrations import update_schema_version
 

--- a/aiida/backends/djsite/db/migrations/0013_django_1_8.py
+++ b/aiida/backends/djsite/db/migrations/0013_django_1_8.py
@@ -11,10 +11,12 @@ from __future__ import unicode_literals
 from __future__ import absolute_import
 
 from django.db import models, migrations
-from aiida.backends.djsite.db.migrations import update_schema_version
+from aiida.backends.djsite.db.migrations import upgrade_schema_version
 
 
-SCHEMA_VERSION = "1.0.13"
+REVISION = '1.0.13'
+DOWN_REVISION = '1.0.12'
+
 
 class Migration(migrations.Migration):
 
@@ -35,5 +37,5 @@ class Migration(migrations.Migration):
             name='email',
             field=models.EmailField(max_length=254, verbose_name='email address', blank=True),
         ),
-        update_schema_version(SCHEMA_VERSION)
+        upgrade_schema_version(REVISION, DOWN_REVISION)
     ]

--- a/aiida/backends/djsite/db/migrations/0014_add_node_uuid_unique_constraint.py
+++ b/aiida/backends/djsite/db/migrations/0014_add_node_uuid_unique_constraint.py
@@ -14,11 +14,11 @@ from __future__ import absolute_import
 
 from django.db import migrations
 from django_extensions.db.fields import UUIDField
-from aiida.backends.djsite.db.migrations import update_schema_version
+from aiida.backends.djsite.db.migrations import upgrade_schema_version
 from aiida.backends.settings import AIIDANODES_UUID_VERSION
-from aiida.manage.database.integrity import verify_node_uuid_uniqueness
 
-SCHEMA_VERSION = "1.0.14"
+REVISION = '1.0.14'
+DOWN_REVISION = '1.0.13'
 
 
 def verify_node_uuid_uniqueness(apps, schema_editor):
@@ -34,6 +34,10 @@ def verify_node_uuid_uniqueness(apps, schema_editor):
     verify_node_uuid_uniqueness()
 
 
+def reverse_code(apps, schema_editor):
+    pass
+
+
 class Migration(migrations.Migration):
     """Add a uniqueness constraint to the uuid column of DbNode table."""
 
@@ -42,11 +46,11 @@ class Migration(migrations.Migration):
     ]
 
     operations = [
-        migrations.RunPython(verify_node_uuid_uniqueness),
+        migrations.RunPython(verify_node_uuid_uniqueness, reverse_code=reverse_code),
         migrations.AlterField(
             model_name='dbnode',
             name='uuid',
             field=UUIDField(auto=True, version=AIIDANODES_UUID_VERSION, unique=True),
         ),
-        update_schema_version(SCHEMA_VERSION)
+        upgrade_schema_version(REVISION, DOWN_REVISION)
     ]

--- a/aiida/backends/djsite/db/migrations/0014_add_node_uuid_unique_constraint.py
+++ b/aiida/backends/djsite/db/migrations/0014_add_node_uuid_unique_constraint.py
@@ -7,25 +7,31 @@
 # For further information on the license, see the LICENSE.txt file        #
 # For further information please visit http://www.aiida.net               #
 ###########################################################################
+# pylint: disable=invalid-name
+"""Add a uniqueness constraint to the uuid column of DbNode table."""
 from __future__ import unicode_literals
 from __future__ import absolute_import
 
 from django.db import migrations
+from django_extensions.db.fields import UUIDField
 from aiida.backends.djsite.db.migrations import update_schema_version
+from aiida.backends.settings import AIIDANODES_UUID_VERSION
 
-
-SCHEMA_VERSION = "1.0.12"
+SCHEMA_VERSION = "1.0.14"
 
 
 class Migration(migrations.Migration):
+    """Add a uniqueness constraint to the uuid column of DbNode table."""
 
     dependencies = [
-        ('db', '0011_delete_kombu_tables'),
+        ('db', '0013_django_1_8'),
     ]
 
     operations = [
-        migrations.DeleteModel(
-            name='DbLock',
+        migrations.AlterField(
+            model_name='dbnode',
+            name='uuid',
+            field=UUIDField(auto=True, version=AIIDANODES_UUID_VERSION, unique=True),
         ),
         update_schema_version(SCHEMA_VERSION)
     ]

--- a/aiida/backends/djsite/db/migrations/__init__.py
+++ b/aiida/backends/djsite/db/migrations/__init__.py
@@ -7,10 +7,9 @@
 # For further information on the license, see the LICENSE.txt file        #
 # For further information please visit http://www.aiida.net               #
 ###########################################################################
-
 from __future__ import absolute_import
 
-LATEST_MIGRATION = '0013_django_1_8'
+LATEST_MIGRATION = '0014_add_node_uuid_unique_constraint'
 
 
 def _update_schema_version(version, apps, schema_editor):

--- a/aiida/backends/djsite/db/migrations/__init__.py
+++ b/aiida/backends/djsite/db/migrations/__init__.py
@@ -17,11 +17,13 @@ def _update_schema_version(version, apps, schema_editor):
     set_db_schema_version(version)
 
 
-def update_schema_version(version):
+def upgrade_schema_version(up_revision, down_revision):
     from functools import partial
     from django.db import migrations
 
-    return migrations.RunPython(partial(_update_schema_version, version))
+    return migrations.RunPython(
+        partial(_update_schema_version, up_revision),
+        reverse_code=partial(_update_schema_version, down_revision))
 
 
 def current_schema_version():
@@ -29,6 +31,6 @@ def current_schema_version():
     # files start with numbers which are not a valid package name
     latest_migration = __import__(
         "aiida.backends.djsite.db.migrations.{}".format(LATEST_MIGRATION),
-        fromlist=['SCHEMA_VERSION']
+        fromlist=['REVISION']
     )
-    return latest_migration.SCHEMA_VERSION
+    return latest_migration.REVISION

--- a/aiida/backends/djsite/db/models.py
+++ b/aiida/backends/djsite/db/models.py
@@ -129,7 +129,7 @@ class DbNode(m.Model):
        in the DbAttribute field). Moreover, Attributes define uniquely the
        Node so should be immutable
     """
-    uuid = UUIDField(auto=True, version=AIIDANODES_UUID_VERSION, db_index=True)
+    uuid = UUIDField(auto=True, version=AIIDANODES_UUID_VERSION, unique=True)
     # in the form data.upffile., data.structure., calculation., ...
     # Note that there is always a final dot, to allow to do queries of the
     # type (type__startswith="calculation.") and avoid problems with classes

--- a/aiida/backends/djsite/db/subtests/migrations.py
+++ b/aiida/backends/djsite/db/subtests/migrations.py
@@ -1,0 +1,121 @@
+# -*- coding: utf-8 -*-
+from __future__ import absolute_import
+from six.moves import range
+
+import tempfile
+
+from django.apps import apps
+from django.db.migrations.executor import MigrationExecutor
+from django.db import connection
+from aiida.backends.testbase import AiidaTestCase
+from aiida.common.exceptions import IntegrityError
+from aiida.manage.database.integrity import deduplicate_node_uuids, verify_node_uuid_uniqueness
+
+
+class TestMigrations(AiidaTestCase):
+
+    @property
+    def app(self):
+        return apps.get_containing_app_config(type(self).__module__).name.split('.')[-1]
+
+    migrate_from = None
+    migrate_to = None
+
+    def setUp(self):
+        assert self.migrate_from and self.migrate_to, \
+            "TestCase '{}' must define migrate_from and migrate_to properties".format(type(self).__name__)
+        self.migrate_from = [(self.app, self.migrate_from)]
+        self.migrate_to = [(self.app, self.migrate_to)]
+        executor = MigrationExecutor(connection)
+        old_apps = executor.loader.project_state(self.migrate_from).apps
+
+        # Reverse to the original migration
+        executor.migrate(self.migrate_from)
+
+        self.setUpBeforeMigration(old_apps)
+
+        # Run the migration to test
+        executor = MigrationExecutor(connection)
+        executor.loader.build_graph()
+        executor.migrate(self.migrate_to)
+
+        self.apps = executor.loader.project_state(self.migrate_to).apps
+
+    def setUpBeforeMigration(self, apps):
+        pass
+
+
+class TestDuplicateNodeUuidMigration(TestMigrations):
+
+    migrate_from = '0013_django_1_8'
+    migrate_to = '0014_add_node_uuid_unique_constraint'
+
+    def setUpBeforeMigration(self, apps):
+        from aiida.orm.data.bool import Bool
+        from aiida.orm.data.int import Int
+
+        self.file_name = 'test.temp'
+        self.file_content = '#!/bin/bash\n\necho test run\n'
+
+        with tempfile.NamedTemporaryFile(mode='w+') as handle:
+            handle.write(self.file_content)
+            handle.flush()
+
+            self.nodes_boolean = []
+            self.nodes_integer = []
+            self.n_bool_duplicates = 2
+            self.n_int_duplicates = 4
+
+            node_bool = Bool(True)
+            node_bool.add_path(handle.name, self.file_name)
+            node_bool.store()
+
+            node_int = Int(1)
+            node_int.add_path(handle.name, self.file_name)
+            node_int.store()
+
+            self.nodes_boolean.append(node_bool)
+            self.nodes_integer.append(node_int)
+
+            for i in range(self.n_bool_duplicates):
+                node = Bool(True)
+                node.dbnode.uuid = node_bool.uuid
+                node.add_path(handle.name, self.file_name)
+                node.store()
+                self.nodes_boolean.append(node)
+
+            for i in range(self.n_int_duplicates):
+                node = Int(1)
+                node.dbnode.uuid = node_int.uuid
+                node.add_path(handle.name, self.file_name)
+                node.store()
+                self.nodes_integer.append(node)
+
+        # Verify that there are duplicate UUIDs by checking that the following function raises
+        with self.assertRaises(IntegrityError):
+            verify_node_uuid_uniqueness()
+
+        # Now run the function responsible for solving duplicate UUIDs which would also be called by the user
+        # through the `verdi database integrity duplicate-node-uuid` command
+        deduplicate_node_uuids(dry_run=False)
+
+    def test_deduplicated_uuids(self):
+        """Verify that after the migration, all expected nodes are still there with unique UUIDs."""
+        from aiida.orm import load_node
+
+        # If the duplicate UUIDs were successfully fixed, the following should not raise.
+        verify_node_uuid_uniqueness()
+
+        # Reload the nodes by PK and check that all UUIDs are now unique
+        nodes_boolean = [load_node(node.pk) for node in self.nodes_boolean]
+        uuids_boolean = [node.uuid for node in nodes_boolean]
+        self.assertEqual(len(set(uuids_boolean)), len(nodes_boolean))
+
+        nodes_integer = [load_node(node.pk) for node in self.nodes_integer]
+        uuids_integer = [node.uuid for node in nodes_integer]
+        self.assertEqual(len(set(uuids_integer)), len(nodes_integer))
+
+        for node in nodes_boolean:
+            with node._get_folder_pathsubfolder.open(self.file_name) as handle:
+                content = handle.read()
+                self.assertEqual(content, self.file_content)

--- a/aiida/backends/djsite/db/subtests/nodes.py
+++ b/aiida/backends/djsite/db/subtests/nodes.py
@@ -16,11 +16,25 @@ from aiida.backends.testbase import AiidaTestCase
 from aiida.orm.node import Node
 
 
-
 class TestDataNodeDjango(AiidaTestCase):
     """
     These tests check the features of Data nodes that differ from the base Node
     """
+
+    def test_uuid_uniquess(self):
+        """
+        A uniqueness constraint on the UUID column of the Node model should prevent multiple nodes with identical UUID
+        """
+        from django.db import IntegrityError
+
+        a = Node()
+        b = Node()
+        b.dbnode.uuid = a.uuid
+        a.store()
+
+        with self.assertRaises(IntegrityError):
+            b.store()
+
     def test_links_and_queries(self):
         from aiida.backends.djsite.db.models import DbNode, DbLink
 
@@ -330,7 +344,7 @@ class TestNodeBasicDjango(AiidaTestCase):
         """
         """
         from aiida.orm import load_node
-        from aiida.common.exceptions import NotExistent, InputValidationError
+        from aiida.common.exceptions import InputValidationError
 
         a = Node()
         a.store()
@@ -347,5 +361,3 @@ class TestNodeBasicDjango(AiidaTestCase):
             load_node(uuid=a.pk)
         with self.assertRaises(InputValidationError):
             load_node()
-
-

--- a/aiida/backends/djsite/queries.py
+++ b/aiida/backends/djsite/queries.py
@@ -18,6 +18,20 @@ class DjangoQueryManager(AbstractQueryManager):
     def __init__(self, backend):
         super(DjangoQueryManager, self).__init__(backend)
 
+    def raw(self, query):
+        """Execute a raw SQL statement and return the result.
+
+        :param query: a string containing a raw SQL statement
+        :return: the result of the query
+        """
+        from django.db import connection
+
+        with connection.cursor() as cursor:
+            cursor.execute(query)
+            results = cursor.fetchall()
+
+        return results
+
     def query_jobcalculations_by_computer_user_state(
             self, state, computer=None, user=None,
             only_computer_user_pairs=False,

--- a/aiida/backends/djsite/utils.py
+++ b/aiida/backends/djsite/utils.py
@@ -23,7 +23,7 @@ def load_dbenv(profile=None):
     """
     _load_dbenv_noschemacheck(profile)
     # Check schema version and the existence of the needed tables
-    check_schema_version()
+    check_schema_version(profile)
 
 
 def _load_dbenv_noschemacheck(profile):
@@ -81,7 +81,7 @@ def long_field_length():
         return 1024
 
 
-def check_schema_version():
+def check_schema_version(profile):
     """
     Check if the version stored in the database is the same of the version
     of the code.
@@ -99,7 +99,6 @@ def check_schema_version():
     """
     import os
     import aiida.backends.djsite.db.models
-    from aiida.backends.utils import get_current_profile
     from django.db import connection
     from aiida.common.exceptions import ConfigurationError
 
@@ -118,17 +117,20 @@ def check_schema_version():
     filepath_utils = os.path.abspath(__file__)
     filepath_manage = os.path.join(os.path.dirname(filepath_utils), 'manage.py')
 
+    if profile is None:
+        from aiida.common.setup import get_default_profile
+        profile = get_default_profile()
+
     if code_schema_version != db_schema_version:
         raise ConfigurationError(
             "The code schema version is {}, but the version stored in the "
             "database (DbSetting table) is {}, stopping.\n"
             "To migrate the database to the current version, run the following commands:"
-            "\n  verdi daemon stop\n  python {} --aiida-profile={} migrate".
-                format(
+            "\n  verdi daemon stop\n  python {} --aiida-profile={} migrate".format(
                 code_schema_version,
                 db_schema_version,
                 filepath_manage,
-                get_current_profile()
+                profile
             )
         )
 

--- a/aiida/backends/general/abstractqueries.py
+++ b/aiida/backends/general/abstractqueries.py
@@ -31,6 +31,18 @@ class AbstractQueryManager(object):
         """
         pass
 
+    def get_duplicate_node_uuids(self):
+        """
+        Return a list of nodes that have an identical UUID
+
+        :return: list of tuples of (pk, uuid) of nodes with duplicate UUIDs
+        """
+        query = """
+            SELECT s.id, s.uuid FROM (SELECT *, COUNT(*) OVER(PARTITION BY uuid) AS c FROM db_dbnode)
+            AS s WHERE c > 1
+            """
+        return self.raw(query)
+
     # This is an example of a query that could be overriden by a better implementation,
     # for performance reasons:
     def query_jobcalculations_by_computer_user_state(

--- a/aiida/backends/general/abstractqueries.py
+++ b/aiida/backends/general/abstractqueries.py
@@ -8,7 +8,7 @@
 # For further information please visit http://www.aiida.net               #
 ###########################################################################
 from __future__ import absolute_import
-from abc import ABCMeta
+from abc import ABCMeta, abstractmethod
 from six.moves import zip
 import six
 
@@ -21,6 +21,15 @@ class AbstractQueryManager(object):
         :type backend: :class:`aiida.orm.Backend`
         """
         self._backend = backend
+
+    @abstractmethod
+    def raw(self, query):
+        """Execute a raw SQL statement and return the result.
+
+        :param query: a string containing a raw SQL statement
+        :return: the result of the query
+        """
+        pass
 
     # This is an example of a query that could be overriden by a better implementation,
     # for performance reasons:

--- a/aiida/backends/sqlalchemy/migrations/versions/62fe0d36de90_add_node_uuid_unique_constraint.py
+++ b/aiida/backends/sqlalchemy/migrations/versions/62fe0d36de90_add_node_uuid_unique_constraint.py
@@ -1,0 +1,23 @@
+"""Add a unique constraint on the UUID column of the Node model
+
+Revision ID: 62fe0d36de90
+Revises: 59edaf8a8b79
+Create Date: 2018-07-02 17:50:42.929382
+
+"""
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision = '62fe0d36de90'
+down_revision = '59edaf8a8b79'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_unique_constraint('db_dbnode_uuid_key', 'db_dbnode', ['uuid'])
+
+
+def downgrade():
+    op.drop_constraint('db_dbnode_uuid_key', 'db_dbnode')

--- a/aiida/backends/sqlalchemy/migrations/versions/62fe0d36de90_add_node_uuid_unique_constraint.py
+++ b/aiida/backends/sqlalchemy/migrations/versions/62fe0d36de90_add_node_uuid_unique_constraint.py
@@ -5,8 +5,9 @@ Revises: 59edaf8a8b79
 Create Date: 2018-07-02 17:50:42.929382
 
 """
+from __future__ import absolute_import
+from __future__ import print_function
 from alembic import op
-
 
 # revision identifiers, used by Alembic.
 revision = '62fe0d36de90'
@@ -15,7 +16,30 @@ branch_labels = None
 depends_on = None
 
 
+def verify_node_uuid_uniqueness():
+    """Check whether the database contains nodes with duplicate UUIDS.
+
+    Note that we have to redefine this method from aiida.manage.database.integrity.verify_node_uuid_uniqueness
+    because that uses the default database connection, while here the one created by Alembic should be used instead.
+
+    :raises: IntegrityError if database contains nodes with duplicate UUIDS.
+    """
+    from alembic import op
+    from sqlalchemy.sql import text
+    from aiida.common.exceptions import IntegrityError
+
+    query = text(
+        'SELECT s.id, s.uuid FROM (SELECT *, COUNT(*) OVER(PARTITION BY uuid) AS c FROM db_dbnode) AS s WHERE c > 1')
+    conn = op.get_bind()
+    duplicates = conn.execute(query).fetchall()
+
+    if duplicates:
+        raise IntegrityError('your database contains nodes with duplicate UUIDS: '
+                             'run `verdi database integrity duplicate-node-uuid` to return to a consistent state')
+
+
 def upgrade():
+    verify_node_uuid_uniqueness()
     op.create_unique_constraint('db_dbnode_uuid_key', 'db_dbnode', ['uuid'])
 
 

--- a/aiida/backends/sqlalchemy/models/node.py
+++ b/aiida/backends/sqlalchemy/models/node.py
@@ -72,7 +72,7 @@ class DbNode(Base):
     aiida_query = _QueryProperty(_AiidaQuery)
 
     id = Column(Integer, primary_key=True)
-    uuid = Column(UUID(as_uuid=True), default=uuid_func)
+    uuid = Column(UUID(as_uuid=True), default=uuid_func, unique=True)
     type = Column(String(255), index=True)
     process_type = Column(String(255), index=True)
     label = Column(String(255), index=True, nullable=True,

--- a/aiida/backends/sqlalchemy/queries.py
+++ b/aiida/backends/sqlalchemy/queries.py
@@ -19,6 +19,19 @@ class SqlaQueryManager(AbstractQueryManager):
     def __init__(self, backend):
         super(SqlaQueryManager, self).__init__(backend)
 
+    def raw(self, query):
+        """Execute a raw SQL statement and return the result.
+
+        :param query: a string containing a raw SQL statement
+        :return: the result of the query
+        """
+        from aiida.backends.sqlalchemy import get_scoped_session
+
+        session = get_scoped_session()
+        result = session.execute(query)
+
+        return result.fetchall()
+
     def get_creation_statistics(
             self,
             user_pk=None

--- a/aiida/backends/sqlalchemy/tests/nodes.py
+++ b/aiida/backends/sqlalchemy/tests/nodes.py
@@ -196,6 +196,20 @@ class TestNodeBasicSQLA(AiidaTestCase):
     (setting of attributes, copying of files, ...)
     """
 
+    def test_uuid_uniquess(self):
+        """
+        A uniqueness constraint on the UUID column of the Node model should prevent multiple nodes with identical UUID
+        """
+        from sqlalchemy.exc import IntegrityError
+
+        a = Node()
+        b = Node()
+        b.dbnode.uuid = a.uuid
+        a.store()
+
+        with self.assertRaises(IntegrityError):
+            b.store()
+
     def test_settings(self):
         """
         Test the settings table (similar to Attributes, but without the key.

--- a/aiida/backends/tests/__init__.py
+++ b/aiida/backends/tests/__init__.py
@@ -25,6 +25,7 @@ db_test_list = {
         'generic': ['aiida.backends.djsite.db.subtests.generic'],
         'nodes': ['aiida.backends.djsite.db.subtests.nodes'],
         'djangomigrations': ['aiida.backends.djsite.db.subtests.djangomigrations'],
+        'migrations': ['aiida.backends.djsite.db.subtests.migrations'],
         'query': ['aiida.backends.djsite.db.subtests.query'],
     },
     BACKEND_SQLA: {

--- a/aiida/backends/tests/query.py
+++ b/aiida/backends/tests/query.py
@@ -994,7 +994,6 @@ class TestManager(AiidaTestCase):
         """
         from aiida.orm import Node, DataFactory, Calculation
         from collections import defaultdict
-        from aiida.backends.general.abstractqueries import AbstractQueryManager
 
         def store_and_add(n, statistics):
             n.store()
@@ -1002,12 +1001,7 @@ class TestManager(AiidaTestCase):
             statistics['types'][n._plugin_type_string] += 1
             statistics['ctime_by_day'][n.ctime.strftime('%Y-%m-%d')] += 1
 
-        class QueryManagerDefault(AbstractQueryManager):
-            pass
-
-        qmanager_default = QueryManagerDefault(self.backend)
-
-        current_db_statistics = qmanager_default.get_creation_statistics()
+        current_db_statistics = self.backend.query_manager.get_creation_statistics()
         types = defaultdict(int)
         types.update(current_db_statistics['types'])
         ctime_by_day = defaultdict(int)
@@ -1026,7 +1020,7 @@ class TestManager(AiidaTestCase):
         store_and_add(ParameterData(), expected_db_statistics)
         store_and_add(Calculation(), expected_db_statistics)
 
-        new_db_statistics = qmanager_default.get_creation_statistics()
+        new_db_statistics = self.backend.query_manager.get_creation_statistics()
         # I only check a few fields
         new_db_statistics = {k: v for k, v in new_db_statistics.items() if k in expected_db_statistics}
 

--- a/aiida/cmdline/commands/__init__.py
+++ b/aiida/cmdline/commands/__init__.py
@@ -16,10 +16,10 @@ import click_completion
 click_completion.init()
 
 # Import to populate the `verdi` sub commands
-from aiida.cmdline.commands import (cmd_calculation, cmd_code, cmd_comment, cmd_computer, cmd_data, cmd_daemon,
-                                    cmd_devel, cmd_export, cmd_graph, cmd_group, cmd_import, cmd_node, cmd_process,
-                                    cmd_profile, cmd_quicksetup, cmd_rehash, cmd_restapi, cmd_run, cmd_setup, cmd_shell,
-                                    cmd_user, cmd_work, cmd_workflow)
+from aiida.cmdline.commands import (cmd_calculation, cmd_code, cmd_comment, cmd_computer, cmd_data, cmd_database,
+                                    cmd_daemon, cmd_devel, cmd_export, cmd_graph, cmd_group, cmd_import, cmd_node,
+                                    cmd_process, cmd_profile, cmd_quicksetup, cmd_rehash, cmd_restapi, cmd_run,
+                                    cmd_setup, cmd_shell, cmd_user, cmd_work, cmd_workflow)
 
 # Import to populate the `verdi data` sub commands
 from aiida.cmdline.commands.cmd_data import (cmd_array, cmd_bands, cmd_cif, cmd_parameter, cmd_remote, cmd_structure,

--- a/aiida/cmdline/commands/cmd_database.py
+++ b/aiida/cmdline/commands/cmd_database.py
@@ -1,0 +1,70 @@
+# -*- coding: utf-8 -*-
+###########################################################################
+# Copyright (c), The AiiDA team. All rights reserved.                     #
+# This file is part of the AiiDA code.                                    #
+#                                                                         #
+# The code is hosted on GitHub at https://github.com/aiidateam/aiida_core #
+# For further information on the license, see the LICENSE.txt file        #
+# For further information please visit http://www.aiida.net               #
+###########################################################################
+"""`verdi database` commands."""
+from __future__ import absolute_import
+
+import click
+
+from aiida.cmdline.commands.cmd_verdi import verdi
+from aiida.cmdline.utils import echo
+
+
+@verdi.group('database')
+def verdi_database():
+    """Inspect and manage the database."""
+    pass
+
+
+@verdi_database.group('integrity')
+def verdi_database_integrity():
+    """Various commands that will check the integrity of the database and fix potential issues when asked."""
+    pass
+
+
+@verdi_database_integrity.command('duplicate-node-uuid')
+@click.option(
+    '-a',
+    '--apply-patch',
+    is_flag=True,
+    help='Apply the proposed changes. If this flag is not passed, a dry run is performed instead.')
+def database_integrity(apply_patch):
+    """Detect and solve nodes with duplicate UUIDs.
+
+    Before aiida-core v1.0.0, there was no uniqueness constraint on the UUID column of the Node table in the database.
+    This made it possible to store multiple nodes with identical UUIDs without the database complaining. This was bug
+    was fixed in aiida-core=1.0.0 by putting an explicit uniqueness constraint on node UUIDs on the database level.
+    However, this would leave databases created before this patch with duplicate UUIDs in an inconsistent state. This
+    command will run an analysis to detect duplicate UUIDs in the node table and solve it by generating new UUIDs. Note
+    that it will not delete or merge any nodes.
+    """
+    from aiida.backends import settings
+    from aiida.backends.utils import _load_dbenv_noschemacheck
+    from aiida.common.setup import get_default_profile
+    from aiida.manage.database.integrity import deduplicate_node_uuids
+
+    if settings.AIIDADB_PROFILE is not None:
+        profile = settings.AIIDADB_PROFILE
+    else:
+        profile = get_default_profile()
+
+    _load_dbenv_noschemacheck(profile)
+
+    try:
+        messages = deduplicate_node_uuids(dry_run=not apply_patch)
+    except Exception as exception:  # pylint: disable=broad-except
+        echo.echo_critical('integrity check failed: {}'.format(str(exception)))
+    else:
+        for message in messages:
+            echo.echo_info(message)
+
+        if apply_patch:
+            echo.echo_success('integrity patch completed')
+        else:
+            echo.echo_success('dry-run of integrity patch completed')

--- a/aiida/cmdline/utils/decorators.py
+++ b/aiida/cmdline/utils/decorators.py
@@ -60,11 +60,11 @@ def with_dbenv(*load_dbenv_args, **load_dbenv_kwargs):
         @wraps(function)
         def decorated_function(*args, **kwargs):
             """Load dbenv if not yet loaded, then run the original function."""
-            from aiida.common.exceptions import ConfigurationError
+            from aiida.common.exceptions import ConfigurationError, IntegrityError
 
             try:
                 load_dbenv_if_not_loaded(*load_dbenv_args, **load_dbenv_kwargs)
-            except ConfigurationError as exception:
+            except (IntegrityError, ConfigurationError) as exception:
                 echo.echo_critical(str(exception))
 
             return function(*args, **kwargs)

--- a/aiida/cmdline/utils/decorators.py
+++ b/aiida/cmdline/utils/decorators.py
@@ -59,8 +59,14 @@ def with_dbenv(*load_dbenv_args, **load_dbenv_kwargs):
 
         @wraps(function)
         def decorated_function(*args, **kwargs):
-            """load dbenv if not yet loaded, then run the original function"""
-            load_dbenv_if_not_loaded(*load_dbenv_args, **load_dbenv_kwargs)
+            """Load dbenv if not yet loaded, then run the original function."""
+            from aiida.common.exceptions import ConfigurationError
+
+            try:
+                load_dbenv_if_not_loaded(*load_dbenv_args, **load_dbenv_kwargs)
+            except ConfigurationError as exception:
+                echo.echo_critical(str(exception))
+
             return function(*args, **kwargs)
 
         return decorated_function

--- a/aiida/manage/database/integrity.py
+++ b/aiida/manage/database/integrity.py
@@ -1,0 +1,76 @@
+# -*- coding: utf-8 -*-
+"""Generic functions to verify the integrity of the database and optionally apply patches to fix problems."""
+from __future__ import absolute_import
+import uuid as UUID
+
+
+def deduplicate_node_uuids(dry_run=True):
+    """Detect and solve nodes with duplicate UUIDs.
+
+    Before aiida-core v1.0.0, there was no uniqueness constraint on the UUID column of the Node table in the database.
+    This made it possible to store multiple nodes with identical UUIDs without the database complaining. This was bug
+    was fixed in aiida-core=1.0.0 by putting an explicit uniqueness constraint on node UUIDs on the database level.
+    However, this would leave databases created before this patch with duplicate UUIDs in an inconsistent state. This
+    command will run an analysis to detect duplicate UUIDs in the node table and solve it by generating new UUIDs. Note
+    that it will not delete or merge any nodes.
+
+    :param dry_run: when True, no actual changes will be made
+    :return: list of strings denoting the performed operations, or those that would have been applied for dry_run=False
+    """
+    from collections import defaultdict
+
+    from aiida.backends.settings import AIIDANODES_UUID_VERSION
+    from aiida.orm import load_node
+    from aiida.orm.backend import construct_backend
+
+    uuid_generator = getattr(UUID, 'uuid{}'.format(AIIDANODES_UUID_VERSION))
+
+    backend = construct_backend()
+    mapping = defaultdict(list)
+
+    query = 'SELECT s.id, s.uuid FROM (SELECT *, COUNT(*) OVER(PARTITION BY uuid) AS c FROM db_dbnode) AS s WHERE c > 1'
+    duplicates = backend.query_manager.raw(query)
+
+    for pk, uuid in duplicates:
+        mapping[uuid].append(int(pk))
+
+    def copy_repo_folder(node_source, uuid):
+        """
+        Copy the repository folder from source node to a new location based on the given UUID.
+
+        :param node_source: the node whose repository folder contents to copy
+        :param uuid: the UUID that will be used to generate the sharded folder location for the copied folder
+        """
+        from aiida.common.folders import RepositoryFolder
+        folder = RepositoryFolder('node', uuid)
+        folder.replace_with_folder(node_source.folder.abspath)
+
+    messages = []
+
+    for uuid, nodes in mapping.items():
+
+        uuid_old = None
+
+        for pk in nodes:
+
+            # We don't have to change all nodes that have the same UUID, the first one can keep the original
+            if uuid_old is None:
+                node_source = load_node(pk)
+                uuid_old = uuid
+                continue
+
+            node = load_node(pk)
+            uuid_new = str(uuid_generator())
+
+            if dry_run:
+                messages.append('would update UUID of Node<{}> from {} to {}'.format(pk, uuid_old, uuid_new))
+            else:
+                node._dbnode.uuid = uuid_new  # pylint: disable=protected-access
+                node._dbnode.save()  # pylint: disable=protected-access
+                copy_repo_folder(node_source, uuid_new)
+                messages.append('updated UUID of Node<{}> from {} to {}'.format(pk, uuid_old, uuid_new))
+
+    if not messages:
+        messages = ['no duplicate UUIDs found']
+
+    return messages

--- a/docs/source/developer_guide/developers.rst
+++ b/docs/source/developer_guide/developers.rst
@@ -72,16 +72,16 @@ If you need to change the database schema follow these steps:
 
 3. Open the generated file and make the following changes::
 
-    from aiida.backends.djsite.db.migrations import update_schema_version
+    from aiida.backends.djsite.db.migrations import upgrade_schema_version
     ...
-    SCHEMA_VERSION = # choose an appropriate version number
-                     # (hint: higher than the last migration!)
+    REVISION = # choose an appropriate version number (hint: higher than the last migration!)
+    DOWN_REVISION = # the revision number of the previous migration
     ...
     class Migration(migrations.Migration):
       ...
       operations = [
         ..
-        update_schema_version(SCHEMA_VERSION)
+        upgrade_schema_version(REVISION, DOWN_REVISION)
       ]
 
 5. Change the ``LATEST_MIGRATION`` variable in


### PR DESCRIPTION
Fixes #1706 

Even though the UUID of Nodes are supposed to be unique, there was no
explicit constraint on the column, allowing two nodes with identical
UUIDS to be stored without complaint from the database. However, these
nodes can now no longer be loaded through their UUID leaving the
database in an unusable state. This PR adds the migrations for both
backends and adds a test to check that attempting to store a Node with
a UUID that already exists will raise an IntegrityError.

In addition, the migration that will apply the uniqueness constraint will first
check if the database contains any duplicates, because if the case, the
migration will fail. If duplicates are found, the user is redirected to a new
command `verdi database integrity duplicate-node-uuid` which will scan the
database for this problem and knows how to fix it if asked to. After this is
done, the migration can be applied normally.