### PR TITLE
Correcting command line option 'code' for 'verdi data ... deposit'

### DIFF
--- a/aiida/cmdline/commands/cmd_data/cmd_deposit.py
+++ b/aiida/cmdline/commands/cmd_data/cmd_deposit.py
@@ -35,6 +35,7 @@ DEPOSIT_OPTIONS = [
     click.option('--url', type=click.STRING, default=None, help="URL of the deposition API."),
     click.option(
         '--code',
+        'code_label',
         type=click.STRING,
         default=None,
         help="Label of the code to be used for the deposition."


### PR DESCRIPTION
Value of ``--code`` has to be stored to key ``code_label`` in order to be passed correctly to ``deposit()``.