### PR TITLE
backends/sqla: allow pgsql conns via unix sockets

### DIFF
--- a/aiida/backends/sqlalchemy/utils.py
+++ b/aiida/backends/sqlalchemy/utils.py
@@ -66,8 +66,8 @@ def reset_session(config):
 
     engine_url = (
         "postgresql://{AIIDADB_USER}:{AIIDADB_PASS}@"
-        "{AIIDADB_HOST}:{AIIDADB_PORT}/{AIIDADB_NAME}"
-    ).format(**config)
+        "{AIIDADB_HOST}{sep}{AIIDADB_PORT}/{AIIDADB_NAME}"
+        ).format(sep=':' if config['AIIDADB_PORT'] else '', **config)
 
     sa.engine = create_engine(engine_url, json_serializer=dumps_json,
                               json_deserializer=loads_json)


### PR DESCRIPTION
SQLA/psycopg2 allows connection via unix sockets instead of TCP/IP.
This allows for secure password-less authentication via PostgreSQL's
socket peer authentication, which is the default on many distros.

Example `pg_hba.conf`:

    local   all             all                                     peer

would allow a user `test` access to the PostgreSQL cluster if a user
`test` exists in PostgreSQL without any password (implicitly assuming
that it is sufficient that the user was already authenticated by the
OS).
Using `pg_ident.conf` one can also map local users to PostgreSQL users
with a different name:

Example `pg_hba.conf`:

    local   aiida           aiida                                   peer map=aiida

Example `pg_ident.conf`:

    aiida           test                 aiida

Would allow the user `aiida` access to the database `aiida` and the map
allows the system user `test` to impersonate the database user `aiida`.

psycopg2 automatically tries the local socket connection if no port is
specified, but for that must the connection string not contain the
colon char otherwise required for the host:port separation.