### PR TITLE
Fix incorrect code snippet in `workflows` section of docs

### DIFF
--- a/docs/source/concepts/include/snippets/workflows/workchains/run_workchain_get_node_pid.py
+++ b/docs/source/concepts/include/snippets/workflows/workchains/run_workchain_get_node_pid.py
@@ -3,7 +3,7 @@ from aiida.work.launch import run_get_node, run_get_pid
 from aiida.work.workchain import WorkChain
 
 class AddAndMultiplyWorkChain(WorkChain):
-	...
+    ...
 
 result, node = run_get_node(AddAndMultiplyWorkChain, a=Int(1), b=Int(2), c=Int(3))
 result, pid = run_get_pid(AddAndMultiplyWorkChain, a=Int(1), b=Int(2), c=Int(3))

--- a/docs/source/concepts/include/snippets/workflows/workchains/run_workchain_keyword.py
+++ b/docs/source/concepts/include/snippets/workflows/workchains/run_workchain_keyword.py
@@ -3,6 +3,6 @@ from aiida.work.launch import run
 from aiida.work.workchain import WorkChain
 
 class AddAndMultiplyWorkChain(WorkChain):
-	...
+    ...
 
 result = run(AddAndMultiplyWorkChain, a=Int(1), b=Int(2), c=Int(3))

--- a/docs/source/concepts/include/snippets/workflows/workchains/run_workchain_submit.py
+++ b/docs/source/concepts/include/snippets/workflows/workchains/run_workchain_submit.py
@@ -3,6 +3,6 @@ from aiida.work.launch import submit
 from aiida.work.workchain import WorkChain
 
 class AddAndMultiplyWorkChain(WorkChain):
-	...
+    ...
 
 node = submit(AddAndMultiplyWorkChain, a=Int(1), b=Int(2), c=Int(3))

--- a/docs/source/concepts/include/snippets/workflows/workchains/run_workchain_submit_append.py
+++ b/docs/source/concepts/include/snippets/workflows/workchains/run_workchain_submit_append.py
@@ -12,10 +12,10 @@ class SomeWorkChain(WorkChain):
         )
 
     def submit_workchains(self)
-    	for i in range(3):
-        	future = self.submit(SomeWorkChain)
-        	self.to_context(workchains=append_(future))
+        for i in range(3):
+            future = self.submit(SomeWorkChain)
+            self.to_context(workchains=append_(future))
 
     def inspect_workchains(self)
-    	for workchain in self.ctx.workchains:
-        	assert workchain.is_finished_ok
+        for workchain in self.ctx.workchains:
+            assert workchain.is_finished_ok

--- a/docs/source/concepts/include/snippets/workflows/workchains/run_workchain_submit_parallel.py
+++ b/docs/source/concepts/include/snippets/workflows/workchains/run_workchain_submit_parallel.py
@@ -12,12 +12,12 @@ class SomeWorkChain(WorkChain):
         )
 
     def submit_workchains(self)
-    	for i in range(3):
-        	future = self.submit(SomeWorkChain)
-        	key = 'workchain_{}'.format(i)
-        	self.to_context(key=future)
+        for i in range(3):
+            future = self.submit(SomeWorkChain)
+            key = 'workchain_{}'.format(i)
+            self.to_context(key=future)
 
     def inspect_workchains(self)
-    	for i in range(3):
-        	key = 'workchain_{}'.format(i)
-        	assert self.ctx[key].is_finished_ok
+        for i in range(3):
+            key = 'workchain_{}'.format(i)
+            assert self.ctx[key].is_finished_ok

--- a/docs/source/concepts/workflows.rst
+++ b/docs/source/concepts/workflows.rst
@@ -727,7 +727,7 @@ Appending
 When you want to add a future of a submitted sub process to the context, but append it to a list rather than assign it to a key, you can use the :func:`~aiida.work.context.append_` function.
 Consider the example from the previous section, but now we will use the ``append_`` function instead:
 
-.. include:: include/snippets/workflows/workchains/run_workchain_submit_parallel.py
+.. include:: include/snippets/workflows/workchains/run_workchain_submit_append.py
     :code: python
 
 Notice that in the ``submit_workchains`` step we no longer have to generate a unique key based on the index but we simply wrap the future in the ``append_`` function and assign it to the generic key ``workchains``.
@@ -791,7 +791,7 @@ The parent workchain can easily request the exit status of the child workchain t
 Workfunction exit codes
 ^^^^^^^^^^^^^^^^^^^^^^^
 The method of setting the exit status for a ``WorkChain`` by returning an ``ExitCode``, as explained in the previous section, works almost exactly the same for ``workfunctions``.
-The only difference is that for a workfunction, we do not have access to the convenience ``exit_codes`` property of then ``WorkChain``, but rather we have to import and return an ``ExitCode`` ourselves.
+The only difference is that for a workfunction, we do not have access to the convenience ``exit_codes`` property of the ``WorkChain``, but rather we have to import and return an ``ExitCode`` ourselves.
 This named tuple can be constructed with an integer, to denote the desired exit status and an optional message, and when returned, the workflow engine will mark the node of the workfunction as ``Finished`` and set the exit status and message to the value of the tuple.
 Consider the following example:
 


### PR DESCRIPTION
Fixes #1616 

The snippet for the `append_` method was pointing to the wrong file
due to a copy and paste error.