### PR TITLE
Abstract common code in `_setup_db_record` for various Processes

### DIFF
--- a/aiida/backends/tests/work/job_processes.py
+++ b/aiida/backends/tests/work/job_processes.py
@@ -96,6 +96,26 @@ class TestJobProcess(AiidaTestCase):
         self.assertEquals(job.calc.label, label)
         self.assertEquals(job.calc.description, description)
 
+    def test_job_process_label(self):
+        """
+        Verify that the process_label attribute is set equal to the class name of the calculation from which the
+        JobProcess class was generated
+        """
+        inputs = {
+            'options': {
+                'computer': self.computer,
+                'resources': {
+                    'num_machines': 1,
+                    'num_mpiprocs_per_machine': 1
+                },
+                'max_wallclock_seconds': 10,
+            },
+        }
+        process = TemplatereplacerCalculation.process()
+        job = process(inputs)
+
+        self.assertEquals(job.calc.process_label, TemplatereplacerCalculation.__name__)
+
     def test_job_process_set_none(self):
         """
         Verify that calculation label and description can be not set.

--- a/aiida/cmdline/utils/query/calculation.py
+++ b/aiida/cmdline/utils/query/calculation.py
@@ -9,7 +9,7 @@ class CalculationQueryBuilder(object):
 
     _default_projections = ('pk', 'ctime', 'state', 'process_label')
     _valid_projections = ('pk', 'uuid', 'ctime', 'mtime', 'state', 'process_state', 'exit_status', 'sealed',
-                          'process_label', 'label', 'description', 'type')
+                          'process_label', 'label', 'description', 'type', 'process_type')
 
     def __init__(self, mapper=None):
         if mapper is None:

--- a/aiida/work/job_processes.py
+++ b/aiida/work/job_processes.py
@@ -499,15 +499,26 @@ class JobProcess(processes.Process):
     def get_or_create_db_record(self):
         return self._calc_class()
 
+    @property
+    def process_class(self):
+        """
+        Return the class that represents this Process, for the JobProcess this is JobCalculation class it wraps.
+
+        For a standard Process or sub class of Process, this is the class itself. However, for legacy reasons,
+        the Process class is a wrapper around another class. This function returns that original class, i.e. the
+        class that really represents what was being executed.
+        """
+        return self._calc_class
+
     @override
-    def _setup_db_record(self):
+    def _setup_db_inputs(self):
         """
-        Link up all the retrospective provenance for this JobCalculation
+        Create the links that connect the inputs to the calculation node that represents this Process
+
+        For a JobProcess, the inputs also need to be mapped onto the `use_` and `set_` methods of the
+        legacy JobCalculation class. If a code is defined in the inputs and no computer has been set
+        yet for the calculation node, the computer configured for the code is used to set on the node.
         """
-        from aiida.common.links import LinkType
-
-        self.calc._set_process_type(self._calc_class)
-
         for name, input_value in self.get_provenance_inputs_iterator():
 
             port = self.spec().inputs[name]
@@ -518,7 +529,7 @@ class JobProcess(processes.Process):
             # Call the 'set' attribute methods for the contents of the 'option' namespace
             if name == self.OPTIONS_INPUT_LABEL:
                 for option_name, option_value in input_value.items():
-                    getattr(self._calc, 'set_{}'.format(option_name))(option_value)
+                    getattr(self.calc, 'set_{}'.format(option_name))(option_value)
                 continue
 
             # Call the 'use' methods to set up the data-calc links
@@ -527,27 +538,20 @@ class JobProcess(processes.Process):
 
                 for k, v in input_value.iteritems():
                     try:
-                        getattr(self._calc, 'use_{}'.format(name))(v, **{additional: k})
+                        getattr(self.calc, 'use_{}'.format(name))(v, **{additional: k})
                     except AttributeError:
                         raise AttributeError(
                             "You have provided for an input the key '{}' but"
                             "the JobCalculation has no such use_{} method".format(name, name))
 
             else:
-                getattr(self._calc, 'use_{}'.format(name))(input_value)
+                getattr(self.calc, 'use_{}'.format(name))(input_value)
 
         # Get the computer from the code if necessary
-        if self._calc.get_computer() is None and 'code' in self.inputs:
+        if self.calc.get_computer() is None and 'code' in self.inputs:
             code = self.inputs['code']
             if not code.is_local():
-                self._calc.set_computer(code.get_remote_computer())
-
-        parent_calc = self.get_parent_calc()
-
-        if parent_calc:
-            self._calc.add_link_from(parent_calc, 'CALL', LinkType.CALL)
-
-        self._add_description_and_label()
+                self.calc.set_computer(code.get_remote_computer())
 
     # endregion
 

--- a/aiida/work/processes.py
+++ b/aiida/work/processes.py
@@ -397,16 +397,50 @@ class Process(plumpy.Process):
             if utils.is_work_calc_type(self.calc):
                 value.add_link_from(self.calc, label, LinkType.RETURN)
 
+    @property
+    def process_class(self):
+        """
+        Return the class that represents this Process.
+
+        For a standard Process or sub class of Process, this is the class itself. However, for legacy reasons,
+        the Process class is a wrapper around another class. This function returns that original class, i.e. the
+        class that really represents what was being executed.
+        """
+        return self.__class__
+
     def _setup_db_record(self):
+        """
+        Create the database record for this process and the links with respect to its inputs
+
+        This function will set various attributes on the node that serve as a proxy for attributes of the Process.
+        This is essential as otherwise this information could only be introspected through the Process itself, which
+        is only available to the interpreter that has it in memory. To make this data introspectable from any
+        interpreter, for example for the command line interface, certain Process attributes are proxied through the
+        calculation node.
+
+        In addition, the parent calculation will be setup with a CALL link if applicable and all inputs will be
+        linked up as well.
+        """
         assert self.inputs is not None
-        assert not self.calc.is_sealed, \
-            "Calculation cannot be sealed when setting up the database record"
+        assert not self.calc.is_sealed, 'Calculation cannot be sealed when setting up the database record'
 
-        # Save the name of this process
+        # Store important process attributes in the node proxy
         self.calc._set_process_state(None)
-        self.calc._set_process_label(self.__class__.__name__)
-        self.calc._set_process_type(self.__class__)
+        self.calc._set_process_label(self.process_class.__name__)
+        self.calc._set_process_type(self.process_class)
 
+        parent_calc = self.get_parent_calc()
+
+        if parent_calc:
+            self.calc.add_link_from(parent_calc, 'CALL', link_type=LinkType.CALL)
+
+        self._setup_db_inputs()
+        self._add_description_and_label()
+
+    def _setup_db_inputs(self):
+        """
+        Create the links that connect the inputs to the calculation node that represents this Process
+        """
         parent_calc = self.get_parent_calc()
 
         for name, input_value in self._flat_inputs().iteritems():
@@ -417,16 +451,11 @@ class Process(plumpy.Process):
             if not input_value.is_stored:
                 # If the input isn't stored then assume our parent created it
                 if parent_calc:
-                    input_value.add_link_from(parent_calc, "CREATE", link_type=LinkType.CREATE)
+                    input_value.add_link_from(parent_calc, 'CREATE', link_type=LinkType.CREATE)
                 if self.inputs.store_provenance:
                     input_value.store()
 
             self.calc.add_link_from(input_value, name)
-
-        if parent_calc:
-            self.calc.add_link_from(parent_calc, "CALL", link_type=LinkType.CALL)
-
-        self._add_description_and_label()
 
     def _add_description_and_label(self):
         if self.inputs:
@@ -681,6 +710,17 @@ class FunctionProcess(Process):
             raise RuntimeError('Cannot persist a workfunction')
         super(FunctionProcess, self).__init__(enable_persistence=False, *args, **kwargs)
 
+    @property
+    def process_class(self):
+        """
+        Return the class that represents this Process, for the FunctionProcess this is the function itself.
+
+        For a standard Process or sub class of Process, this is the class itself. However, for legacy reasons,
+        the Process class is a wrapper around another class. This function returns that original class, i.e. the
+        class that really represents what was being executed.
+        """
+        return self._func
+
     def execute(self):
         result = super(FunctionProcess, self).execute()
         # Create a special case for Process functions: They can return
@@ -694,7 +734,6 @@ class FunctionProcess(Process):
     def _setup_db_record(self):
         super(FunctionProcess, self)._setup_db_record()
         self.calc.store_source_info(self._func)
-        self.calc._set_process_label(self._func.__name__)
 
     @override
     def _run(self):


### PR DESCRIPTION
Fixes #1859 

The `_setup_db_record` method of the `Process` class was completely
reimplemented for the `JobProcess` sub class even though there is a
significant overlap of functionality, leading to discrepancies, such
as the `process_label` attribute not being set for `JobProcess` instances.

Abstract the common functionality such that `JobProcess` can call the
super implementation. The only real difference was the setting up of
inputs links which has been moved to `_setup_db_inputs` and is implemented
separately for the `JobProcess` sub class.