### PR TITLE
Ensure that SqlAlchemy Node._del_attr throws AttributeError

### DIFF
--- a/aiida/backends/sqlalchemy/models/node.py
+++ b/aiida/backends/sqlalchemy/models/node.py
@@ -224,7 +224,7 @@ class DbNode(Base):
             raise ValueError("We don't know how to treat key with dot in it yet")
 
         if key not in d:
-            raise ValueError("Key {} does not exists".format(key))
+            raise AttributeError("Key {} does not exists".format(key))
 
         del d[key]
 

--- a/aiida/backends/tests/calculation_node.py
+++ b/aiida/backends/tests/calculation_node.py
@@ -80,6 +80,10 @@ class TestCalcNode(AiidaTestCase):
         a._set_attr(Calculation.PROCESS_STATE_KEY, 'FINISHED')
         a._del_attr(Calculation.PROCESS_STATE_KEY)
 
+        # Deleting non-existing attribute should raise attribute error
+        with self.assertRaises(AttributeError):
+            a._del_attr(Calculation.PROCESS_STATE_KEY)
+
         with self.assertRaises(ModificationNotAllowed):
             a._set_attr('bool', False)
 


### PR DESCRIPTION
Fixes #1878 

The abstract implementation specifies that Node._del_attr should
throw an AttributeError if the specified key does not correspond
to an existing attribute. The SqlAlchemy implementation however,
threw a ValueError. This was not caught, because this behavior
was only tested for unstored nodes, which follows a different code
path. With the introduction of the Sealable concept, where certain
attributes can be modified even after storing the node, this new
code path became available, thus exposing the bug.