### PR TITLE
Check for `test_` keyword in repo path only on last directory

### DIFF
--- a/aiida/common/setup.py
+++ b/aiida/common/setup.py
@@ -702,23 +702,21 @@ def create_configuration(profile='default'):
         if not os.path.isabs(new_repo_path):
             raise ValueError("You must specify an absolute path")
 
-        # Check if the new repository is a test repository and if it already
-        # exists.
+        # Check if the new repository is a test repository and if it already exists.
         if is_test_profile:
-            if TEST_KEYWORD not in new_repo_path:
-                raise ValueError("The test prefix {} should be contained only"
-                                 "in repository names related to test "
-                                 "profiles.".format(TEST_KEYWORD))
+            if TEST_KEYWORD not in os.path.basename(new_repo_path):
+                raise ValueError(
+                    "The repository directory for test profiles should "
+                    "contain the test keyword '{}'".format(TEST_KEYWORD))
 
             if os.path.isdir(new_repo_path):
                 print("The repository {} already exists. It will be used for "
-                      "tests. Any content may be deleted."
-                      .format(new_repo_path))
+                      "tests. Any content may be deleted.".format(new_repo_path))
         else:
-            if TEST_KEYWORD in new_repo_path:
-                raise ValueError("Only test profiles can have a test "
-                                 "repository. Your repository contains the "
-                                 "test prefix {}.".format(TEST_KEYWORD))
+            if TEST_KEYWORD in os.path.basename(new_repo_path):
+                raise ValueError(
+                    "The repository directory for non-test profiles cannot "
+                    "contain the test keyword '{}'".format(TEST_KEYWORD))
 
         if not os.path.isdir(new_repo_path):
             print("The repository {} will be created.".format(new_repo_path))


### PR DESCRIPTION
Fixes #1482 

The `create_configuration` function would check the repository path for the
`test_` keyword and would raise if it was absent for a test profile or present
for a non-test profile. However, the check was performed on whether the prefix
was present in the entire path. This is too strict, as this would disallow any
path that even downstream would contain the string `test_`. Here, we change
the test to just check the last directory of the absolute path, which was the
intended behavior