### PR TITLE
Include `transport.open()` call in exponential backoff retry coroutine

### DIFF
--- a/aiida/backends/tests/work/test_utils.py
+++ b/aiida/backends/tests/work/test_utils.py
@@ -52,4 +52,8 @@ class TestExponentialBackoffRetry(AiidaTestCase):
 
         max_attempts = MAX_ITERATIONS - 1
         with self.assertRaises(RuntimeError):
-            loop.run_sync(lambda: exponential_backoff_retry(coro, initial_interval=0.1, max_attempts=max_attempts))
+            try:
+                loop.run_sync(lambda: exponential_backoff_retry(coro, initial_interval=0.1, max_attempts=max_attempts))
+            except Exception as e:
+                print(e)
+                raise

--- a/aiida/orm/authinfo.py
+++ b/aiida/orm/authinfo.py
@@ -33,6 +33,14 @@ class AuthInfoCollection(Collection):
         pass
 
     @abc.abstractmethod
+    def remove(self, authinfo_id):
+        """
+        Remove an AuthInfo from the collection with the given id
+        :param authinfo_id: The ID of the authinfo to delete
+        """
+        pass
+
+    @abc.abstractmethod
     def get(self, computer, user):
         """
         Return a AuthInfo given a computer and a user

--- a/aiida/orm/implementation/django/authinfo.py
+++ b/aiida/orm/implementation/django/authinfo.py
@@ -60,6 +60,13 @@ class DjangoAuthInfoCollection(AuthInfoCollection):
                 "computer {}! Only one configuration is allowed".format(
                     user.email, computer.name))
 
+    def remove(self, authinfo_id):
+        from django.core.exceptions import ObjectDoesNotExist
+        try:
+            DbAuthInfo.objects.get(pk=authinfo_id).delete()
+        except ObjectDoesNotExist:
+            raise exceptions.NotExistent("AuthInfo with id '{}' not found".format(authinfo_id))
+
     def from_dbmodel(self, dbmodel):
         return DjangoAuthInfo.from_dbmodel(dbmodel, self.backend)
 

--- a/aiida/orm/implementation/sqlalchemy/authinfo.py
+++ b/aiida/orm/implementation/sqlalchemy/authinfo.py
@@ -55,6 +55,17 @@ class SqlaAuthInfoCollection(AuthInfoCollection):
                 "computer {}! Only one configuration is allowed".format(
                     user.email, computer.name))
 
+    def remove(self, authinfo_id):
+        from sqlalchemy.orm.exc import NoResultFound
+        from aiida.backends.sqlalchemy import get_scoped_session
+
+        session = get_scoped_session()
+        try:
+            session.query(DbAuthInfo).filter_by(id=authinfo_id).delete()
+            session.commit()
+        except NoResultFound:
+            raise exceptions.NotExistent("AuthInfo with id '{}' not found".format(authinfo_id))
+
     def from_dbmodel(self, dbmodel):
         return SqlaAuthInfo.from_dbmodel(dbmodel, self.backend)
 

--- a/aiida/orm/implementation/sqlalchemy/utils.py
+++ b/aiida/orm/implementation/sqlalchemy/utils.py
@@ -49,8 +49,7 @@ class ModelWrapper(object):
     def save(self):
         """ Store the model (possibly updating values if changed) """
         try:
-            self._model.save()
-            self._model.session.commit()
+            self._model.save(commit=True)
         except sqlalchemy.exc.IntegrityError as e:
             self._model.session.rollback()
             raise exceptions.IntegrityError(str(e))


### PR DESCRIPTION
Fixes #1846 

Changed job process retry functions to retry on transport fail
Before it was just the function that was using the transport that was in
the exponential retry function, now if the transport fails it will also
be retried as part of the same function.