### PR TITLE
Pause `JobProcess` when transport task falls through exponential backoff

### DIFF
--- a/aiida/work/utils.py
+++ b/aiida/work/utils.py
@@ -11,7 +11,6 @@
 """Utilities for the workflow engine."""
 import contextlib
 import logging
-import traceback
 import tornado.ioloop
 from tornado.concurrent import Future
 from tornado.gen import coroutine, sleep, Return
@@ -134,8 +133,8 @@ def exponential_backoff_retry(fct, initial_interval=10.0, max_attempts=5, logger
                 logger.warning('maximum attempts %d of calling %s, exceeded', max_attempts, coro.__name__)
                 raise
             else:
-                logger.warning('iteration %d of %s excepted, retrying after %d seconds\n%s', iteration + 1,
-                               coro.__name__, interval, traceback.format_exc())
+                logger.warning('iteration %d of %s excepted, retrying after %d seconds', iteration + 1, coro.__name__,
+                               interval)
                 yield sleep(interval)
                 interval *= 2
 


### PR DESCRIPTION
Fixes #1835 

All transport tasks for the `JobProcess` are wrapped in the exponential
backoff retry coroutine utility, which when an exception occurs during
the transport task, will reschedule the task with an exponential backoff.
However, the backoff has a maximum number of retries, which when hit would
bubble up the exception and causing the process to except. With the new
pausing functionality in place, instead we can catch the
`TransportTaskException` and pause the process. The user then has the chance
to investigate the logs to determine the problem. If the problem was just
of a temporary nature, the user can then resume the process. If instead
the failure was of unrecoverable nature, the user can always decide to kill
the process.