### PR TITLE
Add warning message for `verdi process` commands if daemon not running

### DIFF
--- a/aiida/cmdline/commands/cmd_daemon.py
+++ b/aiida/cmdline/commands/cmd_daemon.py
@@ -10,7 +10,6 @@
 """`verdi daemon` commands."""
 from __future__ import absolute_import
 import os
-import sys
 import subprocess
 import time
 
@@ -18,7 +17,7 @@ import click
 from click_spinner import spinner
 
 from aiida.cmdline.commands.cmd_verdi import verdi
-from aiida.cmdline.utils import decorators
+from aiida.cmdline.utils import decorators, echo
 from aiida.cmdline.utils.common import get_env_with_venv_bin
 from aiida.cmdline.utils.daemon import get_daemon_status, print_client_response_status
 from aiida.common.profile import get_current_profile_name
@@ -33,7 +32,7 @@ def verdi_daemon():
 
 
 @verdi_daemon.command()
-@click.option('--foreground', is_flag=True, help='Run in foreground')
+@click.option('--foreground', is_flag=True, help='Run in foreground.')
 @decorators.with_dbenv()
 @decorators.check_circus_zmq_version
 def start(foreground):
@@ -42,7 +41,7 @@ def start(foreground):
     """
     client = DaemonClient()
 
-    click.echo('Starting the daemon... ', nl=False)
+    echo.echo('Starting the daemon... ', nl=False)
 
     if foreground:
         command = ['verdi', '-p', client.profile_name, 'daemon', '_start_circus', '--foreground']
@@ -53,8 +52,7 @@ def start(foreground):
         currenv = get_env_with_venv_bin()
         subprocess.check_output(command, env=currenv)
     except subprocess.CalledProcessError as exception:
-        click.echo('failed: {}'.format(exception))
-        sys.exit(1)
+        echo.echo_critical('{}'.format(exception))
 
     # We add a small timeout to give the pid-file a chance to be created
     with spinner():
@@ -65,7 +63,7 @@ def start(foreground):
 
 
 @verdi_daemon.command()
-@click.option('--all', 'all_profiles', is_flag=True, help='Show all daemons')
+@click.option('--all', 'all_profiles', is_flag=True, help='Show all daemons.')
 def status(all_profiles):
     """
     Print the status of the current daemon or all daemons
@@ -80,12 +78,12 @@ def status(all_profiles):
         click.secho('Profile: ', fg='red', bold=True, nl=False)
         click.secho('{}'.format(profile_name), bold=True)
         result = get_daemon_status(client)
-        click.echo(result)
+        echo.echo(result)
 
 
 @verdi_daemon.command()
 @click.argument('number', default=1, type=int)
-@decorators.only_if_daemon_pid
+@decorators.only_if_daemon_running()
 def incr(number):
     """
     Add NUMBER [default=1] workers to the running daemon
@@ -97,7 +95,7 @@ def incr(number):
 
 @verdi_daemon.command()
 @click.argument('number', default=1, type=int)
-@decorators.only_if_daemon_pid
+@decorators.only_if_daemon_running()
 def decr(number):
     """
     Remove NUMBER [default=1] workers from the running daemon
@@ -123,8 +121,8 @@ def logshow():
 
 
 @verdi_daemon.command()
-@click.option('--no-wait', is_flag=True, help='Do not wait for confirmation')
-@click.option('--all', 'all_profiles', is_flag=True, help='Stop all daemons')
+@click.option('--no-wait', is_flag=True, help='Do not wait for confirmation.')
+@click.option('--all', 'all_profiles', is_flag=True, help='Stop all daemons.')
 def stop(no_wait, all_profiles):
     """
     Stop the daemon
@@ -142,15 +140,15 @@ def stop(no_wait, all_profiles):
         click.secho('{}'.format(profile_name), bold=True)
 
         if not client.is_daemon_running:
-            click.echo('Daemon was not running')
+            echo.echo('Daemon was not running')
             continue
 
         wait = not no_wait
 
         if wait:
-            click.echo('Waiting for the daemon to shut down... ', nl=False)
+            echo.echo('Waiting for the daemon to shut down... ', nl=False)
         else:
-            click.echo('Shutting the daemon down')
+            echo.echo('Shutting the daemon down')
 
         response = client.stop_daemon(wait)
 
@@ -159,11 +157,11 @@ def stop(no_wait, all_profiles):
 
 
 @verdi_daemon.command()
-@click.option('--reset', is_flag=True, help='Completely reset the daemon')
-@click.option('--no-wait', is_flag=True, help='Do not wait for confirmation')
+@click.option('--reset', is_flag=True, help='Completely reset the daemon.')
+@click.option('--no-wait', is_flag=True, help='Do not wait for confirmation.')
 @click.pass_context
 @decorators.with_dbenv()
-@decorators.only_if_daemon_pid
+@decorators.only_if_daemon_running()
 def restart(ctx, reset, no_wait):
     """
     Restart the daemon. By default will only reset the workers of the running daemon.
@@ -181,9 +179,9 @@ def restart(ctx, reset, no_wait):
     else:
 
         if wait:
-            click.echo('Restarting the daemon... ', nl=False)
+            echo.echo('Restarting the daemon... ', nl=False)
         else:
-            click.echo('Restarting the daemon')
+            echo.echo('Restarting the daemon')
 
         response = client.restart_daemon(wait)
 
@@ -192,7 +190,7 @@ def restart(ctx, reset, no_wait):
 
 
 @verdi_daemon.command()
-@click.option('--foreground', is_flag=True, help='Run in foreground')
+@click.option('--foreground', is_flag=True, help='Run in foreground.')
 @decorators.with_dbenv()
 @decorators.check_circus_zmq_version
 def _start_circus(foreground):
@@ -236,7 +234,7 @@ def _start_circus(foreground):
             },
             'env': get_env_with_venv_bin(),
         }]
-    } # yapf: disable
+    }  # yapf: disable
 
     if not foreground:
         daemonize()
@@ -247,8 +245,7 @@ def _start_circus(foreground):
     try:
         pidfile.create(os.getpid())
     except RuntimeError as exception:
-        click.echo(str(exception))
-        sys.exit(1)
+        echo.echo_critical(str(exception))
 
     # Configure the logger
     loggerconfig = None
@@ -275,5 +272,3 @@ def _start_circus(foreground):
             arbiter = None
             if pidfile is not None:
                 pidfile.unlink()
-
-    sys.exit(0)

--- a/aiida/cmdline/commands/cmd_process.py
+++ b/aiida/cmdline/commands/cmd_process.py
@@ -60,6 +60,7 @@ def process_list(all_entries, process_state, exit_status, failed, past_days, lim
 @arguments.PROCESSES()
 @options.TIMEOUT()
 @decorators.with_dbenv()
+@decorators.only_if_daemon_running(echo.echo_warning, 'daemon is not running, so process may not be reachable')
 def process_kill(processes, timeout):
     """Kill running processes."""
     from aiida.work import RemoteException, DeliveryFailed, CommunicationTimeout, new_blocking_control_panel
@@ -86,6 +87,7 @@ def process_kill(processes, timeout):
 @arguments.PROCESSES()
 @options.TIMEOUT()
 @decorators.with_dbenv()
+@decorators.only_if_daemon_running(echo.echo_warning, 'daemon is not running, so process may not be reachable')
 def process_pause(processes, timeout):
     """Pause running processes."""
     from aiida.work import RemoteException, DeliveryFailed, CommunicationTimeout, new_blocking_control_panel
@@ -112,6 +114,7 @@ def process_pause(processes, timeout):
 @arguments.PROCESSES()
 @options.TIMEOUT()
 @decorators.with_dbenv()
+@decorators.only_if_daemon_running(echo.echo_warning, 'daemon is not running, so process may not be reachable')
 def process_play(processes, timeout):
     """Play paused processes."""
     from aiida.work import RemoteException, DeliveryFailed, CommunicationTimeout, new_blocking_control_panel
@@ -137,6 +140,7 @@ def process_play(processes, timeout):
 @verdi_process.command('watch')
 @arguments.PROCESSES()
 @decorators.with_dbenv()
+@decorators.only_if_daemon_running(echo.echo_warning, 'daemon is not running, so process may not be reachable')
 def process_watch(processes):
     """Watch the state transitions for a process."""
     from kiwipy import BroadcastFilter

--- a/aiida/cmdline/utils/decorators.py
+++ b/aiida/cmdline/utils/decorators.py
@@ -20,12 +20,14 @@ Provides:
 
 """
 from __future__ import absolute_import
-import sys
 from contextlib import contextmanager
 from functools import wraps
 
-import click
 from click_spinner import spinner
+
+from . import echo
+
+DAEMON_NOT_RUNNING_DEFAULT_MESSAGE = 'daemon is not running'
 
 
 def load_dbenv_if_not_loaded(**kwargs):
@@ -106,33 +108,45 @@ def dbenv():
     yield
 
 
-def only_if_daemon_pid(function):
+def only_if_daemon_running(echo_function=echo.echo_critical, message=None):
     """
-    Function decorator to exit with a message if the daemon is not found running (by checking pid file)
+    Function decorator for CLI command to print critical error and exit automatically when daemon is not running.
+
+    The error printing and exit behavior can be controlled with the decorator keyword arguments. The default message
+    that is printed can be overridden as well as the echo function that is to be used. By default it uses the
+    `aiida.cmdline.utils.echo.echo_critical` function which automatically aborts the command. The function can be
+    substituted by for example `aiida.cmdline.utils.echo.echo_warning` to instead print just a warning and continue.
 
     Example::
 
-        @only_if_daemon_pid
+        @only_if_daemon_running(echo_function=echo.echo_warning, message='beware that the daemon is not running')
         def create_my_calculation():
             pass
+
+    :param echo_function: echo function to issue the message, should be from `aiida.cmdline.utils.echo`
+    :param message: optional message to override the default message
     """
+    if message is None:
+        message = DAEMON_NOT_RUNNING_DEFAULT_MESSAGE
 
-    @wraps(function)
-    def decorated_function(*args, **kwargs):
-        """
-        If daemon pid file is not found / empty, exit without doing anything
-        """
-        from aiida.daemon.client import DaemonClient
+    def decorator(function):
+        """Function decorator that checks if daemon is running and echo's message if not."""
 
-        daemon_client = DaemonClient()
+        @wraps(function)
+        def decorated_function(*args, **kwargs):
+            """If daemon pid file is not found / empty, echo message and call decorated function."""
+            from aiida.daemon.client import DaemonClient
 
-        if not daemon_client.get_daemon_pid():
-            click.echo('The daemon is not running')
-            sys.exit(0)
+            daemon_client = DaemonClient()
 
-        return function(*args, **kwargs)
+            if not daemon_client.get_daemon_pid():
+                echo_function(message)
 
-    return decorated_function
+            return function(*args, **kwargs)
+
+        return decorated_function
+
+    return decorator
 
 
 def check_circus_zmq_version(function):
@@ -158,12 +172,10 @@ def check_circus_zmq_version(function):
             if len(zmq_version) < 2:
                 raise ValueError()
         except (AttributeError, ValueError):
-            click.echo('Unknown PyZQM version - aborting...')
-            sys.exit(0)
+            echo.echo_critical('Unknown PyZQM version - aborting...')
 
         if zmq_version[0] < 13 or (zmq_version[0] == 13 and zmq_version[1] < 1):
-            click.echo('AiiDA daemon needs PyZMQ >= 13.1.0 to run - aborting...')
-            sys.exit(0)
+            echo.echo_critical('AiiDA daemon needs PyZMQ >= 13.1.0 to run - aborting...')
 
         return function(*args, **kwargs)
 
@@ -188,7 +200,7 @@ def deprecated_command(message):
         @wraps(function)
         def decorated_function(*args, **kwargs):
             """Echo a deprecation warning before doing anything else."""
-            from aiida.cmdline.utils import echo, templates
+            from aiida.cmdline.utils import templates
             from textwrap import wrap
 
             template = templates.env.get_template('deprecated.tpl')


### PR DESCRIPTION
Fixes #1942 

We add the `only_if_daemon_running` decorator to all `verdi process`
commands that rely on the daemon running. Note, however, that we override
the default behavior of emitting a critical error and exiting when the
daemon is not running, because although most likely these operations
will time out if the daemon is not running, it is not guaranteed. Even
if a user runs a process in a normal runner (i.e. not a runner launched
and controlled by the daemon) that process is still reachable through
the `verdi process` commands, since all runners have RabbitMQ comms.
However, since this usecase will probably be rare, and most of the time
users will only run processes through daemon runners, emitting a warning
when the daemon is not running, to indicate that the call will most
likely timeout because the process is not reachable, seems in order.

Note that these changes required a change in the `only_if_daemon_running`
decorator to allow the message and exit behavior to be customized.