### PR TITLE
Add `-v/--verbose` flag to `verdi devel tests`

### DIFF
--- a/aiida/backends/testbase.py
+++ b/aiida/backends/testbase.py
@@ -185,8 +185,9 @@ def run_aiida_db_tests(tests_to_run, verbose=False):
         print >> sys.stderr, (
             "DB tests that will be run: {} (expecting {} tests)".format(
                 ",".join(actually_run_tests), num_tests_expected))
-
-    results = unittest.TextTestRunner(failfast=False).run(test_suite)
+        results = unittest.TextTestRunner(failfast=False, verbosity=2).run(test_suite)
+    else:
+        results = unittest.TextTestRunner(failfast=False).run(test_suite)
 
     if verbose:
         print "Run tests: {}".format(results.testsRun)

--- a/aiida/cmdline/commands/cmd_devel.py
+++ b/aiida/cmdline/commands/cmd_devel.py
@@ -166,8 +166,9 @@ def devel_run_daemon():
 
 @verdi_devel.command('tests')
 @click.argument('paths', nargs=-1, type=TestModuleParamType(), required=False)
+@options.VERBOSE(help='Print the class and function name for each test.')
 @decorators.with_dbenv()
-def devel_tests(paths):  # pylint: disable=too-many-locals,too-many-statements,too-many-branches
+def devel_tests(paths, verbose):  # pylint: disable=too-many-locals,too-many-statements,too-many-branches
     """Run the unittest suite or parts of it."""
     import os
     import sys
@@ -238,7 +239,7 @@ def devel_tests(paths):  # pylint: disable=too-many-locals,too-many-statements,t
         echo.echo('v' * 75)
         echo.echo('>>> Tests for {} db application'.format(settings.BACKEND))
         echo.echo('^' * 75)
-        db_results = run_aiida_db_tests(db_test_list)
+        db_results = run_aiida_db_tests(db_test_list, verbose)
         test_skipped.extend(db_results.skipped)
         test_failures.extend(db_results.failures)
         test_errors.extend(db_results.errors)

--- a/aiida/cmdline/params/options/__init__.py
+++ b/aiida/cmdline/params/options/__init__.py
@@ -311,3 +311,8 @@ PORT = OverridableOption(
 FREQUENCY = OverridableOption(
     '-F', '--frequency', 'frequency',
     type=click.INT)
+
+VERBOSE = OverridableOption(
+    '-v', '--verbose',
+    is_flag=True, default=False,
+    help='Be more verbose in printing output.')


### PR DESCRIPTION
Fixes #1805 

This flag will cause the unittest test runner to print the class
and function name of each test that is run. This is useful when
tracking down a particular test that is failing or is causing the
tests to hang.