### PR TITLE
Fix the help message generator of InteractiveOption for Choice params

### DIFF
--- a/aiida/cmdline/params/options/interactive.py
+++ b/aiida/cmdline/params/options/interactive.py
@@ -145,8 +145,13 @@ class InteractiveOption(ConditionalOption):
         msg = self.help or 'Expecting {}'.format(self.type.name)
         choices = getattr(self.type, 'complete', lambda x, y: [])(None, '')
         if choices:
-            msg += '\none of:\n'
-            choice_table = ['\t{:<12} {}'.format(*choice) for choice in choices]
+            choice_table = []
+            msg += '\nSelect one of:\n'
+            for choice in choices:
+                if isinstance(choice, tuple):
+                    choice_table.append('\t{:<12} {}'.format(*choice))
+                else:
+                    choice_table.append('\t{:<12}'.format(choice))
             msg += '\n'.join(choice_table)
         return msg
 


### PR DESCRIPTION
Fixes #1950 

The `InteractiveOption.format_help_message` method was expecting the list of
choices, in the case of a `Choice` parameter type, to be a list of tuples where
the first element is the name of the value and the second a description. However,
the default `complete` method for the `click.Choice`, which is defined by the
`click-completion` plugin, returns a flat list. Here we update the format method
to be able to deal with both a flat list as well as a list of tuples.