### PR TITLE
Remove subfunction definition from cmdline shell with exec

### DIFF
--- a/aiida/cmdline/commands/cmd_shell.py
+++ b/aiida/cmdline/commands/cmd_shell.py
@@ -15,135 +15,32 @@ import click
 
 from aiida.cmdline.commands.cmd_verdi import verdi
 from aiida.cmdline.utils import decorators, echo
-
-
-def get_start_namespace():
-    """Load all default and custom modules"""
-    from aiida.cmdline.utils.shell import DEFAULT_MODULES_LIST
-    from aiida.common.setup import get_property
-
-    user_ns = {}
-    # load default modules
-    for app_mod, model_name, alias in DEFAULT_MODULES_LIST:
-        user_ns[alias] = getattr(__import__(app_mod, {}, {}, model_name), model_name)
-
-    # load custom modules
-    custom_modules_list = [
-        (str(e[0]), str(e[2]))
-        for e in [p.rpartition('.') for p in get_property('verdishell.modules', default="").split(':')]
-        if e[1] == '.'
-    ]
-
-    for app_mod, model_name in custom_modules_list:
-        try:
-            user_ns[model_name] = getattr(__import__(app_mod, {}, {}, model_name), model_name)
-        except AttributeError:
-            # if the module does not exist, we ignore it
-            pass
-
-    return user_ns
-
-
-def _ipython_pre_011():
-    """Start IPython pre-0.11"""
-    from IPython.Shell import IPShell  # pylint: disable=import-error,no-name-in-module
-
-    user_ns = get_start_namespace()
-    if user_ns:
-        ipy_shell = IPShell(argv=[], user_ns=user_ns)
-    else:
-        ipy_shell = IPShell(argv=[])
-    ipy_shell.mainloop()
-
-
-def _ipython_pre_100():
-    """Start IPython pre-1.0.0"""
-    from IPython.frontend.terminal.ipapp import TerminalIPythonApp  # pylint: disable=import-error,no-name-in-module
-
-    app = TerminalIPythonApp.instance()
-    app.initialize(argv=[])
-    user_ns = get_start_namespace()
-    if user_ns:
-        app.shell.user_ns.update(user_ns)
-    app.start()
-
-
-def _ipython():
-    """Start IPython >= 1.0"""
-    from IPython import start_ipython  # pylint: disable=import-error
-
-    user_ns = get_start_namespace()
-    if user_ns:
-        start_ipython(argv=[], user_ns=user_ns)
-    else:
-        start_ipython(argv=[])
-
-
-def ipython():
-    """Start any version of IPython"""
-    for ipy_version in (_ipython, _ipython_pre_100, _ipython_pre_011):
-        try:
-            ipy_version()
-        except ImportError:
-            pass
-        else:
-            return
-    # no IPython, raise ImportError
-    raise ImportError("No IPython")
-
-
-def bpython():
-    """Start a bpython shell."""
-    import bpython as bpy_shell  # pylint: disable=import-error
-
-    user_ns = get_start_namespace()
-    if user_ns:
-        bpy_shell.embed(user_ns)
-    else:
-        bpy_shell.embed()
-
-
-SHELLS = {'ipython': ipython, 'bpython': bpython}
+from aiida.cmdline.utils.shell import AVAILABLE_SHELLS, run_shell
 
 
 @verdi.command('shell')
 @decorators.with_dbenv()
-@click.option('--plain', is_flag=True, help='Tells Django to use plain Python, not IPython or bpython.)')
+@click.option('--plain', is_flag=True, help='Use a plain Python shell.)')
 @click.option(
     '--no-startup',
     is_flag=True,
-    help='When using plain Python, ignore the PYTHONSTARTUP environment '
-    'variable and ~/.pythonrc.py script.')
+    help='When using plain Python, ignore the PYTHONSTARTUP environment variable and ~/.pythonrc.py script.')
 @click.option(
-    '-i', '--interface', type=click.Choice(SHELLS.keys()), help='Specify an interactive interpreter interface.')
+    '-i',
+    '--interface',
+    type=click.Choice(AVAILABLE_SHELLS.keys()),
+    help='Specify an interactive interpreter interface.')
 def shell(plain, no_startup, interface):
     """Start a python shell with preloaded AiiDA environment."""
-
-    def run_shell(interface=None):
-        """Start the chosen external shell."""
-
-        # Check that there is at least one type of shell declared
-        if not SHELLS:
-            echo.echo_critical("No shells are available")
-
-        available_shells = [SHELLS[interface]] if interface else SHELLS.values()
-
-        # Try the specified or the available shells one by one until you
-        # find one that is available. If the wanted shell is not available
-        # then an ImportError is raised leading the the loading of a generic
-        # shell.
-        for curr_shell in available_shells:
-            try:
-                curr_shell()
-                return
-            except ImportError:
-                pass
-        raise ImportError
 
     try:
         if plain:
             # Don't bother loading IPython, because the user wants plain Python.
             raise ImportError
+
+        # If a non-plain python interpreter is requested, check that there is at least one type of shell available
+        if not AVAILABLE_SHELLS:
+            echo.echo_critical('No shells are available')
 
         run_shell(interface=interface)
     except ImportError:
@@ -179,6 +76,7 @@ def shell(plain, no_startup, interface):
                         exec (compile(handle.read(), pythonrc, 'exec'), imported_objects)  # pylint: disable=exec-used
                 except NameError:
                     pass
+
         # The pylint disabler is necessary because the builtin code module
         # clashes with the local commands.code module here.
         code.interact(local=imported_objects)  # pylint: disable=no-member

--- a/aiida/cmdline/utils/shell.py
+++ b/aiida/cmdline/utils/shell.py
@@ -17,3 +17,109 @@ DEFAULT_MODULES_LIST = [
     ('aiida.orm.querybuilder', 'QueryBuilder', 'QueryBuilder'),
     ('aiida.orm.utils', 'load_node', 'load_node'),
 ]
+
+
+def ipython():
+    """Start any version of IPython"""
+    for ipy_version in (_ipython, _ipython_pre_100, _ipython_pre_011):
+        try:
+            ipy_version()
+        except ImportError:
+            pass
+        else:
+            return
+
+    raise ImportError('No IPython available')
+
+
+def bpython():
+    """Start a bpython shell."""
+    import bpython as bpy_shell  # pylint: disable=import-error
+
+    user_ns = get_start_namespace()
+    if user_ns:
+        bpy_shell.embed(user_ns)
+    else:
+        bpy_shell.embed()
+
+
+AVAILABLE_SHELLS = {'ipython': ipython, 'bpython': bpython}
+
+
+def run_shell(interface=None):
+    """Start the chosen external shell."""
+
+    available_shells = [AVAILABLE_SHELLS[interface]] if interface else AVAILABLE_SHELLS.values()
+
+    # Try the specified or the available shells one by one until you
+    # find one that is available. If the wanted shell is not available
+    # then an ImportError is raised leading the the loading of a generic
+    # shell.
+    for curr_shell in available_shells:
+        try:
+            curr_shell()
+            return
+        except ImportError:
+            pass
+    raise ImportError
+
+
+def get_start_namespace():
+    """Load all default and custom modules"""
+    from aiida.common.setup import get_property
+
+    user_ns = {}
+    # load default modules
+    for app_mod, model_name, alias in DEFAULT_MODULES_LIST:
+        user_ns[alias] = getattr(__import__(app_mod, {}, {}, model_name), model_name)
+
+    # load custom modules
+    custom_modules_list = [
+        (str(e[0]), str(e[2]))
+        for e in [p.rpartition('.') for p in get_property('verdishell.modules', default="").split(':')]
+        if e[1] == '.'
+    ]
+
+    for app_mod, model_name in custom_modules_list:
+        try:
+            user_ns[model_name] = getattr(__import__(app_mod, {}, {}, model_name), model_name)
+        except AttributeError:
+            # if the module does not exist, we ignore it
+            pass
+
+    return user_ns
+
+
+def _ipython_pre_011():
+    """Start IPython pre-0.11"""
+    from IPython.Shell import IPShell  # pylint: disable=import-error,no-name-in-module
+
+    user_ns = get_start_namespace()
+    if user_ns:
+        ipy_shell = IPShell(argv=[], user_ns=user_ns)
+    else:
+        ipy_shell = IPShell(argv=[])
+    ipy_shell.mainloop()
+
+
+def _ipython_pre_100():
+    """Start IPython pre-1.0.0"""
+    from IPython.frontend.terminal.ipapp import TerminalIPythonApp  # pylint: disable=import-error,no-name-in-module
+
+    app = TerminalIPythonApp.instance()
+    app.initialize(argv=[])
+    user_ns = get_start_namespace()
+    if user_ns:
+        app.shell.user_ns.update(user_ns)
+    app.start()
+
+
+def _ipython():
+    """Start IPython >= 1.0"""
+    from IPython import start_ipython  # pylint: disable=import-error
+
+    user_ns = get_start_namespace()
+    if user_ns:
+        start_ipython(argv=[], user_ns=user_ns)
+    else:
+        start_ipython(argv=[])

--- a/docs/requirements_for_rtd.txt
+++ b/docs/requirements_for_rtd.txt
@@ -50,7 +50,7 @@ psutil==5.4.5
 pymatgen==2018.4.20
 pyparsing==2.2.0
 pytest-cov==2.5.1
-pytest==3.5.1
+pytest==3.6.0
 python-dateutil==2.7.2
 python-memcached==1.59
 python-mimeparse==1.6.0

--- a/setup_requirements.py
+++ b/setup_requirements.py
@@ -114,7 +114,7 @@ extras_require = {
         'toml==0.9.4'
     ],
     'dev_sphinxext': [
-        'pytest==3.5.1',
+        'pytest==3.6.0',
         'pytest-cov==2.5.1',
     ],
     'bpython': [


### PR DESCRIPTION
Fixes #1884 and fixes #1796 

I changed python version for Travis to `2.7.6` to make sure that the
tests run on that version. Python 2.7.5 was not available, but I installed
it locally and this particular bug is fixed for that version as well. The only
problem with `2.7.6` on Travis is that the `pytest` sphinxtests run into
an `RecursionLimit` exception, failing the tests.

Calling `exec` in a function that defines a sub function with local
variables is not supported for `python<=2.7.6`. When called the
following exception will be thrown:

	SyntaxError: unqualified exec is not allowed in function
	'shell' it contains a nested function with free variables

However, this was used in the `verdi shell` command implementation.
To maintain backwards compatibility with older python version, that
are often still installed by default on OS'es or clusters,  the sub
function is refactored to be defined as a top level function.