### PR TITLE
Persist `paused` future of `Process` to maintain it after loading

### DIFF
--- a/docs/requirements_for_rtd.txt
+++ b/docs/requirements_for_rtd.txt
@@ -45,7 +45,7 @@ passlib==1.7.1
 pathlib2
 pgtest==1.1.0
 pika==0.11.2
-plumpy==0.10.5
+plumpy==0.10.6
 psutil==5.4.5
 pymatgen==2018.4.20
 pyparsing==2.2.0

--- a/setup_requirements.py
+++ b/setup_requirements.py
@@ -43,7 +43,7 @@ install_requires = [
     'ecdsa==0.13',
     'pika==0.11.2',
     'ipython<6.0',  # Version of ipython non enforced, because some still prefer version 4 rather than the latest
-    'plumpy==0.10.5',
+    'plumpy==0.10.6',
     'circus==0.14.0',
     'tornado==4.5.3',  # As of 2018/03/06 Tornado released v5.0 which breaks circus 0.14.0
 ]


### PR DESCRIPTION
Fixes #1889 

If a process is paused, indicated by the `_paused` attribute being
set to a future, it should remain paused when that process is recreated
from a saved checkpoint. To achieve this, we turn the `_paused` future
into a persistable future and make sure that it is persisted for the
`Process` class.