### PR TITLE
Properly set future exception if transport fails to open

### DIFF
--- a/aiida/work/transports.py
+++ b/aiida/work/transports.py
@@ -85,8 +85,13 @@ class TransportQueue(object):
                 if transport_request.count > 0:
                     # The user still wants the transport so open it
                     _LOGGER.debug('Transport request opening transport for %s', authinfo)
-                    transport.open()
-                    transport_request.future.set_result(transport)
+                    try:
+                        transport.open()
+                    except Exception as exception:  # pylint: disable=broad-except
+                        _LOGGER.error('exception occurred while trying to open transport:\n %s', exception)
+                        transport_request.future.set_exception(exception)
+                    else:
+                        transport_request.future.set_result(transport)
 
             # Save the handle so that we can cancel the callback if the user no longer wants it
             open_callback_handle = self._loop.call_later(safe_open_interval, do_open)


### PR DESCRIPTION
Fixes #1843 

The `do_open` callback of the `request_transport` method of the
`TransportQueue` was not catching any exceptions when calling
`transport.open()`. As a result, the future's exception would
never be set, causing the thread to wait forever. We wrap the
open call in try except block and set the exception on the future
accordingly when the open call excepts