### PR TITLE
Add the option `--version` to `verdi` to display current version

### DIFF
--- a/aiida/cmdline/commands/__init__.py
+++ b/aiida/cmdline/commands/__init__.py
@@ -16,11 +16,20 @@ import click_completion
 click_completion.init()
 
 
-@click.group()
-@click.option('-p', '--profile', help='Execute the command for this profile instead of the default profile')
+@click.group(invoke_without_command=True)
+@click.option('-p', '--profile', help='Execute the command for this profile instead of the default profile.')
+@click.option('--version', is_flag=True, default=False, help='Print the version of AiiDA that is currently installed.')
 @click.pass_context
-def verdi(ctx, profile):
+def verdi(ctx, profile, version):
     """The command line interface of AiiDA."""
+    import sys
+    import aiida
+    from aiida.cmdline.utils import echo
+
+    if version:
+    	echo.echo('AiiDA version {}'.format(aiida.__version__))
+    	sys.exit(0)
+
     if profile is not None:
         from aiida.backends import settings
         settings.AIIDADB_PROFILE = profile


### PR DESCRIPTION
Fixes #1569 partially. The issue also requested the ability to detect where the current version is installed and if from a git repository which commit is checked out. I am not sure this is trivial to implement and should maybe be handled in a separate issue, as it would be good to already add this simplified version of the feature to `develop`.