### PR TITLE
Fix bug in the RemoteData._clean method

### DIFF
--- a/aiida/backends/tests/__init__.py
+++ b/aiida/backends/tests/__init__.py
@@ -78,6 +78,7 @@ db_test_list = {
         'control.computer': ['aiida.backends.tests.control.test_computer_ctrl'],
         'daemon.client': ['aiida.backends.tests.daemon.test_client'],
         'orm.data.frozendict': ['aiida.backends.tests.orm.data.frozendict'],
+        'orm.data.remote': ['aiida.backends.tests.orm.data.remote'],
         'orm.log': ['aiida.backends.tests.orm.log'],
         'orm.mixins': ['aiida.backends.tests.orm.mixins'],
         'orm.utils.loaders': ['aiida.backends.tests.orm.utils.loaders'],

--- a/aiida/backends/tests/orm/data/remote.py
+++ b/aiida/backends/tests/orm/data/remote.py
@@ -1,0 +1,60 @@
+# -*- coding: utf-8 -*-
+###########################################################################
+# Copyright (c), The AiiDA team. All rights reserved.                     #
+# This file is part of the AiiDA code.                                    #
+#                                                                         #
+# The code is hosted on GitHub at https://github.com/aiidateam/aiida_core #
+# For further information on the license, see the LICENSE.txt file        #
+# For further information please visit http://www.aiida.net               #
+###########################################################################
+import errno
+import os
+import shutil
+import tempfile
+
+from aiida.backends.testbase import AiidaTestCase
+from aiida.orm import Computer
+from aiida.orm.backend import construct_backend
+from aiida.orm.data.remote import RemoteData
+
+
+class TestRemoteData(AiidaTestCase):
+    """Test for the RemoteData class."""
+
+    @classmethod
+    def setUpClass(cls):
+        super(TestRemoteData, cls).setUpClass()
+        backend = construct_backend()
+        user = backend.users.get_automatic_user()
+        authinfo = backend.authinfos.create(cls.computer, user)
+        authinfo.store()
+
+    def setUp(self):
+        """Create a dummy RemoteData on the default computer."""
+        self.tmp_path = tempfile.mkdtemp()
+        self.remote = RemoteData(computer=self.computer)
+        self.remote.set_remote_path(self.tmp_path)
+
+        with open(os.path.join(self.tmp_path, 'file.txt'), 'w') as handle:
+            handle.write('test string')
+
+        self.remote.set_computer(self.computer)
+        self.remote.store()
+
+    def tearDown(self):
+        """Delete the temporary path for the dummy RemoteData node."""
+        try:
+            shutil.rmtree(self.tmp_path)
+        except OSError as exception:
+            if exception.errno == errno.ENOENT:
+                pass
+            elif exception.errno == errno.ENOTDIR:
+                os.remove(the_path)
+            else:
+                raise IOError(exception)
+
+    def test_clean(self):
+        """Try cleaning a RemoteData node."""
+        self.assertFalse(self.remote.is_empty())
+        self.remote._clean()
+        self.assertTrue(self.remote.is_empty())

--- a/aiida/orm/implementation/django/authinfo.py
+++ b/aiida/orm/implementation/django/authinfo.py
@@ -29,7 +29,7 @@ class DjangoAuthInfoCollection(AuthInfoCollection):
         :param user: a User instance
         :return: an AuthInfo object associated with the given computer and user
         """
-        return DjangoAuthInfo(self, computer, user)
+        return DjangoAuthInfo(self.backend, computer, user)
 
     def get(self, computer, user):
         """

--- a/aiida/orm/implementation/django/user.py
+++ b/aiida/orm/implementation/django/user.py
@@ -25,7 +25,7 @@ class DjangoUserCollection(UserCollection):
         :return: A new user object
         :rtype: :class:`aiida.orm.User`
         """
-        return DjangoUser(self,
+        return DjangoUser(self.backend,
                           email=normalize_email(email),
                           first_name=first_name,
                           last_name=last_name,

--- a/aiida/orm/implementation/sqlalchemy/authinfo.py
+++ b/aiida/orm/implementation/sqlalchemy/authinfo.py
@@ -20,7 +20,7 @@ from . import utils
 class SqlaAuthInfoCollection(AuthInfoCollection):
 
     def create(self, computer, user):
-        return SqlaAuthInfo(self, computer, user)
+        return SqlaAuthInfo(self.backend, computer, user)
 
     def get(self, computer, user):
         """

--- a/aiida/orm/implementation/sqlalchemy/user.py
+++ b/aiida/orm/implementation/sqlalchemy/user.py
@@ -24,7 +24,7 @@ class SqlaUserCollection(UserCollection):
         :return: A new user object
         :rtype: :class:`aiida.orm.User`
         """
-        return SqlaUser(self, normalize_email(email), first_name, last_name, institution)
+        return SqlaUser(self.backend, normalize_email(email), first_name, last_name, institution)
 
     def find(self, email=None, id=None):
         # Constructing the default query


### PR DESCRIPTION
Fixes #1844 

The `clean_remote` free function was not imported. Fix the import,
and add a test to trigger this code path. As a result, a bug was
found in the AuthInfo and User backend implementations, where the
wrong type for `backend` argument were being passed to the constructor
by the Collection.