### PR TITLE
Fixed capitalisation of job_states

### DIFF
--- a/aiida/scheduler/datastructures.py
+++ b/aiida/scheduler/datastructures.py
@@ -451,7 +451,7 @@ class JobInfo(DefaultFieldsAttributeDict):
        * ``annotation``: human-readable description of the reason for the job
          being in the current state or substate.
        * ``job_state``: the job state (one of those defined in
-         ``aiida.scheduler.datastructures.job_states``)
+         ``aiida.scheduler.datastructures.JOB_STATES``)
        * ``job_substate``: a string with the implementation-specific sub-state
        * ``allocated_machines``: a list of machines used for the current job.
          This is a list of :py:class:`MachineInfo` objects.

--- a/aiida/scheduler/plugins/direct.py
+++ b/aiida/scheduler/plugins/direct.py
@@ -57,9 +57,9 @@ _MAP_STATUS_PS = {
     'Z': JOB_STATES.DONE,
     # Not sure about these three, I comment them out (they used to be in
     # here, but they don't appear neither on ubuntu nor on Mac)
-    #    'F': job_states.DONE,
-    #    'H': job_states.QUEUED_HELD,
-    #    'Q': job_states.QUEUED,
+    #    'F': JOB_STATES.DONE,
+    #    'H': JOB_STATES.QUEUED_HELD,
+    #    'Q': JOB_STATES.QUEUED,
 }
 
 

--- a/aiida/work/job_processes.py
+++ b/aiida/work/job_processes.py
@@ -434,14 +434,14 @@ class JobProcess(processes.Process):
         """The Process excepted so we set the calculation and scheduler state."""
         super(JobProcess, self).on_excepted()
         self.calc._set_state(calc_states.FAILED)
-        self.calc._set_scheduler_state(job_states.DONE)
+        self.calc._set_scheduler_state(JOB_STATES.DONE)
 
     @override
     def on_killed(self):
         """The Process was killed so we set the calculation and scheduler state."""
         super(JobProcess, self).on_excepted()
         self.calc._set_state(calc_states.FAILED)
-        self.calc._set_scheduler_state(job_states.DONE)
+        self.calc._set_scheduler_state(JOB_STATES.DONE)
 
     @override
     def update_outputs(self):


### PR DESCRIPTION
In a merge a couple of places still used the (old) lowercase version.
These have all been capitalised.