### PR TITLE
Fix 1582 - Migrate verdi computer non-interactive options to click

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,6 +15,7 @@
         aiida/cmdline/tests/.*.py|  # the .*.py (.* matches everything)
         aiida/cmdline/commands/calculation.py|
         aiida/cmdline/commands/comment.py|
+        aiida/cmdline/commands/computer.py|
         aiida/cmdline/commands/daemon.py|
         aiida/cmdline/commands/code.py|
         aiida/cmdline/commands/graph.py|

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,14 +8,13 @@
       (?x)^(   # (?x) -> multiline regex, ^ -> beginning of file path
         .ci/test_plugin_testcase.py|
         .ci/test_setup.py|
-        aiida/backends/tests/cmdline/commands/*.py|
+        #aiida/backends/tests/cmdline/commands/.*.py|
         aiida/backends/tests/cmdline/params/types/workflow.py|
         aiida/backends/tests/verdi_commands.py|
         aiida/control/.*.py|        # must match the whole path, therefore
         aiida/cmdline/tests/.*.py|  # the .*.py (.* matches everything)
         aiida/cmdline/commands/calculation.py|
         aiida/cmdline/commands/comment.py|
-        aiida/cmdline/commands/computer.py|
         aiida/cmdline/commands/daemon.py|
         aiida/cmdline/commands/code.py|
         aiida/cmdline/commands/graph.py|

--- a/aiida/backends/tests/cmdline/commands/test_computer.py
+++ b/aiida/backends/tests/cmdline/commands/test_computer.py
@@ -468,3 +468,100 @@ class TestVerdiComputerCommands(AiidaTestCase):
         with Capturing():
             ComputerCmd().run('test', self.computer_name)
 
+    def test_computer_list(self):
+        """
+        Test if 'verdi computer list' command works
+        """
+        for opt in ['', '-o', '--only-usable', '-p', '--parsable', '-a', '--all-comps']:
+            options = [opt]
+            result = self.cli_runner.invoke(computer.list, options)
+            # No exceptions should arise
+            self.assertIsNone(result.exception)
+            # Something should be printed to stdout
+            self.assertIsNotNone(result.output)
+    
+    def test_computer_list(self):
+        """
+        Test if 'verdi computer list' command works
+        """
+        for opt in ['', '-o', '--only-usable', '-p', '--parsable', '-a', '--all-comps']:
+            options = [opt]
+            result = self.cli_runner.invoke(computer.list, options)
+            # No exceptions should arise
+            self.assertIsNone(result.exception)
+            # Something should be printed to stdout
+            self.assertIsNotNone(result.output)
+    
+    def test_computer_show(self):
+        """
+        Test if 'verdi computer show' command works
+        """
+        
+        # See if we can display info about the test computer.
+        result = self.cli_runner.invoke(computer.show, 'comp_cli_test_computer')
+        # No exceptions should arise
+        self.assertIsNone(result.exception)
+        # Something should be printed to stdout
+        self.assertIsNotNone(result.output)
+        
+        # See if a non-existant computer will raise an error.
+        result = self.cli_runner.invoke(computer.show, 'not_a_valid_computer')
+        # Exceptions should arise
+        self.assertIsNotNone(result.exception)
+    
+    def test_computer_rename(self):
+        """
+        Test if 'verdi computer rename' command works
+        """
+        from aiida.orm.computer import Computer as AiidaOrmComputer
+    
+        # See if the command complains about not getting an invalid computer
+        options = ['not_a_valid_computer']
+        result = self.cli_runner.invoke(computer.rename, options)
+        # Exception should be raised
+        self.assertIsNotNone(result.exception)
+        
+        # See if the command complains about not getting both names
+        options = ['comp_cli_test_computer']
+        result = self.cli_runner.invoke(computer.rename, options)
+        # Exception should be raised
+        self.assertIsNotNone(result.exception)
+
+        # The new name must be different to the old one
+        options = ['comp_cli_test_computer', 'comp_cli_test_computer']
+        result = self.cli_runner.invoke(computer.rename, options)
+        # Exception should be raised
+        self.assertIsNotNone(result.exception)
+
+        # Change a computer name successully.
+        options = ['comp_cli_test_computer', 'renamed_test_computer']
+        result = self.cli_runner.invoke(computer.rename, options)
+        # Exception should be not be raised
+        self.assertIsNone(result.exception)
+        # Check that the name really was changed
+        try:
+            computer = AiidaOrmComputer.get('renamed_test_computer')
+            self.assertIsNone(computer)
+            computer = AiidaOrmComputer.get('comp_cli_test_computer')
+    
+    def test_computer_delete(self):
+        """
+        Test if 'verdi computer delete' command works
+        """
+        from aiida.orm.computer import Computer as AiidaOrmComputer
+    
+        # See if the command complains about not getting an invalid computer
+        options = ['not_a_valid_computer']
+        result = self.cli_runner.invoke(computer.show, options)
+        # Exception should be raised
+        self.assertIsNotNone(result.exception)
+        
+        # Delete a computer name successully.
+        options = ['comp_cli_test_computer']
+        result = self.cli_runner.invoke(computer.delete, options)
+        # Exception should be not be raised
+        self.assertIsNone(result.exception)
+        # Check that the computer really was deleted
+        try:
+            computer = AiidaOrmComputer.get('comp_cli_test_computer')
+            self.assertIsNone(computer)

--- a/aiida/backends/tests/cmdline/commands/test_computer.py
+++ b/aiida/backends/tests/cmdline/commands/test_computer.py
@@ -582,19 +582,26 @@ class TestVerdiComputerCommands(AiidaTestCase):
         from aiida.orm.computer import Computer as AiidaOrmComputer
         from aiida.common.exceptions import NotExistent
 
+        # Setup a computer to delete during the test
+        comp = AiidaOrmComputer(
+            name='computer_for_test_delete',
+            hostname='localhost',
+            transport_type='local',
+            scheduler_type='direct',
+            workdir='/tmp/aiida')
+        comp.store()
+
         # See if the command complains about not getting an invalid computer
-        options = ['not_existent_computer_name']
+        options = ['non_existent_computer_name']
         result = self.runner.invoke(computer_delete, options)
         # Exception should be raised
         self.assertIsNotNone(result.exception)
 
         # Delete a computer name successully.
-        options = ['comp_cli_test_computer']
+        options = ['computer_for_test_delete']
         result = self.runner.invoke(computer_delete, options)
         # Exception should be not be raised
         self.assertIsNone(result.exception)
         # Check that the computer really was deleted
         with self.assertRaises(NotExistent):
-            AiidaOrmComputer.get('comp_cli_test_computer')
-        # Restore the computer
-        TestVerdiComputerCommands.setUpClass()
+            AiidaOrmComputer.get('computer_for_test_delete')

--- a/aiida/backends/tests/cmdline/commands/test_computer.py
+++ b/aiida/backends/tests/cmdline/commands/test_computer.py
@@ -1,12 +1,12 @@
 """Tests for the 'verdi computer' command."""
 import os
-from click.testing import CliRunner
 from collections import OrderedDict
-from aiida.common.exceptions import ValidationError
-
+from click.testing import CliRunner
 from aiida.backends.testbase import AiidaTestCase
 from aiida.cmdline.commands.computer import (disable_computer, enable_computer)
 from aiida.cmdline.commands.computer import setup_computer
+from aiida.cmdline.commands.computer import (computer_show, computer_list, computer_rename, computer_delete,
+                                             computer_test)
 from aiida.utils.capturing import Capturing
 
 
@@ -41,13 +41,14 @@ def generate_setup_options_dict(replace_args={}, non_interactive=True):
     valid_noninteractive_options['mpiprocs-per-machine'] = "2"
     # Make them multiline to test also multiline options
     valid_noninteractive_options['prepend-text'] = "date\necho 'second line'"
-    valid_noninteractive_options['append-text'] =  "env\necho '444'\necho 'third line'"
+    valid_noninteractive_options['append-text'] = "env\necho '444'\necho 'third line'"
 
     # I replace kwargs here, so that if they are known, they go at the right order
     for k in replace_args:
         valid_noninteractive_options[k] = replace_args[k]
 
     return valid_noninteractive_options
+
 
 def generate_setup_options(ordereddict):
     """
@@ -61,12 +62,13 @@ def generate_setup_options(ordereddict):
     :return: a list to be passed as command-line arguments.
     """
     options = []
-    for k, v in ordereddict.iteritems():
-        if v is None:
-            options.append('--{}'.format(k))
+    for key, value in ordereddict.iteritems():
+        if value is None:
+            options.append('--{}'.format(key))
         else:
-            options.append('--{}={}'.format(k, v))
+            options.append('--{}={}'.format(key, value))
     return options
+
 
 def generate_setup_options_interactive(ordereddict):
     """
@@ -80,12 +82,13 @@ def generate_setup_options_interactive(ordereddict):
     :return: a list to be passed as command-line arguments.
     """
     options = []
-    for k, v in ordereddict.iteritems():
-        if v is None:
+    for key, value in ordereddict.iteritems():
+        if value is None:
             options.append(True)
         else:
-            options.append(v)
+            options.append(value)
     return options
+
 
 class TestVerdiComputerSetup(AiidaTestCase):
     """Tests for the 'verdi computer setup' command."""
@@ -107,8 +110,7 @@ class TestVerdiComputerSetup(AiidaTestCase):
         os.environ['EDITOR'] = 'sleep 1; vim -cwq'
         label = 'interactive_computer'
 
-        options_dict = generate_setup_options_dict(
-                replace_args={'label': label}, non_interactive=False)
+        options_dict = generate_setup_options_dict(replace_args={'label': label}, non_interactive=False)
         # In any case, these would be managed by the visual editor
         options_dict.pop('prepend-text')
         options_dict.pop('append-text')
@@ -139,8 +141,7 @@ class TestVerdiComputerSetup(AiidaTestCase):
         os.environ['EDITOR'] = 'sleep 1; vim -cwq'
         label = 'mixed_computer'
 
-        options_dict = generate_setup_options_dict(
-            replace_args={'label': label})
+        options_dict = generate_setup_options_dict(replace_args={'label': label})
         options_dict_full = options_dict.copy()
 
         options_dict.pop('non-interactive', 'None')
@@ -171,7 +172,8 @@ class TestVerdiComputerSetup(AiidaTestCase):
         self.assertEqual(new_computer.get_mpirun_command(), options_dict_full['mpirun-command'].split())
         self.assertEqual(new_computer.get_shebang(), options_dict_full['shebang'])
         self.assertEqual(new_computer.get_workdir(), options_dict_full['work-dir'])
-        self.assertEqual(new_computer.get_default_mpiprocs_per_machine(), int(options_dict_full['mpiprocs-per-machine']))
+        self.assertEqual(new_computer.get_default_mpiprocs_per_machine(),
+                         int(options_dict_full['mpiprocs-per-machine']))
         # For now I'm not writing anything in them
         self.assertEqual(new_computer.get_prepend_text(), options_dict_full['prepend-text'])
         self.assertEqual(new_computer.get_append_text(), options_dict_full['append-text'])
@@ -216,10 +218,12 @@ class TestVerdiComputerSetup(AiidaTestCase):
         """
         from aiida.orm import Computer
 
-        options_dict = generate_setup_options_dict({'label': 'computer_disabled',
-                                                    ## Pass the '--disabled' option
-                                                    'disabled': None})
-        options_dict.pop('enabled', None) # Make sure --enabled is not there
+        options_dict = generate_setup_options_dict({
+            'label': 'computer_disabled',
+            ## Pass the '--disabled' option
+            'disabled': None
+        })
+        options_dict.pop('enabled', None)  # Make sure --enabled is not there
         options = generate_setup_options(options_dict)
 
         result = self.runner.invoke(setup_computer, options)
@@ -239,8 +243,8 @@ class TestVerdiComputerSetup(AiidaTestCase):
         from aiida.orm import Computer
 
         options_dict = generate_setup_options_dict({'label': 'computer_enabled'})
-        options_dict.pop('disabled', None) # Make sure 'disabled' is not there
-        options_dict['enabled'] = None # Activate --enabled
+        options_dict.pop('disabled', None)  # Make sure 'disabled' is not there
+        options_dict['enabled'] = None  # Activate --enabled
         options = generate_setup_options(options_dict)
 
         result = self.runner.invoke(setup_computer, options)
@@ -326,7 +330,7 @@ class TestVerdiComputerSetup(AiidaTestCase):
         Check that if fails as expected for an unknown transport
         """
         options_dict = generate_setup_options_dict(replace_args={'label': 'fail_computer'})
-        options_dict['shebang'] = '/bin/bash' # Missing #! in front
+        options_dict['shebang'] = '/bin/bash'  # Missing #! in front
         options = generate_setup_options(options_dict)
         result = self.runner.invoke(setup_computer, options)
 
@@ -354,13 +358,10 @@ class TestVerdiComputerCommands(AiidaTestCase):
 
     @classmethod
     def setUpClass(cls, *args, **kwargs):
-        """Create a new computer> I create a new one because I want to configure it and I don't want to 
+        """Create a new computer> I create a new one because I want to configure it and I don't want to
         interfere with other tests"""
-        from aiida.orm.backend import construct_backend
-
         super(TestVerdiComputerCommands, cls).setUpClass(*args, **kwargs)
         from aiida.orm import Computer
-        backend = construct_backend()
         cls.computer_name = "comp_cli_test_computer"
         cls.comp = Computer(
             name=cls.computer_name,
@@ -383,22 +384,25 @@ class TestVerdiComputerCommands(AiidaTestCase):
         with Capturing():
             ComputerCmd().run('configure', self.comp.name)
 
-        assert self.comp.is_user_configured(
-            self.user), "There was a problem configuring the test computer"
+        assert self.comp.is_user_configured(self.user), "There was a problem configuring the test computer"
 
         self.runner = CliRunner()
 
     def test_enable_disable_globally(self):
         """
         Test if enabling and disabling a computer has the intended effect.
-        Note I have to do it three times, because if because of a bug 
-        'enable' is a no-op and the computer was already enabled, the 
+        Note I have to do it three times, because if because of a bug
+        'enable' is a no-op and the computer was already enabled, the
         test would pass.
         """
+
         def enable_disable_globally_loop(self, user=None, user_enabled_state=True):
             result = self.runner.invoke(enable_computer, [str(self.comp.label)])
             self.assertIsNone(result.exception)
             self.assertTrue(self.comp.is_enabled())
+            """
+            Change global state check if user states are affected
+            """
 
             # Check that the change of global state did not affect the
             # per-user state
@@ -411,14 +415,14 @@ class TestVerdiComputerCommands(AiidaTestCase):
             result = self.runner.invoke(disable_computer, [str(self.comp.label)])
             self.assertIsNone(result.exception)
             self.assertFalse(self.comp.is_enabled())
-            
+
             # Check that the change of global state did not affect the
             # per-user state
             if user is not None:
                 if user_enabled_state:
                     self.assertTrue(self.comp.is_user_enabled(user))
                 else:
-                    self.assertFalse(self.comp.is_user_enabled(user))            
+                    self.assertFalse(self.comp.is_user_enabled(user))
 
             result = self.runner.invoke(enable_computer, [str(self.comp.label)])
             self.assertIsNone(result.exception)
@@ -433,19 +437,25 @@ class TestVerdiComputerCommands(AiidaTestCase):
                     self.assertFalse(self.comp.is_user_enabled(user))
 
         ## Start of actual tests
-        result = self.runner.invoke(enable_computer, ['--only-for-user={}'.format(self.user_email), str(self.comp.label)])
+        result = self.runner.invoke(enable_computer,
+                                    ['--only-for-user={}'.format(self.user_email),
+                                     str(self.comp.label)])
         self.assertIsNone(result.exception, msg="Error, output: {}".format(result.output))    #.stdout, result.stderr))
         self.assertTrue(self.comp.is_user_enabled(self.user))
         # enable and disable the computer globally as well
         enable_disable_globally_loop(self, self.user, user_enabled_state=True)
 
-        result = self.runner.invoke(disable_computer, ['--only-for-user={}'.format(self.user_email), str(self.comp.label)])
+        result = self.runner.invoke(disable_computer,
+                                    ['--only-for-user={}'.format(self.user_email),
+                                     str(self.comp.label)])
         self.assertIsNone(result.exception, msg="Error, output: {}".format(result.output))    #.stdout, result.stderr))
         self.assertFalse(self.comp.is_user_enabled(self.user))
         # enable and disable the computer globally as well
         enable_disable_globally_loop(self, self.user, user_enabled_state=False)
 
-        result = self.runner.invoke(enable_computer, ['--only-for-user={}'.format(self.user_email), str(self.comp.label)])
+        result = self.runner.invoke(enable_computer,
+                                    ['--only-for-user={}'.format(self.user_email),
+                                     str(self.comp.label)])
         self.assertIsNone(result.exception, msg="Error, output: {}".format(result.output))    #.stdout, result.stderr))
         self.assertTrue(self.comp.is_user_enabled(self.user))
         # enable and disable the computer globally as well
@@ -459,109 +469,132 @@ class TestVerdiComputerCommands(AiidaTestCase):
         """
         from aiida.cmdline.commands.computer import Computer as ComputerCmd
 
-        # Check that indeed, if there is a problem, we detect it as such
-        with self.assertRaises(SystemExit):
-            with Capturing(capture_stderr=True):
-                ComputerCmd().run('test', "not_existent_computer_name")
+        # Testing the wrong computer will fail
+        result = self.runner.invoke(computer_test, ['non-existent-computer'])
+        # An exception should arise
+        self.assertIsNotNone(result.exception)
 
-        # Test the computer
-        with Capturing():
-            ComputerCmd().run('test', self.computer_name)
+        # Testing the right computer should pass locally
+        result = self.runner.invoke(computer_test, ['comp_cli_test_computer'])
+        # No exceptions should arise
+        self.assertIsNone(result.exception)
 
     def test_computer_list(self):
         """
         Test if 'verdi computer list' command works
         """
-        for opt in ['', '-o', '--only-usable', '-p', '--parsable', '-a', '--all-comps']:
-            options = [opt]
-            result = self.cli_runner.invoke(computer.list, options)
-            # No exceptions should arise
-            self.assertIsNone(result.exception)
-            # Something should be printed to stdout
-            self.assertIsNotNone(result.output)
-    
-    def test_computer_list(self):
-        """
-        Test if 'verdi computer list' command works
-        """
-        for opt in ['', '-o', '--only-usable', '-p', '--parsable', '-a', '--all-comps']:
-            options = [opt]
-            result = self.cli_runner.invoke(computer.list, options)
-            # No exceptions should arise
-            self.assertIsNone(result.exception)
-            # Something should be printed to stdout
-            self.assertIsNotNone(result.output)
-    
-    def test_computer_show(self):
-        """
-        Test if 'verdi computer show' command works
-        """
-        
-        # See if we can display info about the test computer.
-        result = self.cli_runner.invoke(computer.show, 'comp_cli_test_computer')
+
+        # Check the vanilla command works
+        result = self.runner.invoke(computer_list, [])
         # No exceptions should arise
         self.assertIsNone(result.exception)
         # Something should be printed to stdout
         self.assertIsNotNone(result.output)
-        
-        # See if a non-existant computer will raise an error.
-        result = self.cli_runner.invoke(computer.show, 'not_a_valid_computer')
+
+        # Check all options run
+        for opt in ['-o', '--only-usable', '-p', '--parsable', '-a', '--all-comps']:
+            result = self.runner.invoke(computer_list, [opt])
+            # No exceptions should arise
+            self.assertIsNone(result.exception)
+            # Something should be printed to stdout
+            self.assertIsNotNone(result.output)
+
+    def test_computer_show(self):
+        """
+        Test if 'verdi computer show' command works
+        """
+        result = self.runner.invoke(computer_list, ['-p'])
+
+        # See if we can display info about the test computer.
+        result = self.runner.invoke(computer_show, ['comp_cli_test_computer'])
+
+        # No exceptions should arise
+        self.assertIsNone(result.exception)
+        # Something should be printed to stdout
+        self.assertIsNotNone(result.output)
+
+        # See if a non-existent computer will raise an error.
+        result = self.runner.invoke(computer_show, 'non_existent_computer_name')
         # Exceptions should arise
         self.assertIsNotNone(result.exception)
-    
+
     def test_computer_rename(self):
         """
         Test if 'verdi computer rename' command works
         """
         from aiida.orm.computer import Computer as AiidaOrmComputer
-    
+        from aiida.common.exceptions import NotExistent
+
         # See if the command complains about not getting an invalid computer
-        options = ['not_a_valid_computer']
-        result = self.cli_runner.invoke(computer.rename, options)
+        options = ['not_existent_computer_name']
+        result = self.runner.invoke(computer_rename, options)
         # Exception should be raised
         self.assertIsNotNone(result.exception)
-        
+
         # See if the command complains about not getting both names
         options = ['comp_cli_test_computer']
-        result = self.cli_runner.invoke(computer.rename, options)
+        result = self.runner.invoke(computer_rename, options)
         # Exception should be raised
         self.assertIsNotNone(result.exception)
 
         # The new name must be different to the old one
         options = ['comp_cli_test_computer', 'comp_cli_test_computer']
-        result = self.cli_runner.invoke(computer.rename, options)
+        result = self.runner.invoke(computer_rename, options)
         # Exception should be raised
         self.assertIsNotNone(result.exception)
 
         # Change a computer name successully.
         options = ['comp_cli_test_computer', 'renamed_test_computer']
-        result = self.cli_runner.invoke(computer.rename, options)
+        result = self.runner.invoke(computer_rename, options)
         # Exception should be not be raised
         self.assertIsNone(result.exception)
+
         # Check that the name really was changed
+        # The old name should not be available
+        with self.assertRaises(NotExistent):
+            AiidaOrmComputer.get('comp_cli_test_computer')
+        # The new name should be avilable
         try:
-            computer = AiidaOrmComputer.get('renamed_test_computer')
-            self.assertIsNone(computer)
-            computer = AiidaOrmComputer.get('comp_cli_test_computer')
-    
+            AiidaOrmComputer.get('renamed_test_computer')
+        except NotExistent:
+            assertTrue(False)
+
+        # Now change the name back
+        options = ['renamed_test_computer', 'comp_cli_test_computer']
+        result = self.runner.invoke(computer_rename, options)
+        # Exception should be not be raised
+        self.assertIsNone(result.exception)
+
+        # Check that the name really was changed
+        # The old name should not be available
+        with self.assertRaises(NotExistent):
+            AiidaOrmComputer.get('renamed_test_computer')
+        # The new name should be avilable
+        try:
+            AiidaOrmComputer.get('comp_cli_test_computer')
+        except NotExistent:
+            assertTrue(False)
+
     def test_computer_delete(self):
         """
         Test if 'verdi computer delete' command works
         """
         from aiida.orm.computer import Computer as AiidaOrmComputer
-    
+        from aiida.common.exceptions import NotExistent
+
         # See if the command complains about not getting an invalid computer
-        options = ['not_a_valid_computer']
-        result = self.cli_runner.invoke(computer.show, options)
+        options = ['not_existent_computer_name']
+        result = self.runner.invoke(computer_delete, options)
         # Exception should be raised
         self.assertIsNotNone(result.exception)
-        
+
         # Delete a computer name successully.
         options = ['comp_cli_test_computer']
-        result = self.cli_runner.invoke(computer.delete, options)
+        result = self.runner.invoke(computer_delete, options)
         # Exception should be not be raised
         self.assertIsNone(result.exception)
         # Check that the computer really was deleted
-        try:
-            computer = AiidaOrmComputer.get('comp_cli_test_computer')
-            self.assertIsNone(computer)
+        with self.assertRaises(NotExistent):
+            AiidaOrmComputer.get('comp_cli_test_computer')
+        # Restore the computer
+        TestVerdiComputerCommands.setUpClass()

--- a/aiida/cmdline/commands/computer.py
+++ b/aiida/cmdline/commands/computer.py
@@ -37,6 +37,7 @@ def get_computer_names():
     else:
         return []
 
+@with_dbenv()
 def get_computer(name):
     """
     Get a Computer object with given name, or raise NotExistent
@@ -45,6 +46,7 @@ def get_computer(name):
     return AiidaOrmComputer.get(name)
 
 
+@with_dbenv()
 def prompt_for_computer_configuration(computer):
     import inspect, readline
     from aiida.orm.computer import Computer
@@ -452,10 +454,7 @@ def computer_rename(computer, new_name):
 
 
 @verdi_computer.command('test')
-@click.option(
-    '-u',
-    '--user',
-    type=types.UserParamType(),
+@options.USER(
     required=False,
     help="Test the connection for a given AiiDA user, specified by"
     "their email address. If not specified, uses the current "

--- a/aiida/cmdline/commands/computer.py
+++ b/aiida/cmdline/commands/computer.py
@@ -36,6 +36,18 @@ def get_computer_names():
     else:
         return []
 
+def get_computer(name):
+    """
+    Get a Computer object with given name, or raise NotExistent
+    """
+    from aiida.orm.computer import Computer as AiidaOrmComputer
+    return AiidaOrmComputer.get(name)
+
+
+def prompt_for_computer_configuration(computer):
+    import inspect, readline
+    from aiida.orm.computer import Computer
+    from aiida.common.exceptions import ValidationError
 
 def shouldcall_default_mpiprocs_per_machine(ctx):
     """
@@ -228,6 +240,300 @@ def disable_computer(ctx, only_for_user, computer):
                 computer.name, only_for_user.first_name, only_for_user.last_name))
 
 
+@verdi_computer.command('list')
+@click.option(
+    '-o',
+    '--only-usable',
+    is_flag=True,
+    help="Show only computers that are usable (i.e., "
+    "configured for the given user and enabled)")
+@click.option(
+    '-p',
+    '--parsable',
+    is_flag=True,
+    help="Show only the computer names, one per line, "
+    "without any other information or string.")
+@click.option('-a', '--all-comps', is_flag=True, help="Show also disabled or unconfigured computers")
+@with_dbenv()
+def computer_list(only_usable, parsable, all_comps):
+    """
+    List available computers
+    """
+    from aiida.orm.computer import Computer as AiiDAOrmComputer
+    from aiida.orm import backend
+    from aiida.orm.backend import construct_backend
+
+    backend = construct_backend()
+
+    computer_names = get_computer_names()
+
+    if not parsable:
+        echo.echo("# List of configured computers:")
+        echo.echo("# (use 'verdi computer show COMPUTERNAME' " "to see the details)")
+    if computer_names:
+        for name in sorted(computer_names):
+            computer = AiiDAOrmComputer.get(name)
+
+            is_configured = computer.is_user_configured(backend.users.get_automatic_user())
+            is_user_enabled = computer.is_user_enabled(backend.users.get_automatic_user())
+
+            is_usable = False  # True if both enabled and configured
+
+            if not all_comps:
+                if not is_configured or not is_user_enabled or not computer.is_enabled():
+                    continue
+
+            if computer.is_enabled():
+                if is_configured:
+                    configured_str = ""
+                    if is_user_enabled:
+                        symbol = "*"
+                        color = 'green'
+                        enabled_str = ""
+                        is_usable = True
+                    else:
+                        symbol = "x"
+                        color = 'red'
+                        enabled_str = "[DISABLED for this user]"
+                else:
+                    symbol = "x"
+                    color = 'reset'
+                    enabled_str = ""
+                    configured_str = " [unconfigured]"
+            else:  # GLOBALLY DISABLED
+                symbol = "x"
+                color = 'red'
+                if is_configured and not is_user_enabled:
+                    enabled_str = " [DISABLED globally AND for this user]"
+                else:
+                    enabled_str = " [DISABLED globally]"
+                if is_configured:
+                    configured_str = ""
+                else:
+                    configured_str = " [unconfigured]"
+
+            if parsable:
+                echo.echo(click.style("{}".format(name), fg=color))
+            else:
+                if (not only_usable) or is_usable:
+                    echo.echo(click.style("{} ".format(symbol), fg=color), nl=False)
+                    echo.echo(click.style("{} ".format(name), bold=True, fg=color), nl=False),
+                    echo.echo(click.style("{}{}".format(enabled_str, configured_str), fg=color))
+
+    else:
+        echo.echo("# No computers configured yet. Use 'verdi computer setup'")
+
+
+@verdi_computer.command('show')
+@arguments.COMPUTER()
+@with_dbenv()
+def computer_show(computer):
+    """
+    Show information on a given computer
+    """
+    from aiida.common.exceptions import NotExistent
+
+    try:
+        computer = get_computer(computer)
+    except NotExistent:
+        echo.echo_critical("No computer in the DB with name {}.".format(computer))
+    echo.echo(computer.full_text_info)
+
+
+@verdi_computer.command('rename')
+@arguments.COMPUTER('OLD-NAME')
+@arguments.LABEL('NEW-NAME')
+@with_dbenv()
+def computer_rename(oldname, newname):
+    """
+    Rename a computer
+    """
+    from aiida.common.exceptions import (NotExistent, UniquenessError, ValidationError)
+
+    if oldname == newname:
+        echo.echo_critical("The initial and final name are the same.")
+
+    try:
+        computer = self.get_computer(name=oldname)
+    except NotExistent:
+        echo.echo_critical("No computer exists with name '{}'".format(oldname))
+
+    try:
+        computer.set_name(newname)
+        computer.store()
+    except ValidationError as e:
+        echo.echo_critical("Invalid input! {}".format(e.message))
+    except UniquenessError as e:
+        echo.echo_critical("Uniqueness error encountered! Probably a "
+                           "computer with name '{}' already exists"
+                           "".format(newname))
+        echo.echo_critical("(Message was: {})".format(e.message))
+
+    echo.echo_success("Computer '{}' renamed to '{}'".format(oldname, newname))
+
+
+@verdi_computer.command('test')
+@click.option(
+    '-u',
+    '--user',
+    type=types.UserParamType(),
+    required=False,
+    help="Test the connection for a given AiiDA user."
+    "If not specified, uses the current "
+    "default user.",
+)
+@click.option(
+    '-t',
+    '--print-traceback',
+    is_flag=True,
+    help="Print the full traceback in case an exception "
+    "is raised",
+)
+@arguments.COMPUTER()
+@with_dbenv()
+def computer_test(user, print_traceback, computer):
+    """
+    Test the connection to a computer.
+
+    It tries to connect, to get the list of calculations on the queue and
+    to perform other tests.
+    """
+    import argparse
+    import traceback
+    from aiida.common.exceptions import NotExistent
+    from aiida.orm.backend import construct_backend
+
+    backend = construct_backend()
+
+    user_email = user
+
+    try:
+        computer = get_computer(name=computer)
+    except NotExistent:
+        echo.echo_critical("No computer exists with name '{}'".format(computer))
+
+    if user_email is None:
+        user = backend.users.get_automatic_user()
+    else:
+        user_list = backend.users.find(email=user_email)
+        # If no user is found
+        if not user_list:
+            echo.echo_critical("No user with email '{}' in the " "database.".format(user_email))
+        user = user_list[0]
+
+    echo.echo("Testing computer '{}' for user {}...".format(computer, user.email))
+    try:
+        authinfo = computer.get_authinfo(user)
+    except NotExistent:
+        echo.echo_critical("User with email '{}' is not yet configured "
+                           "for computer '{}' yet.".format(user.email, computer))
+
+    # Correct way to do this with click.echo?
+    warning_string = None
+    if not authinfo.enabled:
+        warning_string = ("** NOTE! Computer is disabled for the "
+                          "specified user!\n   Do you really want to test it? [y/N] ")
+    if not computer.is_enabled():
+        warning_string = ("** NOTE! Computer is disabled!\n" "   Do you really want to test it? [y/N] ")
+    if warning_string:
+        if not click.confirm(warning_string):
+            sys.exit(0)
+
+    sched = authinfo.computer.get_scheduler()
+    trans = authinfo.get_transport()
+
+    ## STARTING TESTS HERE
+    num_failures = 0
+    num_tests = 0
+
+    try:
+        echo.echo("> Testing connection...")
+        with trans:
+            sched.set_transport(trans)
+            num_tests += 1
+            for test in [self._computer_test_get_jobs, self._computer_create_temp_file]:
+                num_tests += 1
+                try:
+                    succeeded = test(transport=trans, scheduler=sched, authinfo=authinfo)
+                except Exception as e:
+                    print "* The test raised an exception!"
+                    if print_traceback:
+                        print "** Full traceback:"
+                        # Indent
+                        print "\n".join(["   {}".format(l) for l in traceback.format_exc().splitlines()])
+                    else:
+                        print "** {}: {}".format(e.__class__.__name__, e.message)
+                        print("** (use the --traceback option to see the " "full traceback)")
+                    succeeded = False
+
+                if not succeeded:
+                    num_failures += 1
+
+        if num_failures:
+            print "Some tests failed! ({} out of {} failed)".format(num_failures, num_tests)
+        else:
+            print "Test completed (all {} tests succeeded)".format(num_tests)
+    except Exception as e:
+        print "** Error while trying to connect to the computer! Cannot "
+        print "   perform following tests, stopping."
+        if print_traceback:
+            print "** Full traceback:"
+            # Indent
+            print "\n".join(["   {}".format(l) for l in traceback.format_exc().splitlines()])
+        else:
+            print "{}: {}".format(e.__class__.__name__, e.message)
+            print("(use the --traceback option to see the " "full traceback)")
+        succeeded = False
+
+
+def _computer_test_get_jobs(self, transport, scheduler, authinfo):
+    """
+    Internal test to check if it is possible to check the queue state.
+
+    :note: exceptions could be raised
+
+    :param transport: an open transport
+    :param scheduler: the corresponding scheduler class
+    :param authinfo: the authinfo object (from which one can get
+      computer and aiidauser)
+    :return: True if the test succeeds, False if it fails.
+    """
+    print "> Getting job list..."
+    found_jobs = scheduler.getJobs(as_dict=True)
+    # For debug
+    # for jid, data in found_jobs.iteritems():
+    #    print jid, data['submission_time'], data['dispatch_time'], data['job_state']
+    print "  `-> OK, {} jobs found in the queue.".format(len(found_jobs))
+    return True
+
+
+@verdi_computer.command('delete')
+@arguments.COMPUTER()
+@with_dbenv()
+def computer_delete(computername):
+    """
+    Configure the authentication information for a given computer
+
+    Does not delete the computer if there are calculations that are using
+    it.
+    """
+
+    from aiida.common.exceptions import (NotExistent, InvalidOperation)
+    from aiida.orm.computer import delete_computer
+
+    try:
+        computer = self.get_computer(name=computername)
+    except NotExistent:
+        echo.echo_critical("No computer exists with name '{}'".format(computername))
+
+    try:
+        delete_computer(computer)
+    except InvalidOperation as e:
+        echo.echo_critical(e.message)
+
+    echo.echo_successful("Computer '{}' deleted.".format(computername))
+
+
 class Computer(VerdiCommandWithSubcommands):
     """
     Setup and manage computers to be used
@@ -242,16 +548,16 @@ class Computer(VerdiCommandWithSubcommands):
         super(Computer, self).__init__()
 
         self.valid_subcommands = {
-            'list': (self.computer_list, self.complete_none),
-            'show': (self.computer_show, self.complete_computers),
-            'setup': (verdi, self.complete_none),
+            'list': (verdi, self.complete_none),
+            'show': (verdi, self.complete_computers),
+            'setup': (self.computer_setup, self.complete_none),
             'update': (self.computer_update, self.complete_computers),
             'enable': (verdi, self.complete_computers),
             'disable': (verdi, self.complete_computers),
-            'rename': (self.computer_rename, self.complete_computers),
+            'rename': (verdi, self.complete_computers),
             'configure': (self.computer_configure, self.complete_computers),
-            'test': (self.computer_test, self.complete_computers),
-            'delete': (self.computer_delete, self.complete_computers),
+            'test': (verdi, self.complete_computers),
+            'delete': (verdi, self.complete_computers),
         }
 
     def complete_computers(self, subargs_idx, subargs):
@@ -260,161 +566,6 @@ class Computer(VerdiCommandWithSubcommands):
         computer_names = self.get_computer_names()
         print computer_names
         return "\n".join(computer_names)
-
-    def computer_list(self, *args):
-        """
-        List available computers
-        """
-        import argparse
-
-        if not is_dbenv_loaded():
-            load_dbenv()
-        from aiida.orm.computer import Computer as AiiDAOrmComputer
-
-        parser = argparse.ArgumentParser(
-            prog=self.get_full_command_name(), description='List the computers in the database.')
-        # The default states are those that are shown if no option is given
-        parser.add_argument(
-            '-C',
-            '--color',
-            action='store_true',
-            help="Use colors to help visualizing the different categories",
-        )
-        parser.add_argument(
-            '-o',
-            '--only-usable',
-            action='store_true',
-            help="Show only computers that are usable (i.e., "
-            "configured for the given user and enabled)",
-        )
-        parser.add_argument(
-            '-p',
-            '--parsable',
-            action='store_true',
-            help="Show only the computer names, one per line, "
-            "without any other information or string.",
-        )
-        parser.add_argument(
-            '-a',
-            '--all',
-            action='store_true',
-            help="Show also disabled or unconfigured computers",
-        )
-        parser.set_defaults(also_disabled=False)
-        parsed_args = parser.parse_args(args)
-        use_colors = parsed_args.color
-        only_usable = parsed_args.only_usable
-        parsable = parsed_args.parsable
-        all_comps = parsed_args.all
-
-        computer_names = self.get_computer_names()
-
-        if use_colors:
-            color_id = 90  # Dark gray
-            color_id = None  # Default color
-            if color_id is not None:
-                start_color = "\x1b[{}m".format(color_id)
-                end_color = "\x1b[0m"
-            else:
-                start_color = ""
-                end_color = ""
-        else:
-            start_color = ""
-            end_color = ""
-
-        if not parsable:
-            print "{}# List of configured computers:{}".format(start_color, end_color)
-            print("{}# (use 'verdi computer show COMPUTERNAME' " "to see the details){}".format(start_color, end_color))
-        if computer_names:
-            for name in sorted(computer_names):
-                computer = AiiDAOrmComputer.get(name)
-
-                # color_id = 90 # Dark gray
-                # color_id = 34 # Blue
-
-                is_configured = computer.is_user_configured(self.backend.users.get_automatic_user())
-                is_user_enabled = computer.is_user_enabled(self.backend.users.get_automatic_user())
-
-                is_usable = False  # True if both enabled and configured
-
-                if not all_comps:
-                    if not is_configured or not is_user_enabled or not computer.is_enabled():
-                        continue
-
-                if computer.is_enabled():
-                    if is_configured:
-                        configured_str = ""
-                        if is_user_enabled:
-                            symbol = "*"
-                            color_id = None
-                            enabled_str = ""
-                            is_usable = True
-                        else:
-                            symbol = "x"
-                            color_id = 31  # Red
-                            enabled_str = "[DISABLED for this user]"
-                    else:
-                        symbol = "x"
-                        color_id = 90  # Dark gray
-                        enabled_str = ""
-                        configured_str = " [unconfigured]"
-                else:  # GLOBALLY DISABLED
-                    symbol = "x"
-                    color_id = 31  # Red
-                    if is_configured and not is_user_enabled:
-                        enabled_str = " [DISABLED globally AND for this user]"
-                    else:
-                        enabled_str = " [DISABLED globally]"
-                    if is_configured:
-                        configured_str = ""
-                    else:
-                        configured_str = " [unconfigured]"
-
-                if use_colors:
-                    if color_id is not None:
-                        start_color = "\x1b[{}m".format(color_id)
-                        bold_sequence = "\x1b[1;{}m".format(color_id)
-                        nobold_sequence = "\x1b[0;{}m".format(color_id)
-                    else:
-                        start_color = "\x1b[0m"
-                        bold_sequence = "\x1b[1m"
-                        nobold_sequence = "\x1b[0m"
-                    end_color = "\x1b[0m"
-                else:
-                    start_color = ""
-                    end_color = ""
-                    bold_sequence = ""
-                    nobold_sequence = ""
-
-                if parsable:
-                    print "{}{}{}".format(start_color, name, end_color)
-                else:
-                    if (not only_usable) or is_usable:
-                        print "{}{} {}{}{} {}{}{}".format(start_color, symbol, bold_sequence, name, nobold_sequence,
-                                                          enabled_str, configured_str, end_color)
-
-        else:
-            print "# No computers configured yet. Use 'verdi computer setup'"
-
-    def computer_show(self, *args):
-        """
-        Show information on a given computer
-        """
-        if not is_dbenv_loaded():
-            load_dbenv()
-
-        from aiida.common.exceptions import NotExistent
-
-        if len(args) != 1:
-            print >> sys.stderr, ("after 'computer show' there should be one "
-                                  "argument only, being the computer name.")
-            sys.exit(1)
-        try:
-            computer = self.get_computer(name=args[0])
-        except NotExistent:
-            print >> sys.stderr, "No computer in the DB with name {}.".format(args[0])
-            sys.exit(1)
-        print computer.full_text_info
 
     def computer_update(self, *args):
         """
@@ -478,46 +629,6 @@ class Computer(VerdiCommandWithSubcommands):
         print "OK"
         pass
 
-    def computer_rename(self, *args):
-        """
-        Rename a computer
-        """
-        if not is_dbenv_loaded():
-            load_dbenv()
-
-        from aiida.common.exceptions import (NotExistent, UniquenessError, ValidationError)
-
-        try:
-            oldname = args[0]
-            newname = args[1]
-        except IndexError:
-            print >> sys.stderr, "Pass as parameters the old and the new name"
-            sys.exit(1)
-
-        if oldname == newname:
-            print >> sys.stderr, "The initial and final name are the same."
-            sys.exit(1)
-
-        try:
-            computer = self.get_computer(name=oldname)
-        except NotExistent:
-            print >> sys.stderr, "No computer exists with name '{}'".format(oldname)
-            sys.exit(1)
-
-        try:
-            computer.set_name(newname)
-            computer.store()
-        except ValidationError as e:
-            print >> sys.stderr, "Invalid input! {}".format(e.message)
-            sys.exit(1)
-        except UniquenessError as e:
-            print >> sys.stderr, ("Uniqueness error encountered! Probably a "
-                                  "computer with name '{}' already exists"
-                                  "".format(newname))
-            print >> sys.stderr, "(Message was: {})".format(e.message)
-            sys.exit(1)
-
-        print "Computer '{}' renamed to '{}'".format(oldname, newname)
 
     def computer_configure(self, *args):
         """
@@ -641,183 +752,6 @@ class Computer(VerdiCommandWithSubcommands):
         authinfo.store()
         print "Configuration stored for your user on computer '{}'.".format(computername)
 
-    def computer_delete(self, *args):
-        """
-        Configure the authentication information for a given computer
-
-        Does not delete the computer if there are calculations that are using
-        it.
-        """
-        if not is_dbenv_loaded():
-            load_dbenv()
-
-        from aiida.common.exceptions import (NotExistent, InvalidOperation)
-        from aiida.orm.computer import delete_computer
-
-        if len(args) != 1:
-            print >> sys.stderr, ("after 'computer delete' there should be one "
-                                  "argument only, being the computer name.")
-            sys.exit(1)
-
-        computername = args[0]
-
-        try:
-            computer = self.get_computer(name=computername)
-        except NotExistent:
-            print >> sys.stderr, "No computer exists with name '{}'".format(computername)
-            sys.exit(1)
-
-        try:
-            delete_computer(computer)
-        except InvalidOperation as e:
-            print >> sys.stderr, e.message
-            sys.exit(1)
-
-        print "Computer '{}' deleted.".format(computername)
-
-    def computer_test(self, *args):
-        """
-        Test the connection to a computer.
-
-        It tries to connect, to get the list of calculations on the queue and
-        to perform other tests.
-        """
-        import argparse
-        import traceback
-
-        if not is_dbenv_loaded():
-            load_dbenv()
-
-        from aiida.common.exceptions import NotExistent
-
-        parser = argparse.ArgumentParser(prog=self.get_full_command_name(), description='Test a remote computer')
-        # The default states are those that are shown if no option is given
-        parser.add_argument(
-            '-u',
-            '--user',
-            type=str,
-            metavar='EMAIL',
-            dest='user_email',
-            help="Test the connection for a given AiiDA user."
-            "If not specified, uses the current "
-            "default user.",
-        )
-        parser.add_argument(
-            '-t',
-            '--traceback',
-            action='store_true',
-            help="Print the full traceback in case an exception "
-            "is raised",
-        )
-        parser.add_argument('computer', type=str, help="The name of the computer that you " "want to test")
-
-        parsed_args = parser.parse_args(args)
-
-        user_email = parsed_args.user_email
-        computername = parsed_args.computer
-        print_traceback = parsed_args.traceback
-
-        try:
-            computer = self.get_computer(name=computername)
-        except NotExistent:
-            print >> sys.stderr, "No computer exists with name '{}'".format(computername)
-            sys.exit(1)
-
-        if user_email is None:
-            user = self.backend.users.get_automatic_user()
-        else:
-            user_list = self.backend.users.find(email=user_email)
-            # If no user is found
-            if not user_list:
-                print >> sys.stderr, ("No user with email '{}' in the " "database.".format(user_email))
-                sys.exit(1)
-            user = user_list[0]
-
-        print "Testing computer '{}' for user {}...".format(computername, user.email)
-        try:
-            authinfo = computer.get_authinfo(user)
-        except NotExistent:
-            print >> sys.stderr, ("User with email '{}' is not yet configured "
-                                  "for computer '{}' yet.".format(user.email, computername))
-            sys.exit(1)
-
-        warning_string = None
-        if not authinfo.enabled:
-            warning_string = ("** NOTE! Computer is disabled for the "
-                              "specified user!\n   Do you really want to test it? [y/N] ")
-        if not computer.is_enabled():
-            warning_string = ("** NOTE! Computer is disabled!\n" "   Do you really want to test it? [y/N] ")
-        if warning_string:
-            answer = raw_input(warning_string)
-            if not (answer == 'y' or answer == 'Y'):
-                sys.exit(0)
-
-        s = authinfo.computer.get_scheduler()
-        t = authinfo.get_transport()
-
-        ## STARTING TESTS HERE
-        num_failures = 0
-        num_tests = 0
-
-        try:
-            print "> Testing connection..."
-            with t:
-                s.set_transport(t)
-                num_tests += 1
-                for test in [self._computer_test_get_jobs, self._computer_create_temp_file]:
-                    num_tests += 1
-                    try:
-                        succeeded = test(transport=t, scheduler=s, authinfo=authinfo)
-                    except Exception as e:
-                        print "* The test raised an exception!"
-                        if print_traceback:
-                            print "** Full traceback:"
-                            # Indent
-                            print "\n".join(["   {}".format(l) for l in traceback.format_exc().splitlines()])
-                        else:
-                            print "** {}: {}".format(e.__class__.__name__, e.message)
-                            print("** (use the --traceback option to see the " "full traceback)")
-                        succeeded = False
-
-                    if not succeeded:
-                        num_failures += 1
-
-            if num_failures:
-                print "Some tests failed! ({} out of {} failed)".format(num_failures, num_tests)
-            else:
-                print "Test completed (all {} tests succeeded)".format(num_tests)
-        except Exception as e:
-            print "** Error while trying to connect to the computer! Cannot "
-            print "   perform following tests, stopping."
-            if print_traceback:
-                print "** Full traceback:"
-                # Indent
-                print "\n".join(["   {}".format(l) for l in traceback.format_exc().splitlines()])
-            else:
-                print "{}: {}".format(e.__class__.__name__, e.message)
-                print("(use the --traceback option to see the " "full traceback)")
-            succeeded = False
-
-    def _computer_test_get_jobs(self, transport, scheduler, authinfo):
-        """
-        Internal test to check if it is possible to check the queue state.
-
-        :note: exceptions could be raised
-
-        :param transport: an open transport
-        :param scheduler: the corresponding scheduler class
-        :param authinfo: the authinfo object (from which one can get
-          computer and aiidauser)
-        :return: True if the test succeeds, False if it fails.
-        """
-        print "> Getting job list..."
-        found_jobs = scheduler.getJobs(as_dict=True)
-        # For debug
-        # for jid, data in found_jobs.iteritems():
-        #    print jid, data['submission_time'], data['dispatch_time'], data['job_state']
-        print "  `-> OK, {} jobs found in the queue.".format(len(found_jobs))
-        return True
-
     def _computer_create_temp_file(self, transport, scheduler, authinfo):
         """
         Internal test to check if it is possible to create a temporary file
@@ -887,25 +821,3 @@ class Computer(VerdiCommandWithSubcommands):
         transport.remove(remote_file_path)
         print "  [Deleted successfully]"
         return True
-
-    def get_computer_names(self):
-        """
-        Retrieve the list of computers in the DB.
-
-        ToDo: use an API or cache the results, sometime it is quite slow!
-        """
-        from aiida.orm.querybuilder import QueryBuilder
-        qb = QueryBuilder()
-        qb.append(type='computer', project=['name'])
-        if qb.count() > 0:
-            return zip(*qb.all())[0]
-        else:
-            return None
-
-    def get_computer(self, name):
-        """
-        Get a Computer object with given name, or raise NotExistent
-        """
-        from aiida.orm.computer import Computer as AiidaOrmComputer
-
-        return AiidaOrmComputer.get(name)


### PR DESCRIPTION
Converts the non-interactive verdi computer commands to click and adds tests for these.

Giovanni is still working on "verdi computer configure" and "verdi computer update" and will include these in a later pull request.

Note: The changed files are not in the yaml config file yet to avoid pylint complaints as this is a only a partial fix to issue 1582.