### PR TITLE
Enable auto completion of verdi parameter values

### DIFF
--- a/aiida/cmdline/commands/__init__.py
+++ b/aiida/cmdline/commands/__init__.py
@@ -9,6 +9,11 @@
 ###########################################################################
 """The `verdi` command line interface."""
 import click
+import click_completion
+
+
+# Activate the completion of parameter types provided by the click_completion package
+click_completion.init()
 
 
 @click.group()

--- a/aiida/cmdline/commands/cmd_user.py
+++ b/aiida/cmdline/commands/cmd_user.py
@@ -45,6 +45,7 @@ PASSWORD_UNCHANGED = '***'  # noqa
 
 @verdi_user.command()
 @click.argument('user', metavar='USER', type=UserParamType(create=True))
+@options.NON_INTERACTIVE()
 @click.option(
     '--first-name',
     prompt='First name',
@@ -72,7 +73,6 @@ PASSWORD_UNCHANGED = '***'  # noqa
     default=PASSWORD_UNCHANGED,
     confirmation_prompt=True,
     cls=options.InteractiveOption)
-@options.NON_INTERACTIVE()
 @with_dbenv()
 def configure(user, first_name, last_name, institution, password, non_interactive):
     """

--- a/aiida/cmdline/params/types/user.py
+++ b/aiida/cmdline/params/types/user.py
@@ -1,7 +1,5 @@
-"""
-User param type for click
-"""
-
+# -*- coding: utf-8 -*-
+"""User param type for click."""
 import click
 
 from aiida.cmdline.utils.decorators import with_dbenv
@@ -35,3 +33,17 @@ class UserParamType(click.ParamType):
             self.fail("Multiple users found with email '{}': {}".format(value, results))
 
         return results[0]
+
+    @with_dbenv()
+    def complete(self, ctx, incomplete):  # pylint: disable=unused-argument,no-self-use
+        """
+        Return possible completions based on an incomplete value
+
+        :returns: list of tuples of valid entry points (matching incomplete) and a description
+        """
+        from aiida.orm.backend import construct_backend
+
+        backend = construct_backend()
+        users = backend.users.find()
+
+        return [(user.email, '') for user in users if user.email.startswith(incomplete)]

--- a/docs/requirements_for_rtd.txt
+++ b/docs/requirements_for_rtd.txt
@@ -20,6 +20,7 @@ anyjson==0.3.3
 ase==3.12.0
 chainmap
 circus==0.14.0
+click-completion==0.3.1
 click-plugins==1.0.3
 click-spinner==0.1.7
 click==6.7

--- a/setup_requirements.py
+++ b/setup_requirements.py
@@ -32,6 +32,7 @@ install_requires = [
     'passlib==1.7.1',
     'validate-email==1.3',
     'click==6.7',
+    'click-completion==0.3.1',
     'click-plugins==1.0.3',
     'click-spinner==0.1.7',
     'tabulate==0.8.2',


### PR DESCRIPTION
Fixes #1798, fixes #1662 

This feature is not supported by `click` out of the box, which
only auto completes the commands, sub commands and the parameters
themselves. For the parameter value completion, we add the package
click-completion, which is then initialized in the the module
`aiida.cmdline.commands`, just like the `verdi` command group.
This now allows `ParamType` instances to implement the `complete`
method, which takes the `ctx` and the `incomplete` string and
should return a list of strings, with the completed values.

As a result of this PR, bug #1802 was discovered