### PR TITLE
Disable caching for inline calculations

### DIFF
--- a/aiida/backends/tests/inline_calculation.py
+++ b/aiida/backends/tests/inline_calculation.py
@@ -34,22 +34,3 @@ class TestInlineCalculation(AiidaTestCase):
         for i in [-4, 0, 3, 10]:
             calc, res = self.incr_inline(inp=Int(i))
             self.assertEqual(res['res'].value, i + 1)
-
-    def test_caching(self):
-        with enable_caching(InlineCalculation):
-            calc1, res1 = self.incr_inline(inp=Int(11))
-            calc2, res2 = self.incr_inline(inp=Int(11))
-            self.assertEquals(res1['res'].value, res2['res'].value, 12)
-            self.assertEquals(calc1.get_extra('_aiida_cached_from', calc1.uuid), calc2.get_extra('_aiida_cached_from'))
-
-    def test_caching_change_code(self):
-        with enable_caching(InlineCalculation):
-            calc1, res1 = self.incr_inline(inp=Int(11))
-
-            @make_inline
-            def incr_inline(inp):
-                return {'res': Int(inp.value + 2)}
-
-            calc2, res2 = incr_inline(inp=Int(11))
-            self.assertNotEquals(res1['res'].value, res2['res'].value)
-            self.assertFalse('_aiida_cached_from' in calc2.extras())

--- a/aiida/orm/implementation/general/calculation/inline.py
+++ b/aiida/orm/implementation/general/calculation/inline.py
@@ -21,7 +21,7 @@ class InlineCalculation(Calculation):
     for a simple calculation
     """
 
-    _cacheable = True
+    _cacheable = False
 
     def get_desc(self):
         """


### PR DESCRIPTION
Fixes #1871 

Caching on inline calculations was broken since the switch to using the ``workfunction`` for their implementation, although unfortunately in a way that was not caught by the tests (see #1871).

Since caching isn't implemented for the ``workfunction``, there is not immediate way to fix this. It's probably possible, but will work correctly only if the user adheres to the design rules for inline calcs, for example to not rely on some external parameter in the calculation.

Given all this, and the fact that inline calcs are supposed to be very fast operations anyway, the best course of action right now seems to me to just disable caching for the ``InlineCalculation``.