### PR TITLE
Homogenize the interface of `verdi quicksetup` and `verdi setup`

### DIFF
--- a/.ci/setup_profiles.sh
+++ b/.ci/setup_profiles.sh
@@ -14,10 +14,10 @@ then
     psql -h localhost -c "CREATE DATABASE test_$TEST_AIIDA_BACKEND;" -U postgres -w
 
     # Here I setup the actual AiiDA profile, non-interactively
-    verdi -p $TEST_AIIDA_BACKEND setup --non-interactive --backend=$TEST_AIIDA_BACKEND --email="aiida@localhost" --db_host="localhost" --db_port=5432 --db_name="$TEST_AIIDA_BACKEND" --db_user=postgres --db_pass='' --repo="/tmp/repository_${TEST_AIIDA_BACKEND}/" --first-name=AiiDA --last-name=test --institution="AiiDA Team"
+    verdi setup --non-interactive --backend=$TEST_AIIDA_BACKEND --email="aiida@localhost" --db-host="localhost" --db-port=5432 --db-name="$TEST_AIIDA_BACKEND" --db-username=postgres --db-password='' --repository="/tmp/repository_${TEST_AIIDA_BACKEND}/" --first-name=AiiDA --last-name=test --institution="AiiDA Team" $TEST_AIIDA_BACKEND
 
     # Here I setup the test AiiDA profile, non-interactively
-    verdi -p test_$TEST_AIIDA_BACKEND setup --non-interactive --backend=$TEST_AIIDA_BACKEND --email="aiida@localhost" --db_host="localhost" --db_port=5432 --db_name="test_$TEST_AIIDA_BACKEND" --db_user=postgres --db_pass='' --repo="/tmp/test_repository_test_${TEST_AIIDA_BACKEND}/" --first-name=AiiDA --last-name=test --institution="AiiDA Team"
+    verdi setup --non-interactive --backend=$TEST_AIIDA_BACKEND --email="aiida@localhost" --db-host="localhost" --db-port=5432 --db-name="test_$TEST_AIIDA_BACKEND" --db-username=postgres --db-password='' --repository="/tmp/test_repository_test_${TEST_AIIDA_BACKEND}/" --first-name=AiiDA --last-name=test --institution="AiiDA Team" test_$TEST_AIIDA_BACKEND
 
     # Maybe not needed, but set this profile to be the default one
     verdi profile setdefault $TEST_AIIDA_BACKEND

--- a/.ci/test_setup.py
+++ b/.ci/test_setup.py
@@ -32,7 +32,7 @@ from aiida.backends import settings as backend_settings
 
 
 class QuicksetupTestCase(unittest.TestCase):
-    """Test ``verdi quicksetup``"""
+    """Test `verdi quicksetup`."""
 
     def setUp(self):
         self.runner = CliRunner()
@@ -40,28 +40,27 @@ class QuicksetupTestCase(unittest.TestCase):
 
     def test_user_setup(self):
         """
-        Test ``verdi quicksetup`` non-interactively
+        Test `verdi quicksetup` non-interactively
         """
         backend_settings.AIIDADB_PROFILE = None
         result = self.runner.invoke(quicksetup, [
-            '--profile=giuseppe-{}'.format(self.backend), '--backend={}'.format(
-                self.backend), '--email=giuseppe.verdi@ope.ra',
-            '--first-name=Giuseppe', '--last-name=Verdi', '--institution=Scala', '--db-name=aiida_giuseppe_{}'.format(
-                self.backend), '--repo=aiida_giuseppe_{}'.format(self.backend), '--no-set-default'
+            '--backend={}'.format(self.backend), '--email=giuseppe.verdi@ope.ra', '--first-name=Giuseppe',
+            '--last-name=Verdi', '--institution=Scala', '--db-name=aiida_giuseppe_{}'.format(self.backend),
+            '--repository=aiida_giuseppe_{}'.format(self.backend), 'giuseppe-{}'.format(self.backend)
         ])
         self.assertFalse(result.exception, msg=get_debug_msg(result))
 
     def test_postgres_failure(self):
         """
-        Test ``verdi quicksetup`` non-interactively
+        Test `verdi quicksetup` non-interactively
         """
         backend_settings.AIIDADB_PROFILE = None
         result = self.runner.invoke(
             quicksetup, [
-                '--profile=giuseppe2-{}'.format(self.backend), '--backend={}'.format(
-                    self.backend), '--email=giuseppe2.verdi@ope.ra', '--first-name=Giuseppe', '--last-name=Verdi',
-                '--institution=Scala', '--db-port=1111', '--db-name=aiida_giuseppe2_{}'.format(self.backend),
-                '--repo=aiida_giuseppe2_{}'.format(self.backend), '--no-set-default', '--non-interactive'
+                '--backend={}'.format(self.backend), '--email=giuseppe2.verdi@ope.ra', '--first-name=Giuseppe',
+                '--last-name=Verdi', '--institution=Scala', '--db-port=1111', '--db-name=aiida_giuseppe2_{}'.format(
+                    self.backend), '--repository=aiida_giuseppe2_{}'.format(
+                        self.backend), '--non-interactive', 'giuseppe2-{}'.format(self.backend)
             ],
             input='nohost\n1111\naiida_giuseppe2_{}\npostgres\n\n'.format(self.backend),
             catch_exceptions=False)
@@ -69,7 +68,7 @@ class QuicksetupTestCase(unittest.TestCase):
 
 
 class SetupTestCase(unittest.TestCase):
-    """Test ``verdi setup``"""
+    """Test `verdi setup`."""
 
     def setUp(self):
         self.runner = CliRunner()
@@ -84,7 +83,7 @@ class SetupTestCase(unittest.TestCase):
         self.dbname = 'aiida_test_setup_{}'.format(self.backend)
         self.postgres.create_dbuser(self.dbuser, self.dbpass)
         self.postgres.create_db(self.dbuser, self.dbname)
-        self.repo = abspath('./aiida_radames_{}'.format(self.backend))
+        self.repository = abspath('./aiida_radames_{}'.format(self.backend))
 
     def tearDown(self):
         self.postgres.drop_db(self.dbname)
@@ -93,35 +92,42 @@ class SetupTestCase(unittest.TestCase):
 
     def test_user_setup(self):
         """
-        Test ``verdi setup`` non-interactively
+        Test `verdi setup` non-interactively
         """
         backend_settings.AIIDADB_PROFILE = None
         result = self.runner.invoke(setup, [
-            'radames_{}'.format(self.backend), '--non-interactive', '--backend={}'.format(self.backend),
-            '--email=radames.verdi@ope.ra', '--first-name=Radames', '--last-name=Verdi', '--institution=Scala',
-            '--repo={}'.format(self.repo), '--db_host=localhost', '--db_port={}'.format(self.pg_test.port),
-            '--db_name={}'.format(self.dbname), '--db_user={}'.format(self.dbuser), '--db_pass={}'.format(self.dbpass)
+            '--non-interactive', '--backend={}'.format(self.backend), '--email=radames.verdi@ope.ra',
+            '--first-name=Radames', '--last-name=Verdi', '--institution=Scala', '--repository={}'.format(
+                self.repository), '--db-host=localhost', '--db-port={}'.format(self.pg_test.port),
+            '--db-name={}'.format(self.dbname), '--db-username={}'.format(self.dbuser), '--db-password={}'.format(
+                self.dbpass), 'radames_{}'.format(self.backend)
         ])
         self.assertFalse(result.exception, msg=get_debug_msg(result))
 
     def test_user_configure(self):
         """
-        Test ``verdi setup`` configure user
+        Test `verdi setup` configure user
         """
         backend_settings.AIIDADB_PROFILE = None
         self.runner.invoke(setup, [
-            'radames2_{}'.format(self.backend), '--non-interactive', '--backend={}'.format(self.backend),
-            '--email=radames.verdi@ope.ra', '--first-name=Radames', '--last-name=Verdi', '--institution=Scala',
-            '--repo={}'.format(self.repo), '--db_host=localhost', '--db_port={}'.format(self.pg_test.port),
-            '--db_name={}'.format(self.dbname), '--db_user={}'.format(self.dbuser), '--db_pass={}'.format(self.dbpass)
+            '--non-interactive', '--backend={}'.format(self.backend), '--email=radames.verdi@ope.ra',
+            '--first-name=Radames', '--last-name=Verdi', '--institution=Scala', '--repository={}'.format(
+                self.repository), '--db-host=localhost', '--db-port={}'.format(self.pg_test.port),
+            '--db-name={}'.format(self.dbname), '--db-username={}'.format(self.dbuser), '--db-password={}'.format(
+                self.dbpass), 'radames2_{}'.format(self.backend)
         ])
 
+        tpl = '{email}\n{first_name}\n{last_name}\n{institution}\nyes\n{email}\n{engine}\n\n\n\n\n\n{repo}\nno\n\n'
         backend_settings.AIIDADB_PROFILE = None
         result = self.runner.invoke(
             setup, ['radames2_{}'.format(self.backend), '--only-config'],
-            input=
-            'yes\nradames.verdi@ope.ra\npostgresql_psycopg2\n\n\n\n\n\n{repo}\nRadames2\nVerdi2\nScala2\nyes\nno\n'.
-            format(repo=self.repo),
+            input=tpl.format(
+                email='radames.verdi@ope.ra',
+                first_name='Radames2',
+                last_name='Verdi2',
+                institution='Scala2',
+                engine='postgresql_psycopg2',
+                repo=self.repository),
             catch_exceptions=False)
         self.assertFalse(result.exception, msg=get_debug_msg(result))
 

--- a/aiida/cmdline/commands/cmd_setup.py
+++ b/aiida/cmdline/commands/cmd_setup.py
@@ -9,47 +9,47 @@
 # For further information please visit http://www.aiida.net               #
 ###########################################################################
 """`verdi setup` command."""
-import click
-
 from aiida.cmdline.commands import verdi
+from aiida.cmdline.params import arguments, options
 from aiida.control.profile import setup_profile
 
 
 @verdi.command('setup')
-@click.argument('profile', default='', type=str)
-@click.option('--only-config', is_flag=True)
-@click.option('--non-interactive', is_flag=True, help='never prompt the user for input, read values from options')
-@click.option(
-    '--backend',
-    type=click.Choice(['django', 'sqlalchemy']),
-)
-@click.option('--email', type=str)
-@click.option('--db_host', type=str)
-@click.option('--db_port', type=int)
-@click.option('--db_name', type=str)
-@click.option('--db_user', type=str)
-@click.option('--db_pass', type=str)
-@click.option('--first-name', type=str)
-@click.option('--last-name', type=str)
-@click.option('--institution', type=str)
-@click.option('--repo', type=str)
-def setup(profile, only_config, non_interactive, backend, email, db_host, db_port, db_name, db_user, db_pass,
-          first_name, last_name, institution, repo):
+@arguments.PROFILE_NAME()
+@options.PROFILE_ONLY_CONFIG()
+@options.PROFILE_SET_DEFAULT()
+@options.NON_INTERACTIVE()
+@options.BACKEND()
+@options.DB_HOST()
+@options.DB_PORT()
+@options.DB_NAME()
+@options.DB_USERNAME()
+@options.DB_PASSWORD()
+@options.REPOSITORY_PATH()
+@options.USER_EMAIL()
+@options.USER_FIRST_NAME()
+@options.USER_LAST_NAME()
+@options.USER_INSTITUTION()
+def setup(profile_name, only_config, set_default, non_interactive, backend, db_host, db_port, db_name, db_username,
+          db_password, repository, email, first_name, last_name, institution):
     """Setup and configure a new profile."""
     kwargs = dict(
-        profile=profile,
+        profile=profile_name,
         only_config=only_config,
+        set_default=set_default,
         non_interactive=non_interactive,
         backend=backend,
-        email=email,
         db_host=db_host,
         db_port=db_port,
         db_name=db_name,
-        db_user=db_user,
-        db_pass=db_pass,
+        db_user=db_username,
+        db_pass=db_password,
+        repo=repository,
+        email=email,
         first_name=first_name,
         last_name=last_name,
-        institution=institution,
-        repo=repo)
+        institution=institution)
+
     kwargs = {k: v for k, v in kwargs.items() if v is not None}
+
     setup_profile(**kwargs)

--- a/aiida/cmdline/params/arguments/__init__.py
+++ b/aiida/cmdline/params/arguments/__init__.py
@@ -40,3 +40,5 @@ OUTPUT_FILE = OverridableArgument('output_file', metavar='OUTPUT_FILE', type=cli
 LABEL = OverridableArgument('label')
 
 USER = OverridableArgument('user', metavar='USER', type=types.UserParamType())
+
+PROFILE_NAME = OverridableArgument('profile_name', type=click.STRING)

--- a/aiida/cmdline/params/options/__init__.py
+++ b/aiida/cmdline/params/options/__init__.py
@@ -4,6 +4,7 @@
 
 import click
 
+from aiida.backends.profile import BACKEND_DJANGO, BACKEND_SQLA
 from aiida.cmdline.params import types
 from aiida.cmdline.params.options.conditional import ConditionalOption
 from aiida.cmdline.params.options.interactive import InteractiveOption
@@ -47,122 +48,266 @@ def active_process_states():
     ])
 
 
-CALCULATION = OverridableOption('-C', '--calculation', 'calculation', type=types.CalculationParamType(),
-                                help='a single calculation identified by its ID or UUID')
+CALCULATION = OverridableOption(
+    '-C', '--calculation', 'calculation',
+    type=types.CalculationParamType(),
+    help='A single calculation identified by its ID or UUID.')
 
-CALCULATIONS = OverridableOption('-C', '--calculations', 'calculations', cls=MultipleValueOption,
-                                 type=types.CalculationParamType(),
-                                 help='one or multiple calculations identified by their ID or UUID')
+CALCULATIONS = OverridableOption(
+    '-C', '--calculations', 'calculations',
+    type=types.CalculationParamType(), cls=MultipleValueOption,
+    help='One or multiple calculations identified by their ID or UUID.')
 
-CODE = OverridableOption('-X', '--code', 'code', type=types.CodeParamType(),
-                         help='a single code identified by its ID, UUID or label')
+CODE = OverridableOption(
+    '-X', '--code', 'code',
+    type=types.CodeParamType(),
+    help='A single code identified by its ID, UUID or label.')
 
-CODES = OverridableOption('-X', '--codes', 'codes', cls=MultipleValueOption, type=types.CodeParamType(),
-                          help='one or multiple codes identified by their ID, UUID or label')
+CODES = OverridableOption(
+    '-X', '--codes', 'codes',
+    type=types.CodeParamType(), cls=MultipleValueOption,
+    help='One or multiple codes identified by their ID, UUID or label.')
 
-COMPUTER = OverridableOption('-Y', '--computer', 'computer', type=types.ComputerParamType(),
-                             help='a single computer identified by its ID, UUID or label')
+COMPUTER = OverridableOption(
+    '-Y', '--computer', 'computer',
+    type=types.ComputerParamType(),
+    help='A single computer identified by its ID, UUID or label.')
 
-COMPUTERS = OverridableOption('-Y', '--computers', 'computers', cls=MultipleValueOption, type=types.ComputerParamType(),
-                              help='one or multiple computers identified by their ID, UUID or label')
+COMPUTERS = OverridableOption(
+    '-Y', '--computers', 'computers',
+    type=types.ComputerParamType(), cls=MultipleValueOption,
+    help='One or multiple computers identified by their ID, UUID or label.')
 
-DATUM = OverridableOption('-D', '--datum', 'datum', type=types.DataParamType(),
-                          help='a single datum identified by its ID, UUID or label')
+DATUM = OverridableOption(
+    '-D', '--datum', 'datum',
+    type=types.DataParamType(),
+    help='A single datum identified by its ID, UUID or label.')
 
-DATA = OverridableOption('-D', '--data', 'data', cls=MultipleValueOption, type=types.DataParamType(),
-                         help='one or multiple data identified by their ID, UUID or label')
+DATA = OverridableOption(
+    '-D', '--data', 'data',
+    type=types.DataParamType(), cls=MultipleValueOption,
+    help='One or multiple data identified by their ID, UUID or label.')
 
-GROUP = OverridableOption('-G', '--group', 'group', type=types.GroupParamType(),
-                          help='a single group identified by its ID, UUID or name')
+GROUP = OverridableOption(
+    '-G', '--group', 'group',
+    type=types.GroupParamType(),
+    help='A single group identified by its ID, UUID or name.')
 
-GROUPS = OverridableOption('-G', '--groups', 'groups', cls=MultipleValueOption, type=types.GroupParamType(),
-                           help='one or multiple groups identified by their ID, UUID or name')
+GROUPS = OverridableOption(
+    '-G', '--groups', 'groups',
+    type=types.GroupParamType(), cls=MultipleValueOption,
+    help='One or multiple groups identified by their ID, UUID or name.')
 
-NODE = OverridableOption('-N', '--node', 'node', type=types.NodeParamType(),
-                         help='a single node identified by its ID or UUID')
+NODE = OverridableOption(
+    '-N', '--node', 'node',
+    type=types.NodeParamType(),
+    help='A single node identified by its ID or UUID.')
 
-NODES = OverridableOption('-N', '--nodes', 'nodes', cls=MultipleValueOption, type=types.NodeParamType(),
-                          help='one or multiple nodes identified by their ID or UUID')
+NODES = OverridableOption(
+    '-N', '--nodes', 'nodes',
+    type=types.NodeParamType(), cls=MultipleValueOption,
+    help='One or multiple nodes identified by their ID or UUID.')
 
-FORCE = OverridableOption('-f', '--force', is_flag=True, default=False,
-                          help='do not ask for confirmation')
+FORCE = OverridableOption(
+    '-f', '--force',
+    is_flag=True, default=False,
+    help='Do not ask for confirmation.')
 
-SILENT = OverridableOption('-s', '--silent', is_flag=True, default=False,
-                           help='suppress any output printed to stdout')
+SILENT = OverridableOption(
+    '-s', '--silent',
+    is_flag=True, default=False,
+    help='Suppress any output printed to stdout.')
 
-ARCHIVE_FORMAT = OverridableOption('-F', '--archive-format', type=click.Choice(['zip', 'zip-uncompressed', 'tar.gz']),
-                                   help='the format of the archive file', default='zip', show_default=True)
+ARCHIVE_FORMAT = OverridableOption(
+    '-F', '--archive-format',
+    type=click.Choice(['zip', 'zip-uncompressed', 'tar.gz']), default='zip', show_default=True,
+    help='The format of the archive file.')
 
-NON_INTERACTIVE = OverridableOption('-n', '--non-interactive', is_flag=True, is_eager=True,
-                                    help='noninteractive mode: never prompt the user for input')
+NON_INTERACTIVE = OverridableOption(
+    '-n', '--non-interactive',
+    is_flag=True, is_eager=True,
+    help='Non-interactive mode: never prompt for input.')
 
-PREPEND_TEXT = OverridableOption('--prepend-text', type=str, default='',
-                                 help='bash script to be executed before an action')
+USER_EMAIL = OverridableOption(
+    '--email',
+    type=click.STRING, prompt='Email Address (identifies your data when sharing)',
+    help='Email address that will be associated with your data and will be exported along with it, '
+    'should you choose to share any of your work.')
 
-APPEND_TEXT = OverridableOption('--append-text', type=str, default='',
-                                help='bash script to be executed after an action has completed')
+USER_FIRST_NAME = OverridableOption(
+    '--first-name',
+    type=click.STRING, prompt='First name',
+    help='First name of the user.')
 
-LABEL = OverridableOption('-L', '--label', type=click.STRING, metavar='LABEL', help='short name to be used as a label')
+USER_LAST_NAME = OverridableOption(
+    '--last-name',
+    type=click.STRING, prompt='Last name',
+    help='Last name of the user.')
 
-DESCRIPTION = OverridableOption('-D', '--description', type=click.STRING, metavar='DESCRIPTION',
-                                help='a detailed description', default="", required=False)
+USER_INSTITUTION = OverridableOption(
+    '--institution',
+    type=click.STRING, prompt='Institution',
+    help='Institution name of the user.')
 
-INPUT_PLUGIN = OverridableOption('-P', '--input-plugin', help='calculation input plugin string',
-                                 type=types.PluginParamType(group='calculations'))
+BACKEND = OverridableOption(
+    '--backend',
+    type=click.Choice([BACKEND_DJANGO, BACKEND_SQLA]), default=BACKEND_DJANGO,
+    help='Database backend to use.')
 
-CALCULATION_STATE = OverridableOption('-s', '--calculation-state', 'calculation_state', cls=MultipleValueOption,
-                                      type=types.LazyChoice(valid_calculation_states),
-                                      help='only include entries with this calculation state',
-                                      default=active_calculation_states)
+DB_HOST = OverridableOption(
+    '--db-host',
+    type=click.STRING,
+    help='Database server host.')
 
-PROCESS_STATE = OverridableOption('-S', '--process-state', 'process_state', cls=MultipleValueOption,
-                                  type=types.LazyChoice(valid_process_states),
-                                  help='only include entries with this process state', default=active_process_states)
+DB_PORT = OverridableOption(
+    '--db-port',
+    type=click.INT,
+    help='Database server port.')
 
-EXIT_STATUS = OverridableOption('-E', '--exit-status', 'exit_status', type=click.INT,
-                                help='only include entries with this exit status')
+DB_USERNAME = OverridableOption(
+    '--db-username',
+    type=click.STRING,
+    help='Database user name.')
 
-FAILED = OverridableOption('-x', '--failed', 'failed', is_flag=True, default=False,
-                           help='only include entries that have failed')
+DB_PASSWORD = OverridableOption(
+    '--db-password',
+    type=click.STRING,
+    help='Database user password.')
 
-LIMIT = OverridableOption('-l', '--limit', 'limit', type=click.INT, default=None,
-                          help='limit the number of entries to display')
+DB_NAME = OverridableOption(
+    '--db-name',
+    type=click.STRING,
+    help='Database name.')
 
-PROJECT = OverridableOption('-P', '--project', 'project', cls=MultipleValueOption,
-                            help='select the list of entity attributes to project')
+REPOSITORY_PATH = OverridableOption(
+    '--repository',
+    type=click.Path(file_okay=False),
+    help='Absolute path for the file system repository.')
 
-ORDER_BY = OverridableOption('-o', '--order-by', 'order_by', type=click.Choice(['id', 'ctime']),
-                             help='order the entries by this attribute', default='ctime', show_default=True)
+PROFILE_ONLY_CONFIG = OverridableOption(
+    '--only-config',
+    is_flag=True, default=False,
+    help='Only configure the user and skip creating the database.')
 
-PAST_DAYS = OverridableOption('-p', '--past-days', 'past_days', type=click.INT, metavar='PAST_DAYS',
-                              help='only include entries created in the last PAST_DAYS number of days')
+PROFILE_SET_DEFAULT = OverridableOption(
+    '--set-default',
+    is_flag=True, default=False,
+    help='Set the profile as the new default.')
 
-OLDER_THAN = OverridableOption('-o', '--older-than', 'older_than', type=click.INT, metavar='OLDER_THAN',
-                               help='only include entries created before OLDER_THAN days ago')
+PREPEND_TEXT = OverridableOption(
+    '--prepend-text',
+    type=click.STRING, default='',
+    help='Bash script to be executed before an action.')
 
-ALL = OverridableOption('-a', '--all', 'all_entries', is_flag=True, default=False,
-                        help='include all entries, disregarding all other filter options and flags')
+APPEND_TEXT = OverridableOption(
+    '--append-text',
+    type=click.STRING, default='',
+    help='Bash script to be executed after an action has completed.')
 
-ALL_STATES = OverridableOption('-A', '--all-states', is_flag=True, help='do not limit to items in running state')
+LABEL = OverridableOption(
+    '-L', '--label',
+    type=click.STRING, metavar='LABEL',
+    help='Short name to be used as a label.')
 
-ALL_USERS = OverridableOption('-A', '--all-users', 'all_users', is_flag=True, default=False,
-                              help='include all entries regardless of the owner')
+DESCRIPTION = OverridableOption(
+    '-D', '--description',
+    type=click.STRING, metavar='DESCRIPTION', default='', required=False,
+    help='A detailed description.')
 
-RAW = OverridableOption('-r', '--raw', 'raw', is_flag=True, default=False,
-                        help='display only raw query results, without any headers or footers')
+INPUT_PLUGIN = OverridableOption(
+    '-P', '--input-plugin',
+    type=types.PluginParamType(group='calculations'),
+    help='Calculation input plugin string.')
 
-HOSTNAME = OverridableOption('-H', '--hostname', help='hostname')
+CALCULATION_STATE = OverridableOption(
+    '-s', '--calculation-state', 'calculation_state',
+    type=types.LazyChoice(valid_calculation_states), cls=MultipleValueOption, default=active_calculation_states,
+    help='Only include entries with this calculation state.')
 
-TRANSPORT = OverridableOption('-T', '--transport', help='transport type',
-                              type=types.PluginParamType(group='transports'), required=True)
+PROCESS_STATE = OverridableOption(
+    '-S', '--process-state', 'process_state',
+    type=types.LazyChoice(valid_process_states), cls=MultipleValueOption, default=active_process_states,
+    help='Only include entries with this process state.')
 
-SCHEDULER = OverridableOption('-S', '--scheduler', help='scheduler type',
-                              type=types.PluginParamType(group='schedulers'), required=True)
+EXIT_STATUS = OverridableOption(
+    '-E', '--exit-status', 'exit_status',
+    type=click.INT,
+    help='Only include entries with this exit status.')
 
-USER = OverridableOption('-u', '--user', 'user', type=types.UserParamType(),
-                         help='the email address of the user')
+FAILED = OverridableOption(
+    '-x', '--failed', 'failed',
+    is_flag=True, default=False,
+    help='Only include entries that have failed.')
 
-PORT_NR = OverridableOption('-P', '--port', 'port', type=int, help='Port number')
+LIMIT = OverridableOption(
+    '-l', '--limit', 'limit',
+    type=click.INT, default=None,
+    help='Limit the number of entries to display.')
 
+PROJECT = OverridableOption(
+    '-P', '--project', 'project',
+    cls=MultipleValueOption,
+    help='Select the list of entity attributes to project.')
 
-FREQUENCY = OverridableOption('-F', '--frequency', 'frequency', type=int)
+ORDER_BY = OverridableOption(
+    '-O', '--order-by', 'order_by',
+    type=click.Choice(['id', 'ctime']), default='ctime', show_default=True,
+    help='Order the entries by this attribute.')
+
+PAST_DAYS = OverridableOption(
+    '-p', '--past-days', 'past_days',
+    type=click.INT, metavar='PAST_DAYS',
+    help='Only include entries created in the last PAST_DAYS number of days.')
+
+OLDER_THAN = OverridableOption(
+    '-o', '--older-than', 'older_than',
+    type=click.INT, metavar='OLDER_THAN',
+    help='Only include entries created before OLDER_THAN days ago.')
+
+ALL = OverridableOption(
+    '-a', '--all', 'all_entries',
+    is_flag=True, default=False,
+    help='Include all entries, disregarding all other filter options and flags.')
+
+ALL_STATES = OverridableOption(
+    '-A', '--all-states',
+    is_flag=True,
+    help='Do not limit to items in running state.')
+
+ALL_USERS = OverridableOption(
+    '-A', '--all-users', 'all_users',
+    is_flag=True, default=False,
+    help='Include all entries regardless of the owner.')
+
+RAW = OverridableOption(
+    '-r', '--raw', 'raw',
+    is_flag=True, default=False,
+    help='Display only raw query results, without any headers or footers.')
+
+HOSTNAME = OverridableOption(
+    '-H', '--hostname',
+    help='Hostname.')
+
+TRANSPORT = OverridableOption(
+    '-T', '--transport',
+    type=types.PluginParamType(group='transports'), required=True,
+    help='Transport type.')
+
+SCHEDULER = OverridableOption(
+    '-S', '--scheduler',
+    type=types.PluginParamType(group='schedulers'), required=True,
+    help='Scheduler type.')
+
+USER = OverridableOption(
+    '-u', '--user', 'user',
+    type=types.UserParamType(),
+    help='Email address of the user.')
+
+PORT = OverridableOption(
+    '-P', '--port', 'port',
+    type=click.INT,
+    help='Port number.')
+
+FREQUENCY = OverridableOption(
+    '-F', '--frequency', 'frequency',
+    type=click.INT)

--- a/aiida/control/postgres.py
+++ b/aiida/control/postgres.py
@@ -65,16 +65,19 @@ class Postgres(object):
             print('setup sucessful!')
     """
 
-    def __init__(self, port=None, interactive=False, quiet=True):
+    def __init__(self, host='localhost', port=None, interactive=False, quiet=True):
         self.interactive = interactive
         self.quiet = quiet
         self.pg_execute = _pg_execute_not_connected
         self.dbinfo = {}
-        if port:
-            self.set_port(port)
         self.setup_fail_callback = None
         self.setup_fail_counter = 0
         self.setup_max_tries = 1
+
+        if host:
+            self.set_host(host)
+        if port:
+            self.set_port(port)
 
     def set_setup_fail_callback(self, callback):
         """
@@ -83,6 +86,10 @@ class Postgres(object):
         :param callback: a callable with signature ``callback(interactive, dbinfo)``
         """
         self.setup_fail_callback = callback
+
+    def set_host(self, host):
+        """Set the host manually"""
+        self.dbinfo['host'] = host
 
     def set_port(self, port):
         """Set the port manually"""

--- a/aiida/transport/plugins/ssh.py
+++ b/aiida/transport/plugins/ssh.py
@@ -63,7 +63,7 @@ class SshTransport(aiida.transport.Transport):
     # aiida log file.
     _valid_connect_options = [
         ('username', {'prompt': 'User name', 'help': 'user name for the computer', 'non_interactive_default': True}),
-        ('port', {'option': options.PORT_NR, 'prompt': 'port Nr', 'non_interactive_default': True}),
+        ('port', {'option': options.PORT, 'prompt': 'port Nr', 'non_interactive_default': True}),
         ('look_for_keys', {'switch': True, 'prompt': 'Look for keys', 'help': 'switch automatic key file discovery on / off', 'non_interactive_default': True}),
         ('key_filename', {'type': AbsolutePathParamType(dir_okay=False, exists=True), 'prompt': 'SSH key file', 'help': 'Manually pass a key file', 'non_interactive_default': True}),
         ('timeout', {'type': int, 'prompt': 'Connection timeout in s', 'help': 'time in seconds to wait for connection before giving up', 'non_interactive_default': True}),

--- a/aiida/utils/fixtures.py
+++ b/aiida/utils/fixtures.py
@@ -183,7 +183,7 @@ class FixtureManager(object):
         backend_settings.AIIDADB_PROFILE = None
         aiida_cfg.create_base_dirs()
         profile_name = 'test_profile'
-        setup(profile=profile_name, only_config=False, non_interactive=True, **self.profile)
+        setup(profile_name=profile_name, only_config=False, non_interactive=True, **self.profile)
         aiida_cfg.set_default_profile(profile_name)
         self.__is_running_on_test_profile = True
 
@@ -202,12 +202,12 @@ class FixtureManager(object):
         profile = {
             'backend': self.backend,
             'email': self.email,
-            'repo': self.repo,
+            'repository': self.repo,
             'db_host': self.db_host,
             'db_port': self.db_port,
-            'db_user': self.db_user,
-            'db_pass': self.db_pass,
             'db_name': self.db_name,
+            'db_username': self.db_user,
+            'db_password': self.db_pass,
             'first_name': self.first_name,
             'last_name': self.last_name,
             'institution': self.institution


### PR DESCRIPTION
Fixes #969 

These two commands should essentially provide the exact same interface
to the user, as the only difference is that `verdi quicksetup` will
try to guess most of the required variables to setup a profile.
However, the functionality once all required variables are defined
should be identical for the two commands.

 * Both commands now have the same options and arguments
 * All options and arguments are defined once as Overridable*
 * All options now have a help string