### PR TITLE
Fix the message for `verdi computer configure`

### DIFF
--- a/aiida/cmdline/commands/cmd_computer.py
+++ b/aiida/cmdline/commands/cmd_computer.py
@@ -268,7 +268,7 @@ def setup_computer(non_interactive, **kwargs):
     echo.echo_info('pk: {}, uuid: {}'.format(computer.pk, computer.uuid))
 
     echo.echo_info("Note: before using it with AiiDA, configure it using the command")
-    echo.echo_info("  verdi computer configure {}".format(computer.name))
+    echo.echo_info("  verdi computer configure {} {}".format(computer.get_transport_type(), computer.name))
     echo.echo_info("(Note: machine_dependent transport parameters cannot be set via ")
     echo.echo_info("the command-line interface at the moment)")
 


### PR DESCRIPTION
Fixes #1829 

After the `click` migration, the `verdi computer configure` command changed
as each transport type now has its own sub command. The `verdi computer setup`
command was still printing the wrong command after successful setup on how
to configure the computer