### PR TITLE
Restore copy behavior

### DIFF
--- a/aiida/orm/implementation/django/node.py
+++ b/aiida/orm/implementation/django/node.py
@@ -470,7 +470,8 @@ class Node(AbstractNode):
             if k != Sealable.SEALED_KEY:
                 newobject._set_attr(k, v)
 
-        newobject.folder.replace_with_folder(self.folder.abspath, move=False, overwrite=True)
+        for path in self.get_folder_list():
+            newobject.add_path(self.get_abs_path(path), path)
 
         return newobject
 

--- a/aiida/orm/implementation/general/node.py
+++ b/aiida/orm/implementation/general/node.py
@@ -1698,6 +1698,7 @@ class AbstractNode(object):
         return self
 
     def _store_from_cache(self, cache_node, with_transaction):
+        from aiida.orm.mixins import Sealable
         new_node = type(cache_node)()
         new_node._dbnode.type = cache_node._dbnode.type  # Inherit type
         new_node.label = cache_node.label  # Inherit label

--- a/aiida/orm/implementation/general/node.py
+++ b/aiida/orm/implementation/general/node.py
@@ -1698,7 +1698,18 @@ class AbstractNode(object):
         return self
 
     def _store_from_cache(self, cache_node, with_transaction):
-        new_node = cache_node.copy(include_updatable_attrs=True)
+        new_node = type(cache_node)()
+        new_node._dbnode.type = cache_node._dbnode.type  # Inherit type
+        new_node.label = cache_node.label  # Inherit label
+        new_node.description = cache_node.description  # Inherit description
+        new_node._dbnode.dbcomputer = cache_node._dbnode.dbcomputer  # Inherit computer
+
+        for k, v in cache_node.iterattrs():
+            if k != Sealable.SEALED_KEY:
+                new_node._set_attr(k, v)
+
+        new_node.folder.replace_with_folder(cache_node.folder.abspath, move=False, overwrite=True)
+
         inputlinks_cache = self._inputlinks_cache
         # "impersonate" the copied node by getting all its attributes
         self.__dict__ = new_node.__dict__

--- a/aiida/orm/implementation/sqlalchemy/node.py
+++ b/aiida/orm/implementation/sqlalchemy/node.py
@@ -550,7 +550,8 @@ class Node(AbstractNode):
             if k != Sealable.SEALED_KEY:
                 newobject._set_attr(k, v)
 
-        newobject.folder.replace_with_folder(self.folder.abspath, move=False, overwrite=True)
+        for path in self.get_folder_list():
+            newobject.add_path(self.get_abs_path(path), path)
 
         return newobject
 


### PR DESCRIPTION
The cache folder issue is fixed by explicitly copying the ``copy`` code into the ``_store_from_cached`` method. This isn't very nice, but since it's only the backport of the fix I think it's acceptable.