### PR TITLE
Use equality in OrmEntityLoader UUID filter for complete UUIDs

### DIFF
--- a/aiida/backends/tests/orm/utils/loaders.py
+++ b/aiida/backends/tests/orm/utils/loaders.py
@@ -49,7 +49,6 @@ class TestOrmUtils(AiidaTestCase):
         with self.assertRaises(NotExistent):
             load_group('non-existent-uuid')
 
-
     def test_load_node(self):
         """
         Test the functionality of load_node

--- a/aiida/orm/utils/loaders.py
+++ b/aiida/orm/utils/loaders.py
@@ -103,6 +103,8 @@ class OrmEntityLoader(object):
         :param classes: a tuple of orm classes to which the identifier should be mapped
         :returns: the query builder instance
         """
+        from uuid import UUID
+
         uuid = identifier.replace('-', '')
 
         if query_with_dashes:
@@ -112,7 +114,14 @@ class OrmEntityLoader(object):
 
         qb = QueryBuilder()
         qb.append(cls=classes, tag='entity', project=['*'])
-        qb.add_filter('entity', {'uuid': {'like': '{}%'.format(uuid)}})
+
+        # If a UUID can be constructed from the identifier, it is a full UUID and the query can use an equality operator
+        try:
+            UUID(uuid)
+        except ValueError:
+            qb.add_filter('entity', {'uuid': {'like': '{}%'.format(uuid)}})
+        else:
+            qb.add_filter('entity', {'uuid': uuid})
 
         return qb
 


### PR DESCRIPTION
Fixes #1868 

If the `_get_query_builder_uuid_identifier` method of `OrmEntityLoader`
gets an identifier that constitutes a complete UUID, the query builder
can use an equality operator instead of the like operator. This should
be preferred since the former is a lot more efficient database
operation. To verify whether the provided UUID is a complete UUID, we
simply try to construct a UUID object out of it, which should work only
for complete UUIDs and throw a ValueError in all other cases.