### PR TITLE
Correcting command line option for 'verdi data ... deposit'

### DIFF
--- a/aiida/cmdline/commands/cmd_data/cmd_deposit.py
+++ b/aiida/cmdline/commands/cmd_data/cmd_deposit.py
@@ -39,7 +39,7 @@ DEPOSIT_OPTIONS = [
         default=None,
         help="Label of the code to be used for the deposition."
         " Default: cif_cod_deposit."),
-    click.option('--computer', type=click.STRING, default=None, help="Name of the computer to be used for deposition."),
+    click.option('--computer', 'computer_name', type=click.STRING, default=None, help="Name of the computer to be used for deposition."),
     click.option(
         '--replace', type=click.INT, default=None, help="ID of the structure to be redeposited (replaced), if any."),
     click.option(


### PR DESCRIPTION
Value of ``--computer`` has to be stored to key ``computer_name`` in order to be passed correctly to ``deposit()``.