### PR TITLE
Fix minor bugs for local transport and Django authinfo implementation

### DIFF
--- a/aiida/cmdline/utils/common.py
+++ b/aiida/cmdline/utils/common.py
@@ -214,8 +214,8 @@ def get_calculation_log_report(calculation):
     scheduler_state = calculation.get_scheduler_state()
 
     if calculation_state == calc_states.WITHSCHEDULER:
-        state_string = '{}, scheduler state: {}'.format(calculation_state, scheduler_state
-                                                        if scheduler_state else '(unknown)')
+        state_string = '{}, scheduler state: {}\n'.format(calculation_state, scheduler_state
+                                                          if scheduler_state else '(unknown)')
     else:
         state_string = '{}'.format(calculation_state)
 
@@ -224,26 +224,27 @@ def get_calculation_log_report(calculation):
     result = "*** {}{}: {}".format(calculation.pk, label_string, state_string)
 
     if scheduler_out is None:
-        result += '*** Scheduler output: N/A'
+        result += '*** Scheduler output: N/A\n'
     elif scheduler_out:
-        result += '*** Scheduler output:\n{}'.format(scheduler_out)
+        result += '*** Scheduler output:\n{}\n'.format(scheduler_out)
     else:
-        result += '*** (empty scheduler output file)'
+        result += '*** (empty scheduler output file)\n'
 
     if scheduler_err is None:
-        result += '*** Scheduler errors: N/A'
+        result += '*** Scheduler errors: N/A\n'
     elif scheduler_err:
-        result += '*** Scheduler errors:\n{}'.format(scheduler_err)
+        result += '*** Scheduler errors:\n{}\n'.format(scheduler_err)
     else:
-        result += '*** (empty scheduler errors file)'
+        result += '*** (empty scheduler errors file)\n'
 
     if log_messages:
-        result += '*** {} LOG MESSAGES:'.format(len(log_messages))
+        result += '*** {} LOG MESSAGES:\n'.format(len(log_messages))
     else:
-        result += '*** 0 LOG MESSAGES'
+        result += '*** 0 LOG MESSAGES\n'
 
     for log in log_messages:
         result += '+-> {} at {}'.format(log['levelname'], log['time'])
-        result += '\n'.join(['|   {}'.format(message) for message in log['message'].splitlines()])
+        result += '\n'.join([' | {}'.format(message) for message in log['message'].splitlines()])
+        result += '\n'
 
     return result

--- a/aiida/orm/implementation/django/authinfo.py
+++ b/aiida/orm/implementation/django/authinfo.py
@@ -64,7 +64,10 @@ class DjangoAuthInfoCollection(AuthInfoCollection):
                     user.email, computer.name))
 
     def _from_dbmodel(self, dbmodel):
-        return DjangoAuthInfo._from_dbmodel(self, dbmodel)
+        from aiida.orm.backend import construct_backend
+        backend = construct_backend()
+
+        return DjangoAuthInfo._from_dbmodel(backend, dbmodel)
 
 
 class DjangoAuthInfo(AuthInfo):

--- a/aiida/transport/plugins/local.py
+++ b/aiida/transport/plugins/local.py
@@ -26,8 +26,8 @@ import subprocess
 import StringIO
 import glob
 
+from aiida.transport import cli as transport_cli
 from aiida.transport.transport import Transport, TransportInternalError
-from aiida import transport
 
 
 # refactor or raise the limit: issue #1784
@@ -871,4 +871,4 @@ class LocalTransport(Transport):
         return cls._DEFAULT_SAFE_OPEN_INTERVAL
 
 
-CONFIGURE_LOCAL_CMD = transport.cli.create_configure_cmd('local')
+CONFIGURE_LOCAL_CMD = transport_cli.create_configure_cmd('local')


### PR DESCRIPTION
The `DjangoAuthInfo` was constructed with the wrong type for the backend
argument and for the local transport the dynamically generated computer
configure command had an import ambiguity leading to the command not
being generated.