### PR TITLE
Add `verdi work show`

### DIFF
--- a/aiida/backends/tests/cmdline/commands/test_work.py
+++ b/aiida/backends/tests/cmdline/commands/test_work.py
@@ -195,3 +195,27 @@ class TestVerdiWork(AiidaTestCase):
         """Test the plugins command. As of writing there are no default plugins defined for aiida-core."""
         result = self.cli_runner.invoke(cmd_work.work_plugins, ['non_existent'])
         self.assertIsNotNone(result.exception)
+
+    def test_work_show(self):
+        """Test verdi work show"""
+        workchain_one = WorkCalculation().store()
+        workchain_two = WorkCalculation().store()
+        workchains = [workchain_one, workchain_two]
+
+        # Running without identifiers should not except and not print anything
+        options = []
+        result = self.cli_runner.invoke(cmd_work.work_show, options)
+        self.assertIsNone(result.exception)
+        self.assertEquals(len(get_result_lines(result)), 0)
+
+        # Giving a single identifier should print a non empty string message
+        options = [str(workchain_one.pk)]
+        result = self.cli_runner.invoke(cmd_work.work_show, options)
+        self.assertIsNone(result.exception)
+        self.assertTrue(len(get_result_lines(result)) > 0)
+
+        # Giving multiple identifiers should print a non empty string message
+        options = [str(workchain.pk) for workchain in workchains]
+        result = self.cli_runner.invoke(cmd_work.work_show, options)
+        self.assertIsNone(result.exception)
+        self.assertTrue(len(get_result_lines(result)) > 0)

--- a/aiida/cmdline/commands/__init__.py
+++ b/aiida/cmdline/commands/__init__.py
@@ -7,35 +7,11 @@
 # For further information on the license, see the LICENSE.txt file        #
 # For further information please visit http://www.aiida.net               #
 ###########################################################################
-# pylint: disable=cyclic-import
 """The `verdi` command line interface."""
-import click
 import click_completion
 
 # Activate the completion of parameter types provided by the click_completion package
 click_completion.init()
-
-
-@click.group(invoke_without_command=True)
-@click.option('-p', '--profile', help='Execute the command for this profile instead of the default profile.')
-@click.option('--version', is_flag=True, default=False, help='Print the version of AiiDA that is currently installed.')
-@click.pass_context
-def verdi(ctx, profile, version):
-    """The command line interface of AiiDA."""
-    import sys
-    import aiida
-    from aiida.cmdline.utils import echo
-
-    if version:
-        echo.echo('AiiDA version {}'.format(aiida.__version__))
-        sys.exit(0)
-
-    if profile is not None:
-        from aiida.backends import settings
-        settings.AIIDADB_PROFILE = profile
-
-    ctx.help_option_names = ['-h', '--help']
-
 
 # Import to populate the `verdi` sub commands
 # pylint: disable=wrong-import-position

--- a/aiida/cmdline/commands/cmd_calculation.py
+++ b/aiida/cmdline/commands/cmd_calculation.py
@@ -13,14 +13,14 @@ import os
 
 import click
 
-from aiida.cmdline.commands import verdi
+from aiida.cmdline.commands.cmd_verdi import verdi
 from aiida.cmdline.params import arguments, options, types
 from aiida.cmdline.utils import decorators, echo
 from aiida.common.setup import get_property
 
+LIST_CMDLINE_PROJECT_DEFAULT = get_property('verdishell.calculation_list')
 LIST_CMDLINE_PROJECT_CHOICES = ('pk', 'state', 'ctime', 'job_state', 'calculation_state', 'scheduler_state', 'computer',
                                 'type', 'description', 'label', 'uuid', 'mtime', 'user', 'sealed')
-LIST_CMDLINE_PROJECT_DEFAULT = get_property('verdishell.calculation_list')
 
 
 @verdi.group('calculation')
@@ -30,7 +30,8 @@ def verdi_calculation():
 
 
 @verdi_calculation.command('gotocomputer')
-@arguments.CALCULATION(type=types.CalculationParamType(sub_classes=('aiida.calculations:job',)))
+@arguments.CALCULATION(
+    type=types.CalculationParamType(sub_classes=('aiida.calculations:job', 'aiida.calculations:inline')))
 def calculation_gotocomputer(calculation):
     """
     Open a shell and go to the calculation folder on the computer
@@ -56,7 +57,8 @@ def calculation_gotocomputer(calculation):
 
 
 @verdi_calculation.command('list')
-@arguments.CALCULATIONS(type=types.CalculationParamType(sub_classes=('aiida.calculations:job',)))
+@arguments.CALCULATIONS(
+    type=types.CalculationParamType(sub_classes=('aiida.calculations:job', 'aiida.calculations:inline')))
 @options.CALCULATION_STATE()
 @options.PROCESS_STATE(default=None)
 @options.EXIT_STATUS()
@@ -126,7 +128,8 @@ def calculation_list(calculations, past_days, groups, all_entries, calculation_s
 
 
 @verdi_calculation.command('res')
-@arguments.CALCULATION(type=types.CalculationParamType(sub_classes=('aiida.calculations:job',)))
+@arguments.CALCULATION(
+    type=types.CalculationParamType(sub_classes=('aiida.calculations:job', 'aiida.calculations:inline')))
 @click.option('-f', '--format', 'fmt', type=click.STRING, default='json+date', help='format for the output')
 @click.option('-k', '--keys', 'keys', type=click.STRING, cls=options.MultipleValueOption, help='show only these keys')
 @decorators.with_dbenv()
@@ -148,7 +151,8 @@ def calculation_res(calculation, fmt, keys):
 
 
 @verdi_calculation.command('show')
-@arguments.CALCULATIONS(type=types.CalculationParamType(sub_classes=('aiida.calculations:job',)))
+@arguments.CALCULATIONS(
+    type=types.CalculationParamType(sub_classes=('aiida.calculations:job', 'aiida.calculations:inline')))
 @decorators.with_dbenv()
 def calculation_show(calculations):
     """Show a summary for one or multiple calculations."""
@@ -159,7 +163,8 @@ def calculation_show(calculations):
 
 
 @verdi_calculation.command('logshow')
-@arguments.CALCULATIONS(type=types.CalculationParamType(sub_classes=('aiida.calculations:job',)))
+@arguments.CALCULATIONS(
+    type=types.CalculationParamType(sub_classes=('aiida.calculations:job', 'aiida.calculations:inline')))
 @decorators.with_dbenv()
 def calculation_logshow(calculations):
     """Show the log for one or multiple calculations."""
@@ -202,7 +207,8 @@ def calculation_plugins(entry_point):
 
 
 @verdi_calculation.command('inputcat')
-@arguments.CALCULATION(type=types.CalculationParamType(sub_classes=('aiida.calculations:job',)))
+@arguments.CALCULATION(
+    type=types.CalculationParamType(sub_classes=('aiida.calculations:job', 'aiida.calculations:inline')))
 @click.argument('path', type=click.STRING, required=False)
 @decorators.with_dbenv()
 def calculation_inputcat(calculation, path):
@@ -211,7 +217,7 @@ def calculation_inputcat(calculation, path):
 
     If PATH is not specified, the default input file path will be used, if defined by the calculation plugin class.
     """
-    from aiida.cmdline.commands.cmd_node import cat_repo_files
+    from aiida.cmdline.utils.repository import cat_repo_files
     from aiida.plugins.entry_point import get_entry_point_from_class
 
     if path is None:
@@ -238,7 +244,8 @@ def calculation_inputcat(calculation, path):
 
 
 @verdi_calculation.command('outputcat')
-@arguments.CALCULATION(type=types.CalculationParamType(sub_classes=('aiida.calculations:job',)))
+@arguments.CALCULATION(
+    type=types.CalculationParamType(sub_classes=('aiida.calculations:job', 'aiida.calculations:inline')))
 @click.argument('path', type=click.STRING, required=False)
 @decorators.with_dbenv()
 def calculation_outputcat(calculation, path):
@@ -248,7 +255,7 @@ def calculation_outputcat(calculation, path):
     If PATH is not specified, the default output file path will be used, if defined by the calculation plugin class.
     Content can only be shown after the daemon has retrieved the remote files.
     """
-    from aiida.cmdline.commands.cmd_node import cat_repo_files
+    from aiida.cmdline.utils.repository import cat_repo_files
     from aiida.plugins.entry_point import get_entry_point_from_class
 
     if path is None:
@@ -281,7 +288,8 @@ def calculation_outputcat(calculation, path):
 
 @verdi_calculation.command('inputls')
 @decorators.with_dbenv()
-@arguments.CALCULATION(type=types.CalculationParamType(sub_classes=('aiida.calculations:job',)))
+@arguments.CALCULATION(
+    type=types.CalculationParamType(sub_classes=('aiida.calculations:job', 'aiida.calculations:inline')))
 @click.argument('path', type=click.STRING, required=False)
 @click.option('-c', '--color', 'color', is_flag=True, default=False, help='color folders with a different color')
 def calculation_inputls(calculation, path, color):
@@ -290,7 +298,7 @@ def calculation_inputls(calculation, path, color):
 
     If PATH is not specified, the base path of the input folder will be used.
     """
-    from aiida.cmdline.commands.cmd_node import list_repo_files
+    from aiida.cmdline.utils.repository import list_repo_files
     from aiida.orm.implementation.general.calculation.job import _input_subfolder
 
     if path is not None:
@@ -306,7 +314,8 @@ def calculation_inputls(calculation, path, color):
 
 @verdi_calculation.command('outputls')
 @decorators.with_dbenv()
-@arguments.CALCULATION(type=types.CalculationParamType(sub_classes=('aiida.calculations:job',)))
+@arguments.CALCULATION(
+    type=types.CalculationParamType(sub_classes=('aiida.calculations:job', 'aiida.calculations:inline')))
 @click.argument('path', type=click.STRING, required=False)
 @click.option('-c', '--color', 'color', is_flag=True, default=False, help='color folders with a different color')
 def calculation_outputls(calculation, path, color):
@@ -316,7 +325,7 @@ def calculation_outputls(calculation, path, color):
     If PATH is not specified, the base path of the retrieved folder will be used.
     Content can only be showm after the daemon has retrieved the remote files.
     """
-    from aiida.cmdline.commands.cmd_node import list_repo_files
+    from aiida.cmdline.utils.repository import list_repo_files
 
     if path is not None:
         fullpath = os.path.join(calculation._path_subfolder_name, path)
@@ -336,7 +345,8 @@ def calculation_outputls(calculation, path, color):
 
 @verdi_calculation.command('kill')
 @decorators.with_dbenv()
-@arguments.CALCULATIONS(type=types.CalculationParamType(sub_classes=('aiida.calculations:job',)))
+@arguments.CALCULATIONS(
+    type=types.CalculationParamType(sub_classes=('aiida.calculations:job', 'aiida.calculations:inline')))
 @options.FORCE()
 def calculation_kill(calculations, force):
     """Kill one or multiple running calculations."""
@@ -365,7 +375,8 @@ def calculation_kill(calculations, force):
 
 @verdi_calculation.command('cleanworkdir')
 @decorators.with_dbenv()
-@arguments.CALCULATIONS(type=types.CalculationParamType(sub_classes=('aiida.calculations:job',)))
+@arguments.CALCULATIONS(
+    type=types.CalculationParamType(sub_classes=('aiida.calculations:job', 'aiida.calculations:inline')))
 @options.PAST_DAYS(default=None)
 @options.OLDER_THAN(default=None)
 @options.COMPUTERS(help='include only calculations that were ran on these computers')

--- a/aiida/cmdline/commands/cmd_code.py
+++ b/aiida/cmdline/commands/cmd_code.py
@@ -13,7 +13,7 @@ This allows to setup and configure a code from command line.
 import click
 import tabulate
 
-from aiida.cmdline.commands import verdi
+from aiida.cmdline.commands.cmd_verdi import verdi
 from aiida.cmdline.params import options, arguments, types
 from aiida.cmdline.params.options.interactive import InteractiveOption
 from aiida.cmdline.utils import echo

--- a/aiida/cmdline/commands/cmd_comment.py
+++ b/aiida/cmdline/commands/cmd_comment.py
@@ -13,7 +13,7 @@ This allows to manage comments from command line.
 """
 import click
 
-from aiida.cmdline.commands import verdi
+from aiida.cmdline.commands.cmd_verdi import verdi
 from aiida.cmdline.params import arguments, options
 from aiida.cmdline.utils import decorators, echo, multi_line_input
 

--- a/aiida/cmdline/commands/cmd_computer.py
+++ b/aiida/cmdline/commands/cmd_computer.py
@@ -12,7 +12,7 @@
 import sys
 import click
 
-from aiida.cmdline.commands import verdi
+from aiida.cmdline.commands.cmd_verdi import verdi
 from aiida.cmdline.params import options, arguments
 from aiida.cmdline.params import types
 from aiida.cmdline.params.options.interactive import InteractiveOption

--- a/aiida/cmdline/commands/cmd_daemon.py
+++ b/aiida/cmdline/commands/cmd_daemon.py
@@ -16,7 +16,7 @@ import time
 import click
 from click_spinner import spinner
 
-from aiida.cmdline.commands import verdi
+from aiida.cmdline.commands.cmd_verdi import verdi
 from aiida.cmdline.utils import decorators
 from aiida.cmdline.utils.common import get_env_with_venv_bin
 from aiida.cmdline.utils.daemon import get_daemon_status, print_client_response_status

--- a/aiida/cmdline/commands/cmd_data/__init__.py
+++ b/aiida/cmdline/commands/cmd_data/__init__.py
@@ -10,7 +10,7 @@
 """The `verdi data` command line interface."""
 import click
 
-from aiida.cmdline.commands import verdi
+from aiida.cmdline.commands.cmd_verdi import verdi
 from aiida.cmdline.utils import decorators, echo
 from aiida.cmdline.utils.pluginable import Pluginable
 

--- a/aiida/cmdline/commands/cmd_devel.py
+++ b/aiida/cmdline/commands/cmd_devel.py
@@ -10,7 +10,7 @@
 """`verdi devel` commands."""
 import click
 
-from aiida.cmdline.commands import verdi
+from aiida.cmdline.commands.cmd_verdi import verdi
 from aiida.cmdline.params import options
 from aiida.cmdline.params.types import TestModuleParamType
 from aiida.cmdline.utils import decorators, echo

--- a/aiida/cmdline/commands/cmd_export.py
+++ b/aiida/cmdline/commands/cmd_export.py
@@ -11,7 +11,7 @@
 """`verdi export` command."""
 import click
 
-from aiida.cmdline.commands import verdi
+from aiida.cmdline.commands.cmd_verdi import verdi
 from aiida.cmdline.params import arguments
 from aiida.cmdline.params import options
 from aiida.cmdline.utils import echo

--- a/aiida/cmdline/commands/cmd_graph.py
+++ b/aiida/cmdline/commands/cmd_graph.py
@@ -10,7 +10,7 @@
 """`verdi graph` commands"""
 import click
 
-from aiida.cmdline.commands import verdi
+from aiida.cmdline.commands.cmd_verdi import verdi
 from aiida.cmdline.params import arguments
 from aiida.cmdline.utils import decorators, echo
 

--- a/aiida/cmdline/commands/cmd_group.py
+++ b/aiida/cmdline/commands/cmd_group.py
@@ -13,7 +13,7 @@ It defines subcommands for verdi group command.
 import click
 
 from aiida.common.exceptions import UniquenessError
-from aiida.cmdline.commands import verdi
+from aiida.cmdline.commands.cmd_verdi import verdi
 from aiida.cmdline.utils import echo
 from aiida.cmdline.utils.decorators import with_dbenv
 from aiida.cmdline.params import options, arguments

--- a/aiida/cmdline/commands/cmd_import.py
+++ b/aiida/cmdline/commands/cmd_import.py
@@ -10,7 +10,7 @@
 """`verdi import` command."""
 import click
 
-from aiida.cmdline.commands import verdi
+from aiida.cmdline.commands.cmd_verdi import verdi
 from aiida.cmdline.params.options import MultipleValueOption
 from aiida.cmdline.utils import decorators, echo
 

--- a/aiida/cmdline/commands/cmd_node.py
+++ b/aiida/cmdline/commands/cmd_node.py
@@ -10,11 +10,10 @@
 """"
 Manipulating and printing information of nodes.
 """
-import sys
 import click
 import tabulate
 
-from aiida.cmdline.commands import verdi
+from aiida.cmdline.commands.cmd_verdi import verdi
 from aiida.cmdline.params import options, arguments
 from aiida.cmdline.utils import echo
 from aiida.cmdline.utils.decorators import with_dbenv
@@ -37,6 +36,8 @@ def verdi_node_repo():
 @with_dbenv()
 def repo_cat(node, relative_path):
     """Output the content of a file in the repository folder."""
+    from aiida.cmdline.utils.repository import cat_repo_files
+
     try:
         cat_repo_files(node, relative_path)
     except ValueError as exc:
@@ -50,48 +51,6 @@ def repo_cat(node, relative_path):
             echo.echo_critical(exc.message)
 
 
-def cat_repo_files(node, path):
-    """
-    Given a Node and a relative path to a file in the Node repository directory,
-    prints in output the content of the file.
-
-    :param node: a Node instance
-    :param path: a string with the relative path to list. Must be a file.
-    :raise ValueError: if the file is not found, or is a directory.
-    """
-    import os
-
-    fldr = node.folder
-
-    is_dir = False
-    parts = path.split(os.path.sep)
-    # except the last item
-    for item in parts[:-1]:
-        fldr = fldr.get_subfolder(item)
-    if parts:
-        if fldr.isdir(parts[-1]):
-            fldr = fldr.get_subfolder(parts[-1])
-            is_dir = True
-        else:
-            fname = parts[-1]
-    else:
-        is_dir = True
-
-    if is_dir:
-        if not fldr.isdir('.'):
-            raise ValueError("No directory '{}' in the repo".format(path))
-        else:
-            raise ValueError("'{}' is a directory".format(path))
-    else:
-        if not fldr.isfile(fname):
-            raise ValueError("No file '{}' in the repo".format(path))
-
-        absfname = fldr.get_abs_path(fname)
-        with open(absfname) as repofile:
-            for line in repofile:
-                sys.stdout.write(line)
-
-
 @verdi_node_repo.command('ls')
 @arguments.NODE()
 @click.argument('relative_path', type=str, default='.')
@@ -99,57 +58,12 @@ def cat_repo_files(node, path):
 @with_dbenv()
 def repo_ls(node, relative_path, color):
     """List files in the repository folder."""
+    from aiida.cmdline.utils.repository import list_repo_files
 
     try:
         list_repo_files(node, relative_path, color)
     except ValueError as exc:
         echo.echo_critical(exc.message)
-
-
-def list_repo_files(node, path, color):
-    """
-    Given a Node and a relative path prints in output the list of files
-    in the given path in the Node repository directory.
-
-    :param node: a Node instance
-    :param path: a string with the relative path to list. Can be a file.
-    :param color: boolean, if True prints with the codes to show colors.
-    :raise ValueError: if the file or directory is not found.
-    """
-    import os
-
-    fldr = node.folder
-
-    is_dir = False
-    parts = path.split(os.path.sep)
-    # except the last item
-    for item in parts[:-1]:
-        fldr = fldr.get_subfolder(item)
-    if parts:
-        if fldr.isdir(parts[-1]):
-            fldr = fldr.get_subfolder(parts[-1])
-            is_dir = True
-        else:
-            fname = parts[-1]
-    else:
-        is_dir = True
-
-    if is_dir:
-        if not fldr.isdir('.'):
-            raise ValueError("{}: No such file or directory in the repo".format(path))
-
-        for elem, elem_is_file in sorted(fldr.get_content_list(only_paths=False)):
-            if elem_is_file or not color:
-                print elem
-            else:
-                # BOLD("1;") and color 34=blue
-                outstr = "\x1b[1;{color_id}m{elem}\x1b[0m".format(color_id=34, elem=elem)
-                print outstr
-    else:
-        if not fldr.isfile(fname):
-            raise ValueError("{}: No such file or directory in the repo".format(path))
-
-        print fname
 
 
 @verdi_node.command('label')

--- a/aiida/cmdline/commands/cmd_profile.py
+++ b/aiida/cmdline/commands/cmd_profile.py
@@ -12,7 +12,7 @@ This allows to manage profiles from command line.
 """
 import click
 
-from aiida.cmdline.commands import verdi
+from aiida.cmdline.commands.cmd_verdi import verdi
 from aiida.cmdline.utils import echo
 from aiida.cmdline.params import options
 from aiida.control.postgres import Postgres

--- a/aiida/cmdline/commands/cmd_quicksetup.py
+++ b/aiida/cmdline/commands/cmd_quicksetup.py
@@ -14,7 +14,7 @@ import sys
 
 import click
 
-from aiida.cmdline.commands import verdi
+from aiida.cmdline.commands.cmd_verdi import verdi
 from aiida.cmdline.params import arguments, options
 from aiida.control.profile import setup_profile
 from aiida.control.postgres import Postgres, manual_setup_instructions, prompt_db_info

--- a/aiida/cmdline/commands/cmd_rehash.py
+++ b/aiida/cmdline/commands/cmd_rehash.py
@@ -10,7 +10,7 @@
 """`verdi rehash` command."""
 import click
 
-from aiida.cmdline.commands import verdi
+from aiida.cmdline.commands.cmd_verdi import verdi
 from aiida.cmdline.params import arguments
 from aiida.cmdline.params.types.plugin import PluginParamType
 from aiida.cmdline.utils import decorators, echo

--- a/aiida/cmdline/commands/cmd_restapi.py
+++ b/aiida/cmdline/commands/cmd_restapi.py
@@ -17,7 +17,7 @@ import os
 import click
 
 import aiida.restapi
-from aiida.cmdline.commands import verdi
+from aiida.cmdline.commands.cmd_verdi import verdi
 
 DEFAULT_CONFIG_DIR = os.path.join(os.path.split(os.path.abspath(aiida.restapi.__file__))[0], 'common')
 

--- a/aiida/cmdline/commands/cmd_run.py
+++ b/aiida/cmdline/commands/cmd_run.py
@@ -6,7 +6,7 @@ import sys
 
 import click
 
-from aiida.cmdline.commands import verdi
+from aiida.cmdline.commands.cmd_verdi import verdi
 from aiida.cmdline.params.options.multivalue import MultipleValueOption
 from aiida.cmdline.utils import decorators, echo
 

--- a/aiida/cmdline/commands/cmd_setup.py
+++ b/aiida/cmdline/commands/cmd_setup.py
@@ -9,7 +9,7 @@
 # For further information please visit http://www.aiida.net               #
 ###########################################################################
 """`verdi setup` command."""
-from aiida.cmdline.commands import verdi
+from aiida.cmdline.commands.cmd_verdi import verdi
 from aiida.cmdline.params import arguments, options
 from aiida.control.profile import setup_profile
 

--- a/aiida/cmdline/commands/cmd_shell.py
+++ b/aiida/cmdline/commands/cmd_shell.py
@@ -13,7 +13,7 @@ from __future__ import absolute_import
 import os
 import click
 
-from aiida.cmdline.commands import verdi
+from aiida.cmdline.commands.cmd_verdi import verdi
 from aiida.cmdline.utils import decorators, echo
 
 

--- a/aiida/cmdline/commands/cmd_user.py
+++ b/aiida/cmdline/commands/cmd_user.py
@@ -13,7 +13,7 @@ This allows to setup and configure a user from command line.
 from functools import partial
 import click
 
-from aiida.cmdline.commands import verdi
+from aiida.cmdline.commands.cmd_verdi import verdi
 from aiida.cmdline.params.types.user import UserParamType
 from aiida.cmdline.utils.decorators import with_dbenv
 from aiida.cmdline.params import options

--- a/aiida/cmdline/commands/cmd_verdi.py
+++ b/aiida/cmdline/commands/cmd_verdi.py
@@ -1,0 +1,24 @@
+# -*- coding: utf-8 -*-
+"""The main `verdi` click group."""
+import click
+
+
+@click.group(invoke_without_command=True)
+@click.option('-p', '--profile', help='Execute the command for this profile instead of the default profile.')
+@click.option('--version', is_flag=True, default=False, help='Print the version of AiiDA that is currently installed.')
+@click.pass_context
+def verdi(ctx, profile, version):
+    """The command line interface of AiiDA."""
+    import sys
+    import aiida
+    from aiida.cmdline.utils import echo
+
+    if version:
+        echo.echo('AiiDA version {}'.format(aiida.__version__))
+        sys.exit(0)
+
+    if profile is not None:
+        from aiida.backends import settings
+        settings.AIIDADB_PROFILE = profile
+
+    ctx.help_option_names = ['-h', '--help']

--- a/aiida/cmdline/commands/cmd_work.py
+++ b/aiida/cmdline/commands/cmd_work.py
@@ -11,7 +11,7 @@
 """`verdi work` command."""
 import click
 
-from aiida.cmdline.commands import verdi
+from aiida.cmdline.commands.cmd_verdi import verdi
 from aiida.cmdline.params import arguments, options, types
 from aiida.cmdline.utils import decorators, echo
 from aiida.common.log import LOG_LEVELS
@@ -158,6 +158,18 @@ def work_list(past_days, all_entries, process_state, exit_status, failed, limit,
         echo.echo(tabulated)
         echo.echo('\nTotal results: {}\n'.format(len(table)))
         print_last_process_state_change(process_type='work')
+
+
+@verdi_work.command('show')
+@arguments.CALCULATIONS(
+    type=types.CalculationParamType(sub_classes=('aiida.calculations:work', 'aiida.calculations:function')))
+@decorators.with_dbenv()
+def work_show(calculations):
+    """Show a summary for one or multiple calculations."""
+    from aiida.cmdline.utils.common import get_node_info
+
+    for calculation in calculations:
+        echo.echo(get_node_info(calculation))
 
 
 @verdi_work.command('report')

--- a/aiida/cmdline/commands/cmd_workflow.py
+++ b/aiida/cmdline/commands/cmd_workflow.py
@@ -10,7 +10,7 @@
 """The CLI for legacy workflows."""
 import click
 
-from aiida.cmdline.commands import verdi
+from aiida.cmdline.commands.cmd_verdi import verdi
 from aiida.cmdline.params.types import LegacyWorkflowParamType
 from aiida.cmdline.params.options.multivalue import MultipleValueOption
 from aiida.cmdline.params import options

--- a/aiida/cmdline/utils/repository.py
+++ b/aiida/cmdline/utils/repository.py
@@ -1,0 +1,92 @@
+# -*- coding: utf-8 -*-
+"""Utility functions for command line commands operating on the repository."""
+from aiida.cmdline.utils import echo
+
+
+def cat_repo_files(node, path):
+    """
+    Given a Node and a relative path to a file in the Node repository directory,
+    prints in output the content of the file.
+
+    :param node: a Node instance
+    :param path: a string with the relative path to list. Must be a file.
+    :raise ValueError: if the file is not found, or is a directory.
+    """
+    import os
+    import sys
+
+    fldr = node.folder
+
+    is_dir = False
+    parts = path.split(os.path.sep)
+    # except the last item
+    for item in parts[:-1]:
+        fldr = fldr.get_subfolder(item)
+    if parts:
+        if fldr.isdir(parts[-1]):
+            fldr = fldr.get_subfolder(parts[-1])
+            is_dir = True
+        else:
+            fname = parts[-1]
+    else:
+        is_dir = True
+
+    if is_dir:
+        if not fldr.isdir('.'):
+            raise ValueError("No directory '{}' in the repo".format(path))
+        else:
+            raise ValueError("'{}' is a directory".format(path))
+    else:
+        if not fldr.isfile(fname):
+            raise ValueError("No file '{}' in the repo".format(path))
+
+        absfname = fldr.get_abs_path(fname)
+        with open(absfname) as repofile:
+            for line in repofile:
+                sys.stdout.write(line)
+
+
+def list_repo_files(node, path, color):
+    """
+    Given a Node and a relative path prints in output the list of files
+    in the given path in the Node repository directory.
+
+    :param node: a Node instance
+    :param path: a string with the relative path to list. Can be a file.
+    :param color: boolean, if True prints with the codes to show colors.
+    :raise ValueError: if the file or directory is not found.
+    """
+    import os
+
+    fldr = node.folder
+
+    is_dir = False
+    parts = path.split(os.path.sep)
+    # except the last item
+    for item in parts[:-1]:
+        fldr = fldr.get_subfolder(item)
+    if parts:
+        if fldr.isdir(parts[-1]):
+            fldr = fldr.get_subfolder(parts[-1])
+            is_dir = True
+        else:
+            fname = parts[-1]
+    else:
+        is_dir = True
+
+    if is_dir:
+        if not fldr.isdir('.'):
+            raise ValueError("{}: No such file or directory in the repo".format(path))
+
+        for elem, elem_is_file in sorted(fldr.get_content_list(only_paths=False)):
+            if elem_is_file or not color:
+                echo.echo(elem)
+            else:
+                # BOLD("1;") and color 34=blue
+                outstr = "\x1b[1;{color_id}m{elem}\x1b[0m".format(color_id=34, elem=elem)
+                echo.echo(outstr)
+    else:
+        if not fldr.isfile(fname):
+            raise ValueError("{}: No such file or directory in the repo".format(path))
+
+        echo.echo(fname)

--- a/setup.py
+++ b/setup.py
@@ -58,7 +58,7 @@ if __name__ == '__main__':
         reentry_register=True,
         entry_points={
             'console_scripts': [
-                'verdi=aiida.cmdline.commands:verdi',
+                'verdi=aiida.cmdline.commands.cmd_verdi:verdi',
                 'verdi-plug = aiida.cmdline.verdi_plug:verdi_plug'
             ],
             # following are AiiDA plugin entry points:


### PR DESCRIPTION
Fixes #1815 

In working on this issue, it was also found that the `verdi calculation`
commands, no longer accepted `InlineCalculation` nodes but only calcs of
the type `JobCalculation`. This was has been addressed as well.

Finally, with the `verdi` click group being defined in the module init
of `aiida.cmdline`, as well as all sub commands being imported, such that
they are registered, the sub commands having to import the verdi group
to attach themselves, caused a cyclic import. By moving the `verdi`
group to its own file, this cyclicity is broken.