### PR TITLE
Implement a standard timeout for `verdi process` commands

### DIFF
--- a/aiida/cmdline/params/options/__init__.py
+++ b/aiida/cmdline/params/options/__init__.py
@@ -316,3 +316,8 @@ VERBOSE = OverridableOption(
     '-v', '--verbose',
     is_flag=True, default=False,
     help='Be more verbose in printing output.')
+
+TIMEOUT = OverridableOption(
+    '-t', '--timeout',
+    type=click.FLOAT, default=5.0, show_default=True,
+    help='Time in seconds to wait for a response before timing out.')


### PR DESCRIPTION
Fixes #1824 

If the target of the affected `verdi process` commands is not reachable,
either because there are no subscribers for that process or the subscriber
is too busy too respond, the command should timeout instead of hang.