### PR TITLE
fix bug in mixins.py when copying node

### DIFF
--- a/aiida/orm/mixins.py
+++ b/aiida/orm/mixins.py
@@ -96,7 +96,7 @@ class Sealable(object):
 
         # Remove the updatable attributes
         if not include_updatable_attrs:
-            for key, value in self._iter_updatable_attributes():
+            for key, value in clone._iter_updatable_attributes():
                 clone._del_attr(key)
 
         return clone


### PR DESCRIPTION
`_sealed` attribute is not copied in superclass `Node.copy()` method and but here it tries to delete it again, which throws an `AttributeError` exception. We should use `clone._iter_updatable_attributes()` instead for deleting unwanted updatable attributes of the _clone_.