### PR TITLE
Enable tab-completion for `verdi devel tests`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,11 +15,10 @@
         #aiida/cmdline/commands/.*.py|
         aiida/cmdline/commands/cmd_setup.py|
         aiida/cmdline/commands/cmd_quicksetup.py|
-        aiida/cmdline/options/types/legacy_workflow.py|
         aiida/cmdline/options/interactive.py|
         aiida/cmdline/params/types/path.py|
+        aiida/cmdline/params/types/test_module.py|
         aiida/cmdline/params/.*.py|
-        aiida/cmdline/optiontypes/.*.py|
         aiida/cmdline/utils/multi_line_input.py|
         aiida/cmdline/utils/test_multiline.py|
         aiida/cmdline/utils/templates.py|

--- a/aiida/cmdline/commands/cmd_devel.py
+++ b/aiida/cmdline/commands/cmd_devel.py
@@ -12,6 +12,7 @@ import click
 
 from aiida.cmdline.commands import verdi
 from aiida.cmdline.params import options
+from aiida.cmdline.params.types import TestModuleParamType
 from aiida.cmdline.utils import decorators, echo
 from aiida.common.exceptions import TestsNotAllowedError
 
@@ -164,7 +165,7 @@ def devel_run_daemon():
 
 
 @verdi_devel.command('tests')
-@click.argument('paths', nargs=-1, type=click.STRING, required=False)
+@click.argument('paths', nargs=-1, type=TestModuleParamType(), required=False)
 @decorators.with_dbenv()
 def devel_tests(paths):  # pylint: disable=too-many-locals,too-many-statements,too-many-branches
     """Run the unittest suite or parts of it."""

--- a/aiida/cmdline/params/types/__init__.py
+++ b/aiida/cmdline/params/types/__init__.py
@@ -1,23 +1,25 @@
 # -*- coding: utf-8 -*-
 """Provides all parameter types."""
 
-from .choice import LazyChoice
 from .calculation import CalculationParamType
+from .choice import LazyChoice
 from .code import CodeParamType
 from .computer import ComputerParamType, ShebangParamType, MpirunCommandParamType
 from .data import DataParamType
 from .group import GroupParamType
 from .identifier import IdentifierParamType
-from .node import NodeParamType
+from .legacy_workflow import LegacyWorkflowParamType
 from .multiple import MultipleValueParamType
+from .node import NodeParamType
 from .nonemptystring import NonemptyStringParamType
 from .path import AbsolutePathParamType
-from .user import UserParamType
 from .plugin import PluginParamType
-from .legacy_workflow import LegacyWorkflowParamType
+from .user import UserParamType
+from .test_module import TestModuleParamType
 
 __all__ = [
     'LazyChoice', 'IdentifierParamType', 'CalculationParamType', 'CodeParamType', 'ComputerParamType', 'DataParamType',
     'GroupParamType', 'NodeParamType', 'MpirunCommandParamType', 'MultipleValueParamType', 'NonemptyStringParamType',
-    'PluginParamType', 'AbsolutePathParamType', 'ShebangParamType', 'LegacyWorkflowParamType', 'UserParamType'
+    'PluginParamType', 'AbsolutePathParamType', 'ShebangParamType', 'LegacyWorkflowParamType', 'UserParamType',
+    'TestModuleParamType'
 ]

--- a/aiida/cmdline/params/types/test_module.py
+++ b/aiida/cmdline/params/types/test_module.py
@@ -1,0 +1,48 @@
+# -*- coding: utf-8 -*-
+"""Test module parameter type for click."""
+import click
+
+from aiida.cmdline.utils.decorators import with_dbenv
+
+
+class TestModuleParamType(click.ParamType):
+    """Parameter type to represent a unittest module."""
+
+    name = 'test module'
+
+    @staticmethod
+    def get_test_modules():
+        """Returns a list of known test modules."""
+        from aiida.backends.tests import get_db_test_names
+
+        prefix_db = 'db'
+        modules_db = get_db_test_names()
+        modules_base = [
+            'aiida.scheduler', 'aiida.transport', 'aiida.common', 'aiida.tests.work', 'aiida.utils', 'aiida.control',
+            'aiida.cmdline.tests'
+        ]
+
+        test_modules = {}
+
+        for module in modules_base:
+            test_modules[module] = None
+
+        for module in modules_db:
+            test_modules['{}.{}'.format(prefix_db, module)] = [module]
+
+        test_modules[prefix_db] = modules_db
+
+        return test_modules
+
+    @with_dbenv()
+    def convert(self, value, param, ctx):
+        return value
+
+    @with_dbenv()
+    def complete(self, ctx, incomplete):  # pylint: disable=unused-argument,no-self-use
+        """
+        Return possible completions based on an incomplete value
+
+        :returns: list of tuples of valid entry points (matching incomplete) and a description
+        """
+        return [(test_module, '') for test_module in self.get_test_modules() if test_module.startswith(incomplete)]


### PR DESCRIPTION
Fixes #1808 

This is accomplished by creating a new parameter type for the
`paths` argument of the command, the TestModulePath. This parameter
type implements the `complete` method to return a list of known
test modules that match the current `incomplete` value.