### PR TITLE
differentiate quicksetup based on project folder

### DIFF
--- a/aiida/cmdline/commands/cmd_quicksetup.py
+++ b/aiida/cmdline/commands/cmd_quicksetup.py
@@ -11,6 +11,7 @@
 """`verdi quicksetup` command."""
 import os
 import sys
+import hashlib
 
 import click
 
@@ -68,11 +69,12 @@ def quicksetup(profile_name, only_config, set_default, non_interactive, backend,
     # be named test_...
     import getpass
     osuser = getpass.getuser()
-    dbname = db_name or profile_name + '_' + osuser
+    aiida_base_dir_hash = hashlib.md5(AIIDA_CONFIG_FOLDER).hexdigest()
+    dbname = db_name or profile_name + '_' + osuser + '_' + aiida_base_dir_hash
 
     # default database user name is aiida_qs_<login-name>
     # default password is random
-    dbuser = db_username or 'aiida_qs_' + osuser
+    dbuser = db_username or 'aiida_qs_' + osuser + '_' + aiida_base_dir_hash
     from aiida.common.setup import generate_random_secret_key
     dbpass = db_password or generate_random_secret_key()
 


### PR DESCRIPTION
## Problem:
When using quicksetup with a custom location for the .aiida/ config folder, it might try to create and use an existing dbuser with a new password, causing naive use of quicksetup to fail.

## Solution:
Add a uuid of the current `AIIDA_PATH` folder to the db user and db name during quicksetup.