### PR TITLE
setup: bump version of Django to 1.8.19 for py3 support

### DIFF
--- a/aiida/backends/djsite/db/migrations/0013_django_1_8.py
+++ b/aiida/backends/djsite/db/migrations/0013_django_1_8.py
@@ -1,0 +1,39 @@
+# -*- coding: utf-8 -*-
+###########################################################################
+# Copyright (c), The AiiDA team. All rights reserved.                     #
+# This file is part of the AiiDA code.                                    #
+#                                                                         #
+# The code is hosted on GitHub at https://github.com/aiidateam/aiida_core #
+# For further information on the license, see the LICENSE.txt file        #
+# For further information please visit http://www.aiida.net               #
+###########################################################################
+from __future__ import unicode_literals
+
+from __future__ import absolute_import
+from django.db import models, migrations
+from aiida.backends.djsite.db.migrations import update_schema_version
+
+
+SCHEMA_VERSION = "1.0.13"
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('db', '0012_drop_dblock'),
+    ]
+
+    # An amalgamation from django:django/contrib/auth/migrations/
+    # these changes are already the default for SQLA at this point
+    operations = [
+        migrations.AlterField(
+            model_name='dbuser',
+            name='last_login',
+            field=models.DateTimeField(null=True, verbose_name='last login', blank=True),
+        ),
+        migrations.AlterField(
+            model_name='dbuser',
+            name='email',
+            field=models.EmailField(max_length=254, verbose_name='email address', blank=True),
+        ),
+        update_schema_version(SCHEMA_VERSION)
+    ]

--- a/aiida/backends/djsite/db/migrations/__init__.py
+++ b/aiida/backends/djsite/db/migrations/__init__.py
@@ -9,7 +9,7 @@
 ###########################################################################
 
 
-LATEST_MIGRATION = '0012_drop_dblock'
+LATEST_MIGRATION = '0013_django_1_8'
 
 
 def _update_schema_version(version, apps, schema_editor):

--- a/docs/requirements_for_rtd.txt
+++ b/docs/requirements_for_rtd.txt
@@ -26,7 +26,7 @@ click==6.7
 codecov==2.0.15
 coverage==4.5.1
 django-extensions==1.5.0
-django==1.7.11
+django==1.8.19
 docutils==0.14
 ecdsa==0.13
 enum34==1.1.6

--- a/setup_requirements.py
+++ b/setup_requirements.py
@@ -12,7 +12,7 @@ install_requires = [
     'reentry==1.2.0',
     'python-dateutil==2.7.2',
     'python-mimeparse==1.6.0',
-    'django==1.7.11',  # Upgrade to Django 1.9 does prevent AiiDA functioning
+    'django==1.8.19',
     'django-extensions==1.5.0',
     'tzlocal==1.5.1',
     'pytz==2018.4',


### PR DESCRIPTION
include a migration to drop the 'not null' constraint on
`auth_user.last_login` and increase the field length for the email as
documented in the release notes.
Both changes are already set for SQLA.