### PR TITLE
 Refactor ORM collection and collection entries to always take the backend

### DIFF
--- a/aiida/backends/djsite/db/models.py
+++ b/aiida/backends/djsite/db/models.py
@@ -102,7 +102,7 @@ class DbUser(AbstractBaseUser, PermissionsMixin):
     def get_aiida_class(self):
         from aiida.orm.implementation.django.user import DjangoUser
         from aiida.orm.backend import construct_backend
-        return DjangoUser._from_dbmodel(construct_backend(), self)
+        return DjangoUser.from_dbmodel(self, construct_backend())
 
 
 @python_2_unicode_compatible

--- a/aiida/backends/sqlalchemy/models/user.py
+++ b/aiida/backends/sqlalchemy/models/user.py
@@ -48,4 +48,4 @@ class DbUser(Base):
     def get_aiida_class(self):
         from aiida.orm.implementation.sqlalchemy.user import SqlaUser
         from aiida.orm.backend import construct_backend
-        return SqlaUser._from_dbmodel(construct_backend(), self)
+        return SqlaUser.from_dbmodel(self, construct_backend())

--- a/aiida/backends/tests/orm/log.py
+++ b/aiida/backends/tests/orm/log.py
@@ -36,7 +36,7 @@ class TestBackendLog(AiidaTestCase):
         Delete all the created log entries
         """
         super(TestBackendLog, self).tearDown()
-        self._backend.log.delete_many({})
+        self._backend.logs.delete_many({})
 
     def test_create_backend(self):
         """
@@ -52,18 +52,18 @@ class TestBackendLog(AiidaTestCase):
         """
         count = 10
         for _ in range(count):
-            self._backend.log.create_entry(**self._record)
+            self._backend.logs.create_entry(**self._record)
 
-        self.assertEquals(len(self._backend.log.find()), count)
-        self._backend.log.delete_many({})
-        self.assertEquals(len(self._backend.log.find()), 0)
+        self.assertEquals(len(self._backend.logs.find()), count)
+        self._backend.logs.delete_many({})
+        self.assertEquals(len(self._backend.logs.find()), 0)
 
     def test_create_log_message(self):
         """
         Test the manual creation of a log entry 
         """
         record = self._record
-        entry = self._backend.log.create_entry(
+        entry = self._backend.logs.create_entry(
             record['time'],
             record['loggername'],
             record['levelname'],
@@ -88,15 +88,15 @@ class TestBackendLog(AiidaTestCase):
         for pk in range(10):
             record = self._record
             record['objpk'] = pk
-            self._backend.log.create_entry(**record)
+            self._backend.logs.create_entry(**record)
 
         order_by = [OrderSpecifier('objpk', ASCENDING)]
-        entries = self._backend.log.find(order_by=order_by)
+        entries = self._backend.logs.find(order_by=order_by)
 
         self.assertEquals(entries[0].objpk, 0)
 
         order_by = [OrderSpecifier('objpk', DESCENDING)]
-        entries = self._backend.log.find(order_by=order_by)
+        entries = self._backend.logs.find(order_by=order_by)
 
         self.assertEquals(entries[0].objpk, 9)
 
@@ -106,9 +106,9 @@ class TestBackendLog(AiidaTestCase):
         """
         limit = 2
         for _ in range(limit * 2):
-            self._backend.log.create_entry(**self._record)
+            self._backend.logs.create_entry(**self._record)
 
-        entries = self._backend.log.find(limit=limit)
+        entries = self._backend.logs.find(limit=limit)
         self.assertEquals(len(entries), limit)
 
     def test_find_filter(self):
@@ -119,9 +119,9 @@ class TestBackendLog(AiidaTestCase):
         for pk in range(10):
             record = self._record
             record['objpk'] = pk
-            self._backend.log.create_entry(**record)
+            self._backend.logs.create_entry(**record)
 
-        entries = self._backend.log.find(filter_by={'objpk': target_pk})
+        entries = self._backend.logs.find(filter_by={'objpk': target_pk})
         self.assertEquals(len(entries), 1)
         self.assertEquals(entries[0].objpk, target_pk)
 
@@ -137,14 +137,14 @@ class TestBackendLog(AiidaTestCase):
         # Firing a log for an unstored should not end up in the database
         calc.logger.critical(message)
 
-        logs = self._backend.log.find()
+        logs = self._backend.logs.find()
 
         self.assertEquals(len(logs), 0)
 
         # After storing the node, logs above log level should be stored
         calc.store()
         calc.logger.critical(message)
-        logs = self._backend.log.find()
+        logs = self._backend.logs.find()
 
         self.assertEquals(len(logs), 1)
         self.assertEquals(logs[0].message, message)

--- a/aiida/backends/tests/work/work_chain.py
+++ b/aiida/backends/tests/work/work_chain.py
@@ -483,12 +483,12 @@ class TestWorkchain(AiidaTestCase):
             def run(self):
                 from aiida.orm.backend import construct_backend
                 self._backend = construct_backend()
-                self._backend.log.delete_many({})
+                self._backend.logs.delete_many({})
                 self.report("Testing the report function")
                 return
 
             def check(self):
-                logs = self._backend.log.find()
+                logs = self._backend.logs.find()
                 assert len(logs) == 1
 
         run_and_check_success(TestWorkChain)

--- a/aiida/cmdline/commands/cmd_work.py
+++ b/aiida/cmdline/commands/cmd_work.py
@@ -200,7 +200,7 @@ def work_report(calculations, levelname, indent_size, max_depth):
             'objpk': pk,
         }
 
-        entries = backend.log.find(filter_by=filters)
+        entries = backend.logs.find(filter_by=filters)
         entries = [entry for entry in entries if LOG_LEVELS[entry.levelname] >= LOG_LEVELS[levelname]]
         return [(_, depth) for _ in entries]
 

--- a/aiida/common/log.py
+++ b/aiida/common/log.py
@@ -58,7 +58,7 @@ class DBLogHandler(logging.Handler):
 
         try:
             backend = construct_backend()
-            backend.log.create_entry_from_record(record)
+            backend.logs.create_entry_from_record(record)
 
         except ImproperlyConfigured:
             # Probably, the logger was called without the

--- a/aiida/orm/authinfo.py
+++ b/aiida/orm/authinfo.py
@@ -11,11 +11,14 @@ import abc
 
 from aiida.transport import TransportFactory
 from aiida.common.exceptions import (ConfigurationError, MissingPluginError)
+from .backend import Collection, CollectionEntry
 
 __all__ = ['AuthInfo', 'AuthInfoCollection']
 
 
-class AuthInfoCollection(object):
+class AuthInfoCollection(Collection):
+    """The collection of AuthInfo entries."""
+
     __metaclass__ = abc.ABCMeta
 
     @abc.abstractmethod
@@ -23,9 +26,9 @@ class AuthInfoCollection(object):
         """
         Create a AuthInfo given a computer and a user
 
-        :param computer: A Computer or DbComputer instance
-        :param user: A User or DbUser instance
-        :return: a AuthInfo object associated to the given computer and User
+        :param computer: a Computer instance
+        :param user: a User instance
+        :return: a AuthInfo object associated to the given computer and user
         """
         pass
 
@@ -34,30 +37,24 @@ class AuthInfoCollection(object):
         """
         Return a AuthInfo given a computer and a user
 
-        :param computer: A Computer or DbComputer instance
-        :param user: A User or DbUser instance
-        :return: a AuthInfo object associated to the given computer and User, if any
+        :param computer: a Computer instance
+        :param user: a User instance
+        :return: a AuthInfo object associated to the given computer and user
         :raise NotExistent: if the user is not configured to use computer
         :raise sqlalchemy.orm.exc.MultipleResultsFound: if the user is configured
-             more than once to use the computer! Should never happen
+            more than once to use the computer! Should never happen
         """
         pass
 
 
-class AuthInfo(object):
+class AuthInfo(CollectionEntry):
     """
     Base class to map a DbAuthInfo, that contains computer configuration
     specific to a given user (authorization info and other metadata, like
     how often to check on a given computer etc.)
     """
+
     __metaclass__ = abc.ABCMeta
-
-    def __init__(self, backend):
-        self._backend = backend
-
-    @property
-    def backend(self):
-        return self._backend
 
     def pk(self):
         """
@@ -171,6 +168,5 @@ class AuthInfo(object):
             raise ConfigurationError('No transport found for {} [type {}], message: {}'.format(
                 computer.hostname, computer.get_transport_type(), e.message))
 
-        params = dict(computer.get_transport_params().items() +
-                      self.get_auth_params().items())
+        params = dict(computer.get_transport_params().items() + self.get_auth_params().items())
         return ThisTransport(machine=computer.hostname, **params)

--- a/aiida/orm/backend.py
+++ b/aiida/orm/backend.py
@@ -50,7 +50,7 @@ class Backend(object):
     __metaclass__ = ABCMeta
 
     @abstractproperty
-    def log(self):
+    def logs(self):
         """
         Get an object that implements the logging utilities interface.
 

--- a/aiida/orm/backend.py
+++ b/aiida/orm/backend.py
@@ -15,11 +15,9 @@ _SQLA_BACKEND = None
 
 def construct_backend(backend_type=None):
     """
-    Construct a concrete backend instance based on the backend_type
-    or use the global backend value if not specified.
+    Construct a concrete backend instance based on the backend_type or use the global backend value if not specified.
 
-    :param backend_type: Get a backend instance based on the specified
-        type (or default)
+    :param backend_type: get a backend instance based on the specified type (or default)
     :return: :class:`Backend`
     """
     if backend_type is None:
@@ -43,18 +41,16 @@ def construct_backend(backend_type=None):
 
 
 class Backend(object):
-    """
-    The public interface that defines a backend factory that creates backend
-    specific concrete objects.
-    """
+    """The public interface that defines a backend factory that creates backend specific concrete objects."""
+
     __metaclass__ = ABCMeta
 
     @abstractproperty
     def logs(self):
         """
-        Get an object that implements the logging utilities interface.
+        Return the collection of log entries
 
-        :return: An concrete log utils object
+        :return: the log collection
         :rtype: :class:`aiida.orm.log.Log`
         """
         pass
@@ -62,9 +58,9 @@ class Backend(object):
     @abstractproperty
     def users(self):
         """
-        Get the collection of all users for this backend
+        Return the collection of users
 
-        :return: The users collection
+        :return: the users collection
         :rtype: :class:`aiida.orm.user.UserCollection`
         """
         pass
@@ -72,9 +68,33 @@ class Backend(object):
     @abstractproperty
     def authinfos(self):
         """
-        Get the collection of authorisation information
+        Return the collection of authorisation information objects
 
-        :return: The authinfo collection
+        :return: the authinfo collection
         :rtype: :class:`aiida.orm.authinfo.AuthInfoCollection`
         """
         pass
+
+
+class Collection(object):
+    """Container class that represents a collection of entries of a particular backend entity."""
+
+    def __init__(self, backend):
+        self._backend = backend
+
+    @property
+    def backend(self):
+        """Return the backend."""
+        return self._backend
+
+
+class CollectionEntry(object):
+    """Class that represents an entry within a collection of entries of a particular backend entity."""
+
+    def __init__(self, backend):
+        self._backend = backend
+
+    @property
+    def backend(self):
+        """Return the backend."""
+        return self._backend

--- a/aiida/orm/implementation/django/backend.py
+++ b/aiida/orm/implementation/django/backend.py
@@ -15,14 +15,15 @@ from . import user
 
 
 class DjangoBackend(Backend):
+
     def __init__(self):
-        self._log = log.DjangoLog()
+        self._logs = log.DjangoLogCollection()
         self._users = user.DjangoUserCollection()
         self._authinfos = authinfo.DjangoAuthInfoCollection()
 
     @property
-    def log(self):
-        return self._log
+    def logs(self):
+        return self._logs
 
     @property
     def users(self):

--- a/aiida/orm/implementation/django/backend.py
+++ b/aiida/orm/implementation/django/backend.py
@@ -17,9 +17,9 @@ from . import user
 class DjangoBackend(Backend):
 
     def __init__(self):
-        self._logs = log.DjangoLogCollection()
-        self._users = user.DjangoUserCollection()
-        self._authinfos = authinfo.DjangoAuthInfoCollection()
+        self._logs = log.DjangoLogCollection(self)
+        self._users = user.DjangoUserCollection(self)
+        self._authinfos = authinfo.DjangoAuthInfoCollection(self)
 
     @property
     def logs(self):

--- a/aiida/orm/implementation/django/log.py
+++ b/aiida/orm/implementation/django/log.py
@@ -8,22 +8,21 @@
 # For further information please visit http://www.aiida.net               #
 ###########################################################################
 import json
-from aiida.orm.log import Log, LogEntry
-from aiida.orm.log import OrderSpecifier, ASCENDING, DESCENDING
+from aiida.orm.log import LogCollection, Log
+from aiida.orm.log import ASCENDING
 from aiida.backends.djsite.db.models import DbLog
-from aiida.utils import timezone
 
 
-class DjangoLog(Log):
-    def create_entry(self, time, loggername, levelname, objname,
-                     objpk=None, message="", metadata=None):
+class DjangoLogCollection(LogCollection):
+
+    def create_entry(self, time, loggername, levelname, objname, objpk=None, message="", metadata=None):
         """
         Create a log entry if and only if objpk and objname are set
         """
         if objpk is None or objname is None:
             return None
 
-        entry = DjangoLogEntry(
+        entry = DjangoLog(
             DbLog(
                 time=time,
                 loggername=loggername,
@@ -49,7 +48,7 @@ class DjangoLog(Log):
         if not filter_by:
             filter_by = {}
 
-        # Map the LogEntry property names to DbLog field names
+        # Map the Log property names to DbLog field names
         for key, value in filter_by.iteritems():
             filters[key] = value
 
@@ -67,7 +66,7 @@ class DjangoLog(Log):
         else:
             entries = DbLog.objects.filter().order_by(*order)[:limit]
 
-        return [DjangoLogEntry(entry) for entry in entries]
+        return [DjangoLog(entry) for entry in entries]
 
     def delete_many(self, filter):
         """
@@ -81,7 +80,8 @@ class DjangoLog(Log):
                 "currently supported")
 
 
-class DjangoLogEntry(LogEntry):
+class DjangoLog(Log):
+
     def __init__(self, model):
         """
         :param model: :class:`aiida.backends.djsite.db.models.DbLog`

--- a/aiida/orm/implementation/django/user.py
+++ b/aiida/orm/implementation/django/user.py
@@ -17,6 +17,7 @@ from . import utils
 
 
 class DjangoUserCollection(UserCollection):
+
     def create(self, email, first_name='', last_name='', institution=''):
         """
         Create a user with the provided email address
@@ -29,9 +30,6 @@ class DjangoUserCollection(UserCollection):
                           first_name=first_name,
                           last_name=last_name,
                           institution=institution)
-
-    def from_dbmodel(self, dbuser):
-        return DjangoUser._from_dbmodel(self, dbuser)
 
     def find(self, email=None, id=None):
         # Constructing the default query
@@ -56,24 +54,28 @@ class DjangoUserCollection(UserCollection):
             users.append(self.from_dbmodel(dbuser))
         return users
 
+    def from_dbmodel(self, dbmodel):
+        return DjangoUser.from_dbmodel(dbmodel, self.backend)
+
 
 class DjangoUser(User):
+
     @classmethod
-    def _from_dbmodel(cls, backend, dbuser):
+    def from_dbmodel(cls, dbmodel, backend):
         """
         Create a DjangoUser from a dbmodel instance
 
         :param backend: The backend
         :type backend: :class:`DjangoUserCollection`
-        :param dbuser: The dbuser instance
-        :type dbuser: :class:`aiida.backends.djsite.db.models.DbUser`
+        :param dbmodel: The dbmodel instance
+        :type dbmodel: :class:`aiida.backends.djsite.db.models.DbUser`
         :return: A DjangoUser instance
         :rtype: :class:`DjangoUser`
         """
-        type_check(dbuser, DbUser)
+        type_check(dbmodel, DbUser)
         user = cls.__new__(cls)
         super(DjangoUser, user).__init__(backend)
-        user._dbuser = utils.ModelWrapper(dbuser)
+        user._dbuser = utils.ModelWrapper(dbmodel)
         return user
 
     def __init__(self, backend, email, first_name, last_name, institution):

--- a/aiida/orm/implementation/sqlalchemy/authinfo.py
+++ b/aiida/orm/implementation/sqlalchemy/authinfo.py
@@ -8,9 +8,9 @@
 # For further information please visit http://www.aiida.net               #
 ###########################################################################
 from aiida.backends.sqlalchemy.models.authinfo import DbAuthInfo
-from aiida.orm.authinfo import AuthInfoCollection, AuthInfo
 from aiida.common import exceptions
 from aiida.common.utils import type_check
+from aiida.orm.authinfo import AuthInfoCollection, AuthInfo
 
 from . import computer as computers
 from . import user as users
@@ -18,6 +18,7 @@ from . import utils
 
 
 class SqlaAuthInfoCollection(AuthInfoCollection):
+
     def create(self, computer, user):
         return SqlaAuthInfo(self, computer, user)
 
@@ -25,9 +26,9 @@ class SqlaAuthInfoCollection(AuthInfoCollection):
         """
         Return a SqlaAuthInfo given a computer and a user
 
-        :param computer: A Computer or DbComputer instance
-        :param user: A User or DbUser instance
-        :return: a SqlaAuthInfo object associated to the given computer and User, if any
+        :param computer: a Computer instance
+        :param user: a User instance
+        :return: an AuthInfo object associated with the given computer and user
         :raise NotExistent: if the user is not configured to use computer
         :raise sqlalchemy.orm.exc.MultipleResultsFound: if the user is configured
              more than once to use the computer! Should never happen
@@ -43,7 +44,7 @@ class SqlaAuthInfoCollection(AuthInfoCollection):
                 aiidauser_id=user.id,
             ).one()
 
-            return self._from_dbmodel(authinfo)
+            return self.from_dbmodel(authinfo)
         except NoResultFound:
             raise exceptions.NotExistent(
                 "The aiida user {} is not configured to use computer {}".format(
@@ -54,17 +55,15 @@ class SqlaAuthInfoCollection(AuthInfoCollection):
                 "computer {}! Only one configuration is allowed".format(
                     user.email, computer.name))
 
-    def _from_dbmodel(self, dbmodel):
-        return SqlaAuthInfo._from_dbmodel(self, dbmodel)
+    def from_dbmodel(self, dbmodel):
+        return SqlaAuthInfo.from_dbmodel(dbmodel, self.backend)
 
 
 class SqlaAuthInfo(AuthInfo):
-    """
-    AuthInfo implementation for SQLAlchemy
-    """
+    """AuthInfo implementation for SQLAlchemy."""
 
     @classmethod
-    def _from_dbmodel(cls, backend, dbmodel):
+    def from_dbmodel(cls, dbmodel, backend):
         type_check(dbmodel, DbAuthInfo)
         authinfo = SqlaAuthInfo.__new__(cls)
         super(SqlaAuthInfo, authinfo).__init__(backend)
@@ -74,19 +73,14 @@ class SqlaAuthInfo(AuthInfo):
     def __init__(self, backend, computer, user):
         """
         Construct an SqlaAuthInfo
+
+        :param computer: a Computer instance
+        :param user: a User instance
+        :return: an AuthInfo object associated with the given computer and user
         """
-        from aiida.orm.computer import Computer
-
         super(SqlaAuthInfo, self).__init__(backend)
-
         type_check(user, users.SqlaUser)
-
-        # Takes care of always getting a Computer instance from a DbComputer, Computer or string
-        dbcomputer = Computer.get(computer).dbcomputer
-        # user.email exists both for DbUser and User, so I'm robust w.r.t. the type of what I get
-        dbuser = user.dbuser
-        self._dbauthinfo = utils.ModelWrapper(
-            DbAuthInfo(dbcomputer=dbcomputer, aiidauser=dbuser))
+        self._dbauthinfo = utils.ModelWrapper(DbAuthInfo(dbcomputer=computer.dbcomputer, aiidauser=user.dbuser))
 
     @property
     def dbauthinfo(self):
@@ -95,9 +89,9 @@ class SqlaAuthInfo(AuthInfo):
     @property
     def is_stored(self):
         """
-        Is it already stored or not?
+        Return whether the AuthInfo is stored
 
-        :return: Boolean
+        :return: True if stored, False otherwise
         """
         return self._dbauthinfo.is_saved()
 

--- a/aiida/orm/implementation/sqlalchemy/backend.py
+++ b/aiida/orm/implementation/sqlalchemy/backend.py
@@ -15,14 +15,15 @@ from . import user
 
 
 class SqlaBackend(Backend):
+
     def __init__(self):
-        self._log = log.SqlaLog()
+        self._logs = log.SqlaLogCollection()
         self._users = user.SqlaUserCollection()
         self._authinfos = authinfo.SqlaAuthInfoCollection()
 
     @property
-    def log(self):
-        return self._log
+    def logs(self):
+        return self._logs
 
     @property
     def users(self):

--- a/aiida/orm/implementation/sqlalchemy/backend.py
+++ b/aiida/orm/implementation/sqlalchemy/backend.py
@@ -17,9 +17,9 @@ from . import user
 class SqlaBackend(Backend):
 
     def __init__(self):
-        self._logs = log.SqlaLogCollection()
-        self._users = user.SqlaUserCollection()
-        self._authinfos = authinfo.SqlaAuthInfoCollection()
+        self._logs = log.SqlaLogCollection(self)
+        self._users = user.SqlaUserCollection(self)
+        self._authinfos = authinfo.SqlaAuthInfoCollection(self)
 
     @property
     def logs(self):

--- a/aiida/orm/implementation/sqlalchemy/log.py
+++ b/aiida/orm/implementation/sqlalchemy/log.py
@@ -7,23 +7,24 @@
 # For further information on the license, see the LICENSE.txt file        #
 # For further information please visit http://www.aiida.net               #
 ###########################################################################
-from aiida.orm.log import Log, LogEntry
-from aiida.orm.log import OrderSpecifier, ASCENDING, DESCENDING
+from aiida.orm.log import LogCollection, Log
+from aiida.orm.log import ASCENDING
 from aiida.backends.sqlalchemy import get_scoped_session
 from aiida.backends.sqlalchemy.models.log import DbLog
+
 session = get_scoped_session()
 
 
-class SqlaLog(Log):
-    def create_entry(self, time, loggername, levelname, objname,
-                     objpk=None, message="", metadata=None):
+class SqlaLogCollection(LogCollection):
+
+    def create_entry(self, time, loggername, levelname, objname, objpk=None, message="", metadata=None):
         """
         Create a log entry.
         """
         if objpk is None or objname is None:
             return None
 
-        entry = SqlaLogEntry(
+        entry = SqlaLog(
             DbLog(
                 time=time,
                 loggername=loggername,
@@ -49,7 +50,7 @@ class SqlaLog(Log):
         if not filter_by:
             filter_by = {}
 
-        # Map the LogEntry property names to DbLog field names
+        # Map the Log property names to DbLog field names
         for key, value in filter_by.iteritems():
             filters[key] = value
 
@@ -72,7 +73,7 @@ class SqlaLog(Log):
         else:
             entries = session.query(DbLog).order_by(*order).limit(limit)
 
-        return [SqlaLogEntry(entry) for entry in entries]
+        return [SqlaLog(entry) for entry in entries]
 
     def delete_many(self, filter):
         """
@@ -88,7 +89,8 @@ class SqlaLog(Log):
                 "currently supported")
 
 
-class SqlaLogEntry(LogEntry):
+class SqlaLog(Log):
+
     def __init__(self, model):
         """
         :param model: :class:`aiida.backends.sqlalchemy.models.log.DbLog`

--- a/aiida/orm/log.py
+++ b/aiida/orm/log.py
@@ -17,7 +17,7 @@ DESCENDING = -1
 OrderSpecifier = namedtuple("OrderSpecifier", ['field', 'direction'])
 
 
-class Log(object):
+class LogCollection(object):
     """
     This class represents the collection of logs and can be used to create
     and retrieve logs.
@@ -46,7 +46,7 @@ class Log(object):
         :param metadata: Any (optional) metadata, should be JSON serializable dictionary
         :type metadata: :class:`dict`
         :return: An object implementing the log entry interface
-        :rtype: :class:`aiida.orm.log.LogEntry`
+        :rtype: :class:`aiida.orm.log.Log`
         """
         pass
 
@@ -58,7 +58,7 @@ class Log(object):
         :param record: The record created by the logging module
         :type record: :class:`logging.record`
         :return: An object implementing the log entry interface
-        :rtype: :class:`aiida.orm.log.LogEntry`
+        :rtype: :class:`aiida.orm.log.Log`
         """
         from datetime import datetime
 
@@ -103,7 +103,7 @@ class Log(object):
         pass
 
 
-class LogEntry(object):
+class Log(object):
     __metaclass__ = ABCMeta
 
     @abstractproperty
@@ -192,6 +192,6 @@ class LogEntry(object):
         Persist the log entry to the database
 
         :return: reference of self
-        :rtype: :class: LogEntry
+        :rtype: :class: Log
         """
         pass

--- a/aiida/orm/log.py
+++ b/aiida/orm/log.py
@@ -10,6 +10,7 @@
 from abc import abstractmethod, abstractproperty, ABCMeta
 from collections import namedtuple
 from aiida.utils import timezone
+from .backend import Collection, CollectionEntry
 
 ASCENDING = 1
 DESCENDING = -1
@@ -17,7 +18,7 @@ DESCENDING = -1
 OrderSpecifier = namedtuple("OrderSpecifier", ['field', 'direction'])
 
 
-class LogCollection(object):
+class LogCollection(Collection):
     """
     This class represents the collection of logs and can be used to create
     and retrieve logs.
@@ -103,7 +104,7 @@ class LogCollection(object):
         pass
 
 
-class Log(object):
+class Log(CollectionEntry):
     __metaclass__ = ABCMeta
 
     @abstractproperty

--- a/aiida/orm/user.py
+++ b/aiida/orm/user.py
@@ -15,11 +15,12 @@ import abc
 
 from aiida.common.hashing import is_password_usable
 from aiida.common import exceptions
+from .backend import Collection, CollectionEntry
 
 __all__ = ['User', 'UserCollection']
 
 
-class UserCollection(object):
+class UserCollection(Collection):
     """
     The collection of users stored in a backend
     """
@@ -125,7 +126,7 @@ class UserCollection(object):
         return [_[0] for _ in query.all()]
 
 
-class User(object):
+class User(CollectionEntry):
     """
     This is the base class for User information in AiiDA.  An implementing
     backend needs to provide a concrete version.
@@ -136,15 +137,8 @@ class User(object):
 
     __metaclass__ = abc.ABCMeta
 
-    def __init__(self, backend):
-        self._backend = backend
-
     def __str__(self):
         return self.email
-
-    @property
-    def backend(self):
-        return self._backend
 
     @abc.abstractproperty
     def pk(self):


### PR DESCRIPTION
Fixes #1838 

Certain ORM collection entries, such as the AuthInfo class, require an
instance of the backend class, to retrieve other backend collections
and or entries. To ensure that these get properly constructed the concept
is abstracted by the Collection and CollectionEntry class which will are
to be sub classed for the various ORM classes. These base classes will
ensure that the backend is passed at construction time and provides a
property to retrieve it.