### PR TITLE
Ported job calculation to use coroutines for tasks

### DIFF
--- a/aiida/backends/tests/__init__.py
+++ b/aiida/backends/tests/__init__.py
@@ -92,6 +92,7 @@ db_test_list = {
         'work.rmq': ['aiida.backends.tests.work.test_rmq'],
         'work.run': ['aiida.backends.tests.work.run'],
         'work.runners': ['aiida.backends.tests.work.test_runners'],
+        'work.test_transport': ['aiida.backends.tests.work.test_transport'],
         'work.utils': ['aiida.backends.tests.work.utils'],
         'work.work_chain': ['aiida.backends.tests.work.work_chain'],
         'work.workfunctions': ['aiida.backends.tests.work.test_workfunctions'],

--- a/aiida/backends/tests/computer.py
+++ b/aiida/backends/tests/computer.py
@@ -15,8 +15,6 @@ from aiida.transport import TransportFactory
 from aiida.common.exceptions import NotExistent
 
 
-
-
 class TestComputer(AiidaTestCase):
 
     def test_get_transport(self):
@@ -26,17 +24,18 @@ class TestComputer(AiidaTestCase):
         import tempfile
         from aiida.orm import Computer
         from aiida.orm.backend import construct_backend
-        backend = construct_backend()
 
         new_comp = Computer(name='bbb',
-                                hostname='localhost',
-                                transport_type='local',
-                                scheduler_type='direct',
-                                workdir='/tmp/aiida')
+                            hostname='localhost',
+                            transport_type='local',
+                            scheduler_type='direct',
+                            workdir='/tmp/aiida')
         new_comp.store()
 
         # Configure the computer - no parameters for local transport
-        authinfo = backend.authinfos.create(computer=new_comp, user=backend.users.get_automatic_user())
+        authinfo = self.backend.authinfos.create(
+            computer=new_comp,
+            user=self.backend.users.get_automatic_user())
         authinfo.store()
 
         transport = new_comp.get_transport()
@@ -51,20 +50,19 @@ class TestComputer(AiidaTestCase):
     def test_delete(self):
         from aiida.orm import Computer
         new_comp = Computer(name='aaa',
-                                hostname='aaa',
-                                transport_type='local',
-                                scheduler_type='pbspro',
-                                workdir='/tmp/aiida')
+                            hostname='aaa',
+                            transport_type='local',
+                            scheduler_type='pbspro',
+                            workdir='/tmp/aiida')
         new_comp.store()
 
         comp_pk = new_comp.pk
 
         check_computer = Computer.get(comp_pk)
         self.assertEquals(comp_pk, check_computer.pk)
-        
+
         from aiida.orm.computer import delete_computer
         delete_computer(pk=comp_pk)
 
         with self.assertRaises(NotExistent):
             Computer.get(comp_pk)
-

--- a/aiida/backends/tests/work/test_transport.py
+++ b/aiida/backends/tests/work/test_transport.py
@@ -1,0 +1,78 @@
+from tornado.gen import coroutine, Return
+
+from aiida.backends.testbase import AiidaTestCase
+from aiida.work.transports import TransportQueue
+
+
+class TestTransportQueue(AiidaTestCase):
+    """ Tests for the transport queue """
+
+    @classmethod
+    def setUpClass(cls, *args, **kwargs):
+        """ Set up a simple authinfo and for later use """
+        super(TestTransportQueue, cls).setUpClass(*args, **kwargs)
+        # Configure the computer - no parameters for local transport
+        # WARNING: This is not deleted as there is no API facing way to do this
+        # it would require a backend specific call
+        cls.authinfo = cls.backend.authinfos.create(
+            computer=cls.computer,
+            user=cls.backend.users.get_automatic_user())
+        cls.authinfo.store()
+
+    def test_simple_request(self):
+        """ Test a simple transport request """
+        queue = TransportQueue()
+        loop = queue.loop()
+
+        @coroutine
+        def test():
+            trans = None
+            with queue.request_transport(self.authinfo) as request:
+                trans = yield request
+                self.assertTrue(trans.is_open)
+            self.assertFalse(trans.is_open)
+
+        loop.run_sync(lambda: test())
+
+    def test_get_transport_nested(self):
+        """ Test nesting calls to get the same transport """
+        transport_queue = TransportQueue()
+        loop = transport_queue.loop()
+
+        @coroutine
+        def nested(queue, authinfo):
+            with queue.request_transport(authinfo) as request1:
+                trans1 = yield request1
+                self.assertTrue(trans1.is_open)
+                with queue.request_transport(authinfo) as request2:
+                    trans2 = yield request2
+                    self.assertIs(trans1, trans2)
+                    self.assertTrue(trans2.is_open)
+
+        loop.run_sync(lambda: nested(transport_queue, self.authinfo))
+
+    def test_get_transport_interleaved(self):
+        """ Test interleaved calls to get the same transport """
+        transport_queue = TransportQueue()
+        loop = transport_queue.loop()
+
+        @coroutine
+        def interleaved(authinfo):
+            with transport_queue.request_transport(authinfo) as trans_future:
+                yield trans_future
+
+        loop.run_sync(lambda: [interleaved(self.authinfo), interleaved(self.authinfo)])
+
+    def test_return_from_context(self):
+        """ Test raising a Return from coroutine context """
+        queue = TransportQueue()
+        loop = queue.loop()
+
+        @coroutine
+        def test():
+            with queue.request_transport(self.authinfo) as request:
+                trans = yield request
+                raise Return(trans.is_open)
+
+        retval = loop.run_sync(lambda: test())
+        self.assertTrue(retval)

--- a/aiida/transport/transport.py
+++ b/aiida/transport/transport.py
@@ -72,7 +72,12 @@ class Transport(object):
         """
         # Keep track of how many times enter has been called
         if self._enters == 0:
-            self.open()
+            if self.is_open:
+                # Already open, so just add one to the entered counter
+                # this way on the final exit we will not close
+                self._enters += 1
+            else:
+                self.open()
         self._enters += 1
         return self
 

--- a/aiida/work/transports.py
+++ b/aiida/work/transports.py
@@ -9,20 +9,32 @@
 ###########################################################################
 """A transport queue to batch process multiple tasks that require a Transport."""
 from collections import namedtuple
+import contextlib
 import logging
-import threading
 import traceback
-
-from aiida.utils import DEFAULT_TRANSPORT_INTERVAL
+import tornado.gen
+import tornado.concurrent
+import tornado.ioloop
+import tornado.locks
 
 _LOGGER = logging.getLogger(__name__)
+
+
+class TransportRequest(object):
+    """ Information kept about request for a transport object """
+
+    # pylint: disable=too-few-public-methods
+    def __init__(self):
+        super(TransportRequest, self).__init__()
+        self.future = tornado.concurrent.Future()
+        self.count = 0
 
 
 class TransportQueue(object):
     """
     A queue to get transport objects from authinfo.  This class allows clients
     to register their interest in a transport object which will be provided at
-    some point in the future using a callback.
+    some point in the future.
 
     Internally the class will wait for a specific interval at the end of which
     it will open the transport and give it to all the clients that asked for it
@@ -31,65 +43,72 @@ class TransportQueue(object):
     """
     AuthInfoEntry = namedtuple('AuthInfoEntry', ['authinfo', 'transport', 'callbacks', 'callback_handle'])
 
-    def __init__(self, loop=None, interval=DEFAULT_TRANSPORT_INTERVAL):
+    def __init__(self, loop=None):
         """
-        :param loop: The io loop
-        :param interval: The callback interval in seconds
+        :param loop: The event loop to use, will use tornado.ioloop.IOLoop.current() if not supplied
         """
-        self._loop = loop
-        self._entries = {}
-        self._interval = interval
-        self._entries_lock = threading.Lock()
-        self._callback_handle = None
+        self._loop = loop if loop is not None else tornado.ioloop.IOLoop.current()
+        self._transport_requests = {}
 
-    def call_me_with_transport(self, authinfo, callback):
+    def loop(self):
+        """ Get the loop being used by this transport queue """
+        return self._loop
+
+    @contextlib.contextmanager
+    def request_transport(self, authinfo):
         """
-        Add a callback to the queue
+        Request a transport from an authinfo.  Because the client is not allowed to
+        request a transport immediately they will instead be given back a future
+        that can be yielded to get the transport::
 
-        :param authinfo: the AuthInfo that the callback should use for the Transport
-        :param callback: the function to be called with Transport
+            @tornado.gen.coroutine
+            def transport_task(transport_queue, authinfo):
+                with transport_queue.request_transport(authinfo) as request:
+                    transport = yield request
+                    # Do some work with the transport
+
+        :param authinfo: The authinfo to be used to get transport
+        :return: A future that can be yielded to give the transport
         """
-        _LOGGER.debug("Got request for transport with callback '%s'", callback)
+        transport_request = self._transport_requests.get(authinfo.id, None)
 
-        with self._entries_lock:
-            self._get_or_create_entry(authinfo).callbacks.append(callback)
+        open_callback_handle = None
+        if transport_request is None:
+            transport_request = TransportRequest()
+            self._transport_requests[authinfo.id] = transport_request
 
-    def _get_or_create_entry(self, authinfo):
-        """
-        Create a callback entry for the given authinfo from which the appropriate Transport will be retrieved
+            transport = authinfo.get_transport()
+            safe_open_interval = transport.get_safe_open_interval()
 
-        :param authinfo: the AuthInfo from which the Transport is to be retrieved
-        :returns: the constructed AuthInfoEntry
-        """
-        if authinfo.id in self._entries:
-            return self._entries[authinfo.id]
+            def do_open():
+                """ Actually open the transport """
+                if transport_request.count > 0:
+                    # The user still wants the transport so open it
+                    _LOGGER.debug('Transport request opening transport for %s', authinfo)
+                    transport.open()
+                    transport_request.future.set_result(transport)
 
-        transport = authinfo.get_transport()
+            # Save the handle so that we can cancel the callback if the user no longer wants it
+            open_callback_handle = self._loop.call_later(safe_open_interval, do_open)
 
-        # Check if the transport is happy to be opened with any frequency
-        # I put <= 0 to avoid that if the user, by mistake, puts a negative
-        # number, we get errors. Negative errors will be considered as zero.
-        safe_open_interval = transport.get_safe_open_interval()
-        if safe_open_interval <= 0.:
-            callback_handle = self._loop.add_callback(self._do_callback, authinfo.id)
-        else:
-            # Ok, we have to use a delay
-            callback_handle = self._loop.call_later(safe_open_interval, self._do_callback, authinfo.id)
+        try:
+            transport_request.count += 1
+            yield transport_request.future
+        except tornado.gen.Return:
+            # Have to have this special case so tornado returns are propagated up to the loop
+            raise
+        except Exception:
+            _LOGGER.error("Exception whilst using transport:\n%s", traceback.format_exc())
+            raise
+        finally:
+            transport_request.count -= 1
+            assert transport_request.count >= 0, "Transport request count dropped blow 0!"
+            # Check if there are no longer any users that want the transport
+            if transport_request.count == 0:
+                if transport_request.future.done():
+                    _LOGGER.debug('Transport request closing transport for %s', authinfo)
+                    transport_request.future.result().close()
+                elif open_callback_handle is not None:
+                    self._loop.remove_timeout(open_callback_handle)
 
-        entry = self.AuthInfoEntry(authinfo, transport, [], callback_handle)
-        self._entries[authinfo.id] = entry
-
-        return entry
-
-    def _do_callback(self, authinfo_id):
-        """Perform the callback for the given AuthInfoEntry id."""
-        entry = self._entries.pop(authinfo_id)
-        with entry.transport:
-            for callback in entry.callbacks:
-                _LOGGER.debug('Passing transport to %s..', callback)
-                try:
-                    callback(entry.authinfo, entry.transport)
-                except BaseException:
-                    _LOGGER.error("Callback '%s' raised exception when passed transport:\n%s", callback,
-                                  traceback.format_exc())
-                _LOGGER.debug('...callback finished')
+                del self._transport_requests[authinfo.id]


### PR DESCRIPTION
Fixes #1828 

This way the event loop has a chance to schedule other operations while
a transport request is made i.e. if multiple job calculations all
request the same transport (a common scenario) then in the past they
would all run as one loop callback effectively blocking the loop (and
crucially pika heartbeats).  Now they are schedule as seperate callbacks
thanks to yield, hopefully, allowing the loop to schedule other
necessary tasks in between.