### PR TITLE
Fix #1913 Added minimum scheduler poll interval

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -220,7 +220,6 @@
         aiida/orm/calculation/job/simpleplugins/templatereplacer.py|
         aiida/orm/calculation/work.py|
         aiida/orm/code.py|
-        aiida/orm/computer.py|
         aiida/orm/data/array/bands.py|
         aiida/orm/data/array/__init__.py|
         aiida/orm/data/array/kpoints.py|

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -458,7 +458,11 @@
   sha: a234ce4e185cf77a55632888f1811d83b4ad9ef2
   hooks:
   - id: python-modernize
-    exclude: ^docs/
+    exclude: >
+      (?x)^(
+        docs/.*|
+        aiida/work/utils.py  # exclude because tornado WaitIterator.next() does not work with next(...)
+      )$
     args:
       - --write
       - --nobackups

--- a/aiida/backends/tests/work/test_utils.py
+++ b/aiida/backends/tests/work/test_utils.py
@@ -10,10 +10,12 @@
 from __future__ import division
 from __future__ import absolute_import
 from __future__ import print_function
+import unittest
 from tornado.ioloop import IOLoop
 from tornado.gen import coroutine
 
 from aiida.backends.testbase import AiidaTestCase
+import aiida.work as work
 from aiida.work.utils import exponential_backoff_retry
 
 ITERATION = 0
@@ -68,3 +70,65 @@ class TestExponentialBackoffRetry(AiidaTestCase):
             except Exception as e:
                 print(e)
                 raise
+
+
+class RefObjectsStore(unittest.TestCase):
+    def test_simple(self):
+        """ Test the reference counting works """
+        IDENTIFIER = 'a'
+        OBJECT = 'my string'
+        obj_store = work.utils.RefObjectStore()
+
+        with obj_store.get(IDENTIFIER, lambda: OBJECT) as obj:
+            # Make sure we got back the same object
+            self.assertIs(OBJECT, obj)
+
+            # Now check that the reference has the correct information
+            ref = obj_store._objects['a']
+            self.assertEqual(OBJECT, ref._obj)
+            self.assertEqual(1, ref.count)
+
+            # Now request the object again
+            with obj_store.get(IDENTIFIER) as obj2:
+                # ...and check the reference has had it's count upped
+                self.assertEqual(OBJECT, obj2)
+                self.assertEqual(2, ref.count)
+
+            # Now it should have been reduced
+            self.assertEqual(1, ref.count)
+
+        # Finally the store should be empty  (there are no more references)
+        self.assertEqual(0, len(obj_store._objects))
+
+    def test_get_no_constructor(self):
+        """
+        Test that trying to get an object that does exists and providing
+        no means to construct it fails
+        """
+        obj_store = work.utils.RefObjectStore()
+        with self.assertRaises(ValueError):
+            with obj_store.get('a'):
+                pass
+
+    def test_construct(self):
+        """ Test that construction only gets called when used """
+        IDENTIFIER = 'a'
+        OBJECT = 'my string'
+
+        # Use a list for a  single number so we can get references to it
+        times_constructed = [0, ]
+
+        def construct():
+            times_constructed[0] += 1
+            return OBJECT
+
+        obj_store = work.utils.RefObjectStore()
+        with obj_store.get(IDENTIFIER, construct):
+            self.assertEqual(1, times_constructed[0])
+            with obj_store.get(IDENTIFIER, construct):
+                self.assertEqual(1, times_constructed[0])
+
+        # Now the object should be removed and so another call to get
+        # should create
+        with obj_store.get(IDENTIFIER, construct):
+            self.assertEqual(2, times_constructed[0])

--- a/aiida/daemon/execmanager.py
+++ b/aiida/daemon/execmanager.py
@@ -238,49 +238,6 @@ def submit_calculation(calculation, transport, calc_info, script_filename):
     calculation._set_job_id(job_id)
 
 
-def update_calculation(calculation, transport):
-    """
-    Update the scheduler state of a calculation
-
-    :param calculation: the instance of JobCalculation to update.
-    :param transport: an already opened transport to use to query the scheduler
-    """
-    scheduler = calculation.get_computer().get_scheduler()
-    scheduler.set_transport(transport)
-
-    job_id = calculation.get_job_id()
-
-    kwargs = {'as_dict': True}
-
-    if scheduler.get_feature('can_query_by_user'):
-        kwargs['user'] = "$USER"
-    else:
-        # In general schedulers can either query by user or by jobs, but not both
-        # (see also docs of the Scheduler class)
-        kwargs['jobs'] = [job_id]
-
-    found_jobs = scheduler.getJobs(**kwargs)
-    job_info = found_jobs.get(job_id, None)
-
-    if job_info is None:
-        # If the job is computed or not found assume it's done
-        job_done = True
-        calculation._set_scheduler_state(JOB_STATES.DONE)
-    else:
-        job_done = job_info.job_state == JOB_STATES.DONE
-        update_job_calc_from_job_info(calculation, job_info)
-
-    if job_done:
-        try:
-            detailed_job_info = scheduler.get_detailed_jobinfo(job_id)
-        except exceptions.FeatureNotAvailable:
-            detailed_job_info = ('This scheduler does not implement get_detailed_jobinfo')
-
-        update_job_calc_from_detailed_job_info(calculation, detailed_job_info)
-
-    return job_done
-
-
 def retrieve_calculation(calculation, transport, retrieved_temporary_folder):
     """
     Retrieve all the files of a completed job calculation using the given transport.
@@ -374,43 +331,6 @@ def kill_calculation(calculation, transport):
     return True
 
 
-def update_job_calc_from_job_info(calc, job_info):
-    """
-    Updates the job info for a JobCalculation using job information
-    as obtained from the scheduler.
-
-    :param calc: The job calculation
-    :param job_info: the information returned by the scheduler for this job
-    :return: True if the job state is DONE, False otherwise
-    :rtype: bool
-    """
-    calc._set_scheduler_state(job_info.job_state)
-    calc._set_last_jobinfo(job_info)
-
-    return job_info.job_state in JOB_STATES.DONE
-
-
-def update_job_calc_from_detailed_job_info(calc, detailed_job_info):
-    """
-    Updates the detailed job info for a JobCalculation as obtained from
-    the scheduler
-
-    :param calc: The job calculation
-    :param detailed_job_info: the detailed information as returned by the
-        scheduler for this job
-    """
-    from aiida.scheduler.datastructures import JobInfo
-
-    last_jobinfo = calc._get_last_jobinfo()
-    if last_jobinfo is None:
-        last_jobinfo = JobInfo()
-        last_jobinfo.job_id = calc.get_job_id()
-        last_jobinfo.job_state = JOB_STATES.DONE
-
-    last_jobinfo.detailedJobinfo = detailed_job_info
-    calc._set_last_jobinfo(last_jobinfo)
-
-
 def parse_results(job, retrieved_temporary_folder=None):
     """
     Parse the results for a given JobCalculation (job)
@@ -436,11 +356,11 @@ def parse_results(job, retrieved_temporary_folder=None):
                 files.append("- [F] {}".format(os.path.join(root, filename)))
 
         execlogger.debug("[parsing of calc {}] "
-            "Content of the retrieved_temporary_folder: \n"
-            "{}".format(job.pk, "\n".join(files)), extra=logger_extra)
+                         "Content of the retrieved_temporary_folder: \n"
+                         "{}".format(job.pk, "\n".join(files)), extra=logger_extra)
     else:
         execlogger.debug("[parsing of calc {}] "
-            "No retrieved_temporary_folder.".format(job.pk), extra=logger_extra)
+                         "No retrieved_temporary_folder.".format(job.pk), extra=logger_extra)
 
     if Parser is not None:
 
@@ -461,7 +381,7 @@ def parse_results(job, retrieved_temporary_folder=None):
             pass
         else:
             raise ValueError("parse_from_calc returned an 'exit_code' of invalid_type: {}. It should "
-                "return a boolean, integer or ExitCode instance".format(type(exit_code)))
+                             "return a boolean, integer or ExitCode instance".format(type(exit_code)))
 
         for label, n in new_nodes_tuple:
             n.add_link_from(job, label=label, link_type=LinkType.CREATE)
@@ -571,5 +491,6 @@ def retrieve_files_from_list(calculation, transport, folder, retrieve_list):
                 local_names = [os.path.split(item)[1]]
 
         for rem, loc in zip(remote_names, local_names):
-            transport.logger.debug("[retrieval of calc {}] Trying to retrieve remote item '{}'".format(calculation.pk, rem))
+            transport.logger.debug(
+                "[retrieval of calc {}] Trying to retrieve remote item '{}'".format(calculation.pk, rem))
             transport.get(rem, os.path.join(folder, loc), ignore_nonexisting=True)

--- a/aiida/orm/authinfo.py
+++ b/aiida/orm/authinfo.py
@@ -61,10 +61,12 @@ class AuthInfoCollection(Collection):
 @six.add_metaclass(abc.ABCMeta)
 class AuthInfo(CollectionEntry):
     """
-    Base class to map a DbAuthInfo, that contains computer configuration
-    specific to a given user (authorization info and other metadata, like
-    how often to check on a given computer etc.)
+    Store the settings of a particular user on a given computer.
+    (e.g. authorization info and other metadata, like how often to check on a
+    given computer etc.)
     """
+
+    METADATA_WORKDIR = 'workdir'
 
     def pk(self):
         """
@@ -84,7 +86,7 @@ class AuthInfo(CollectionEntry):
         """
         Is the computer enabled for this user?
 
-        :return: Boolean
+        :rtype: bool
         """
         pass
 
@@ -99,10 +101,22 @@ class AuthInfo(CollectionEntry):
 
     @abc.abstractproperty
     def computer(self):
+        """
+        The computer that this authinfo relates to
+
+        :return: The corresponding computer
+        :rtype: :class:`aiida.orm.Computer`
+        """
         pass
 
     @abc.abstractproperty
     def user(self):
+        """
+        The user that this authinfo relates to
+
+        :return: The corresponding user
+        :rtype: :class:`aiida.orm.User`
+        """
         pass
 
     @abc.abstractproperty
@@ -111,6 +125,7 @@ class AuthInfo(CollectionEntry):
         Is it already stored or not?
 
         :return: Boolean
+        :rtype: bool
         """
         pass
 
@@ -133,7 +148,7 @@ class AuthInfo(CollectionEntry):
         pass
 
     @abc.abstractmethod
-    def get_metadata(self):
+    def _get_metadata(self):
         """
         Get the metadata dictionary
 
@@ -142,11 +157,22 @@ class AuthInfo(CollectionEntry):
         pass
 
     @abc.abstractmethod
-    def set_metadata(self, metadata):
+    def _set_metadata(self, metadata):
         """
         Replace the metadata dictionary in the DB with the provided dictionary
         """
         pass
+
+    def _get_property(self, name):
+        try:
+            return self._get_metadata()[name]
+        except KeyError:
+            raise ValueError('Unknown property: {}'.format(name))
+
+    def _set_property(self, name, value):
+        metadata = self._get_metadata()
+        metadata[name] = value
+        self._set_metadata(metadata)
 
     def get_workdir(self):
         """
@@ -154,11 +180,9 @@ class AuthInfo(CollectionEntry):
 
         :return: a string
         """
-        metadata = self.get_metadata()
-
         try:
-            return metadata['workdir']
-        except KeyError:
+            return self._get_property(self.METADATA_WORKDIR)
+        except ValueError:
             return self.computer.get_workdir()
 
     def __str__(self):

--- a/aiida/orm/backend.py
+++ b/aiida/orm/backend.py
@@ -10,6 +10,7 @@
 from __future__ import division
 from __future__ import print_function
 from __future__ import absolute_import
+import abc
 from abc import abstractproperty, ABCMeta
 import six
 
@@ -46,11 +47,11 @@ def construct_backend(backend_type=None):
         raise ValueError("The specified backend {} is currently not implemented".format(backend_type))
 
 
-@six.add_metaclass(ABCMeta)
+@six.add_metaclass(abc.ABCMeta)
 class Backend(object):
     """The public interface that defines a backend factory that creates backend specific concrete objects."""
 
-    @abstractproperty
+    @abc.abstractproperty
     def logs(self):
         """
         Return the collection of log entries
@@ -59,7 +60,7 @@ class Backend(object):
         :rtype: :class:`aiida.orm.log.Log`
         """
 
-    @abstractproperty
+    @abc.abstractproperty
     def users(self):
         """
         Return the collection of users
@@ -68,7 +69,7 @@ class Backend(object):
         :rtype: :class:`aiida.orm.user.UserCollection`
         """
 
-    @abstractproperty
+    @abc.abstractproperty
     def authinfos(self):
         """
         Return the collection of authorisation information objects
@@ -77,7 +78,7 @@ class Backend(object):
         :rtype: :class:`aiida.orm.authinfo.AuthInfoCollection`
         """
 
-    @abstractproperty
+    @abc.abstractproperty
     def computers(self):
         """
         Return the collection of computer objects
@@ -86,13 +87,20 @@ class Backend(object):
         :rtype: :class:`aiida.orm.computer.ComputerCollection`
         """
 
-    @abstractproperty
+    @abc.abstractproperty
     def query_manager(self):
         """
         Return the query manager for the objects stored in the backend
 
-        :return: The query manger
+        :return: the query manger
         :rtype: :class:`aiida.backends.general.abstractqueries.AbstractQueryManager`
+        """
+
+    @abc.abstractmethod
+    def query_builder(self):
+        """
+        Construct a new instance of a QueryBuilder for this backend
+        :return: the new query builder
         """
 
 

--- a/aiida/orm/computer.py
+++ b/aiida/orm/computer.py
@@ -7,9 +7,11 @@
 # For further information on the license, see the LICENSE.txt file        #
 # For further information please visit http://www.aiida.net               #
 ###########################################################################
+"""The computer backend abstract classes"""
 from __future__ import division
 from __future__ import print_function
 from __future__ import absolute_import
+
 import abc
 import logging
 import os
@@ -27,8 +29,15 @@ class ComputerCollection(Collection):
     """The collection of Computer entries."""
 
     @abc.abstractmethod
-    def create(self, name, hostname, description='', transport_type='', scheduler_type='', workdir=None,
+    def create(self,
+               name,
+               hostname,
+               description='',
+               transport_type='',
+               scheduler_type='',
+               workdir=None,
                enabled_state=True):
+        # pylint: disable=too-many-arguments
         """
         Create new a computer
 
@@ -37,7 +46,7 @@ class ComputerCollection(Collection):
         """
         pass
 
-    def get(self, id=None, name=None, uuid=None):
+    def get(self, id=None, name=None, uuid=None):  # pylint: disable=redefined-builtin, invalid-name
         """
         Get a computer from one of it's unique identifiers
 
@@ -48,9 +57,7 @@ class ComputerCollection(Collection):
         :return: the corresponding computer
         :rtype: :class:`aiida.orm.Computer`
         """
-        from .querybuilder import QueryBuilder
-
-        qb = self.backend.query_builder()
+        query = self.backend.query_builder()
         filters = {}
         if id is not None:
             filters['id'] = {'==': id}
@@ -59,8 +66,8 @@ class ComputerCollection(Collection):
         if uuid is not None:
             filters['uuid'] = {'==': uuid}
 
-        qb.append(Computer, filters=filters)
-        res = [_[0] for _ in qb.all()]
+        query.append(Computer, filters=filters)
+        res = [_[0] for _ in query.all()]
         if not res:
             raise exceptions.NotExistent("No computer with filter '{}' found".format(filters))
         if len(res) > 1:
@@ -76,7 +83,7 @@ class ComputerCollection(Collection):
         pass
 
     @abc.abstractmethod
-    def delete(self, id):
+    def delete(self, id):  # pylint: disable=invalid-name, redefined-builtin
         """ Delete the computer with the given id """
         pass
 
@@ -96,10 +103,12 @@ class Computer(CollectionEntry):
 
     In the plugin, also set the _plugin_type_string, to be set in the DB in the 'type' field.
     """
+    # pylint: disable=too-many-public-methods
+
     _logger = logging.getLogger(__name__)
 
-    PROPERTY_MINIMUM_SCHEDULER_POLL_INTERVAL = 'minimum_scheduler_poll_interval'
-    PROPERTY_MINIMUM_SCHEDULER_POLL_INTERVAL__DEFAULT = 10.
+    PROPERTY_MINIMUM_SCHEDULER_POLL_INTERVAL = 'minimum_scheduler_poll_interval'  # pylint: disable=invalid-name
+    PROPERTY_MINIMUM_SCHEDULER_POLL_INTERVAL__DEFAULT = 10.  # pylint: disable=invalid-name
 
     @staticmethod
     def get_schema():
@@ -159,7 +168,9 @@ class Computer(CollectionEntry):
                         "doc": "Subclass to support the PBSPro scheduler"
                     },
                     "sge": {
-                        "doc": "Support for the Sun Grid Engine scheduler and its variants/forks (Son of Grid Engine, Oracle Grid Engine, ...)"
+                        "doc":
+                        "Support for the Sun Grid Engine scheduler and its variants/forks (Son of Grid Engine, "
+                        "Oracle Grid Engine, ...)"
                     },
                     "slurm": {
                         "doc": "Support for the SLURM scheduler (http://slurm.schedmd.com/)."
@@ -182,10 +193,13 @@ class Computer(CollectionEntry):
                 "type": "str",
                 "valid_choices": {
                     "local": {
-                        "doc": "Support copy and command execution on the same host on which AiiDA is running via direct file copy and execution commands."
+                        "doc":
+                        "Support copy and command execution on the same host on which AiiDA is running via direct file "
+                        "copy and execution commands."
                     },
                     "ssh": {
-                        "doc": "Support connection, command execution and data transfer to remote computers via SSH+SFTP."
+                        "doc":
+                        "Support connection, command execution and data transfer to remote computers via SSH+SFTP."
                     }
                 }
             },
@@ -211,7 +225,7 @@ class Computer(CollectionEntry):
         pass
 
     @abc.abstractproperty
-    def id(self):
+    def id(self):  # pylint: disable=invalid-name
         """
         Return the ID in the DB.
         """
@@ -265,9 +279,8 @@ class Computer(CollectionEntry):
         Validates the hostname.
         """
         if not isinstance(enabled_state, bool):
-            raise exceptions.ValidationError(
-                "Invalid value '{}' for the enabled state, must "
-                "be a boolean".format(str(enabled_state)))
+            raise exceptions.ValidationError("Invalid value '{}' for the enabled state, must "
+                                             "be a boolean".format(str(enabled_state)))
 
     @classmethod
     def _description_validator(cls, description):
@@ -320,8 +333,7 @@ class Computer(CollectionEntry):
         try:
             convertedwd = workdir.format(username="test")
         except KeyError as exc:
-            raise exceptions.ValidationError(
-                "In workdir there is an unknown replacement field {}".format(exc.args[0]))
+            raise exceptions.ValidationError("In workdir there is an unknown replacement field {}".format(exc.args[0]))
         except ValueError as exc:
             raise exceptions.ValidationError("Error in the string: '{}'".format(exc))
 
@@ -333,8 +345,7 @@ class Computer(CollectionEntry):
         Validates the mpirun_command variable. MUST be called after properly
         checking for a valid scheduler.
         """
-        if not isinstance(mpirun_cmd, (tuple, list)) or not (
-                all(isinstance(i, six.string_types) for i in mpirun_cmd)):
+        if not isinstance(mpirun_cmd, (tuple, list)) or not all(isinstance(i, six.string_types) for i in mpirun_cmd):
             raise exceptions.ValidationError("the mpirun_command must be a list of strings")
 
         try:
@@ -349,8 +360,7 @@ class Computer(CollectionEntry):
             for arg in mpirun_cmd:
                 arg.format(**subst)
         except KeyError as exc:
-            raise exceptions.ValidationError(
-                "In workdir there is an unknown replacement field {}".format(exc.args[0]))
+            raise exceptions.ValidationError("In workdir there is an unknown replacement field {}".format(exc.args[0]))
         except ValueError as exc:
             raise exceptions.ValidationError("Error in the string: '{}'".format(exc))
 
@@ -392,11 +402,10 @@ class Computer(CollectionEntry):
             return
 
         if not isinstance(def_cpus_per_machine, six.integer_types) or def_cpus_per_machine <= 0:
-            raise exceptions.ValidationError(
-                "Invalid value for default_mpiprocs_per_machine, "
-                "must be a positive integer, or an empty "
-                "string if you do not want to provide a "
-                "default value.")
+            raise exceptions.ValidationError("Invalid value for default_mpiprocs_per_machine, "
+                                             "must be a positive integer, or an empty "
+                                             "string if you do not want to provide a "
+                                             "default value.")
 
     @abc.abstractmethod
     def copy(self):
@@ -456,32 +465,51 @@ class Computer(CollectionEntry):
         """
         pass
 
-    def _del_property(self, k, raise_exception=True):
+    def _del_property(self, name, raise_exception=True):
+        """
+        Delete a property from this computer
+
+        :param name: the name of the property
+        :param raise_exception: if True raise if the property does not exist, otherwise return None
+        """
         olddata = self._get_metadata()
         try:
-            del olddata[k]
+            del olddata[name]
         except KeyError:
             if raise_exception:
-                raise AttributeError("'{}' property not found".format(k))
+                raise AttributeError("'{}' property not found".format(name))
             else:
                 # Do not reset the metadata, it is not necessary
                 return
         self._set_metadata(olddata)
 
-    def _set_property(self, k, v):
+    def _set_property(self, name, value):
+        """
+        Set a property on this computer
+
+        :param name: the property name
+        :param value: the new value
+        """
         olddata = self._get_metadata()
-        olddata[k] = v
+        olddata[name] = value
         self._set_metadata(olddata)
 
-    def _get_property(self, k, *args):
+    def _get_property(self, name, *args):
+        """
+        Get a property of this computer
+
+        :param name: the property name
+        :param args: additional arguments
+        :return: the property value
+        """
         if len(args) > 1:
             raise TypeError("_get_property expected at most 2 arguments")
         olddata = self._get_metadata()
         try:
-            return olddata[k]
+            return olddata[name]
         except KeyError:
-            if len(args) == 0:
-                raise AttributeError("'{}' property not found".format(k))
+            if not args:
+                raise AttributeError("'{}' property not found".format(name))
             elif len(args) == 1:
                 return args[0]
 
@@ -504,16 +532,14 @@ class Computer(CollectionEntry):
 
         I also provide a sensible default that may be ok in many cases.
         """
-        return self._get_property("mpirun_command",
-                                  ["mpirun", "-np", "{tot_num_mpiprocs}"])
+        return self._get_property("mpirun_command", ["mpirun", "-np", "{tot_num_mpiprocs}"])
 
     def set_mpirun_command(self, val):
         """
         Set the mpirun command. It must be a list of strings (you can use
         string.split() if you have a single, space-separated string).
         """
-        if not isinstance(val, (tuple, list)) or not (
-                all(isinstance(i, six.string_types) for i in val)):
+        if not isinstance(val, (tuple, list)) or not all(isinstance(i, six.string_types) for i in val):
             raise TypeError("the mpirun_command must be a list of strings")
         self._set_property("mpirun_command", val)
 
@@ -557,7 +583,7 @@ class Computer(CollectionEntry):
         """
         self._set_property(self.PROPERTY_MINIMUM_SCHEDULER_POLL_INTERVAL, interval)
 
-    @abstractmethod
+    @abc.abstractmethod
     def get_transport_params(self):
         pass
 
@@ -590,9 +616,8 @@ class Computer(CollectionEntry):
             authinfo = backend.authinfos.get(self, backend.users.get_automatic_user())
         else:
             authinfo = backend.authinfos.get(self, user)
-        transport = authinfo.get_transport()
 
-        return transport
+        return authinfo.get_transport()
 
     @abc.abstractmethod
     def get_workdir(self):
@@ -649,18 +674,41 @@ class Computer(CollectionEntry):
 
     @abc.abstractmethod
     def get_description(self):
+        """
+        Get the description for this computer
+
+        :return: the description
+        :rtype: str
+        """
         pass
 
     @abc.abstractmethod
     def set_description(self, val):
+        """
+        Set the description for this computer
+
+        :param val: the new description
+        :type val: str
+        """
         pass
 
     @abc.abstractmethod
     def get_calculations_on_computer(self):
+        """
+        Get the calculations corresponding to this computer
+
+        :return: a list of calculations on this computer
+        """
         pass
 
     @abc.abstractmethod
     def is_enabled(self):
+        """
+        Is the computer enabled
+
+        :return: True if enabled, False otherwise
+        :rtype: bool
+        """
         pass
 
     def get_authinfo(self, user):
@@ -677,6 +725,12 @@ class Computer(CollectionEntry):
         return self.backend.authinfos.get(computer=self, user=user)
 
     def is_user_configured(self, user):
+        """
+        Check if the user is configured on this computer
+
+        :param user: the user to check
+        :return: True if enabled, False otherwise
+        """
         try:
             self.get_authinfo(user)
             return True
@@ -684,6 +738,12 @@ class Computer(CollectionEntry):
             return False
 
     def is_user_enabled(self, user):
+        """
+        Check if a user is enabled to run on this computer
+
+        :param user: the user to check
+        :return: True if enabled, False otherwise
+        """
         try:
             authinfo = self.get_authinfo(user)
             return authinfo.enabled
@@ -694,25 +754,57 @@ class Computer(CollectionEntry):
 
     @abc.abstractmethod
     def set_enabled_state(self, enabled):
-        pass
+        """
+        Set the enable state for this computer
+
+        :param enabled: True if enabled, False otherwise
+        """
 
     @abc.abstractmethod
     def get_scheduler_type(self):
+        """
+        Get the scheduler type for this computer
+
+        :return: the scheduler ype
+        :rtype: str
+        """
         pass
 
     @abc.abstractmethod
     def set_scheduler_type(self, val):
+        """
+        Set the scheduler type for this computer
+
+        :param val: the new scheduler type
+        :type val: str
+        """
         pass
 
     @abc.abstractmethod
     def get_transport_type(self):
-        pass
+        """
+        Get the transport type for this computer
+
+        :return: the transport type
+        :rtype: str
+        """
 
     @abc.abstractmethod
     def set_transport_type(self, val):
+        """
+        Set the transport type for this computer
+
+        :param val: the new transport type
+        :type val: str
+        """
         pass
 
     def get_transport_class(self):
+        """
+        Get the transport class for this computer.  Can be used to instantiate a transport instance.
+
+        :return: the transport class
+        """
         try:
             # I return the class, not an instance
             return transport.TransportFactory(self.get_transport_type())
@@ -721,6 +813,11 @@ class Computer(CollectionEntry):
                 self.name, self.get_transport_type(), exc))
 
     def get_scheduler(self):
+        """
+        Get the scheduler instance for this computer
+
+        :return: the scheduler
+        """
         try:
             scheduler_class = scheduler.SchedulerFactory(self.get_scheduler_type())
             # I call the init without any parameter
@@ -788,8 +885,6 @@ class Computer(CollectionEntry):
 
     def __str__(self):
         if self.is_enabled():
-            return "{} ({}), pk: {}".format(self.name, self.hostname,
-                                            self.pk)
-        else:
-            return "{} ({}) [DISABLED], pk: {}".format(self.name, self.hostname,
-                                                       self.pk)
+            return "{} ({}), pk: {}".format(self.name, self.hostname, self.pk)
+
+        return "{} ({}) [DISABLED], pk: {}".format(self.name, self.hostname, self.pk)

--- a/aiida/orm/computer.py
+++ b/aiida/orm/computer.py
@@ -50,7 +50,7 @@ class ComputerCollection(Collection):
         """
         from .querybuilder import QueryBuilder
 
-        qb = QueryBuilder()
+        qb = self.backend.query_builder()
         filters = {}
         if id is not None:
             filters['id'] = {'==': id}
@@ -97,6 +97,9 @@ class Computer(CollectionEntry):
     In the plugin, also set the _plugin_type_string, to be set in the DB in the 'type' field.
     """
     _logger = logging.getLogger(__name__)
+
+    PROPERTY_MINIMUM_SCHEDULER_POLL_INTERVAL = 'minimum_scheduler_poll_interval'
+    PROPERTY_MINIMUM_SCHEDULER_POLL_INTERVAL__DEFAULT = 10.
 
     @staticmethod
     def get_schema():
@@ -533,7 +536,28 @@ class Computer(CollectionEntry):
                 raise TypeError("def_cpus_per_machine must be an integer (or None)")
         self._set_property("default_mpiprocs_per_machine", def_cpus_per_machine)
 
-    @abc.abstractmethod
+    def get_minimum_job_poll_interval(self):
+        """
+        Get the minimum interval between subsequent requests to update the list
+        of jobs currently running on this computer.
+
+        :return: The minimum interval (in seconds)
+        :rtype: float
+        """
+        return self._get_property(self.PROPERTY_MINIMUM_SCHEDULER_POLL_INTERVAL,
+                                  self.PROPERTY_MINIMUM_SCHEDULER_POLL_INTERVAL__DEFAULT)
+
+    def set_minimum_job_poll_interval(self, interval):
+        """
+        Set the minimum interval between subsequent requests to update the list
+        of jobs currently running on this computer.
+
+        :param interval: The minimum interval in seconds
+        :type interval: float
+        """
+        self._set_property(self.PROPERTY_MINIMUM_SCHEDULER_POLL_INTERVAL, interval)
+
+    @abstractmethod
     def get_transport_params(self):
         pass
 

--- a/aiida/orm/implementation/django/authinfo.py
+++ b/aiida/orm/implementation/django/authinfo.py
@@ -150,7 +150,7 @@ class DjangoAuthInfo(AuthInfo):
         # Raises ValueError if data is not JSON-serializable
         self._dbauthinfo.auth_params = json.dumps(auth_params)
 
-    def get_metadata(self):
+    def _get_metadata(self):
         """
         Get the metadata dictionary from the DB
 
@@ -165,7 +165,7 @@ class DjangoAuthInfo(AuthInfo):
                 "Error while reading metadata for dbauthinfo, aiidauser={}, computer={}".format(
                     self.aiidauser.email, self.dbcomputer.hostname))
 
-    def set_metadata(self, metadata):
+    def _set_metadata(self, metadata):
         """
         Replace the metadata dictionary in the DB with the provided dictionary
         """

--- a/aiida/orm/implementation/django/backend.py
+++ b/aiida/orm/implementation/django/backend.py
@@ -47,3 +47,10 @@ class DjangoBackend(Backend):
     @property
     def query_manager(self):
         return self._query_manager
+
+    def query_builder(self):
+        # For now this doesn't select the Django one because that's
+        # done in the constructor of QueryBuilder but ideally this
+        # should be reworked so the Django version subclasses QueryBuilder
+        from aiida.orm.querybuilder import QueryBuilder
+        return QueryBuilder()

--- a/aiida/orm/implementation/sqlalchemy/authinfo.py
+++ b/aiida/orm/implementation/sqlalchemy/authinfo.py
@@ -144,7 +144,7 @@ class SqlaAuthInfo(AuthInfo):
         # Raises ValueError if data is not JSON-serializable
         self._dbauthinfo.auth_params = auth_params
 
-    def get_metadata(self):
+    def _get_metadata(self):
         """
         Get the metadata dictionary from the DB
 
@@ -152,7 +152,7 @@ class SqlaAuthInfo(AuthInfo):
         """
         return self._dbauthinfo._metadata
 
-    def set_metadata(self, metadata):
+    def _set_metadata(self, metadata):
         """
         Replace the metadata dictionary in the DB with the provided dictionary
         """

--- a/aiida/orm/implementation/sqlalchemy/backend.py
+++ b/aiida/orm/implementation/sqlalchemy/backend.py
@@ -47,3 +47,7 @@ class SqlaBackend(Backend):
     @property
     def query_manager(self):
         return self._query_manager
+
+    def query_builder(self):
+        from aiida.orm.querybuilder import QueryBuilder
+        return QueryBuilder()

--- a/aiida/scheduler/__init__.py
+++ b/aiida/scheduler/__init__.py
@@ -22,7 +22,7 @@ import aiida.common
 from aiida.common.utils import classproperty, escape_for_bash
 from aiida.common.exceptions import AiidaException, FeatureNotAvailable
 from aiida.plugins.factory import BaseFactory
-from aiida.scheduler.datastructures import JobTemplate
+from aiida.scheduler.datastructures import JobTemplate, JobInfo, JOB_STATES
 
 
 def SchedulerFactory(entry_point):

--- a/aiida/transport/transport.py
+++ b/aiida/transport/transport.py
@@ -63,15 +63,16 @@ class Transport(object):
 
         This object can be used in nested `with` statements and the connection
         will only be opened once and closed when the final `with` scope
-        finishes e.g.:
-        >>> t = Transport()
-        >>> with t:
-        >>>     # Connection is now open..
-        >>>     with t:
-        >>>         # ..still open..
-        >>>         pass
-        >>>     # ..still open..
-        >>> # ...closed
+        finishes e.g.::
+
+            t = Transport()
+            with t:
+                # Connection is now open..
+                with t:
+                    # ..still open..
+                    pass
+                # ..still open..
+            # ...closed
 
         """
         # Keep track of how many times enter has been called

--- a/aiida/work/job_calcs.py
+++ b/aiida/work/job_calcs.py
@@ -71,6 +71,8 @@ class JobsList(object):
             kwargs = {'as_dict': True}
             if scheduler.get_feature('can_query_by_user'):
                 kwargs['user'] = "$USER"
+            else:
+                kwargs['jobs'] = self._get_jobs_with_scheduler()
 
             scheduler_response = scheduler.getJobs(**kwargs)
             jobs_cache = {}
@@ -194,6 +196,15 @@ class JobsList(object):
 
     def _update_requests_outstanding(self):
         return any(not request.done() for request in itervalues(self._job_update_requests))
+
+    def _get_jobs_with_scheduler(self):
+        """
+        Get all the jobs that are currently with scheduler for this authinfo
+
+        :return: the list of jobs with the scheduler
+        :rtype: list
+        """
+        return [str(job_id) for job_id, _ in self._job_update_requests.items()]
 
 
 class JobManager(object):

--- a/aiida/work/job_calcs.py
+++ b/aiida/work/job_calcs.py
@@ -1,0 +1,226 @@
+"""
+Module containing utilities and classes relating to job calculations running
+on systems that require transport.
+"""
+
+from __future__ import absolute_import
+import contextlib
+from functools import partial
+import time
+from six import iteritems, itervalues
+from tornado import concurrent, gen
+
+from aiida import scheduler as schedulers
+from aiida.common import exceptions
+from . import utils
+
+
+class JobsList(object):
+    """
+    A list of submitted jobs on a machine connected to by transport based on the
+    authorisation information.
+    """
+
+    def __init__(self, authinfo, transport_queue):
+        """
+        :param authinfo: The authinfo used to check the jobs list
+        :type authinfo: :class:`aiida.orm.AuthInfo`
+        :param transport_queue: A transport queue
+        :type: :class:`aiida.work.transports.TransportQueue`
+        """
+        self._authinfo = authinfo
+        self._transport_queue = transport_queue
+        self._loop = transport_queue.loop()
+
+        self._jobs_cache = {}
+        self._last_updated = None  # type: float
+        self._job_update_requests = {}  # Mapping: {job_id: Future}
+        self._update_handle = None
+
+    def get_minimum_update_interval(self):
+        """
+        Get the minimum interval that can be expected between updates of the list
+        :return: The minimum interval
+        :rtype: float
+        """
+        return self._authinfo.computer.get_minimum_job_poll_interval()
+
+    def get_last_updated(self):
+        """
+        Get the timestamp of when the list was last updated as produced by `time.time()`
+
+        :return: The last update point
+        :rtype: float
+        """
+        return self._last_updated
+
+    @gen.coroutine
+    def _get_jobs_from_scheduler(self):
+        """
+        Get the current jobs list from the scheduler
+
+        :return: A dictionary of {job_id: job info}
+        :rtype: dict
+        """
+        with self._transport_queue.request_transport(self._authinfo) as request:
+            transport = yield request
+
+            scheduler = self._authinfo.computer.get_scheduler()
+            scheduler.set_transport(transport)
+
+            kwargs = {'as_dict': True}
+            if scheduler.get_feature('can_query_by_user'):
+                kwargs['user'] = "$USER"
+
+            scheduler_response = scheduler.getJobs(**kwargs)
+            jobs_cache = {}
+
+            for job_id, job_info in iteritems(scheduler_response):
+                # If the job is done then get detailed job information
+                detailed_job_info = None
+                if job_info.job_state == schedulers.JOB_STATES.DONE:
+                    try:
+                        detailed_job_info = scheduler.get_detailed_jobinfo(job_id)
+                    except exceptions.FeatureNotAvailable:
+                        detailed_job_info = 'This scheduler does not implement get_detailed_jobinfo'
+
+                job_info.detailedJobinfo = detailed_job_info
+                jobs_cache[job_id] = job_info
+
+            raise gen.Return(jobs_cache)
+
+    @gen.coroutine
+    def _update_job_info(self):
+        """
+        Update all of the job information objects for a given authinfo, that is to say for
+        all the jobs on a particular machine for a particular user.
+
+        This will set the futures for all pending update requests where the corresponding job
+        has a new status compared to the last update.
+        """
+        try:
+            if not self._update_requests_outstanding():
+                return
+
+            # Update our cache of the job states
+            self._jobs_cache = yield self._get_jobs_from_scheduler()
+        except Exception as exception:
+            # Set the exception on all the update futures
+            for future in itervalues(self._job_update_requests):
+                if not future.done():
+                    future.set_exception(exception)
+            raise
+        else:
+            for job_id, future in iteritems(self._job_update_requests):
+                if not future.done():
+                    future.set_result(self._jobs_cache.get(job_id, None))
+        finally:
+            self._job_update_requests = {}
+
+    @contextlib.contextmanager
+    def request_job_info_update(self, job_id):
+        """
+        Request job info about a job when it next changes it's job state.  If the job is not
+        found in the jobs list at the update the future will resolve to None.
+
+        :param job_id: The job identifier
+        :return: A future that will resolve to a JobInfo object when the job changes state
+        """
+        # Get or create the future
+        request = self._job_update_requests.setdefault(job_id, concurrent.Future())
+        assert not request.done(), "The future should be no be in the done state"
+
+        try:
+            self._ensure_updating()
+            yield request
+        finally:
+            pass
+
+    def _ensure_updating(self):
+        """
+        Ensure that we are updating the job list from the remote resource.
+        This will automatically stop if there are no outstanding requests.
+        """
+
+        @gen.coroutine
+        def updating():
+            """ Do the actual update, stop if not requests left """
+            yield self._update_job_info()
+            # Any outstanding requests?
+            if self._update_requests_outstanding():
+                self._update_handle = self._loop.call_later(self._get_next_update_delay(), updating)
+            else:
+                self._update_handle = None
+
+        # Check if we're already updating
+        if self._update_handle is None:
+            self._update_handle = self._loop.call_later(self._get_next_update_delay(), updating)
+
+    @staticmethod
+    def _has_job_state_changed(old, new):
+        """
+        :type old: :class:`aiida.scheduler.JobInfo`
+        :type new: :class:`aiida.scheduler.JobInfo`
+        :rtype: bool
+        """
+        if old is None and new is None:
+            return False
+        elif old is None or new is None:
+            # One is None and the other isn't
+            return True
+
+        return old.job_state != new.job_state or \
+               old.job_substate != new.job_substate
+
+    def _get_next_update_delay(self):
+        """
+        Calculate when we are next allowed to call the scheduler get jobs command
+        based on when we last called it, how long has elapsed and the minimum given
+        update interval.
+
+        :return: The delay (in seconds) for when it's safe to call the get jobs command
+        :rtype: float
+        """
+        if self._last_updated is None:
+            # Never updated, so do it straight away
+            return 0.
+
+        # Make sure to actually 'get' it here, so that if the user changed it
+        # between times we use the current value
+        minimum_interval = self._authinfo.computer.get_minimum_job_poll_interval()
+        elapsed = time.time() - self._last_updated
+
+        return max(minimum_interval - elapsed, 0.)
+
+    def _update_requests_outstanding(self):
+        return any(not request.done() for request in itervalues(self._job_update_requests))
+
+
+class JobManager(object):
+    """
+    A manager for jobs on a (usually) remote resource such as a supercomputer
+    """
+
+    def __init__(self, transport_queue):
+        self._transport_queue = transport_queue
+        self._job_lists = utils.RefObjectStore()
+
+    @contextlib.contextmanager
+    def request_job_info_update(self, authinfo, job_id):
+        """
+        Get a future that will resolve to information about a given job.  This is a context
+        manager so that if the user leaves the context the request is automatically cancelled.
+
+        :return: A tuple containing the JobInfo object and detailed job info.  Both can be None.
+        :rtype: :class:`tornado.concurrent.Future`
+        """
+        # Define a way to create a JobsList if needed
+        create = partial(JobsList, authinfo, self._transport_queue)
+
+        with self._job_lists.get(authinfo.id, create) as job_list:
+            with job_list.request_job_info_update(job_id) as request:
+                try:
+                    yield request
+                finally:
+                    if not request.done():
+                        request.cancel()

--- a/aiida/work/job_processes.py
+++ b/aiida/work/job_processes.py
@@ -63,6 +63,7 @@ def task_upload_job(node, transport_queue, calc_info, script_filename, cancellab
     :param calc_info: the calculation info datastructure returned by `JobCalculation._presubmit`
     :param script_filename: the job launch script returned by `JobCalculation._presubmit`
     :param cancellable: the cancelled flag that will be queried to determine whether the task was cancelled
+    :type cancellable: :class:`aiida.work.utils.InterruptableFuture`
     :raises: Return if the tasks was successfully completed
     :raises: TransportTaskException if after the maximum number of retries the transport task still excepted
     """

--- a/aiida/work/job_processes.py
+++ b/aiida/work/job_processes.py
@@ -34,7 +34,6 @@ from aiida.work.utils import exponential_backoff_retry, interruptable_task
 from . import persistence
 from . import processes
 
-
 __all__ = ['JobProcess']
 
 UPLOAD_COMMAND = 'upload'
@@ -46,12 +45,11 @@ KILL_COMMAND = 'kill'
 TRANSPORT_TASK_RETRY_INITIAL_INTERVAL = 20
 TRANSPORT_TASK_MAXIMUM_ATTEMTPS = 5
 
-
 logger = logging.getLogger(__name__)
 
 
 @coroutine
-def task_upload_job(node, transport_queue, calc_info, script_filename, cancel_flag):
+def task_upload_job(node, transport_queue, calc_info, script_filename, cancellable):
     """
     Transport task that will attempt to upload the files of a job calculation to the remote
 
@@ -64,7 +62,7 @@ def task_upload_job(node, transport_queue, calc_info, script_filename, cancel_fl
     :param transport_queue: the TransportQueue from which to request a Transport
     :param calc_info: the calculation info datastructure returned by `JobCalculation._presubmit`
     :param script_filename: the job launch script returned by `JobCalculation._presubmit`
-    :param cancel_flag: the cancelled flag that will be queried to determine whether the task was cancelled
+    :param cancellable: the cancelled flag that will be queried to determine whether the task was cancelled
     :raises: Return if the tasks was successfully completed
     :raises: TransportTaskException if after the maximum number of retries the transport task still excepted
     """
@@ -83,11 +81,7 @@ def task_upload_job(node, transport_queue, calc_info, script_filename, cancel_fl
     @coroutine
     def do_upload():
         with transport_queue.request_transport(authinfo) as request:
-            transport = yield request
-
-            # It may have taken time to get the transport, check if we've been cancelled
-            if cancel_flag.is_cancelled:
-                raise plumpy.CancelledError('task_upload_job for calculation<{}> cancelled'.format(node.pk))
+            transport = yield cancellable.with_interrupt(request)
 
             logger.info('uploading calculation<{}>'.format(node.pk))
             raise Return(execmanager.upload_calculation(node, transport, calc_info, script_filename))
@@ -106,7 +100,7 @@ def task_upload_job(node, transport_queue, calc_info, script_filename, cancel_fl
 
 
 @coroutine
-def task_submit_job(node, transport_queue, calc_info, script_filename, cancel_flag):
+def task_submit_job(node, transport_queue, calc_info, script_filename, cancellable):
     """
     Transport task that will attempt to submit a job calculation
 
@@ -119,7 +113,8 @@ def task_submit_job(node, transport_queue, calc_info, script_filename, cancel_fl
     :param transport_queue: the TransportQueue from which to request a Transport
     :param calc_info: the calculation info datastructure returned by `JobCalculation._presubmit`
     :param script_filename: the job launch script returned by `JobCalculation._presubmit`
-    :param cancel_flag: the cancelled flag that will be queried to determine whether the task was cancelled
+    :param cancellable: the cancelled flag that will be queried to determine whether the task was cancelled
+    :type cancellable: :class:`aiida.work.utils.InterruptableFuture`
     :raises: Return if the tasks was successfully completed
     :raises: TransportTaskException if after the maximum number of retries the transport task still excepted
     """
@@ -131,11 +126,7 @@ def task_submit_job(node, transport_queue, calc_info, script_filename, cancel_fl
     @coroutine
     def do_submit():
         with transport_queue.request_transport(authinfo) as request:
-            transport = yield request
-
-            # It may have taken time to get the transport, check if we've been cancelled
-            if cancel_flag.is_cancelled:
-                raise plumpy.CancelledError('task_submit_job for calculation<{}> cancelled'.format(node.pk))
+            transport = yield cancellable.with_interrupt(request)
 
             logger.info('submitting calculation<{}>'.format(node.pk))
             raise Return(execmanager.submit_calculation(node, transport, calc_info, script_filename))
@@ -144,8 +135,8 @@ def task_submit_job(node, transport_queue, calc_info, script_filename, cancel_fl
 
     try:
         result = yield exponential_backoff_retry(
-            do_submit, initial_interval, max_attempts, logger=node.logger, ignore_exceptions=plumpy.CancelledError)
-    except plumpy.CancelledError:
+            do_submit, initial_interval, max_attempts, logger=node.logger, ignore_exceptions=plumpy.Interruption)
+    except plumpy.Interruption:
         pass
     except Exception:
         logger.warning('submitting calculation<{}> failed'.format(node.pk))
@@ -157,57 +148,58 @@ def task_submit_job(node, transport_queue, calc_info, script_filename, cancel_fl
 
 
 @coroutine
-def task_update_job(node, transport_queue, cancel_flag):
+def task_update_job(job_calc, job_manager, cancellable):
     """
-    Transport task that will attempt to update the scheduler state of a job calculation
-
-    The task will first request a transport from the queue. Once the transport is yielded, the relevant execmanager
-    function is called, wrapped in the exponential_backoff_retry coroutine, which, in case of a caught exception, will
-    retry after an interval that increases exponentially with the number of retries, for a maximum number of retries.
-    If all retries fail, the task will raise a TransportTaskException
-
-    :param node: the node that represents the job calculation
-    :param transport_queue: the TransportQueue from which to request a Transport
-    :param cancel_flag: the cancelled flag that will be queried to determine whether the task was cancelled
-    :raises: Return if the tasks was successfully completed
-    :raises: TransportTaskException if after the maximum number of retries the transport task still excepted
+    :param job_calc: The job calculation node
+    :type job_calc: :class:`aiida.orm.calculation.JobCalculation`
+    :param job_manager: The job manager
+    :type job_manager: :class:`aiida.work.job_calcs.JobManager`
+    :param cancellable: A cancel flag
+    :type cancellable: :class:`aiida.work.utils.InterruptableFuture`
+    :raises: Return containing True if the tasks was successfully completed, False otherwise
     """
     initial_interval = TRANSPORT_TASK_RETRY_INITIAL_INTERVAL
     max_attempts = TRANSPORT_TASK_MAXIMUM_ATTEMTPS
 
-    authinfo = node.get_computer().get_authinfo(node.get_user())
+    authinfo = job_calc.get_computer().get_authinfo(job_calc.get_user())
+    job_id = job_calc.get_job_id()
 
     @coroutine
     def do_update():
-        with transport_queue.request_transport(authinfo) as request:
-            transport = yield request
+        # Get the update request
+        with job_manager.request_job_info_update(authinfo, job_id) as update_request:
+            job_info = yield cancellable.with_interrupt(update_request)
 
-            # It may have taken time to get the transport, check if we've been cancelled
-            if cancel_flag.is_cancelled:
-                raise plumpy.CancelledError('task_update_job for calculation<{}> cancelled'.format(node.pk))
+        if job_info is None:
+            # If the job is computed or not found assume it's done
+            job_calc._set_scheduler_state(JOB_STATES.DONE)
+            job_done = True
+        else:
+            job_calc._set_last_jobinfo(job_info)
+            job_calc._set_scheduler_state(job_info.job_state)
+            job_done = job_info.job_state == JOB_STATES.DONE
 
-            logger.info('updating calculation<{}>'.format(node.pk))
-            raise Return(execmanager.update_calculation(node, transport))
-
-    state_success = calc_states.COMPUTED
+        raise Return(job_done)
 
     try:
-        result = yield exponential_backoff_retry(
-            do_update, initial_interval, max_attempts, logger=node.logger, ignore_exceptions=plumpy.CancelledError)
-    except plumpy.CancelledError:
-        pass
+        job_done = yield exponential_backoff_retry(
+            do_update, initial_interval, max_attempts, logger=job_calc.logger, ignore_exceptions=plumpy.Interruption)
+    except plumpy.Interruption:
+        raise
     except Exception:
-        logger.warning('updating calculation<{}> failed'.format(node.pk))
+        import traceback
+        logger.warning('updating calculation<{}> failed'.format(job_calc.pk))
         raise TransportTaskException('update_calculation failed {} times consecutively'.format(max_attempts))
     else:
-        logger.info('updating calculation<{}> successful'.format(node.pk))
-        if result:
-            node._set_state(state_success)
-        raise Return(result)
+        logger.info('updating calculation<{}> successful'.format(job_calc.pk))
+        if job_done:
+            job_calc._set_state(calc_states.COMPUTED)
+
+        raise Return(job_done)
 
 
 @coroutine
-def task_retrieve_job(node, transport_queue, retrieved_temporary_folder, cancel_flag):
+def task_retrieve_job(node, transport_queue, retrieved_temporary_folder, cancellable):
     """
     Transport task that will attempt to retrieve all files of a completed job calculation
 
@@ -218,7 +210,8 @@ def task_retrieve_job(node, transport_queue, retrieved_temporary_folder, cancel_
 
     :param node: the node that represents the job calculation
     :param transport_queue: the TransportQueue from which to request a Transport
-    :param cancel_flag: the cancelled flag that will be queried to determine whether the task was cancelled
+    :param cancellable: the cancelled flag that will be queried to determine whether the task was cancelled
+    :type cancellable: :class:`aiida.work.utils.InterruptableFuture`
     :raises: Return if the tasks was successfully completed
     :raises: TransportTaskException if after the maximum number of retries the transport task still excepted
     """
@@ -230,11 +223,7 @@ def task_retrieve_job(node, transport_queue, retrieved_temporary_folder, cancel_
     @coroutine
     def do_retrieve():
         with transport_queue.request_transport(authinfo) as request:
-            transport = yield request
-
-            # It may have taken time to get the transport, check if we've been cancelled
-            if cancel_flag.is_cancelled:
-                raise plumpy.CancelledError('task_retrieve_job for calculation<{}> cancelled'.format(node.pk))
+            transport = yield cancellable.with_interrupt(request)
 
             logger.info('retrieving calculation<{}>'.format(node.pk))
             raise Return(execmanager.retrieve_calculation(node, transport, retrieved_temporary_folder))
@@ -248,9 +237,9 @@ def task_retrieve_job(node, transport_queue, retrieved_temporary_folder, cancel_
 
     try:
         result = yield exponential_backoff_retry(
-            do_retrieve, initial_interval, max_attempts, logger=node.logger, ignore_exceptions=plumpy.CancelledError)
-    except plumpy.CancelledError:
-        pass
+            do_retrieve, initial_interval, max_attempts, logger=node.logger, ignore_exceptions=plumpy.Interruption)
+    except plumpy.Interruption:
+        raise
     except Exception:
         logger.warning('retrieving calculation<{}> failed'.format(node.pk))
         raise TransportTaskException('retrieve_calculation failed {} times consecutively'.format(max_attempts))
@@ -260,7 +249,7 @@ def task_retrieve_job(node, transport_queue, retrieved_temporary_folder, cancel_
 
 
 @coroutine
-def task_kill_job(node, transport_queue, cancel_flag):
+def task_kill_job(node, transport_queue, cancellable):
     """
     Transport task that will attempt to kill a job calculation
 
@@ -271,7 +260,8 @@ def task_kill_job(node, transport_queue, cancel_flag):
 
     :param node: the node that represents the job calculation
     :param transport_queue: the TransportQueue from which to request a Transport
-    :param cancel_flag: the cancelled flag that will be queried to determine whether the task was cancelled
+    :param cancellable: the cancelled flag that will be queried to determine whether the task was cancelled
+    :type cancellable: :class:`aiida.work.utils.InterruptableFuture`
     :raises: Return if the tasks was successfully completed
     :raises: TransportTaskException if after the maximum number of retries the transport task still excepted
     """
@@ -287,19 +277,14 @@ def task_kill_job(node, transport_queue, cancel_flag):
     @coroutine
     def do_kill():
         with transport_queue.request_transport(authinfo) as request:
-            transport = yield request
-
-            # It may have taken time to get the transport, check if we've been cancelled
-            if cancel_flag.is_cancelled:
-                raise plumpy.CancelledError('task_kill_job for calculation<{}> cancelled'.format(node.pk))
-
+            transport = yield cancellable.with_interrupt(request)
             logger.info('killing calculation<{}>'.format(node.pk))
             raise Return(execmanager.kill_calculation(node, transport))
 
     try:
         result = yield exponential_backoff_retry(do_kill, initial_interval, max_attempts, logger=node.logger)
-    except plumpy.CancelledError:
-        pass
+    except plumpy.Interruption:
+        raise
     except Exception:
         logger.warning('killing calculation<{}> failed'.format(node.pk))
         raise TransportTaskException('kill_calculation failed {} times consecutively'.format(max_attempts))
@@ -341,7 +326,8 @@ class Waiting(plumpy.Waiting):
         try:
 
             if command == UPLOAD_COMMAND:
-                calc_info, script_filename = yield self._launch_task(task_upload_job, calculation, transport_queue, *args)
+                calc_info, script_filename = yield self._launch_task(task_upload_job, calculation, transport_queue,
+                                                                     *args)
                 raise Return(self.submit(calc_info, script_filename))
 
             elif command == SUBMIT_COMMAND:
@@ -352,7 +338,8 @@ class Waiting(plumpy.Waiting):
                 job_done = False
 
                 while not job_done:
-                    job_done = yield self._launch_task(task_update_job, calculation, transport_queue)
+                    job_done = yield self._launch_task(task_update_job, calculation,
+                                                       self.process.runner.job_manager)
 
                 raise Return(self.retrieve())
 

--- a/aiida/work/runners.py
+++ b/aiida/work/runners.py
@@ -20,6 +20,7 @@ import tornado.ioloop
 import plumpy
 
 from aiida.orm import load_node, load_workflow
+from . import job_calcs
 from . import futures
 from . import persistence
 from . import rmq
@@ -89,6 +90,7 @@ class Runner(object):
         self._poll_interval = poll_interval
         self._rmq_submit = rmq_submit
         self._transport = transports.TransportQueue(self._loop)
+        self._job_manager = job_calcs.JobManager(self._transport)
 
         if enable_persistence:
             self._persister = persister if persister is not None else persistence.AiiDAPersister()
@@ -133,6 +135,10 @@ class Runner(object):
     @property
     def communicator(self):
         return self._communicator
+
+    @property
+    def job_manager(self):
+        return self._job_manager
 
     def is_closed(self):
         return self._closed

--- a/aiida/work/transports.py
+++ b/aiida/work/transports.py
@@ -15,10 +15,7 @@ from collections import namedtuple
 import contextlib
 import logging
 import traceback
-import tornado.gen
-import tornado.concurrent
-import tornado.ioloop
-import tornado.locks
+from tornado import concurrent, gen, ioloop
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -29,7 +26,7 @@ class TransportRequest(object):
     # pylint: disable=too-few-public-methods
     def __init__(self):
         super(TransportRequest, self).__init__()
-        self.future = tornado.concurrent.Future()
+        self.future = concurrent.Future()
         self.count = 0
 
 
@@ -48,9 +45,10 @@ class TransportQueue(object):
 
     def __init__(self, loop=None):
         """
-        :param loop: The event loop to use, will use tornado.ioloop.IOLoop.current() if not supplied
+        :param loop: The event loop to use, will use `tornado.ioloop.IOLoop.current()` if not supplied
+        :type loop: :class:`tornado.ioloop.IOLoop`
         """
-        self._loop = loop if loop is not None else tornado.ioloop.IOLoop.current()
+        self._loop = loop if loop is not None else ioloop.IOLoop.current()
         self._transport_requests = {}
 
     def loop(self):
@@ -77,6 +75,7 @@ class TransportQueue(object):
         transport_request = self._transport_requests.get(authinfo.id, None)
 
         if transport_request is None:
+            # There is no existing request for this transport (i.e. on this authinfo)
 
             transport_request = TransportRequest()
             self._transport_requests[authinfo.id] = transport_request
@@ -106,7 +105,7 @@ class TransportQueue(object):
         try:
             transport_request.count += 1
             yield transport_request.future
-        except tornado.gen.Return:
+        except gen.Return:
             # Have to have this special case so tornado returns are propagated up to the loop
             raise
         except Exception:
@@ -114,7 +113,7 @@ class TransportQueue(object):
             raise
         finally:
             transport_request.count -= 1
-            assert transport_request.count >= 0, "Transport request count dropped blow 0!"
+            assert transport_request.count >= 0, "Transport request count dropped below 0!"
             # Check if there are no longer any users that want the transport
             if transport_request.count == 0:
                 if transport_request.future.done():

--- a/aiida/work/transports.py
+++ b/aiida/work/transports.py
@@ -76,7 +76,6 @@ class TransportQueue(object):
 
         if transport_request is None:
             # There is no existing request for this transport (i.e. on this authinfo)
-
             transport_request = TransportRequest()
             self._transport_requests[authinfo.id] = transport_request
 

--- a/aiida/work/utils.py
+++ b/aiida/work/utils.py
@@ -152,8 +152,8 @@ def exponential_backoff_retry(fct, initial_interval=10.0, max_attempts=5, logger
                 logger.warning('maximum attempts %d of calling %s, exceeded', max_attempts, coro.__name__)
                 raise
             else:
-                logger.warning('iteration %d of %s excepted, retrying after %d seconds', iteration + 1, coro.__name__,
-                               interval)
+                logger.exception('iteration %d of %s excepted, retrying after %d seconds', iteration + 1, coro.__name__,
+                                 interval)
 
                 yield gen.sleep(interval)
                 interval *= 2

--- a/aiida/work/utils.py
+++ b/aiida/work/utils.py
@@ -17,8 +17,7 @@ import logging
 
 from six.moves import range
 import tornado.ioloop
-from tornado.concurrent import Future
-from tornado.gen import coroutine, sleep, Return
+from tornado import concurrent, gen
 
 from aiida.common.links import LinkType
 from aiida.orm.calculation import Calculation, WorkCalculation, FunctionCalculation
@@ -32,15 +31,39 @@ PROCESS_STATE_CHANGE_DESCRIPTION = 'The last time a process of type {}, changed 
 PROCESS_CALC_TYPES = (WorkCalculation, FunctionCalculation)
 
 
-class CancelFlag(object):
-    """A simple container that can be passed by reference to signal that the task was cancelled."""
+class InterruptableFuture(concurrent.Future):
+    """A future that can be interrupted by calling `interrupt`."""
 
-    def __init__(self):
-        self.cancelled = False
+    def interrupt(self, reason):
+        """This method should be called to interrupt the coroutine represented by this InterruptableFuture."""
+        self.set_exception(reason)
 
-    @property
-    def is_cancelled(self):
-        return self.cancelled
+    @gen.coroutine
+    def with_interrupt(self, yieldable):
+        """
+        Yield a yieldable which will be interrupted if this future is interrupted ::
+
+            from tornado import ioloop, gen
+            loop = ioloop.IOLoop.current()
+
+            interruptable = InterutableFuture()
+            loop.add_callback(interruptable.interrupt, RuntimeError("STOP"))
+            loop.run_sync(lambda: interruptable.with_interrupt(gen.sleep(2)))
+            >>> RuntimeError: STOP
+
+
+        :param yieldable: The yieldable
+        :return: The result of the yieldable
+        """
+        # Wait for one of the two to finish, if it's us that finishes we expect that it was
+        # because of an exception that will have been raised automatically
+        wait_iterator = gen.WaitIterator(yieldable, self)
+        result = yield wait_iterator.next()  # pylint: disable=stop-iteration-return
+        if not wait_iterator.current_index == 0:
+            raise RuntimeError("This interruptible future had it's result set unexpectedly to {}".format(result))
+
+        result = yield [yieldable, self][0]
+        raise gen.Return(result)
 
 
 def interruptable_task(coro, loop=None):
@@ -52,23 +75,14 @@ def interruptable_task(coro, loop=None):
     :return: an InterruptableFuture
     """
 
-    class InterruptableFuture(Future):
-        """A future that can be interrupted by calling `interrupt`."""
-
-        def interrupt(self, reason):
-            """This method should be called to interrupt the coroutine represented by this InterruptableFuture."""
-            cancel_flag.cancelled = True
-            self.set_exception(reason)
-
     loop = loop or tornado.ioloop.IOLoop.current()
     future = InterruptableFuture()
-    cancel_flag = CancelFlag()
 
-    @coroutine
+    @gen.coroutine
     def execute_coroutine():
         """Coroutine that wraps the original coroutine and sets it result on the future only if not already set."""
         try:
-            result = yield coro(cancel_flag)
+            result = yield coro(future)
         except Exception as exception:  # pylint: disable=broad-except
             if not future.done():
                 future.set_exception(exception)
@@ -102,7 +116,7 @@ def ensure_coroutine(fct):
     return wrapper
 
 
-@coroutine
+@gen.coroutine
 def exponential_backoff_retry(fct, initial_interval=10.0, max_attempts=5, logger=None, ignore_exceptions=None):
     """
     Coroutine to call a function, recalling it with an exponential backoff in the case of an exception
@@ -138,14 +152,13 @@ def exponential_backoff_retry(fct, initial_interval=10.0, max_attempts=5, logger
                 logger.warning('maximum attempts %d of calling %s, exceeded', max_attempts, coro.__name__)
                 raise
             else:
-                import traceback
-                traceback.print_exc()
                 logger.warning('iteration %d of %s excepted, retrying after %d seconds', iteration + 1, coro.__name__,
                                interval)
-                yield sleep(interval)
+
+                yield gen.sleep(interval)
                 interval *= 2
 
-    raise Return(result)
+    raise gen.Return(result)
 
 
 def is_work_calc_type(calc_node):
@@ -280,3 +293,83 @@ def get_process_state_change_timestamp(process_type=None):
         return None
 
     return max(timestamps)
+
+
+class RefObjectStore(object):
+    """
+    An object store that has a reference count based on a context manager.
+    Basic usage::
+
+        store = RefObjectStore()
+        with store.get('Martin', lambda: 'martin.uhrin@epfl.ch') as email:
+            with store.get('Martin') as email2:
+                email is email2  # True
+
+    The use case for this store is when you have an object can be used by
+    multiple parts of the code simultaneously (nested or async code) and
+    where there should be one instance that exists for the lifetime of these
+    contexts.  Once noone is using the object, it should be removed from the
+    store (and therefore eventually garbage collected).
+    """
+
+    class Reference(object):
+        """
+        A reference to store the context reference count and the object
+        itself.
+        """
+
+        def __init__(self, obj):
+            self._count = 0
+            self._obj = obj
+
+        @property
+        def count(self):
+            """
+            Get the reference count for the object
+            :return: The reference count
+            :rtype: int
+            """
+            return self._count
+
+        @contextlib.contextmanager
+        def get(self):
+            """
+            Get the object itself.  This will up the reference count for the duration of
+            the context.
+            :return: The object
+            """
+            self._count += 1
+            try:
+                yield self._obj
+            finally:
+                self._count -= 1
+
+    def __init__(self):
+        self._objects = {}
+
+    @contextlib.contextmanager
+    def get(self, identifier, constructor=None):
+        """
+        Get or create an object.  The internal reference count will be upped for
+        the duration of the context.  If the reference count drops to 0 the object
+        will be automatically removed from the list.
+
+        :param identifier: The key identifying the object
+        :param constructor: An optional constructor that is called with no arguments
+            if the object doesn't already exist in the store
+        :return: The object corresponding to the identifier
+        """
+        try:
+            ref = self._objects[identifier]
+        except KeyError:
+            if constructor is None:
+                raise ValueError("Object not found and no constructor given")
+            ref = self.Reference(constructor())
+            self._objects[identifier] = ref
+
+        try:
+            with ref.get() as obj:
+                yield obj
+        finally:
+            if ref.count == 0:
+                self._objects.pop(identifier)

--- a/docs/requirements_for_rtd.txt
+++ b/docs/requirements_for_rtd.txt
@@ -43,7 +43,7 @@ paramiko==2.4.2
 passlib==1.7.1
 pathlib2; python_version<"3.5"
 pgtest==1.1.0
-pika==0.11.2
+pika==0.12.0
 plumpy==0.10.6
 psutil==5.4.5
 pymatgen==2018.4.20

--- a/docs/source/get_started/computers.rst
+++ b/docs/source/get_started/computers.rst
@@ -132,7 +132,7 @@ The configuration of computers happens in two steps.
 
     verdi computer setup
     
-   command. This command allows to create a new computer instance in the DB.   
+   command. This command allows to create a new computer instance in the DB.
    
    .. tip:: The code will ask you a few pieces of information. At every prompt, you can
      type the ``?`` character and press ``<enter>`` to get a more detailed
@@ -164,7 +164,7 @@ The configuration of computers happens in two steps.
    * **Enabled**: either True or False; if False, the computer is disabled
      and calculations associated with it will not be submitted. This allows to
      disable temporarily a computer if it is giving problems or it is down for
-     maintenance, without the need to delete it from the DB.  
+     maintenance, without the need to delete it from the DB.
 
    * **Transport type**: The name of the transport to be used. A list of valid 
      transport types can be obtained typing ``?``
@@ -239,7 +239,7 @@ The configuration of computers happens in two steps.
    simply need to press enter a few times.
 
    .. note:: At the moment, the in-line help (i.e., just typing ``?`` to get
-     some help) is not yet supported in ``verdi configure``, but only in 
+     some help) is not yet supported in ``verdi configure``, but only in
      ``verdi setup``.
 
    For ``local`` transport, you *need to run the command*,
@@ -284,7 +284,7 @@ The configuration of computers happens in two steps.
  After these two steps have been completed, your computer is ready to go!
 
 .. note:: If the cluster you are using requires authentication through a Kerberos
-    token (that you need to obtain before using ssh), you typically need to install 
+    token (that you need to obtain before using ssh), you typically need to install
     ``libffi`` (``sudo apt-get install libffi-dev`` under Ubuntu), and make sure you install
     the ``ssh_kerberos`` :ref:`optional dependencies<install_optional_dependencies>` during the installation process of AiiDA.
     Then, if your ``.ssh/config`` file is configured properly (in particular includes
@@ -300,7 +300,7 @@ The configuration of computers happens in two steps.
   the scheduler queue) to verify that everything works as expected.
 
 .. note:: If you are not sure if your computer is already set up, use the command::
-   
+
      verdi computer list
    
    to get a list of existing computers, and::
@@ -319,7 +319,7 @@ The configuration of computers happens in two steps.
    commands, whose meaning should be self-explanatory.
    
 .. note:: You can delete computers **only if** no entry in the database is using
-  them (as for instance Calculations, or RemoteData objects). Otherwise, you 
+  them (as for instance Calculations, or RemoteData objects). Otherwise, you
   will get an error message. 
 
 .. note:: It is possible to **disable** a computer.
@@ -346,4 +346,37 @@ The configuration of computers happens in two steps.
   
      verdi computer disable COMPUTERNAME --only-for-user USER_EMAIL
   
-  (and the corresponding ``verdi computer enable`` command to re-enable it).  
+  (and the corresponding ``verdi computer enable`` command to re-enable it).
+
+
+On not bombarding the remote computer with requests
+---------------------------------------------------
+
+Some machine (particularly at supercomputing centres) may not tolerate opening
+connections and executing scheduler commands with a high frequency.  To limit this
+AiiDA currently has two settings:
+
+ * The transport safe open interval, and,
+ * the minimum job poll interval
+
+Neither of these can ever be violated.  AiiDA will not try to update the jobs list
+on a remove machine until the job poll interval has elapsed since the last update
+(the first update will be immediate) at which point it will request a transport.
+Because of this the maximum possible time before a job update could be the sum of
+the two intervals, however this is unlikely to happen in practice.
+
+The transport open interval is currently hardcoded by the transport plugin,
+typically SSH is longer than local transport.
+
+The job poll interval can be set programmatically on the corresponding `Computer`
+object in verdi shell::
+
+    Computer.get('localhost').set_minimum_job_poll_interval(30.0)
+
+
+would set the transport interval on a computer called 'localhost' to 30 seconds.
+
+.. note:: All of these intervals apply per *worker* meaning that a daemon with
+   multiple workers will not necessarily, overall, respect these limits.
+   For the time being there is no way around this and if these limits must be
+   respected then do not run with more than one worker.

--- a/docs/source/nitpick-exceptions
+++ b/docs/source/nitpick-exceptions
@@ -133,6 +133,7 @@ py:class  logging.Logger
 
 py:class  paramiko.proxy.ProxyCommand
 
+py:class  plumpy.futures.Future
 py:class  plumpy.processes.Process
 py:class  plumpy.process_comms.ProcessLauncher
 py:class  plumpy.process_spec.ProcessSpec
@@ -154,6 +155,7 @@ py:meth   plumpy.process_spec.ProcessSpec.expose_outputs
 py:class  kiwipy.futures.Future
 py:class  kiwipy.communications.TimeoutError
 
+py:class  tornado.ioloop.IOLoop
 py:class  tornado.concurrent.Future
 
 py:class  IPython.core.magic.Magics

--- a/setup_requirements.py
+++ b/setup_requirements.py
@@ -43,8 +43,8 @@ install_requires = [
     'psycopg2-binary==2.7.4',
     'paramiko==2.4.2',
     'ecdsa==0.13',
-    'pika==0.11.2',
     'ipython>=4.0,<6.0',  # Version of ipython non enforced, because some still prefer version 4 rather than the latest
+    'pika==0.12.0',
     'plumpy==0.10.6',
     'kiwipy==0.2.1',
     'circus==0.14.0',


### PR DESCRIPTION
Now the computer has a property that can be set to regulate the interval
with which the scheduler command to get jobs can be called.  This acts
as a minimum and may in practice be longer if the transport minimum open
interval is longer.

With these changes all jobs in a single runner on the same computer also
have their requests to get the jobs list batched and therefore there
should be a significant decrease in the number of calls asking the
scheduler to list the currently running jobs.