### PR TITLE
Add `reentry_scan=['aiida']` to `setup.py`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -56,6 +56,7 @@ if __name__ == '__main__':
         extras_require=extras_require,
         packages=find_packages(),
         reentry_register=True,
+        reentry_scan=['aiida'],
         entry_points={
             'console_scripts': [
                 'verdi=aiida.cmdline.commands.cmd_verdi:verdi',


### PR DESCRIPTION
Fixes #632 

This will ensure that each time that aiida-core is installed, or
updated, that the reentry cache is updated for the aiida entry
points.