### PR TITLE
Separate JobProcess submit task in folder upload and scheduler submit

### DIFF
--- a/.ci/test_daemon.py
+++ b/.ci/test_daemon.py
@@ -377,6 +377,15 @@ def main():
         print("#" * 78)
         print("####### TIME ELAPSED: {} s".format(time.time() - start_time))
         print("#" * 78)
+        print("Output of 'verdi process list -a':")
+        try:
+            print(subprocess.check_output(
+                ["verdi", "process", "list", "-a"],
+                stderr=subprocess.STDOUT,
+            ))
+        except subprocess.CalledProcessError as e:
+            print("Note: the command failed, message: {}".format(e))
+
         print("Output of 'verdi calculation list -a':")
         try:
             print(subprocess.check_output(

--- a/aiida/common/log.py
+++ b/aiida/common/log.py
@@ -10,7 +10,6 @@
 from __future__ import absolute_import
 import logging
 from copy import deepcopy
-from logging import config
 from aiida.common import setup
 
 # Custom logging level, intended specifically for informative log messages
@@ -151,6 +150,7 @@ LOGGING = {
     },
 }
 
+
 def configure_logging(daemon=False, daemon_log_file=None):
     """
     Setup the logging by retrieving the LOGGING dictionary from aiida and passing it to
@@ -163,6 +163,8 @@ def configure_logging(daemon=False, daemon_log_file=None):
         of the default 'console' StreamHandler
     :param daemon_log_file: absolute filepath of the log file for the RotatingFileHandler
     """
+    from logging.config import dictConfig
+
     config = deepcopy(LOGGING)
     daemon_handler_name = 'daemon_log_file'
 
@@ -185,7 +187,7 @@ def configure_logging(daemon=False, daemon_log_file=None):
         for name, logger in config.get('loggers', {}).items():
             logger.setdefault('handlers', []).append(daemon_handler_name)
 
-    logging.config.dictConfig(config)
+    dictConfig(config)
 
 
 def get_dblogger_extra(obj):


### PR DESCRIPTION
Fixes #1940 

Originally, the submit TransportTask of a JobProcess included both the
uploading of the work directory on the remote machine as well as the
call to the scheduler to submit the job. These have now been separated
into two separate TransportTasks, `upload` and `submit`, in order to
provide finer grained control over the job process control flow.