### PR TITLE
Refactor imports to reduce loading time for `verdi` and keep it snappy

### DIFF
--- a/aiida/cmdline/commands/cmd_computer.py
+++ b/aiida/cmdline/commands/cmd_computer.py
@@ -12,7 +12,6 @@ import sys
 import click
 
 from aiida.common.exceptions import ValidationError
-from aiida.common.utils import escape_for_bash
 from aiida.cmdline.commands import verdi
 from aiida.cmdline.params import options, arguments
 from aiida.cmdline.params import types
@@ -610,7 +609,7 @@ def computer_configure():
 def computer_config_show(computer, user, current, as_option_string):
     """Show the current or default configuration for COMPUTER."""
     import tabulate
-    from pprint import pformat
+    from aiida.common.utils import escape_for_bash
     from aiida.transport import cli as transport_cli
     config = {}
     table = []

--- a/aiida/common/log.py
+++ b/aiida/common/log.py
@@ -11,7 +11,6 @@ import logging
 from copy import deepcopy
 from logging import config
 from aiida.common import setup
-from aiida.backends.utils import is_dbenv_loaded
 
 # Custom logging level, intended specifically for informative log messages
 # reported during WorkChains and Workflows. We want the level between INFO(20)
@@ -50,6 +49,7 @@ class DBLogHandler(logging.Handler):
 
     def emit(self, record):
         # If this is reached before a backend is defined, simply pass
+        from aiida.backends.utils import is_dbenv_loaded
         if not is_dbenv_loaded():
             return
 

--- a/aiida/common/utils.py
+++ b/aiida/common/utils.py
@@ -16,7 +16,6 @@ import string
 import sys
 import numbers
 
-import numpy as np
 from dateutil.parser import parse
 
 from aiida.common.exceptions import ConfigurationError
@@ -225,7 +224,9 @@ def conv_to_fortran(val, quote_strings=True):
     """
     # Note that bool should come before integer, because a boolean matches also
     # isinstance(...,int)
-    if isinstance(val, (bool, np.bool_)):
+    import numpy
+
+    if isinstance(val, (bool, numpy.bool_)):
         if val:
             val_str = '.true.'
         else:

--- a/aiida/plugins/factory.py
+++ b/aiida/plugins/factory.py
@@ -19,3 +19,12 @@ def BaseFactory(group, name):
     :return: the plugin class
     """
     return load_entry_point(group, name)
+
+
+def TransportFactory(entry_point):  # pylint: disable=invalid-name
+    """
+    Return the Transport plugin class for a given entry point
+
+    :param entry_point: the entry point name of the Transport plugin
+    """
+    return BaseFactory('aiida.transports', entry_point)

--- a/aiida/transport/__init__.py
+++ b/aiida/transport/__init__.py
@@ -7,30 +7,6 @@
 # For further information on the license, see the LICENSE.txt file        #
 # For further information please visit http://www.aiida.net               #
 ###########################################################################
-"""
-Transport module
-"""
-
-import aiida.common
-from aiida.common.exceptions import InternalError
-from aiida.common.extendeddicts import FixedFieldsAttributeDict
-
+"""Transport module."""
 from aiida.transport.transport import Transport
-from aiida.transport.util import TransportFactory
-import aiida.transport.cli
-
-
-def copy_from_remote_to_remote(transportsource, transportdestination, remotesource, remotedestination, **kwargs):
-    """
-    Copy files or folders from a remote computer to another remote computer.
-
-    :param transportsource: transport to be used for the source computer
-    :param transportdestination: transport to be used for the destination computer
-    :param str remotesource: path to the remote source directory / file
-    :param str remotedestination: path to the remote destination directory / file
-    :param kwargs: keyword parameters passed to the final put,
-        except for 'dereference' that is passed to the initial get
-
-    .. note:: it uses the method transportsource.copy_from_remote_to_remote
-    """
-    transportsource.copy_from_remote_to_remote(transportdestination, remotesource, remotedestination, **kwargs)
+from aiida.plugins.factory import TransportFactory

--- a/aiida/transport/cli.py
+++ b/aiida/transport/cli.py
@@ -109,7 +109,7 @@ def create_option(name, spec):
 
 
 def list_transport_options(transport_type):
-    from aiida.transport.util import TransportFactory
+    from aiida.transport import TransportFactory
     options_list = [create_option(*item) for item in TransportFactory(transport_type).auth_options.items()]
     return options_list
 

--- a/aiida/transport/plugins/local.py
+++ b/aiida/transport/plugins/local.py
@@ -27,7 +27,6 @@ import StringIO
 import glob
 
 from aiida.transport.transport import Transport, TransportInternalError
-from aiida.transport.util import FileAttribute
 from aiida import transport
 
 
@@ -655,6 +654,8 @@ class LocalTransport(Transport):
         as specified in aiida.transport.
         :param path: the path of the given file.
         """
+        from aiida.transport.util import FileAttribute
+
         os_attr = os.lstat(os.path.join(self.curdir, path))
         aiida_attr = FileAttribute()
         # map the paramiko class into the aiida one

--- a/aiida/transport/plugins/ssh.py
+++ b/aiida/transport/plugins/ssh.py
@@ -12,7 +12,6 @@ import StringIO
 
 import os
 import click
-import paramiko
 import glob
 
 import aiida.transport
@@ -25,13 +24,13 @@ from aiida.cmdline.utils import echo
 from aiida.common import aiidalogger
 from aiida.common.utils import escape_for_bash
 from aiida.common.exceptions import NotExistent
-from aiida.transport.util import FileAttribute
 
 __all__ = ["parse_sshconfig", "convert_to_bool", "SshTransport"]
 
 
 # TODO : callback functions in paramiko are currently not used much and probably broken
 def parse_sshconfig(computername):
+    import paramiko
     config = paramiko.SSHConfig()
     try:
         config.parse(open(os.path.expanduser('~/.ssh/config')))
@@ -426,6 +425,7 @@ class SshTransport(aiida.transport.Transport):
         function (as port, username, password, ...); taken from the
         accepted paramiko.SSHClient.connect() params.
         """
+        import paramiko
         super(SshTransport, self).__init__()
 
         self._is_open = False
@@ -473,6 +473,7 @@ class SshTransport(aiida.transport.Transport):
         :raise InvalidOperation: if the channel is already open
         """
         from aiida.common.exceptions import InvalidOperation
+        from aiida.transport.util import _DetachedProxyCommand
 
         if self._is_open:
             raise InvalidOperation("Cannot open the transport twice")
@@ -550,8 +551,7 @@ class SshTransport(aiida.transport.Transport):
 
     def chdir(self, path):
         """
-        Change directory of the SFTP session. Emulated internally by
-        paramiko.
+        Change directory of the SFTP session. Emulated internally by paramiko.
 
         Differently from paramiko, if you pass None to chdir, nothing
         happens and the cwd is unchanged.
@@ -1067,6 +1067,8 @@ class SshTransport(aiida.transport.Transport):
         Returns the object Fileattribute, specified in aiida.transport
         Receives in input the path of a given file.
         """
+        from aiida.transport.util import FileAttribute
+
         paramiko_attr = self.sftp.lstat(path)
         aiida_attr = FileAttribute()
         # map the paramiko class into the aiida one
@@ -1423,15 +1425,3 @@ class SshTransport(aiida.transport.Transport):
             raise
         else:
             return True
-
-
-
-class _DetachedProxyCommand(paramiko.ProxyCommand):
-    """Modifies paramiko's ProxyCommand by launching the process in a separate process group."""
-
-    def __init__(self, command_line):
-        from subprocess import Popen, PIPE
-        from shlex import split as shlsplit
-        self.cmd = shlsplit(command_line)
-        self.process = Popen(self.cmd, stdin=PIPE, stdout=PIPE, stderr=PIPE, bufsize=0, preexec_fn=os.setsid)
-        self.timeout = None

--- a/aiida/transport/transport.py
+++ b/aiida/transport/transport.py
@@ -15,7 +15,6 @@ import fnmatch
 import sys
 from collections import OrderedDict
 
-import aiida.common
 from aiida.common.exceptions import InternalError
 from aiida.common.utils import classproperty
 from aiida.utils import DEFAULT_TRANSPORT_INTERVAL
@@ -45,7 +44,9 @@ class Transport(object):
         """
         __init__ method of the Transport base class.
         """
-        self._logger = aiida.common.aiidalogger.getChild('transport').getChild(self.__class__.__name__)
+        from aiida.common import aiidalogger
+
+        self._logger = aiidalogger.getChild('transport').getChild(self.__class__.__name__)
         self._logger_extra = None
         self._is_open = False
         self._enters = 0

--- a/aiida/transport/util.py
+++ b/aiida/transport/util.py
@@ -8,17 +8,9 @@
 # For further information please visit http://www.aiida.net               #
 ###########################################################################
 """General utilities for Transport classes."""
+from paramiko import ProxyCommand
+
 from aiida.common.extendeddicts import FixedFieldsAttributeDict
-from aiida.plugins.factory import BaseFactory
-
-
-def TransportFactory(entry_point):  # pylint: disable=invalid-name
-    """
-    Return the Transport plugin class for a given entry point
-
-    :param entry_point: the entry point name of the Transport plugin
-    """
-    return BaseFactory('aiida.transports', entry_point)
 
 
 class FileAttribute(FixedFieldsAttributeDict):
@@ -35,3 +27,33 @@ class FileAttribute(FixedFieldsAttributeDict):
         'st_atime',
         'st_mtime',
     )
+
+
+class _DetachedProxyCommand(ProxyCommand):
+    """Modifies paramiko's ProxyCommand by launching the process in a separate process group."""
+
+    def __init__(self, command_line):
+        import os
+        from subprocess import Popen, PIPE
+        from shlex import split as shlsplit
+        super(_DetachedProxyCommand, self).__init__(command_line)
+
+        self.cmd = shlsplit(command_line)
+        self.process = Popen(self.cmd, stdin=PIPE, stdout=PIPE, stderr=PIPE, bufsize=0, preexec_fn=os.setsid)
+        self.timeout = None
+
+
+def copy_from_remote_to_remote(transportsource, transportdestination, remotesource, remotedestination, **kwargs):
+    """
+    Copy files or folders from a remote computer to another remote computer.
+
+    :param transportsource: transport to be used for the source computer
+    :param transportdestination: transport to be used for the destination computer
+    :param str remotesource: path to the remote source directory / file
+    :param str remotedestination: path to the remote destination directory / file
+    :param kwargs: keyword parameters passed to the final put,
+        except for 'dereference' that is passed to the initial get
+
+    .. note:: it uses the method transportsource.copy_from_remote_to_remote
+    """
+    transportsource.copy_from_remote_to_remote(transportdestination, remotesource, remotedestination, **kwargs)

--- a/docs/source/nitpick-exceptions
+++ b/docs/source/nitpick-exceptions
@@ -120,6 +120,8 @@ py:class  logging.Handler
 py:class  logging.record
 py:class  logging.Logger
 
+py:class  paramiko.proxy.ProxyCommand
+
 py:class  plumpy.processes.Process
 py:class  plumpy.process_comms.ProcessLauncher
 py:class  plumpy.process_spec.ProcessSpec


### PR DESCRIPTION
Fixes #1793 

The recent move of `verdi` to the click infrastructure, also brought
a change to the `verdi computer configure` commands. Each transport
now has its own sub command within that group and these are loaded
dynamically at the bottom of`aiida.cmdline.commands.cmd_computer`.
To dynamically create these commands, the required parameters are
generated from the `_valid_auth_options` from the `Transport` class
implementation, which therefore needs to be imported. The `ssh` module
imported the `paramiko` library at the top level, which if one has
`gss_api` installed will cause the load time to rise to 0.8 seconds.
By moving these imports within the functions, the average load time
for just `verdi` is reduced to ~0.2 which is the maximum acceptable.