### PR TITLE
Determine active nodes in `verdi calculation list` based on process state

### DIFF
--- a/aiida/backends/tests/cmdline/commands/test_calculation.py
+++ b/aiida/backends/tests/cmdline/commands/test_calculation.py
@@ -69,8 +69,8 @@ class TestVerdiCalculation(AiidaTestCase):
             except KeyError:
                 if calculation_state == 'IMPORTED':
                     calc._set_process_state(ProcessState.FINISHED)
-
-                calc._set_process_state(ProcessState.RUNNING)
+                else:
+                    calc._set_process_state(ProcessState.RUNNING)
             else:
                 calc._set_exit_status(exit_status)
                 calc._set_process_state(ProcessState.FINISHED)
@@ -152,7 +152,7 @@ class TestVerdiCalculation(AiidaTestCase):
         options = ['-r']
         result = self.cli_runner.invoke(command.calculation_list, options)
         self.assertIsNone(result.exception)
-        self.assertEquals(len(get_result_lines(result)), 7)
+        self.assertEquals(len(get_result_lines(result)), 7, result.output)
 
         for flag in ['-a', '--all']:
             options = ['-r', flag]
@@ -210,9 +210,9 @@ class TestVerdiCalculation(AiidaTestCase):
                 self.assertIsNone(result.exception)
 
                 if state == 'finished':
-                    self.assertEquals(len(get_result_lines(result)), 5)
+                    self.assertEquals(len(get_result_lines(result)), 6, result.output)
                 else:
-                    self.assertEquals(len(get_result_lines(result)), 8)
+                    self.assertEquals(len(get_result_lines(result)), 7, result.output)
 
     def test_calculation_list_failed(self):
         """Test verdi calculation list with the failed filter"""
@@ -221,7 +221,7 @@ class TestVerdiCalculation(AiidaTestCase):
             result = self.cli_runner.invoke(command.calculation_list, options)
 
             self.assertIsNone(result.exception)
-            self.assertEquals(len(get_result_lines(result)), 4)
+            self.assertEquals(len(get_result_lines(result)), 4, result.output)
 
     def test_calculation_list_exit_status(self):
         """Test verdi calculation list with the exit status filter"""

--- a/aiida/cmdline/commands/cmd_calculation.py
+++ b/aiida/cmdline/commands/cmd_calculation.py
@@ -60,7 +60,7 @@ def calculation_gotocomputer(calculation):
 @arguments.CALCULATIONS(
     type=types.CalculationParamType(sub_classes=('aiida.calculations:job', 'aiida.calculations:inline')))
 @options.CALCULATION_STATE()
-@options.PROCESS_STATE(default=None)
+@options.PROCESS_STATE()
 @options.EXIT_STATUS()
 @options.FAILED()
 @options.PAST_DAYS()
@@ -68,7 +68,7 @@ def calculation_gotocomputer(calculation):
 @options.ORDER_BY()
 @options.PROJECT(type=click.Choice(LIST_CMDLINE_PROJECT_CHOICES), default=LIST_CMDLINE_PROJECT_DEFAULT)
 @options.GROUPS(help='Show only calculations that are contained within one or more of these groups.')
-@options.ALL(help='Show all entries, regardless of their calculation state.')
+@options.ALL(help='Show all entries, regardless of their process state.')
 @options.ALL_USERS()
 @options.RAW()
 @click.option(
@@ -95,6 +95,9 @@ def calculation_list(calculations, past_days, groups, all_entries, calculation_s
 
     filters = {}
 
+    if calculation_state:
+        process_state = None
+
     if process_state:
         calculation_state = None
         filters[PROCESS_STATE_KEY] = {'in': process_state}
@@ -102,7 +105,7 @@ def calculation_list(calculations, past_days, groups, all_entries, calculation_s
     if failed:
         calculation_state = None
         filters[PROCESS_STATE_KEY] = {'==': ProcessState.FINISHED.value}
-        filters[EXIT_STATUS_KEY] = {'!==': 0}
+        filters[EXIT_STATUS_KEY] = {'>': 0}
 
     if exit_status is not None:
         calculation_state = None

--- a/aiida/cmdline/params/options/__init__.py
+++ b/aiida/cmdline/params/options/__init__.py
@@ -24,20 +24,6 @@ def valid_calculation_states():
     return tuple(state for state in calc_states)
 
 
-def active_calculation_states():
-    """Return a list of calculation states that are considered active."""
-    from aiida.common.datastructures import calc_states
-    return ([
-        calc_states.NEW,
-        calc_states.TOSUBMIT,
-        calc_states.SUBMITTING,
-        calc_states.WITHSCHEDULER,
-        calc_states.COMPUTED,
-        calc_states.RETRIEVING,
-        calc_states.PARSING,
-    ])
-
-
 def active_process_states():
     """Return a list of process states that are considered active."""
     from plumpy import ProcessState
@@ -221,7 +207,7 @@ INPUT_PLUGIN = OverridableOption(
 
 CALCULATION_STATE = OverridableOption(
     '-s', '--calculation-state', 'calculation_state',
-    type=types.LazyChoice(valid_calculation_states), cls=MultipleValueOption, default=active_calculation_states,
+    type=types.LazyChoice(valid_calculation_states), cls=MultipleValueOption,
     help='Only include entries with this calculation state.')
 
 PROCESS_STATE = OverridableOption(

--- a/aiida/cmdline/utils/query/calculation.py
+++ b/aiida/cmdline/utils/query/calculation.py
@@ -57,7 +57,7 @@ class CalculationQueryBuilder(object):
 
         if failed:
             filters[process_state_attribute] = {'==': ProcessState.FINISHED.value}
-            filters[exit_status_attribute] = {'!==': 0}
+            filters[exit_status_attribute] = {'>': 0}
 
         if exit_status is not None:
             filters[process_state_attribute] = {'==': ProcessState.FINISHED.value}


### PR DESCRIPTION
Fixes #1817 

The base behavior of `verdi calculation list`, just as its counterpart
`verdi work list`, should be to list all the "active" entries. However,
what constitutes an "active" entry for these two differs. For the work
command, this is determined based on the process state of the nodes.
Any node that is not in a terminal process state, is considered active.
However, for legacy reasons, in `verdi calculation list` the activeness
was still being based on the calculation state, which was not always in
sync with the process state, leading to inconsistent displays.

Here we update the behavior of `verdi calculation list` to determine the
activeness of calculation nodes based on their process state, thus
making it directly equivalent with the behavior of `verdi work list` and
`verdi process list.