### PR TITLE
Make TransportTasks interruptable

### DIFF
--- a/aiida/cmdline/commands/cmd_process.py
+++ b/aiida/cmdline/commands/cmd_process.py
@@ -97,7 +97,7 @@ def process_pause(processes, timeout):
                 continue
 
             try:
-                if control_panel.pause_process(process.pk):
+                if control_panel.pause_process(process.pk, msg='Paused through `verdi process pause`'):
                     echo.echo_success('paused Process<{}>'.format(process.pk))
                 else:
                     echo.echo_error('problem pausing Process<{}>'.format(process.pk))

--- a/aiida/cmdline/utils/query/calculation.py
+++ b/aiida/cmdline/utils/query/calculation.py
@@ -7,9 +7,9 @@ from aiida.cmdline.utils.query.mapping import CalculationProjectionMapper
 class CalculationQueryBuilder(object):
     """Utility class to construct a QueryBuilder instance for Calculation nodes and project the query set."""
 
-    _default_projections = ('pk', 'ctime', 'state', 'process_label')
-    _valid_projections = ('pk', 'uuid', 'ctime', 'mtime', 'state', 'process_state', 'exit_status', 'sealed',
-                          'process_label', 'label', 'description', 'type', 'process_type')
+    _default_projections = ('pk', 'ctime', 'state', 'process_label', 'process_status')
+    _valid_projections = ('pk', 'uuid', 'ctime', 'mtime', 'state', 'process_state', 'process_status', 'exit_status',
+                          'sealed', 'process_label', 'label', 'description', 'type', 'paused', 'process_type')
 
     def __init__(self, mapper=None):
         if mapper is None:

--- a/aiida/cmdline/utils/query/formatting.py
+++ b/aiida/cmdline/utils/query/formatting.py
@@ -17,7 +17,7 @@ def format_relative_time(datetime):
     return str_timedelta(timedelta, negative_to_zero=True, max_num_fields=1)
 
 
-def format_state(process_state, exit_status=None):
+def format_state(process_state, paused=None, exit_status=None):
     """
     Return a string formatted representation of a process' state, which consists of its process state and exit status
 
@@ -25,7 +25,23 @@ def format_state(process_state, exit_status=None):
     :param exit_status: the process' exit status
     :return: string representation of the process' state
     """
-    return '{} | {}'.format(process_state.capitalize() if process_state else None, exit_status)
+    if process_state in ['excepted', 'killed']:
+        symbol = u'\u2A2F'
+    elif process_state in ['created', 'finished']:
+        symbol = u'\u23F9'
+    elif process_state in ['running', 'waiting']:
+        if paused is True:
+            symbol = u'\u23F8'
+        else:
+            symbol = u'\u23F5'
+    else:
+        # Unknown process state, use invisible separator
+        symbol = u'\x00\xA0'
+
+    if process_state == 'finished' and exit_status is not None:
+        return u'{} {} [{}]'.format(symbol, format_process_state(process_state), exit_status)
+
+    return u'{} {}'.format(symbol, format_process_state(process_state))
 
 
 def format_process_state(process_state):

--- a/aiida/cmdline/utils/query/mapping.py
+++ b/aiida/cmdline/utils/query/mapping.py
@@ -77,8 +77,10 @@ class CalculationProjectionMapper(ProjectionMapper):
         self._valid_projections = projections
 
         sealed_key = 'attributes.{}'.format(Sealable.SEALED_KEY)
+        process_paused_key = 'attributes.{}'.format(Calculation.PROCESS_PAUSED_KEY)
         process_label_key = 'attributes.{}'.format(Calculation.PROCESS_LABEL_KEY)
         process_state_key = 'attributes.{}'.format(Calculation.PROCESS_STATE_KEY)
+        process_status_key = 'attributes.{}'.format(Calculation.PROCESS_STATUS_KEY)
         exit_status_key = 'attributes.{}'.format(Calculation.EXIT_STATUS_KEY)
 
         default_labels = {
@@ -91,17 +93,25 @@ class CalculationProjectionMapper(ProjectionMapper):
         default_attributes = {
             'pk': 'id',
             'sealed': sealed_key,
+            'paused': process_paused_key,
             'process_label': process_label_key,
             'process_state': process_state_key,
+            'process_status': process_status_key,
             'exit_status': exit_status_key,
         }
 
+        # pylint: disable=line-too-long
         default_formatters = {
-            'ctime': lambda value: formatting.format_relative_time(value['ctime']),
-            'mtime': lambda value: formatting.format_relative_time(value['mtime']),
-            'state': lambda value: formatting.format_state(value[process_state_key], value[exit_status_key]),
-            'process_state': lambda value: formatting.format_process_state(value[process_state_key]),
-            'sealed': lambda value: formatting.format_sealed(value[sealed_key]),
+            'ctime':
+            lambda value: formatting.format_relative_time(value['ctime']),
+            'mtime':
+            lambda value: formatting.format_relative_time(value['mtime']),
+            'state':
+            lambda value: formatting.format_state(value[process_state_key], value[process_paused_key], value[exit_status_key]),
+            'process_state':
+            lambda value: formatting.format_process_state(value[process_state_key]),
+            'sealed':
+            lambda value: formatting.format_sealed(value[sealed_key]),
         }
 
         if projection_labels is not None:

--- a/aiida/common/exceptions.py
+++ b/aiida/common/exceptions.py
@@ -253,3 +253,10 @@ class DanglingLinkError(Exception):
     Raised when an export archive is detected to contain dangling links when importing
     """
     pass
+
+
+class TransportTaskException(Exception):
+    """
+    Raised when a TransportTask, an task to be completed by the engine that requires transport, fails
+    """
+    pass

--- a/aiida/work/job_processes.py
+++ b/aiida/work/job_processes.py
@@ -7,7 +7,7 @@
 # For further information on the license, see the LICENSE.txt file        #
 # For further information please visit http://www.aiida.net               #
 ###########################################################################
-from collections import namedtuple
+import functools
 import logging
 import shutil
 import sys
@@ -18,14 +18,14 @@ from tornado.gen import coroutine, Return
 import plumpy
 from plumpy.ports import PortNamespace
 from aiida.common.datastructures import calc_states
-from aiida.common.exceptions import InvalidOperation, RemoteOperationError
+from aiida.common.exceptions import TransportTaskException
 from aiida.common import exceptions
 from aiida.common.lang import override
 from aiida.daemon import execmanager
 from aiida.orm.calculation.job import JobCalculation
 from aiida.orm.calculation.job import JobCalculationExitStatus
 from aiida.work.process_builder import JobProcessBuilder
-from aiida.work.utils import exponential_backoff_retry
+from aiida.work.utils import exponential_backoff_retry, interruptable_task
 
 from . import persistence
 from . import processes
@@ -38,15 +38,11 @@ RETRIEVE_COMMAND = 'retrieve'
 KILL_COMMAND = 'kill'
 
 
-class TransportTaskException(Exception):
-    pass
-
-
-LOGGER = logging.getLogger(__name__)
+logger = logging.getLogger(__name__)
 
 
 @coroutine
-def task_submit_job(node, transport_queue, cancelled_flag):
+def task_submit_job(node, transport_queue, cancel_flag):
     """
     Transport task that will attempt to submit a job calculation
 
@@ -57,12 +53,12 @@ def task_submit_job(node, transport_queue, cancelled_flag):
 
     :param node: the node that represents the job calculation
     :param transport_queue: the TransportQueue from which to request a Transport
-    :param cancelled_flag: the cancelled flag that will be queried to determine whethr the job was cancelled
+    :param cancel_flag: the cancelled flag that will be queried to determine whether the task was cancelled
     :raises: Return if the tasks was successfully completed
     :raises: TransportTaskException if after the maximum number of retries the transport task still excepted
     """
     initial_interval = 1
-    max_attempts = 1
+    max_attempts = 5
 
     authinfo = node.get_computer().get_authinfo(node.get_user())
 
@@ -72,27 +68,30 @@ def task_submit_job(node, transport_queue, cancelled_flag):
             transport = yield request
 
             # It may have taken time to get the transport, check if we've been cancelled
-            if cancelled_flag.cancelled:
+            if cancel_flag.is_cancelled:
                 raise plumpy.CancelledError('task_submit_job for calculation<{}> cancelled'.format(node.pk))
 
-            LOGGER.info('submitting calculation<{}>'.format(node.pk))
+            logger.info('submitting calculation<{}>'.format(node.pk))
             node._set_state(calc_states.SUBMITTING)
             raise Return(execmanager.submit_calculation(node, transport))
 
     try:
-        result = yield exponential_backoff_retry(do_submit, initial_interval, max_attempts, logger=node.logger)
+        result = yield exponential_backoff_retry(
+            do_submit, initial_interval, max_attempts, logger=node.logger, ignore_exceptions=plumpy.CancelledError)
+    except plumpy.CancelledError:
+        pass
     except Exception:
-        LOGGER.warning('submitting calculation<{}> failed:\n{}'.format(node.pk, traceback.format_exc()))
+        logger.warning('submitting calculation<{}> failed:\n{}'.format(node.pk, traceback.format_exc()))
         node._set_state(calc_states.SUBMISSIONFAILED)
         raise TransportTaskException('submit_calculation failed {} times consecutively'.format(max_attempts))
     else:
-        LOGGER.info('submitting calculation<{}> successful'.format(node.pk))
+        logger.info('submitting calculation<{}> successful'.format(node.pk))
         node._set_state(calc_states.WITHSCHEDULER)
         raise Return(result)
 
 
 @coroutine
-def task_update_job(node, transport_queue, cancelled_flag):
+def task_update_job(node, transport_queue, cancel_flag):
     """
     Transport task that will attempt to update the scheduler state of a job calculation
 
@@ -103,7 +102,7 @@ def task_update_job(node, transport_queue, cancelled_flag):
 
     :param node: the node that represents the job calculation
     :param transport_queue: the TransportQueue from which to request a Transport
-    :param cancelled_flag: the cancelled flag that will be queried to determine whethr the job was cancelled
+    :param cancel_flag: the cancelled flag that will be queried to determine whether the task was cancelled
     :raises: Return if the tasks was successfully completed
     :raises: TransportTaskException if after the maximum number of retries the transport task still excepted
     """
@@ -118,27 +117,30 @@ def task_update_job(node, transport_queue, cancelled_flag):
             transport = yield request
 
             # It may have taken time to get the transport, check if we've been cancelled
-            if cancelled_flag.cancelled:
+            if cancel_flag.is_cancelled:
                 raise plumpy.CancelledError('task_update_job for calculation<{}> cancelled'.format(node.pk))
 
-            LOGGER.info('updating calculation<{}>'.format(node.pk))
+            logger.info('updating calculation<{}>'.format(node.pk))
             raise Return(execmanager.update_calculation(node, transport))
 
     try:
-        result = yield exponential_backoff_retry(do_update, initial_interval, max_attempts, logger=node.logger)
+        result = yield exponential_backoff_retry(
+            do_update, initial_interval, max_attempts, logger=node.logger, ignore_exceptions=plumpy.CancelledError)
+    except plumpy.CancelledError:
+        pass
     except Exception:
-        LOGGER.warning('updating calculation<{}> failed:\n{}'.format(node.pk, traceback.format_exc()))
+        logger.warning('updating calculation<{}> failed:\n{}'.format(node.pk, traceback.format_exc()))
         node._set_state(calc_states.FAILED)
         raise TransportTaskException('update_calculation failed {} times consecutively'.format(max_attempts))
     else:
-        LOGGER.info('updating calculation<{}> successful'.format(node.pk))
+        logger.info('updating calculation<{}> successful'.format(node.pk))
         if result:
             node._set_state(calc_states.COMPUTED)
         raise Return(result)
 
 
 @coroutine
-def task_retrieve_job(node, transport_queue, cancelled_flag, retrieved_temporary_folder):
+def task_retrieve_job(node, transport_queue, retrieved_temporary_folder, cancel_flag):
     """
     Transport task that will attempt to retrieve all files of a completed job calculation
 
@@ -149,7 +151,7 @@ def task_retrieve_job(node, transport_queue, cancelled_flag, retrieved_temporary
 
     :param node: the node that represents the job calculation
     :param transport_queue: the TransportQueue from which to request a Transport
-    :param cancelled_flag: the cancelled flag that will be queried to determine whethr the job was cancelled
+    :param cancel_flag: the cancelled flag that will be queried to determine whether the task was cancelled
     :raises: Return if the tasks was successfully completed
     :raises: TransportTaskException if after the maximum number of retries the transport task still excepted
     """
@@ -164,27 +166,30 @@ def task_retrieve_job(node, transport_queue, cancelled_flag, retrieved_temporary
             transport = yield request
 
             # It may have taken time to get the transport, check if we've been cancelled
-            if cancelled_flag.cancelled:
+            if cancel_flag.is_cancelled:
                 raise plumpy.CancelledError('task_retrieve_job for calculation<{}> cancelled'.format(node.pk))
 
-            LOGGER.info('retrieving calculation<{}>'.format(node.pk))
+            logger.info('retrieving calculation<{}>'.format(node.pk))
             node._set_state(calc_states.RETRIEVING)
 
             raise Return(execmanager.retrieve_calculation(node, transport, retrieved_temporary_folder))
 
     try:
-        result = yield exponential_backoff_retry(do_retrieve, initial_interval, max_attempts, logger=node.logger)
+        result = yield exponential_backoff_retry(
+            do_retrieve, initial_interval, max_attempts, logger=node.logger, ignore_exceptions=plumpy.CancelledError)
+    except plumpy.CancelledError:
+        pass
     except Exception:
-        LOGGER.warning('retrieving calculation<{}> failed:\n{}'.format(node.pk, traceback.format_exc()))
+        logger.warning('retrieving calculation<{}> failed:\n{}'.format(node.pk, traceback.format_exc()))
         node._set_state(calc_states.RETRIEVALFAILED)
         raise TransportTaskException('retrieve_calculation failed {} times consecutively'.format(max_attempts))
     else:
-        LOGGER.info('retrieving calculation<{}> successful'.format(node.pk))
+        logger.info('retrieving calculation<{}> successful'.format(node.pk))
         raise Return(result)
 
 
 @coroutine
-def task_kill_job(node, transport_queue, cancelled_flag):
+def task_kill_job(node, transport_queue, cancel_flag):
     """
     Transport task that will attempt to kill a job calculation
 
@@ -195,7 +200,7 @@ def task_kill_job(node, transport_queue, cancelled_flag):
 
     :param node: the node that represents the job calculation
     :param transport_queue: the TransportQueue from which to request a Transport
-    :param cancelled_flag: the cancelled flag that will be queried to determine whethr the job was cancelled
+    :param cancel_flag: the cancelled flag that will be queried to determine whether the task was cancelled
     :raises: Return if the tasks was successfully completed
     :raises: TransportTaskException if after the maximum number of retries the transport task still excepted
     """
@@ -204,7 +209,7 @@ def task_kill_job(node, transport_queue, cancelled_flag):
 
     if node.get_state() in [calc_states.NEW, calc_states.TOSUBMIT]:
         node._set_state(calc_states.FAILED)
-        LOGGER.warning('calculation<{}> killed, it was in the {} state'.format(node.pk, node.get_state()))
+        logger.warning('calculation<{}> killed, it was in the {} state'.format(node.pk, node.get_state()))
         raise Return(True)
 
     authinfo = node.get_computer().get_authinfo(node.get_user())
@@ -215,21 +220,23 @@ def task_kill_job(node, transport_queue, cancelled_flag):
             transport = yield request
 
             # It may have taken time to get the transport, check if we've been cancelled
-            if cancelled_flag.cancelled:
+            if cancel_flag.is_cancelled:
                 raise plumpy.CancelledError('task_kill_job for calculation<{}> cancelled'.format(node.pk))
 
-            LOGGER.info('killing calculation<{}>'.format(node.pk))
+            logger.info('killing calculation<{}>'.format(node.pk))
 
             raise Return(execmanager.kill_calculation(node, transport))
 
     try:
         result = yield exponential_backoff_retry(do_kill, initial_interval, max_attempts, logger=node.logger)
+    except plumpy.CancelledError:
+        pass
     except Exception:
-        LOGGER.warning('killing calculation<{}> failed:\n{}'.format(node.pk, traceback.format_exc()))
+        logger.warning('killing calculation<{}> failed:\n{}'.format(node.pk, traceback.format_exc()))
         node._set_state(calc_states.FAILED)
         raise TransportTaskException('kill_calculation failed {} times consecutively'.format(max_attempts))
     else:
-        LOGGER.info('killing calculation<{}> successful'.format(node.pk))
+        logger.info('killing calculation<{}> successful'.format(node.pk))
         raise Return(result)
 
 
@@ -237,88 +244,85 @@ class Waiting(plumpy.Waiting):
     """
     The waiting state for the JobCalculation.
     """
-    CancelFlag = namedtuple('CancelledFlag', ['cancelled'])
 
     def __init__(self, process, done_callback, msg=None, data=None):
         super(Waiting, self).__init__(process, done_callback, msg, data)
-        self._cancel_flag = self.CancelFlag(False)
-        self._kill_future = None
+        self._task = None
 
     def load_instance_state(self, saved_state, load_context):
         super(Waiting, self).load_instance_state(saved_state, load_context)
-        self._cancel_flag = self.CancelFlag(False)
-        self._kill_future = None
+        self._task = None
 
     @coroutine
     def execute(self):
 
-        if self._kill_future:
-            yield self._do_kill()
-            return
-
-        calc = self.process.calc
+        calculation = self.process.calc
         transport_queue = self.process.runner.transport
-        calc.logger.info('Waiting for calculation<{}> on {}'.format(calc.pk, self.data))
+
+        calculation._set_process_status('Waiting for transport task: {}'.format(self.data))
 
         try:
+
             if self.data == SUBMIT_COMMAND:
 
-                yield task_submit_job(calc, transport_queue, self._cancel_flag)
+                try:
+                    transport_task = functools.partial(task_submit_job, calculation, transport_queue)
+                    self._task = interruptable_task(transport_task)
+                    yield self._task
+                finally:
+                    self._task = None
 
-                if self._kill_future:
-                    yield self._do_kill()
-
-                # Now get scheduler updates
                 raise Return(self.scheduler_update())
 
             elif self.data == UPDATE_SCHEDULER_COMMAND:
 
                 job_done = False
 
-                # Keep getting scheduler updates until done
                 while not job_done:
-                    job_done = yield task_update_job(calc, transport_queue, self._cancel_flag)
+                    try:
+                        transport_task = functools.partial(task_update_job, calculation, transport_queue)
+                        self._task = interruptable_task(transport_task)
+                        job_done = yield self._task
+                    finally:
+                        self._task = None
 
-                    if self._kill_future:
-                        yield self._do_kill()
-
-                # Done, go on to retrieve
                 raise Return(self.retrieve())
 
             elif self.data == RETRIEVE_COMMAND:
 
                 # Create a temporary folder that has to be deleted by JobProcess.retrieved after successful parsing
-                retrieved_temporary_folder = tempfile.mkdtemp()
-                yield task_retrieve_job(calc, transport_queue, self._cancel_flag, retrieved_temporary_folder)
+                temp_folder = tempfile.mkdtemp()
 
-                if self._kill_future:
-                    yield self._do_kill()
+                try:
+                    transport_task = functools.partial(task_retrieve_job, calculation, transport_queue, temp_folder)
+                    self._task = interruptable_task(transport_task)
+                    yield self._task
+                finally:
+                    self._task = None
 
-                raise Return(self.retrieved(retrieved_temporary_folder))
+                raise Return(self.retrieved(temp_folder))
 
             else:
                 raise RuntimeError('Unknown waiting command')
 
         except TransportTaskException:
-            exit_status = JobCalculationExitStatus[calc.get_state()].value
+            exit_status = JobCalculationExitStatus[calculation.get_state()].value
             raise Return(self.create_state(processes.ProcessState.FINISHED, exit_status, exit_status is 0))
-        except plumpy.CancelledError:
-            # A task was cancelled because the state (and process) is being killed
-            next_state = yield self._do_kill()
-            raise Return(next_state)
-        except Return:
+        except (plumpy.Interruption, plumpy.CancelledError, Return):
             raise
         except Exception:
             exc_info = sys.exc_info()
             excepted_state = self.create_state(processes.ProcessState.EXCEPTED, exc_info[1], exc_info[2])
             raise Return(excepted_state)
+        finally:
+            calculation._set_process_status(None)
 
     def scheduler_update(self):
         """
         Create the next state to go to
+
         :return: The appropriate WAITING state
         """
-        assert self._kill_future is None, "Currently being killed"
         return self.create_state(
             processes.ProcessState.WAITING,
             None,
@@ -328,9 +332,9 @@ class Waiting(plumpy.Waiting):
     def retrieve(self):
         """
         Create the next state to go to in order to retrieve
+
         :return: The appropriate WAITING state
         """
-        assert self._kill_future is None, "Currently being killed"
         return self.create_state(
             processes.ProcessState.WAITING,
             None,
@@ -344,37 +348,15 @@ class Waiting(plumpy.Waiting):
             be used in parsing.
         :return: The appropriate RUNNING state
         """
-        assert self._kill_future is None, "Currently being killed"
         return self.create_state(
             processes.ProcessState.RUNNING,
             self.process.retrieved,
             retrieved_temporary_folder)
 
-    @coroutine
-    def _do_kill(self):
-        try:
-            yield task_kill_job(self.process.calc, self.process.runner.transport, self._cancel_flag)
-        except (InvalidOperation, RemoteOperationError):
-            pass
-
-        if self._kill_future is not None:
-            self._kill_future.set_result(True)
-            self._kill_future = None
-
-        raise Return(self.create_state(processes.ProcessState.KILLED, 'Got killed yo'))
-
-    def kill(self, msg=None):
-        if self._kill_future is not None:
-            return self._kill_future
-        else:
-            if self.process.calc.get_state() in [calc_states.NEW, calc_states.TOSUBMIT, calc_states.WITHSCHEDULER]:
-                self._kill_future = plumpy.Future()
-                # Cancel the task
-                self._cancel_flag.cancelled = True
-                return self._kill_future
-            else:
-                # Can't be killed
-                return False
+    def interrupt(self, reason):
+        """Interrupt the Waiting state by calling interrupt on the transport task InterruptableFuture."""
+        if self._task is not None:
+            self._task.interrupt(reason)
 
 
 class JobProcess(processes.Process):

--- a/aiida/work/rmq.py
+++ b/aiida/work/rmq.py
@@ -312,8 +312,8 @@ class ProcessControlPanel(object):
     def connect(self):
         return self._communicator.connect()
 
-    def pause_process(self, pid):
-        return self.execute_action(plumpy.PauseAction(pid))
+    def pause_process(self, pid, msg=None):
+        return self.execute_action(plumpy.PauseAction(pid, msg))
 
     def play_process(self, pid):
         return self.execute_action(plumpy.PlayAction(pid))

--- a/aiida/work/utils.py
+++ b/aiida/work/utils.py
@@ -13,6 +13,7 @@ import contextlib
 import logging
 import traceback
 import tornado.ioloop
+from tornado.concurrent import Future
 from tornado.gen import coroutine, sleep, Return
 
 from aiida.common.links import LinkType
@@ -25,6 +26,53 @@ LOGGER = logging.getLogger(__name__)
 PROCESS_STATE_CHANGE_KEY = 'process|state_change|{}'
 PROCESS_STATE_CHANGE_DESCRIPTION = 'The last time a process of type {}, changed state'
 PROCESS_CALC_TYPES = (WorkCalculation, FunctionCalculation)
+
+
+def interruptable_task(coro, loop=None):
+    """
+    Turn the given coroutine into an interruptable task by turning it into an InterruptableFuture and returning it.
+
+    :param coro: the coroutine that should be made interruptable
+    :param loop: the event loop in which to run the coroutine, by default uses tornado.ioloop.IOLoop.current()
+    :return: an InterruptableFuture
+    """
+
+    class CancelFlag(object):
+        """A simple container that can be passed by reference to signal that the task was cancelled."""
+
+        def __init__(self):
+            self.cancelled = False
+
+        @property
+        def is_cancelled(self):
+            return self.cancelled
+
+    cancel_flag = CancelFlag()
+
+    class InterruptableFuture(Future):
+        """A future that can be interrupted by calling `interrupt`."""
+
+        def interrupt(self, reason):
+            """This method should be called to interrupt the coroutine represented by this InterruptableFuture."""
+            cancel_flag.cancelled = True
+            self.set_exception(reason)
+
+    loop = loop or tornado.ioloop.IOLoop.current()
+    future = InterruptableFuture()
+
+    @coroutine
+    def execute_coroutine():
+        """Coroutine that wraps the original coroutine and sets it result on the future only if not already set."""
+        result = yield coro(cancel_flag)
+
+        # If the future has not been set elsewhere, i.e. by the interrupt call, by the time that the coroutine
+        # is executed, set the future's result to the result of the coroutine
+        if not future.done():
+            future.set_result(result)
+
+    loop.add_callback(execute_coroutine)
+
+    return future
 
 
 def ensure_coroutine(fct):
@@ -47,7 +95,7 @@ def ensure_coroutine(fct):
 
 
 @coroutine
-def exponential_backoff_retry(fct, initial_interval=10.0, max_attempts=5, logger=None):
+def exponential_backoff_retry(fct, initial_interval=10.0, max_attempts=5, logger=None, ignore_exceptions=None):
     """
     Coroutine to call a function, recalling it with an exponential backoff in the case of an exception
 
@@ -72,7 +120,12 @@ def exponential_backoff_retry(fct, initial_interval=10.0, max_attempts=5, logger
         try:
             result = yield coro()
             break  # Finished successfully
-        except Exception:  # pylint: disable=broad-except
+        except Exception as exception:  # pylint: disable=broad-except
+
+            # Re-raise exceptions that should be ignored
+            if ignore_exceptions is not None and isinstance(exception, ignore_exceptions):
+                raise
+
             if iteration == max_attempts - 1:
                 logger.warning('maximum attempts %d of calling %s, exceeded', max_attempts, coro.__name__)
                 raise

--- a/docs/requirements_for_rtd.txt
+++ b/docs/requirements_for_rtd.txt
@@ -45,7 +45,7 @@ passlib==1.7.1
 pathlib2
 pgtest==1.1.0
 pika==0.11.2
-plumpy==0.10.3
+plumpy==0.10.4
 psutil==5.4.5
 pymatgen==2018.4.20
 pyparsing==2.2.0

--- a/setup_requirements.py
+++ b/setup_requirements.py
@@ -43,7 +43,7 @@ install_requires = [
     'ecdsa==0.13',
     'pika==0.11.2',
     'ipython<6.0',  # Version of ipython non enforced, because some still prefer version 4 rather than the latest
-    'plumpy==0.10.3',
+    'plumpy==0.10.4',
     'circus==0.14.0',
     'tornado==4.5.3',  # As of 2018/03/06 Tornado released v5.0 which breaks circus 0.14.0
 ]


### PR DESCRIPTION
Fixes #1876 and #1820 

All TransportTasks for the JobProcess Waiting state have been cast
into coroutines, for the purpose of allowing them to yield to other
functionality such as interruptions. However, once in the tasks itself
it could not be interrupted. This led to any interruption being issued
after a task was started, to only be effectuated after the task had
already completed.

Here we wrap all transport tasks in the `interruptable_task` utility
function, which wraps a transport task coroutine and turns it execution
into a future, while also defining a cancel flag that is passed as a
reference to the transport task coroutine. When the Waiting state is
now interrupted, this is piped through to the future, which sets the
cancelled flag. The transport task can now check this flag in its body
whenever it wants to, to check whether it has been cancelled, in which
case it should raise `plumpy.CancelledError`, which will then properly
bubble up to the step function.

The `exponential_backoff_retry` had to be updated to ignore this
particular exception and reraise it to the transport task that called
it.