### PR TITLE
Synchronize heuristics of `verdi work list` and `verdi calculation list`

### DIFF
--- a/aiida/cmdline/commands/cmd_calculation.py
+++ b/aiida/cmdline/commands/cmd_calculation.py
@@ -67,8 +67,8 @@ def calculation_gotocomputer(calculation):
 @options.LIMIT()
 @options.ORDER_BY()
 @options.PROJECT(type=click.Choice(LIST_CMDLINE_PROJECT_CHOICES), default=LIST_CMDLINE_PROJECT_DEFAULT)
-@options.GROUPS(help='show only calculations that are contained within one or more of these groups')
-@options.ALL(help='show all entries, regardless of their calculation state')
+@options.GROUPS(help='Show only calculations that are contained within one or more of these groups.')
+@options.ALL(help='Show all entries, regardless of their calculation state.')
 @options.ALL_USERS()
 @options.RAW()
 @click.option(

--- a/aiida/cmdline/commands/cmd_work.py
+++ b/aiida/cmdline/commands/cmd_work.py
@@ -34,7 +34,7 @@ def verdi_work():
 @options.FAILED()
 @options.PAST_DAYS()
 @options.LIMIT()
-@options.ALL()
+@options.ALL(help='Show all entries, regardless of their process state.')
 @options.RAW()
 @decorators.with_dbenv()
 def work_list(past_days, all_entries, process_state, exit_status, failed, limit, project, raw):


### PR DESCRIPTION
Fixes #1804 

The logic for both these commands should be that for default values of
all the options, all entries are shown that are considered 'active'.
The `-a/--all` flag will cause all entries to be shown, independent
of their 'activeness'. Finally, this list can be limited by passing the
`-p/--past-days` flag. This issue was indirectly addressed by the move
of `verdi` to the `click` infrastructure as now both commands use the
same options, defined in `aiida.cmdline.params.option`.
This commit just updates the help text of the `-a/--all` flag to make
sure that it correctly reflects its behavior.