### PR TITLE
Allow an OverridableOption to be cloned while overriding some kwargs

### DIFF
--- a/aiida/backends/tests/cmdline/commands/test_computer.py
+++ b/aiida/backends/tests/cmdline/commands/test_computer.py
@@ -617,7 +617,7 @@ class TestVerdiComputerCommands(AiidaTestCase):
         self.assertIsNotNone(result.output)
 
         # Check all options run
-        for opt in ['-o', '--only-usable', '-r', '--raw', '-a', '--all']:
+        for opt in ['-r', '--raw', '-a', '--all']:
             result = self.runner.invoke(computer_list, [opt])
             # No exceptions should arise
             self.assertIsNone(result.exception)

--- a/aiida/cmdline/commands/cmd_code.py
+++ b/aiida/cmdline/commands/cmd_code.py
@@ -7,21 +7,19 @@
 # For further information on the license, see the LICENSE.txt file        #
 # For further information please visit http://www.aiida.net               #
 ###########################################################################
-"""
-This allows to setup and configure a code from command line.
-"""
+"""`verdi code` command."""
 from __future__ import absolute_import
 from functools import partial
 import click
 import tabulate
 
 from aiida.cmdline.commands.cmd_verdi import verdi
-from aiida.cmdline.params import options, arguments, types
-from aiida.cmdline.params.options.interactive import InteractiveOption
-from aiida.cmdline.params.options.overridable import OverridableOption
+from aiida.cmdline.params import options, arguments
+from aiida.cmdline.params.options.commands import code as options_code
 from aiida.cmdline.utils import echo
 from aiida.cmdline.utils.decorators import with_dbenv, deprecated_command
 from aiida.cmdline.utils.multi_line_input import ensure_scripts
+from aiida.common.exceptions import InputValidationError
 from aiida.control.code import CodeBuilder
 
 
@@ -29,94 +27,6 @@ from aiida.control.code import CodeBuilder
 def verdi_code():
     """Setup and manage codes."""
     pass
-
-
-def is_on_computer(ctx):
-    return bool(ctx.params.get('on_computer'))
-
-
-def is_not_on_computer(ctx):
-    return bool(not is_on_computer(ctx))
-
-
-# Reusable options (code-specific)
-ON_COMPUTER = OverridableOption(
-    '--on-computer/--store-in-db',
-    is_eager=False,
-    default=True,
-    cls=InteractiveOption,
-    prompt='Installed on target computer?')
-
-REMOTE_ABS_PATH = OverridableOption(
-    '--remote-abs-path',
-    prompt='Remote absolute path',
-    required_fn=is_on_computer,
-    prompt_fn=is_on_computer,
-    type=types.AbsolutePathParamType(dir_okay=False),
-    cls=InteractiveOption,
-    help=('[if --on-computer]: the absolute path to the executable on the remote machine'))
-
-CODE_FOLDER = OverridableOption(
-    '--code-folder',
-    prompt='Local directory containing the code',
-    required_fn=is_not_on_computer,
-    prompt_fn=is_not_on_computer,
-    type=click.Path(file_okay=False, exists=True, readable=True),
-    cls=InteractiveOption,
-    help=('[if --store-in-db]: directory containing the executable and all other files necessary for running it'))
-
-CODE_REL_PATH = OverridableOption(
-    '--code-rel-path',
-    prompt='Relative path of executable inside code folder',
-    required_fn=is_not_on_computer,
-    prompt_fn=is_not_on_computer,
-    type=click.Path(dir_okay=False),
-    cls=InteractiveOption,
-    help=('[if --store-in-db]: relative path of the executable inside the code-folder'))
-
-
-@verdi_code.command('setup')
-@options.LABEL(prompt='Label', cls=InteractiveOption, help='A label to refer to this code')
-@options.DESCRIPTION(prompt='Description', cls=InteractiveOption, help='A human-readable description of this code')
-@options.INPUT_PLUGIN(prompt='Default calculation input plugin', cls=InteractiveOption)
-@ON_COMPUTER()
-@options.COMPUTER(
-    prompt='Computer',
-    cls=InteractiveOption,
-    required_fn=is_on_computer,
-    prompt_fn=is_on_computer,
-    help='Name of the computer, on which the code resides')
-@REMOTE_ABS_PATH()
-@CODE_FOLDER()
-@CODE_REL_PATH()
-@options.PREPEND_TEXT()
-@options.APPEND_TEXT()
-@options.NON_INTERACTIVE()
-@with_dbenv()
-def setup_code(non_interactive, **kwargs):
-    """Add a Code."""
-    from aiida.common.exceptions import ValidationError
-
-    if not non_interactive:
-        pre, post = ensure_scripts(kwargs.pop('prepend_text', ''), kwargs.pop('append_text', ''), kwargs)
-        kwargs['prepend_text'] = pre
-        kwargs['append_text'] = post
-
-    if kwargs.pop('on_computer'):
-        kwargs['code_type'] = CodeBuilder.CodeType.ON_COMPUTER
-    else:
-        kwargs['code_type'] = CodeBuilder.CodeType.STORE_AND_UPLOAD
-    code_builder = CodeBuilder(**kwargs)
-    code = code_builder.new()
-
-    try:
-        code.store()
-        code.reveal()  # newly setup code shall not be hidden
-    except ValidationError as err:
-        echo.echo_critical('Unable to store the code: {}. Exiting...'.format(err))
-
-    echo.echo_success('code "{}" stored in DB.'.format(code.label))
-    echo.echo_info('pk: {}, uuid: {}'.format(code.pk, code.uuid))
 
 
 def get_default(key, ctx):
@@ -151,46 +61,63 @@ def set_code_builder(ctx, param, value):
     return value
 
 
-@verdi_code.command('duplicate')
-@arguments.CODE(callback=set_code_builder)
-@options.LABEL(
-    prompt='Label', cls=InteractiveOption, help='Label for new code', contextual_default=partial(get_default, 'label'))
-@options.DESCRIPTION(
-    prompt='Description',
-    cls=InteractiveOption,
-    help='A human-readable description of this code',
-    contextual_default=partial(get_default, 'description'))
-@options.INPUT_PLUGIN(
-    prompt='Default calculation input plugin',
-    cls=InteractiveOption,
-    contextual_default=partial(get_default, 'input_plugin'))
-@ON_COMPUTER(contextual_default=get_on_computer)
-@options.COMPUTER(
-    prompt='Computer',
-    cls=InteractiveOption,
-    required_fn=is_on_computer,
-    prompt_fn=is_on_computer,
-    help='Name of the computer, on which the code resides',
-    contextual_default=get_computer_name)
-@REMOTE_ABS_PATH(contextual_default=partial(get_default, 'remote_abs_path'))
-@CODE_FOLDER(contextual_default=partial(get_default, 'code_folder'))
-@CODE_REL_PATH(contextual_default=partial(get_default, 'code_rel_path'))
-@click.option(
-    '--hide-original',
-    is_flag=True,
-    default=False,
-    help=('Hide the code being copied.'),
-)
+@verdi_code.command('setup')
+@options_code.LABEL()
+@options_code.DESCRIPTION()
+@options_code.INPUT_PLUGIN()
+@options_code.ON_COMPUTER()
+@options_code.COMPUTER()
+@options_code.REMOTE_ABS_PATH()
+@options_code.FOLDER()
+@options_code.REL_PATH()
 @options.PREPEND_TEXT()
 @options.APPEND_TEXT()
 @options.NON_INTERACTIVE()
+@with_dbenv()
+def setup_code(non_interactive, **kwargs):
+    """Setup a new Code."""
+    from aiida.common.exceptions import ValidationError
+
+    if not non_interactive:
+        pre, post = ensure_scripts(kwargs.pop('prepend_text', ''), kwargs.pop('append_text', ''), kwargs)
+        kwargs['prepend_text'] = pre
+        kwargs['append_text'] = post
+
+    if kwargs.pop('on_computer'):
+        kwargs['code_type'] = CodeBuilder.CodeType.ON_COMPUTER
+    else:
+        kwargs['code_type'] = CodeBuilder.CodeType.STORE_AND_UPLOAD
+
+    code_builder = CodeBuilder(**kwargs)
+    code = code_builder.new()
+
+    try:
+        code.store()
+        code.reveal()
+    except ValidationError as exception:
+        echo.echo_critical('Unable to store the Code: {}'.format(exception))
+
+    echo.echo_success('Code<{}> {} created'.format(code.pk, code.full_label))
+
+
+@verdi_code.command('duplicate')
+@arguments.CODE(callback=set_code_builder)
+@options_code.LABEL(contextual_default=partial(get_default, 'label'))
+@options_code.DESCRIPTION(contextual_default=partial(get_default, 'description'))
+@options_code.INPUT_PLUGIN(contextual_default=partial(get_default, 'input_plugin'))
+@options_code.ON_COMPUTER(contextual_default=get_on_computer)
+@options_code.COMPUTER(contextual_default=get_computer_name)
+@options_code.REMOTE_ABS_PATH(contextual_default=partial(get_default, 'remote_abs_path'))
+@options_code.FOLDER(contextual_default=partial(get_default, 'code_folder'))
+@options_code.REL_PATH(contextual_default=partial(get_default, 'code_rel_path'))
+@options.PREPEND_TEXT()
+@options.APPEND_TEXT()
+@options.NON_INTERACTIVE()
+@click.option('--hide-original', is_flag=True, default=False, help='Hide the code being copied.')
 @click.pass_context
 @with_dbenv()
-# pylint: disable=unused-argument
 def code_duplicate(ctx, code, non_interactive, **kwargs):
-    """
-    Create duplicate of existing code.
-    """
+    """Create duplicate of existing Code."""
     from aiida.common.exceptions import ValidationError
 
     if not non_interactive:
@@ -214,22 +141,19 @@ def code_duplicate(ctx, code, non_interactive, **kwargs):
 
     try:
         new_code.store()
-        new_code.reveal()  # newly setup code shall not be hidden
-    except ValidationError as err:
-        echo.echo_critical('Unable to store the code: {}. Exiting...'.format(err))
+        new_code.reveal()
+    except ValidationError as exception:
+        echo.echo_critical('Unable to store the Code: {}'.format(exception))
 
-    echo.echo_success("Duplicated code '{}'.".format(code.full_label))
-    echo.echo_info('New ' + str(new_code))
+    echo.echo_success('Code<{}> {} created'.format(code.pk, code.full_label))
 
 
 @verdi_code.command()
 @arguments.CODE()
-@click.option('-v', '--verbose', is_flag=True, help='show additional verbose information')
+@options.VERBOSE()
 @with_dbenv()
 def show(code, verbose):
-    """
-    Display information about a Code object identified by CODE_ID which can be the pk or label
-    """
+    """Display detailed information for the given CODE."""
     click.echo(tabulate.tabulate(code.full_text_info(verbose)))
 
 
@@ -237,47 +161,39 @@ def show(code, verbose):
 @arguments.CODES()
 @with_dbenv()
 def delete(codes):
-    """
-    Delete codes.
-
-    Does not delete codes that are used by calculations
-    (i.e., if there are output links)
-    """
+    """Delete codes that have not yet been used for calculations, i.e. if it has outgoing links."""
     from aiida.common.exceptions import InvalidOperation
     from aiida.orm.code import delete_code
 
     for code in codes:
         try:
-            code_str = str(code)
+            pk = code.pk
+            full_label = code.full_label
             delete_code(code)
-        except InvalidOperation as exc:
-            echo.echo_critical(str(exc))
-
-        echo.echo_success("{} deleted.".format(code_str))
+        except InvalidOperation as exception:
+            echo.echo_error(str(exception))
+        else:
+            echo.echo_success('Code<{}> {} deleted'.format(pk, full_label))
 
 
 @verdi_code.command()
 @arguments.CODES()
 @with_dbenv()
 def hide(codes):
-    """
-    Hide one or more codes from the verdi show command
-    """
+    """Hide one or more codes from the `verdi code list` command."""
     for code in codes:
         code.hide()
-        echo.echo_success("Code '{}' hidden.".format(code.pk))
+        echo.echo_success('Code<{}> {} hidden'.format(code.pk, code.full_label))
 
 
 @verdi_code.command()
 @arguments.CODES()
 @with_dbenv()
 def reveal(codes):
-    """
-    Reveal one or more hidden codes to the verdi show command
-    """
+    """Reveal one or more hidden codes to the `verdi code list` command."""
     for code in codes:
         code.reveal()
-        echo.echo_success("Code '{}' revealed.".format(code.pk))
+        echo.echo_success('Code<{}> {} revealed'.format(code.pk, code.full_label))
 
 
 @verdi_code.command()
@@ -286,48 +202,42 @@ def reveal(codes):
 @deprecated_command("Updating codes breaks data provenance. Use 'duplicate' instead.")
 # pylint: disable=unused-argument
 def update(code):
-    """
-    Update an existing code.
-    """
+    """Update an existing code."""
     pass
 
 
 @verdi_code.command()
-@arguments.CODE('old_label')
-@arguments.LABEL('new_label')
+@arguments.CODE()
+@arguments.LABEL()
 @with_dbenv()
-def relabel(old_label, new_label):
-    """
-    Relabel a code.
-    """
-    # Note: old_label actually holds a code but we need to
-    # specify it that way for the click help message
-    code = old_label
+def relabel(code, label):
+    """Relabel a code."""
     old_label = code.full_label
-    code.relabel(new_label)
 
-    echo.echo_success("Relabeled code with ID={} from '{}' to '{}'".format(code.pk, old_label, code.full_label))
+    try:
+        code.relabel(label)
+    except InputValidationError as exception:
+        echo.echo_critical('invalid code name: {}'.format(exception))
+    else:
+        echo.echo_success('Code<{}> relabeled from {} to {}'.format(code.pk, old_label, code.full_label))
 
 
 @verdi_code.command()
-@arguments.CODE('OLD_LABEL')
-@arguments.LABEL('NEW_LABEL')
+@arguments.CODE()
+@arguments.LABEL()
 @with_dbenv()
 @click.pass_context
 @deprecated_command("This command may be removed in a future release. Use 'relabel' instead.")
-# pylint: disable=unused-argument
-def rename(ctx, old_label, new_label):
-    """
-    Rename a code (change its label).
-    """
-    ctx.forward(relabel)
+def rename(ctx, code, label):
+    """Rename a code."""
+    ctx.invoke(relabel, code=code, label=label)
 
 
 @verdi_code.command('list')
-@options.COMPUTER(help="Filter codes by computer")
-@options.INPUT_PLUGIN(help="Filter codes by calculation input plugin.")
-@options.ALL(help="Include hidden codes.")
-@options.ALL_USERS(help="Include codes from all users.")
+@options.COMPUTER(help='Filter codes by computer.')
+@options.INPUT_PLUGIN(help='Filter codes by calculation input plugin.')
+@options.ALL(help='Include hidden codes.')
+@options.ALL_USERS(help='Include codes from all users.')
 @click.option('-o', '--show-owner', 'show_owner', is_flag=True, default=False, help='Show owners of codes.')
 @with_dbenv()
 def code_list(computer, input_plugin, all_entries, all_users, show_owner):

--- a/aiida/cmdline/params/options/commands/__init__.py
+++ b/aiida/cmdline/params/options/commands/__init__.py
@@ -1,0 +1,2 @@
+# -*- coding: utf-8 -*-
+"""Module containing predefined command specific CLI options."""

--- a/aiida/cmdline/params/options/commands/code.py
+++ b/aiida/cmdline/params/options/commands/code.py
@@ -1,0 +1,70 @@
+# -*- coding: utf-8 -*-
+"""Reusable command line interface options for Code commands."""
+from __future__ import absolute_import
+
+import click
+
+from aiida.cmdline.params import options, types
+from aiida.cmdline.params.options.interactive import InteractiveOption
+from aiida.cmdline.params.options.overridable import OverridableOption
+
+
+def is_on_computer(ctx):
+    return bool(ctx.params.get('on_computer'))
+
+
+def is_not_on_computer(ctx):
+    return bool(not is_on_computer(ctx))
+
+
+ON_COMPUTER = OverridableOption(
+    '--on-computer/--store-in-db',
+    is_eager=False,
+    default=True,
+    cls=InteractiveOption,
+    prompt='Installed on target computer?',
+    help='Whether the code is installed on the target computer or should be copied each time from a local path.')
+
+REMOTE_ABS_PATH = OverridableOption(
+    '--remote-abs-path',
+    prompt='Remote absolute path',
+    required_fn=is_on_computer,
+    prompt_fn=is_on_computer,
+    type=types.AbsolutePathParamType(dir_okay=False),
+    cls=InteractiveOption,
+    help=('[if --on-computer]: the absolute path to the executable on the remote machine.'))
+
+FOLDER = OverridableOption(
+    '--code-folder',
+    prompt='Local directory containing the code',
+    required_fn=is_not_on_computer,
+    prompt_fn=is_not_on_computer,
+    type=click.Path(file_okay=False, exists=True, readable=True),
+    cls=InteractiveOption,
+    help=('[if --store-in-db]: directory containing the executable and all other files necessary for running it.'))
+
+REL_PATH = OverridableOption(
+    '--code-rel-path',
+    prompt='Relative path of executable inside code folder',
+    required_fn=is_not_on_computer,
+    prompt_fn=is_not_on_computer,
+    type=click.Path(dir_okay=False),
+    cls=InteractiveOption,
+    help=('[if --store-in-db]: relative path of the executable inside the code-folder.'))
+
+LABEL = options.LABEL.clone(prompt='Label', cls=InteractiveOption, help='A label to refer to this code.')
+
+DESCRIPTION = options.DESCRIPTION.clone(
+    prompt='Description', cls=InteractiveOption, help='A human-readable description of this code.')
+
+INPUT_PLUGIN = options.INPUT_PLUGIN.clone(
+    prompt='Default calculation input plugin',
+    cls=InteractiveOption,
+    help='Default calculation plugin to use for this code.')
+
+COMPUTER = options.COMPUTER.clone(
+    prompt='Computer',
+    cls=InteractiveOption,
+    required_fn=is_on_computer,
+    prompt_fn=is_on_computer,
+    help='Name of the computer, on which the code resides.')

--- a/aiida/cmdline/params/options/commands/computer.py
+++ b/aiida/cmdline/params/options/commands/computer.py
@@ -1,0 +1,109 @@
+# -*- coding: utf-8 -*-
+"""Reusable command line interface options for Computer commands."""
+from __future__ import absolute_import
+
+import click
+
+from aiida.cmdline.params import options, types
+from aiida.cmdline.params.options.interactive import InteractiveOption
+from aiida.cmdline.params.options.overridable import OverridableOption
+
+
+def should_call_default_mpiprocs_per_machine(ctx):  # pylint: disable=invalid-name
+    """
+    Return True if the scheduler can accept 'default_mpiprocs_per_machine',
+    False otherwise.
+
+    If there is a problem in determining the scheduler, return True to
+    avoid exceptions.
+    """
+    from aiida.common.exceptions import ValidationError
+
+    scheduler_ep = ctx.params['scheduler']
+    if scheduler_ep is not None:
+        try:
+            scheduler_cls = scheduler_ep.load()
+        except ImportError:
+            raise ImportError("Unable to load the '{}' scheduler".format(scheduler_ep.name))
+    else:
+        raise ValidationError(
+            "The shouldcall_... function should always be run (and prompted) AFTER asking for a scheduler")
+
+    job_resource_cls = scheduler_cls.job_resource_class
+    if job_resource_cls is None:
+        # Odd situation...
+        return False
+
+    return job_resource_cls.accepts_default_mpiprocs_per_machine()
+
+
+LABEL = options.LABEL.clone(
+    prompt='Computer label', cls=InteractiveOption, required=True, type=types.NonEmptyStringParamType())
+
+HOSTNAME = options.HOSTNAME.clone(
+    prompt='Hostname',
+    cls=InteractiveOption,
+    required=True,
+    help='The fully qualified hostname of this computer; for local transports, use localhost.')
+
+DESCRIPTION = options.DESCRIPTION.clone(
+    prompt='Description', cls=InteractiveOption, help='A human-readable description of this computer.')
+
+ENABLED = OverridableOption(
+    '-e/-d',
+    '--enabled/--disabled',
+    is_flag=True,
+    default=True,
+    help='Calculations on disabled computers will not be submitted until the computer is re-enabled.',
+    prompt='Enable the computer?',
+    cls=InteractiveOption,
+    # IMPORTANT! Do not specify explicitly type=click.BOOL,
+    # Otherwise you would not get a default value when prompting
+)
+
+TRANSPORT = options.TRANSPORT.clone(prompt='Transport plugin.', cls=InteractiveOption)
+
+SCHEDULER = options.SCHEDULER.clone(prompt='Scheduler plugin.', cls=InteractiveOption)
+
+SHEBANG = OverridableOption(
+    '--shebang',
+    prompt='Shebang line (first line of each script, starting with #!)',
+    default='#!/bin/bash',
+    cls=InteractiveOption,
+    help='This line specifies the first line of the submission script for this computer.',
+    type=types.ShebangParamType())
+
+WORKDIR = OverridableOption(
+    '-w',
+    '--work-dir',
+    prompt='Work directory on the computer',
+    default='/scratch/{username}/aiida/',
+    cls=InteractiveOption,
+    help='The absolute path of the directory on the computer where AiiDA will '
+    'run the calculations (typically, the scratch of the computer). You '
+    'can use the {username} replacement, that will be replaced by your '
+    'username on the remote computer.')
+
+MPI_RUN_COMMAND = OverridableOption(
+    '-m',
+    '--mpirun-command',
+    prompt='Mpirun command',
+    default='mpirun -np {tot_num_mpiprocs}',
+    cls=InteractiveOption,
+    help='The mpirun command needed on the cluster to run parallel MPI '
+    'programs. You can use the {tot_num_mpiprocs} replacement, that will be '
+    'replaced by the total number of cpus, or the other scheduler-dependent '
+    'replacement fields (see the scheduler docs for more information).',
+    type=types.MpirunCommandParamType())
+
+MPI_PROCS_PER_MACHINE = OverridableOption(
+    '--mpiprocs-per-machine',
+    prompt='Default number of CPUs per machine',
+    cls=InteractiveOption,
+    prompt_fn=should_call_default_mpiprocs_per_machine,
+    required_fn=False,
+    type=click.INT,
+    help='Enter here the default number of MPI processes per machine (node) that '
+    'should be used if nothing is otherwise specified. Pass the digit 0 '
+    'if you do not want to provide a default value.',
+)

--- a/aiida/cmdline/params/options/overridable.py
+++ b/aiida/cmdline/params/options/overridable.py
@@ -35,19 +35,45 @@ class OverridableOption(object):
             click.echo(os.listdir(folder))
     """
 
-    # pylint: disable=too-few-public-methods
-
     def __init__(self, *args, **kwargs):
         """
-        Store the default args and kwargs
+        Store the default args and kwargs.
+
+        :param args: default arguments to be used for the click option
+        :param kwargs: default keyword arguments to be used that can be overridden in the call
         """
         self.args = args
         self.kwargs = kwargs
 
     def __call__(self, **kwargs):
         """
-        Override the stored kwargs, (ignoring args as we do not allow option name changes) and return the option
+        Override the stored kwargs, (ignoring args as we do not allow option name changes) and return the option.
+
+        :param kwargs: keyword arguments that will override those set in the construction
+        :return: click option constructed with args and kwargs defined during construction and call of this instance
         """
         kw_copy = self.kwargs.copy()
         kw_copy.update(kwargs)
         return click.option(*self.args, **kw_copy)
+
+    def clone(self, **kwargs):
+        """
+        Create a new instance of the OverridableOption by cloning it and updating the stored kwargs with those passed.
+
+        This can be useful when an already predefined OverridableOption needs to be further specified and reused
+        by a set of sub commands. Example::
+
+            LABEL = OverridableOption('-l', '--label', required=False, help='The label of the node'
+            LABEL_COMPUTER = LABEL.clone(required=True, help='The label of the computer')
+
+        If multiple computer related sub commands need the LABEL option, but the default help string and required
+        attribute need to be different, the `clone` method allows to override these and create a new OverridableOption
+        instance that can then be used as a decorator.
+
+        :param kwargs: keyword arguments to update
+        :return: OverridableOption instance with stored keyword arguments updated
+        """
+        import copy
+        clone = copy.deepcopy(self)
+        clone.kwargs.update(kwargs)
+        return clone

--- a/aiida/cmdline/params/types/plugin.py
+++ b/aiida/cmdline/params/types/plugin.py
@@ -29,7 +29,7 @@ class PluginParamType(click.ParamType):
         click.option(... type=PluginParamType(group=('calculations', 'data'))
 
     """
-    name = 'aiida plugin'
+    name = 'plugin'
 
     def __init__(self, group=None, load=False, *args, **kwargs):
         """

--- a/aiida/orm/implementation/django/code.py
+++ b/aiida/orm/implementation/django/code.py
@@ -15,9 +15,7 @@ from django.db import transaction
 
 from aiida.orm.implementation.general.code import AbstractCode
 from aiida.orm.implementation import Computer
-from aiida.common.exceptions import (NotExistent, MultipleObjectsError,
-                                     InvalidOperation)
-
+from aiida.common.exceptions import InvalidOperation
 
 
 class Code(AbstractCode):
@@ -126,8 +124,6 @@ class Code(AbstractCode):
                     self.get_remote_computer().dbcomputer.pk)
 
 
-
-
 def delete_code(code):
     """
     Delete a code from the DB.
@@ -141,15 +137,13 @@ def delete_code(code):
     computer.delete().
     """
     if not isinstance(code, Code):
-        raise TypeError("code must be an instance of "
-                        "aiida.orm.computer.Code")
+        raise TypeError('code must be an instance of aiida.orm.computer.Code')
 
     existing_outputs = code.get_outputs()
 
     if len(existing_outputs) != 0:
-        raise InvalidOperation("Unable to delete the requested code because it "
-                               "has {} output links".format(
-            len(existing_outputs)))
+        raise InvalidOperation('Unable to delete {} because it has {} output links'.format(
+            code.full_label, len(existing_outputs)))
     else:
         repo_folder = code._repository_folder
         with transaction.atomic():

--- a/aiida/orm/implementation/sqlalchemy/code.py
+++ b/aiida/orm/implementation/sqlalchemy/code.py
@@ -12,9 +12,7 @@ from __future__ import absolute_import
 import os
 
 from aiida.backends.sqlalchemy.models.computer import DbComputer
-
-from aiida.common.exceptions import NotExistent, MultipleObjectsError, InvalidOperation
-
+from aiida.common.exceptions import InvalidOperation
 from aiida.orm.implementation.general.code import AbstractCode
 from aiida.orm.implementation.sqlalchemy.computer import Computer
 
@@ -114,15 +112,13 @@ def delete_code(code):
     computer.delete().
     """
     if not isinstance(code, Code):
-        raise TypeError("code must be an instance of "
-                        "aiida.orm.computer.Code")
+        raise TypeError('code must be an instance of aiida.orm.computer.Code')
 
     existing_outputs = code.get_outputs()
 
     if len(existing_outputs) != 0:
-        raise InvalidOperation(
-            "Unable to delete the requested code because it "
-            "has {} output links".format(len(existing_outputs)))
+        raise InvalidOperation('Unable to delete {} because it has {} output links'.format(
+            code.full_label, len(existing_outputs)))
     else:
         repo_folder = code._repository_folder
         from aiida.backends.sqlalchemy import get_scoped_session
@@ -134,5 +130,6 @@ def delete_code(code):
         except:
             session.rollback()
             raise
-    # If all went well, erase also the folder
-    repo_folder.erase()
+        else:
+            # If all went well, erase also the folder
+            repo_folder.erase()


### PR DESCRIPTION
Fixes #1936 

The OverridableOption allows to predefine reusable click options for
the CLI. Calling the constructor will store the args and the kwargs
and by calling the instance, the click option will be generated from
those args and kwargs, while giving the chance to override the kwargs.

However, in many situations, one wants to slightly adapt a predefined
option for a set of sub commands, that largely share the settings of
that predefined option, yet all need to have one or more kwargs
changed. Since the instance is already created and the defaults can
not be changed, this is not possible.

The solution is to define the `clone` method, that will create a
copy of the instance and override the keyword arguments that were
set during construction with those that are passed in the method call.

This concept has now been applied to deduplicate the command line
options for `verdi code setup` and `verdi code duplicate` as well as
their analogues for the `verdi computer` command. Many of their options
are already defined in `aiida.cmdline.params.options` so we wanted to
reuse them, however, the `setup` and `duplicate` both required quite a
few additional kwargs in the call. Which would not have been a problem
if it were not for the fact that `duplicate` in fact needs one more
keyword, namely the `contextual_default`. By using `clone` to clone
the shared predefined options into `code` or `computer` specific cli
options, the old call functionality of the Overridable option can now
be used to pass the `contextual_default` for the options of the
`duplicate` command.