### PR TITLE
Fix inline function build_kind_name of StructureData.set_pymatgen_structure

### DIFF
--- a/aiida/orm/data/structure.py
+++ b/aiida/orm/data/structure.py
@@ -888,7 +888,7 @@ class StructureData(Data):
             species = species_and_occu.keys()
             occupations = species_and_occu.values()
 
-            has_spin = any([specie.as_dict().get('properties', {}).get('spin', 0) != 0 for specie in species])
+            has_spin = any(specie.as_dict().get('properties', {}).get('spin', 0) != 0 for specie in species)
             has_partial_occupancies = (len(occupations) != 1 or occupations[0] != 1.0)
 
             if has_partial_occupancies and has_spin:


### PR DESCRIPTION
Fixes #1916 

The inline function `build_kind_name` used in the `set_pymatgen_structure`
method of the `StructureData` class is tasked with constructing a kind name
given a pymatgen object with the species and their weights, in the case that
any of the sites in the pymatgen structure did not already have a kind name.
The original implementation was using list comprehension variables outside
of its scope, which is not allowed in python3 and most likely indicated a
broken implementation. The documentation also mentioned that in the case of
no spin, it would simply return the specie, but in fact it returned None in
that case and on top of that, the documentation then fails to consider cases
with more than one specie.

The solution here is to first check if the kind is both composite and is
tagged as having spin, which is not supported and so it raises.

For the spin case, the returned value is then simply the specie name with
a digit appended to indicate the spin channel.

For a composite species, the kind name is built by concatenating the species
with their respective weights into a single string.

Note that as a result of this change, some pymatgen roundtrip tests had to be
adapted in their expectation value, but hopefully this was justified given
that the original expected values were wrong due to the flawed implementation
of build kind name.