### PR TITLE
Ensure congruence of calculation state with the process state

### DIFF
--- a/aiida/backends/tests/__init__.py
+++ b/aiida/backends/tests/__init__.py
@@ -76,6 +76,7 @@ db_test_list = {
         'cmdline.params.types.node': ['aiida.backends.tests.cmdline.params.types.test_node'],
         'cmdline.params.types.plugin': ['aiida.backends.tests.cmdline.params.types.test_plugin'],
         'cmdline.params.types.workflow': ['aiida.backends.tests.cmdline.params.types.test_workflow'],
+        'common.datastructures': ['aiida.backends.tests.common.test_datastructures'],
         'control.computer': ['aiida.backends.tests.control.test_computer_ctrl'],
         'daemon.client': ['aiida.backends.tests.daemon.test_client'],
         'orm.data.frozendict': ['aiida.backends.tests.orm.data.frozendict'],

--- a/aiida/backends/tests/cmdline/commands/test_group.py
+++ b/aiida/backends/tests/cmdline/commands/test_group.py
@@ -164,7 +164,7 @@ class TestVerdiGroupSetup(AiidaTestCase):
         result = self.runner.invoke(group_removenodes, ["--force", "--group=dummygroup1", calc.uuid])
         self.assertIsNone(result.exception)
         # check if node is added in group using group show command
-        result = self.runner.invoke(group_show, ["dummygroup1"])
+        result = self.runner.invoke(group_show, ['-r', 'dummygroup1'])
         self.assertIsNone(result.exception)
         self.assertNotIn("Calculation", result.output)
         self.assertNotIn(str(calc.pk), result.output)

--- a/aiida/backends/tests/common/test_datastructures.py
+++ b/aiida/backends/tests/common/test_datastructures.py
@@ -1,0 +1,30 @@
+# -*- coding: utf-8 -*-
+from aiida.backends.testbase import AiidaTestCase
+from aiida.common.datastructures import _sorted_datastates, calc_states, is_progressive_state_change
+
+
+class TestCommonDataStructures(AiidaTestCase):
+
+    def test_is_progressive_state_change(self):
+        """Test the `is_progressive_state_change` utility function by testing all possible state change permutations."""
+        for i, state_one in enumerate(_sorted_datastates):
+
+            for j, state_two in enumerate(_sorted_datastates):
+
+                # States will be equal and should not count as progressive state change
+                if i == j:
+                    self.assertFalse(is_progressive_state_change(state_one, state_two))
+                elif i > j:
+                    self.assertFalse(is_progressive_state_change(state_one, state_two))
+                elif i < j:
+                    self.assertTrue(is_progressive_state_change(state_one, state_two))
+                else:
+                    assert True, 'we broke math'
+
+    def test_is_progressive_state_change_invalid_states(self):
+        """Test `is_progressive_state_change` function should raise ValueError for invalid states."""
+        with self.assertRaises(ValueError):
+            is_progressive_state_change('NOTEXISTENT', calc_states.NEW)
+
+        with self.assertRaises(ValueError):
+            is_progressive_state_change(calc_states.NEW, 'NOTEXISTENT')

--- a/aiida/cmdline/commands/cmd_process.py
+++ b/aiida/cmdline/commands/cmd_process.py
@@ -71,7 +71,7 @@ def process_kill(processes, timeout):
                 continue
 
             try:
-                if control_panel.kill_process(process.pk):
+                if control_panel.kill_process(process.pk, msg='Killed through `verdi process kill`'):
                     echo.echo_success('killed Process<{}>'.format(process.pk))
                 else:
                     echo.echo_error('problem killing Process<{}>'.format(process.pk))

--- a/aiida/cmdline/utils/query/formatting.py
+++ b/aiida/cmdline/utils/query/formatting.py
@@ -25,8 +25,10 @@ def format_state(process_state, paused=None, exit_status=None):
     :param exit_status: the process' exit status
     :return: string representation of the process' state
     """
-    if process_state in ['excepted', 'killed']:
+    if process_state in ['excepted']:
         symbol = u'\u2A2F'
+    elif process_state in ['killed']:
+        symbol = u'\u2620'
     elif process_state in ['created', 'finished']:
         symbol = u'\u23F9'
     elif process_state in ['running', 'waiting']:

--- a/aiida/common/datastructures.py
+++ b/aiida/common/datastructures.py
@@ -78,6 +78,30 @@ def sort_states(list_states, use_key=False):
     return [_[1] for _ in list_to_sort[::-1]]
 
 
+def is_progressive_state_change(state_old, state_new):
+    """
+    Return whether a state change from `state_old` to `state_new` would be progressive, i.e. moving forward in time
+
+    :param state_old: the old calculation state
+    :param state_new: the new calculation state
+    :return: True if the change from `state_old` to `state_new` is progressive, False otherwise
+    :raise: ValueError if either `state_old` or `state_new` is not a valid calculation state
+    """
+    states = list(_sorted_datastates)
+
+    try:
+        index_old = states.index(state_old)
+    except ValueError:
+        raise ValueError('state_old {} is not a valid calculation state'.format(state_old))
+
+    try:
+        index_new = states.index(state_new)
+    except ValueError:
+        raise ValueError('state_new {} is not a valid calculation state'.format(state_new))
+
+    return index_new > index_old
+
+
 class CalcInfo(DefaultFieldsAttributeDict):
     """
     This object will store the data returned by the calculation plugin and to be

--- a/aiida/daemon/execmanager.py
+++ b/aiida/daemon/execmanager.py
@@ -21,7 +21,7 @@ from aiida.common.datastructures import calc_states
 from aiida.common.folders import SandboxFolder
 from aiida.common.links import LinkType
 from aiida.common.log import get_dblogger_extra
-from aiida.orm import load_node, DataFactory
+from aiida.orm import DataFactory
 from aiida.orm.data.folder import FolderData
 from aiida.scheduler.datastructures import JOB_STATES
 
@@ -29,21 +29,25 @@ from aiida.scheduler.datastructures import JOB_STATES
 execlogger = aiidalogger.getChild('execmanager')
 
 
-def submit_calculation(calculation, transport):
+def submit_calculation(calculation, transport, calc_info, script_filename):
     """
     Submit a calculation
 
     :param calculation: the instance of JobCalculation to submit.
     :param transport: an already opened transport to use to submit the calculation.
+    :param calc_info: the calculation info datastructure returned by `JobCalculation._presubmit`
+    :param script_filename: the job launch script returned by `JobCalculation._presubmit`
     """
-    from aiida.orm import Code
-    from aiida.common.exceptions import InputValidationError
+    from aiida.orm import load_node, Code
     from aiida.orm.data.remote import RemoteData
 
     computer = calculation.get_computer()
 
     if not computer.is_enabled():
         return
+
+    codes_info = calc_info.codes_info
+    input_codes = [load_node(_.code_uuid, sub_class=Code) for _ in codes_info]
 
     logger_extra = get_dblogger_extra(calculation)
     transport._set_logger_extra(logger_extra)
@@ -55,159 +59,142 @@ def submit_calculation(calculation, transport):
                          "test_submit() method, otherwise store all links"
                          "first".format(calculation.pk))
 
-    s = computer.get_scheduler()
-    s.set_transport(transport)
+    folder = calculation._raw_input_folder
 
-    with SandboxFolder() as folder:
-        calcinfo, script_filename = calculation._presubmit(folder, use_unstored_links=False)
+    # NOTE: some logic is partially replicated in the 'test_submit'
+    # method of JobCalculation. If major logic changes are done
+    # here, make sure to update also the test_submit routine
+    remote_user = transport.whoami()
+    # TODO Doc: {username} field
+    # TODO: if something is changed here, fix also 'verdi computer test'
+    remote_working_directory = computer.get_workdir().format(
+        username=remote_user)
+    if not remote_working_directory.strip():
+        raise exceptions.ConfigurationError(
+            "[submission of calculation {}] "
+            "No remote_working_directory configured for computer "
+            "'{}'".format(calculation.pk, computer.name))
 
-        codes_info = calcinfo.codes_info
-        input_codes = [load_node(_.code_uuid, sub_class=Code) for _ in codes_info]
-
-        for code in input_codes:
-            if not code.can_run_on(computer):
-                raise InputValidationError(
-                    "The selected code {} for calculation "
-                    "{} cannot run on computer {}".
-                        format(code.pk, calculation.pk, computer.name))
-
-        # After this call, no modifications to the folder should be done
-        calculation._store_raw_input_folder(folder.abspath)
-
-        # NOTE: some logic is partially replicated in the 'test_submit'
-        # method of JobCalculation. If major logic changes are done
-        # here, make sure to update also the test_submit routine
-        remote_user = transport.whoami()
-        # TODO Doc: {username} field
-        # TODO: if something is changed here, fix also 'verdi computer test'
-        remote_working_directory = computer.get_workdir().format(
-            username=remote_user)
-        if not remote_working_directory.strip():
+    # If it already exists, no exception is raised
+    try:
+        transport.chdir(remote_working_directory)
+    except IOError:
+        execlogger.debug(
+            "[submission of calculation {}] Unable to chdir in {}, trying to create it".format(
+                calculation.pk, remote_working_directory), extra=logger_extra)
+        try:
+            transport.makedirs(remote_working_directory)
+            transport.chdir(remote_working_directory)
+        except (IOError, OSError) as e:
             raise exceptions.ConfigurationError(
                 "[submission of calculation {}] "
-                "No remote_working_directory configured for computer "
-                "'{}'".format(calculation.pk, computer.name))
+                "Unable to create the remote directory {} on "
+                "computer '{}': {}".format(
+                    calculation.pk, remote_working_directory, computer.name, e.message))
+    # Store remotely with sharding (here is where we choose
+    # the folder structure of remote jobs; then I store this
+    # in the calculation properties using _set_remote_dir
+    # and I do not have to know the logic, but I just need to
+    # read the absolute path from the calculation properties.
+    transport.mkdir(calc_info.uuid[:2], ignore_existing=True)
+    transport.chdir(calc_info.uuid[:2])
+    transport.mkdir(calc_info.uuid[2:4], ignore_existing=True)
+    transport.chdir(calc_info.uuid[2:4])
+    transport.mkdir(calc_info.uuid[4:])
+    transport.chdir(calc_info.uuid[4:])
+    workdir = transport.getcwd()
+    # I store the workdir of the calculation for later file
+    # retrieval
+    calculation._set_remote_workdir(workdir)
 
-        # If it already exists, no exception is raised
-        try:
-            transport.chdir(remote_working_directory)
-        except IOError:
-            execlogger.debug(
-                "[submission of calculation {}] "
-                "Unable to chdir in {}, trying to create it".
-                    format(calculation.pk, remote_working_directory),
-                extra=logger_extra)
-            try:
-                transport.makedirs(remote_working_directory)
-                transport.chdir(remote_working_directory)
-            except (IOError, OSError) as e:
-                raise exceptions.ConfigurationError(
-                    "[submission of calculation {}] "
-                    "Unable to create the remote directory {} on "
-                    "computer '{}': {}".
-                        format(calculation.pk, remote_working_directory, computer.name,
-                               e.message))
-        # Store remotely with sharding (here is where we choose
-        # the folder structure of remote jobs; then I store this
-        # in the calculation properties using _set_remote_dir
-        # and I do not have to know the logic, but I just need to
-        # read the absolute path from the calculation properties.
-        transport.mkdir(calcinfo.uuid[:2], ignore_existing=True)
-        transport.chdir(calcinfo.uuid[:2])
-        transport.mkdir(calcinfo.uuid[2:4], ignore_existing=True)
-        transport.chdir(calcinfo.uuid[2:4])
-        transport.mkdir(calcinfo.uuid[4:])
-        transport.chdir(calcinfo.uuid[4:])
-        workdir = transport.getcwd()
-        # I store the workdir of the calculation for later file
-        # retrieval
-        calculation._set_remote_workdir(workdir)
+    # I first create the code files, so that the code can put
+    # default files to be overwritten by the plugin itself.
+    # Still, beware! The code file itself could be overwritten...
+    # But I checked for this earlier.
+    for code in input_codes:
+        if code.is_local():
+            # Note: this will possibly overwrite files
+            for f in code.get_folder_list():
+                transport.put(code.get_abs_path(f), f)
+            transport.chmod(code.get_local_executable(), 0o755)  # rwxr-xr-x
 
-        # I first create the code files, so that the code can put
-        # default files to be overwritten by the plugin itself.
-        # Still, beware! The code file itself could be overwritten...
-        # But I checked for this earlier.
-        for code in input_codes:
-            if code.is_local():
-                # Note: this will possibly overwrite files
-                for f in code.get_folder_list():
-                    transport.put(code.get_abs_path(f), f)
-                transport.chmod(code.get_local_executable(), 0o755)  # rwxr-xr-x
+    # copy all files, recursively with folders
+    for f in folder.get_content_list():
+        execlogger.debug("[submission of calculation {}] "
+                         "copying file/folder {}...".format(calculation.pk, f),
+                         extra=logger_extra)
+        transport.put(folder.get_abs_path(f), f)
 
-        # copy all files, recursively with folders
-        for f in folder.get_content_list():
+    # local_copy_list is a list of tuples,
+    # each with (src_abs_path, dest_rel_path)
+    # NOTE: validation of these lists are done
+    # inside calculation._presubmit()
+    local_copy_list = calc_info.local_copy_list
+    remote_copy_list = calc_info.remote_copy_list
+    remote_symlink_list = calc_info.remote_symlink_list
+
+    if local_copy_list is not None:
+        for src_abs_path, dest_rel_path in local_copy_list:
             execlogger.debug("[submission of calculation {}] "
-                             "copying file/folder {}...".format(calculation.pk, f),
-                             extra=logger_extra)
-            transport.put(folder.get_abs_path(f), f)
+                             "copying local file/folder to {}".format(
+                calculation.pk, dest_rel_path),
+                extra=logger_extra)
+            transport.put(src_abs_path, dest_rel_path)
 
-        # local_copy_list is a list of tuples,
-        # each with (src_abs_path, dest_rel_path)
-        # NOTE: validation of these lists are done
-        # inside calculation._presubmit()
-        local_copy_list = calcinfo.local_copy_list
-        remote_copy_list = calcinfo.remote_copy_list
-        remote_symlink_list = calcinfo.remote_symlink_list
-
-        if local_copy_list is not None:
-            for src_abs_path, dest_rel_path in local_copy_list:
+    if remote_copy_list is not None:
+        for (remote_computer_uuid, remote_abs_path,
+             dest_rel_path) in remote_copy_list:
+            if remote_computer_uuid == computer.uuid:
                 execlogger.debug("[submission of calculation {}] "
-                                 "copying local file/folder to {}".format(
-                    calculation.pk, dest_rel_path),
-                    extra=logger_extra)
-                transport.put(src_abs_path, dest_rel_path)
+                                 "copying {} remotely, directly on the machine "
+                                 "{}".format(calculation.pk, dest_rel_path, computer.name))
+                try:
+                    transport.copy(remote_abs_path, dest_rel_path)
+                except (IOError, OSError):
+                    execlogger.warning("[submission of calculation {}] "
+                                       "Unable to copy remote resource from {} to {}! "
+                                       "Stopping.".format(calculation.pk,
+                                                          remote_abs_path, dest_rel_path),
+                                       extra=logger_extra)
+                    raise
+            else:
+                # TODO: implement copy between two different
+                # machines!
+                raise NotImplementedError(
+                    "[presubmission of calculation {}] "
+                    "Remote copy between two different machines is "
+                    "not implemented yet".format(calculation.pk))
 
-        if remote_copy_list is not None:
-            for (remote_computer_uuid, remote_abs_path,
-                 dest_rel_path) in remote_copy_list:
-                if remote_computer_uuid == computer.uuid:
-                    execlogger.debug("[submission of calculation {}] "
-                                     "copying {} remotely, directly on the machine "
-                                     "{}".format(calculation.pk, dest_rel_path, computer.name))
-                    try:
-                        transport.copy(remote_abs_path, dest_rel_path)
-                    except (IOError, OSError):
-                        execlogger.warning("[submission of calculation {}] "
-                                           "Unable to copy remote resource from {} to {}! "
-                                           "Stopping.".format(calculation.pk,
-                                                              remote_abs_path, dest_rel_path),
-                                           extra=logger_extra)
-                        raise
-                else:
-                    # TODO: implement copy between two different
-                    # machines!
-                    raise NotImplementedError(
-                        "[presubmission of calculation {}] "
-                        "Remote copy between two different machines is "
-                        "not implemented yet".format(calculation.pk))
+    if remote_symlink_list is not None:
+        for (remote_computer_uuid, remote_abs_path,
+             dest_rel_path) in remote_symlink_list:
+            if remote_computer_uuid == computer.uuid:
+                execlogger.debug("[submission of calculation {}] "
+                                 "copying {} remotely, directly on the machine "
+                                 "{}".format(calculation.pk, dest_rel_path, computer.name))
+                try:
+                    transport.symlink(remote_abs_path, dest_rel_path)
+                except (IOError, OSError):
+                    execlogger.warning("[submission of calculation {}] "
+                                       "Unable to create remote symlink from {} to {}! "
+                                       "Stopping.".format(calculation.pk,
+                                                          remote_abs_path, dest_rel_path),
+                                       extra=logger_extra)
+                    raise
+            else:
+                raise IOError("It is not possible to create a symlink "
+                              "between two different machines for "
+                              "calculation {}".format(calculation.pk))
 
-        if remote_symlink_list is not None:
-            for (remote_computer_uuid, remote_abs_path,
-                 dest_rel_path) in remote_symlink_list:
-                if remote_computer_uuid == computer.uuid:
-                    execlogger.debug("[submission of calculation {}] "
-                                     "copying {} remotely, directly on the machine "
-                                     "{}".format(calculation.pk, dest_rel_path, computer.name))
-                    try:
-                        transport.symlink(remote_abs_path, dest_rel_path)
-                    except (IOError, OSError):
-                        execlogger.warning("[submission of calculation {}] "
-                                           "Unable to create remote symlink from {} to {}! "
-                                           "Stopping.".format(calculation.pk,
-                                                              remote_abs_path, dest_rel_path),
-                                           extra=logger_extra)
-                        raise
-                else:
-                    raise IOError("It is not possible to create a symlink "
-                                  "between two different machines for "
-                                  "calculation {}".format(calculation.pk))
+    remotedata = RemoteData(computer=computer, remote_path=workdir)
+    remotedata.add_link_from(calculation, label='remote_folder', link_type=LinkType.CREATE)
+    remotedata.store()
 
-        remotedata = RemoteData(computer=computer, remote_path=workdir)
-        remotedata.add_link_from(calculation, label='remote_folder', link_type=LinkType.CREATE)
-        remotedata.store()
+    scheduler = computer.get_scheduler()
+    scheduler.set_transport(transport)
 
-        job_id = s.submit_from_script(transport.getcwd(), script_filename)
-        calculation._set_job_id(job_id)
+    job_id = scheduler.submit_from_script(transport.getcwd(), script_filename)
+    calculation._set_job_id(job_id)
 
 
 def update_calculation(calculation, transport):

--- a/aiida/orm/implementation/general/calculation/job/__init__.py
+++ b/aiida/orm/implementation/general/calculation/job/__init__.py
@@ -250,11 +250,11 @@ class AbstractJobCalculation(AbstractCalculation):
         :param folder_path: the path to the folder from which the content
                should be taken
         """
-        # This function can be called only if the state is SUBMITTING
-        if self.get_state() != calc_states.SUBMITTING:
+        # This function can be called only if the state is TOSUBMIT
+        if self.get_state() != calc_states.TOSUBMIT:
             raise ModificationNotAllowed(
                 "The raw input folder can be stored only if the "
-                "state is SUBMITTING, it is instead {}".format(
+                "state is TOSUBMIT, it is instead {}".format(
                     self.get_state()))
 
         # get subfolder and replace with copy
@@ -735,10 +735,10 @@ class AbstractJobCalculation(AbstractCalculation):
         return self.get_attr('remote_workdir', None)
 
     def _set_retrieve_list(self, retrieve_list):
-        if self.get_state() not in (calc_states.SUBMITTING, calc_states.NEW):
+        if self.get_state() not in (calc_states.TOSUBMIT, calc_states.NEW):
             raise ModificationNotAllowed(
                 "Cannot set the retrieve_list for a calculation that is neither "
-                "NEW nor SUBMITTING (current state is {})".format(self.get_state()))
+                "NEW nor TOSUBMIT (current state is {})".format(self.get_state()))
 
         # accept format of: [ 'remotename',
         #                     ['remotepath','localpath',0] ]
@@ -780,10 +780,10 @@ class AbstractJobCalculation(AbstractCalculation):
         Set the list of paths that are to retrieved for parsing and be deleted as soon
         as the parsing has been completed.
         """
-        if self.get_state() not in (calc_states.SUBMITTING, calc_states.NEW):
+        if self.get_state() not in (calc_states.TOSUBMIT, calc_states.NEW):
             raise ModificationNotAllowed(
                 'Cannot set the retrieve_temporary_list for a calculation that is neither '
-                'NEW nor SUBMITTING (current state is {})'.format(self.get_state()))
+                'NEW nor TOSUBMIT (current state is {})'.format(self.get_state()))
 
         if not (isinstance(retrieve_temporary_list, (tuple, list))):
             raise ValueError('You should pass a list/tuple')
@@ -819,10 +819,10 @@ class AbstractJobCalculation(AbstractCalculation):
         """
         Set the list of information for the retrieval of singlefiles
         """
-        if self.get_state() not in (calc_states.SUBMITTING, calc_states.NEW):
+        if self.get_state() not in (calc_states.TOSUBMIT, calc_states.NEW):
             raise ModificationNotAllowed(
                 "Cannot set the retrieve_singlefile_list for a calculation that is neither "
-                "NEW nor SUBMITTING (current state is {})".format(self.get_state()))
+                "NEW nor TOSUBMIT (current state is {})".format(self.get_state()))
 
         if not isinstance(retrieve_singlefile_list, (tuple, list)):
             raise ValueError("You have to pass a list (or tuple) of lists of "
@@ -1449,8 +1449,7 @@ class AbstractJobCalculation(AbstractCalculation):
           Calculation only in the cache.
 
         :return calcinfo: the CalcInfo object containing the information
-          needed by the daemon to handle operations.
-        :return script_filename: the name of the job scheduler script
+            needed by the daemon to handle operations.
         """
         import os
         import StringIO
@@ -1663,8 +1662,7 @@ class AbstractJobCalculation(AbstractCalculation):
         # TODO: give possibility to use a different name??
         script_filename = '_aiidasubmit.sh'
         script_content = s.get_submit_script(job_tmpl)
-        folder.create_file_from_filelike(
-            StringIO.StringIO(script_content), script_filename)
+        folder.create_file_from_filelike(StringIO.StringIO(script_content), script_filename)
 
         subfolder = folder.get_subfolder('.aiida', create=True)
         subfolder.create_file_from_filelike(

--- a/aiida/transport/plugins/local.py
+++ b/aiida/transport/plugins/local.py
@@ -47,7 +47,7 @@ class LocalTransport(Transport):
     # There is no real limit on how fast you can connect to localhost
     # you should not be banned (as instead it is the case in SSH).
     # So I set the (default) limit to zero.
-    _DEFAULT_SAFE_OPEN_INTERVAL = 0.
+    _DEFAULT_SAFE_OPEN_INTERVAL = 2.
 
     def __init__(self, **kwargs):
         super(LocalTransport, self).__init__()

--- a/aiida/work/job_processes.py
+++ b/aiida/work/job_processes.py
@@ -17,7 +17,7 @@ from tornado.gen import coroutine, Return
 
 import plumpy
 from plumpy.ports import PortNamespace
-from aiida.common.datastructures import calc_states
+from aiida.common.datastructures import calc_states, is_progressive_state_change
 from aiida.common.exceptions import TransportTaskException
 from aiida.common import exceptions
 from aiida.common.lang import override
@@ -42,7 +42,7 @@ logger = logging.getLogger(__name__)
 
 
 @coroutine
-def task_submit_job(node, transport_queue, cancel_flag):
+def task_submit_job(node, transport_queue, calc_info, script_filename, cancel_flag):
     """
     Transport task that will attempt to submit a job calculation
 
@@ -53,6 +53,8 @@ def task_submit_job(node, transport_queue, cancel_flag):
 
     :param node: the node that represents the job calculation
     :param transport_queue: the TransportQueue from which to request a Transport
+    :param calc_info: the calculation info datastructure returned by `JobCalculation._presubmit`
+    :param script_filename: the job launch script returned by `JobCalculation._presubmit`
     :param cancel_flag: the cancelled flag that will be queried to determine whether the task was cancelled
     :raises: Return if the tasks was successfully completed
     :raises: TransportTaskException if after the maximum number of retries the transport task still excepted
@@ -72,8 +74,16 @@ def task_submit_job(node, transport_queue, cancel_flag):
                 raise plumpy.CancelledError('task_submit_job for calculation<{}> cancelled'.format(node.pk))
 
             logger.info('submitting calculation<{}>'.format(node.pk))
-            node._set_state(calc_states.SUBMITTING)
-            raise Return(execmanager.submit_calculation(node, transport))
+            raise Return(execmanager.submit_calculation(node, transport, calc_info, script_filename))
+
+    state_pending = calc_states.SUBMITTING
+    state_failure = calc_states.SUBMISSIONFAILED
+    state_success = calc_states.WITHSCHEDULER
+
+    if is_progressive_state_change(node.get_state(), state_pending):
+        node._set_state(state_pending)
+    else:
+        logger.warning('ignored invalid proposed state change: {} to {}'.format(node.get_state(), state_pending))
 
     try:
         result = yield exponential_backoff_retry(
@@ -82,11 +92,11 @@ def task_submit_job(node, transport_queue, cancel_flag):
         pass
     except Exception:
         logger.warning('submitting calculation<{}> failed:\n{}'.format(node.pk, traceback.format_exc()))
-        node._set_state(calc_states.SUBMISSIONFAILED)
+        node._set_state(state_failure)
         raise TransportTaskException('submit_calculation failed {} times consecutively'.format(max_attempts))
     else:
         logger.info('submitting calculation<{}> successful'.format(node.pk))
-        node._set_state(calc_states.WITHSCHEDULER)
+        node._set_state(state_success)
         raise Return(result)
 
 
@@ -123,6 +133,9 @@ def task_update_job(node, transport_queue, cancel_flag):
             logger.info('updating calculation<{}>'.format(node.pk))
             raise Return(execmanager.update_calculation(node, transport))
 
+    state_failure = calc_states.FAILED
+    state_success = calc_states.COMPUTED
+
     try:
         result = yield exponential_backoff_retry(
             do_update, initial_interval, max_attempts, logger=node.logger, ignore_exceptions=plumpy.CancelledError)
@@ -130,12 +143,12 @@ def task_update_job(node, transport_queue, cancel_flag):
         pass
     except Exception:
         logger.warning('updating calculation<{}> failed:\n{}'.format(node.pk, traceback.format_exc()))
-        node._set_state(calc_states.FAILED)
+        node._set_state(state_failure)
         raise TransportTaskException('update_calculation failed {} times consecutively'.format(max_attempts))
     else:
         logger.info('updating calculation<{}> successful'.format(node.pk))
         if result:
-            node._set_state(calc_states.COMPUTED)
+            node._set_state(state_success)
         raise Return(result)
 
 
@@ -170,9 +183,15 @@ def task_retrieve_job(node, transport_queue, retrieved_temporary_folder, cancel_
                 raise plumpy.CancelledError('task_retrieve_job for calculation<{}> cancelled'.format(node.pk))
 
             logger.info('retrieving calculation<{}>'.format(node.pk))
-            node._set_state(calc_states.RETRIEVING)
-
             raise Return(execmanager.retrieve_calculation(node, transport, retrieved_temporary_folder))
+
+    state_pending = calc_states.RETRIEVING
+    state_failure = calc_states.RETRIEVALFAILED
+
+    if is_progressive_state_change(node.get_state(), state_pending):
+        node._set_state(state_pending)
+    else:
+        logger.warning('ignored invalid proposed state change: {} to {}'.format(node.get_state(), state_pending))
 
     try:
         result = yield exponential_backoff_retry(
@@ -181,7 +200,7 @@ def task_retrieve_job(node, transport_queue, retrieved_temporary_folder, cancel_
         pass
     except Exception:
         logger.warning('retrieving calculation<{}> failed:\n{}'.format(node.pk, traceback.format_exc()))
-        node._set_state(calc_states.RETRIEVALFAILED)
+        node._set_state(state_failure)
         raise TransportTaskException('retrieve_calculation failed {} times consecutively'.format(max_attempts))
     else:
         logger.info('retrieving calculation<{}> successful'.format(node.pk))
@@ -207,8 +226,7 @@ def task_kill_job(node, transport_queue, cancel_flag):
     initial_interval = 1
     max_attempts = 5
 
-    if node.get_state() in [calc_states.NEW, calc_states.TOSUBMIT]:
-        node._set_state(calc_states.FAILED)
+    if node.get_state() in [calc_states.NEW, calc_states.TOSUBMIT, calc_states.SUBMITTING]:
         logger.warning('calculation<{}> killed, it was in the {} state'.format(node.pk, node.get_state()))
         raise Return(True)
 
@@ -224,7 +242,6 @@ def task_kill_job(node, transport_queue, cancel_flag):
                 raise plumpy.CancelledError('task_kill_job for calculation<{}> cancelled'.format(node.pk))
 
             logger.info('killing calculation<{}>'.format(node.pk))
-
             raise Return(execmanager.kill_calculation(node, transport))
 
     try:
@@ -259,47 +276,32 @@ class Waiting(plumpy.Waiting):
         calculation = self.process.calc
         transport_queue = self.process.runner.transport
 
-        calculation._set_process_status('Waiting for transport task: {}'.format(self.data))
+        if isinstance(self.data, tuple):
+            command = self.data[0]
+            args = self.data[1:]
+        else:
+            command = self.data
+
+        calculation._set_process_status('Waiting for transport task: {}'.format(command))
 
         try:
 
-            if self.data == SUBMIT_COMMAND:
-
-                try:
-                    transport_task = functools.partial(task_submit_job, calculation, transport_queue)
-                    self._task = interruptable_task(transport_task)
-                    yield self._task
-                finally:
-                    self._task = None
-
+            if command == SUBMIT_COMMAND:
+                yield self._launch_task(task_submit_job, calculation, transport_queue, *args)
                 raise Return(self.scheduler_update())
 
             elif self.data == UPDATE_SCHEDULER_COMMAND:
-
                 job_done = False
 
                 while not job_done:
-                    try:
-                        transport_task = functools.partial(task_update_job, calculation, transport_queue)
-                        self._task = interruptable_task(transport_task)
-                        job_done = yield self._task
-                    finally:
-                        self._task = None
+                    job_done = yield self._launch_task(task_update_job, calculation, transport_queue)
 
                 raise Return(self.retrieve())
 
             elif self.data == RETRIEVE_COMMAND:
-
                 # Create a temporary folder that has to be deleted by JobProcess.retrieved after successful parsing
                 temp_folder = tempfile.mkdtemp()
-
-                try:
-                    transport_task = functools.partial(task_retrieve_job, calculation, transport_queue, temp_folder)
-                    self._task = interruptable_task(transport_task)
-                    yield self._task
-                finally:
-                    self._task = None
-
+                yield self._launch_task(task_retrieve_job, calculation, transport_queue, temp_folder)
                 raise Return(self.retrieved(temp_folder))
 
             else:
@@ -316,6 +318,24 @@ class Waiting(plumpy.Waiting):
             raise Return(excepted_state)
         finally:
             calculation._set_process_status(None)
+            raise
+        except (plumpy.Interruption, plumpy.CancelledError):
+            calculation._set_process_status('Transport task {} was interrupted'.format(command))
+            raise
+        finally:
+            # If we were trying to kill but we didn't deal with it, make sure it's set here
+            if self._killing and not self._killing.done():
+                self._killing.set_result(False)
+
+    @coroutine
+    def _launch_task(self, coro, *args, **kwargs):
+        task_fn = functools.partial(coro, *args, **kwargs)
+        try:
+            self._task = interruptable_task(task_fn)
+            result = yield self._task
+            raise Return(result)
+        finally:
+            self._task = None
 
     def scheduler_update(self):
         """
@@ -543,20 +563,37 @@ class JobProcess(processes.Process):
         Run the calculation, we put it in the TOSUBMIT state and then wait for it
         to be copied over, submitted, retrieved, etc.
         """
-        calc_state = self.calc.get_state()
+        from aiida.orm import Code, load_node
+        from aiida.common.folders import SandboxFolder
+        from aiida.common.exceptions import InputValidationError
 
-        if calc_state == calc_states.FINISHED:
+        if self.calc.is_terminated:
             return 0
-        elif calc_state != calc_states.NEW:
-            raise exceptions.InvalidOperation(
-                'Cannot submit a calculation not in {} state (the current state is {})'.format(
-                    calc_states.NEW, calc_state
-                ))
 
-        self.calc._set_state(calc_states.TOSUBMIT)
+        state_current = self.calc.get_state()
+        state_pending = calc_states.TOSUBMIT
+
+        if is_progressive_state_change(state_current, state_pending):
+            self.calc._set_state(state_pending)
+        else:
+            logger.warning('ignored invalid proposed state change: {} to {}'.format(state_current, state_pending))
+
+        with SandboxFolder() as folder:
+            computer = self.calc.get_computer()
+            calc_info, script_filename = self.calc._presubmit(folder, use_unstored_links=False)
+            input_codes = [load_node(_.code_uuid, sub_class=Code) for _ in calc_info.codes_info]
+
+            for code in input_codes:
+                if not code.can_run_on(computer):
+                    raise InputValidationError(
+                        'The selected code {} for calculation {} cannot run on computer {}'.format(
+                            code.pk, self.calc.pk, computer.name))
+
+            # After this call, no modifications to the folder should be done
+            self.calc._store_raw_input_folder(folder.abspath)
 
         # Launch the submit operation
-        return plumpy.Wait(msg='Waiting to submit', data=SUBMIT_COMMAND)
+        return plumpy.Wait(msg='Waiting to submit', data=(SUBMIT_COMMAND, calc_info, script_filename))
 
     def retrieved(self, retrieved_temporary_folder=None):
         """

--- a/docs/requirements_for_rtd.txt
+++ b/docs/requirements_for_rtd.txt
@@ -45,7 +45,7 @@ passlib==1.7.1
 pathlib2
 pgtest==1.1.0
 pika==0.11.2
-plumpy==0.10.4
+plumpy==0.10.5
 psutil==5.4.5
 pymatgen==2018.4.20
 pyparsing==2.2.0

--- a/setup_requirements.py
+++ b/setup_requirements.py
@@ -43,7 +43,7 @@ install_requires = [
     'ecdsa==0.13',
     'pika==0.11.2',
     'ipython<6.0',  # Version of ipython non enforced, because some still prefer version 4 rather than the latest
-    'plumpy==0.10.4',
+    'plumpy==0.10.5',
     'circus==0.14.0',
     'tornado==4.5.3',  # As of 2018/03/06 Tornado released v5.0 which breaks circus 0.14.0
 ]


### PR DESCRIPTION
Fixes #1698 

This pull request implements various smaller fixes and refactors to guarantee that
the legacy calculation state of a `JobCalculation` will always be congruent with the
leading process state. The `execmanager.submit_calculation` is refactored to place
the creation of the raw input folder and set the relevant attributes in the `run` method
of the `Process`, such that `submit_calculation` transport tasks is solely responsible
for transport related operations, as much as possible. The `kill_calculation` transport
task was made more robust by not excepting if a job no longer existed causing the
actual `scheduler.kill` operation to fail, despite the desired result having been achieved.