### PR TITLE
Fix composite requirement string for ipython

### DIFF
--- a/docs/requirements_for_rtd.txt
+++ b/docs/requirements_for_rtd.txt
@@ -32,7 +32,7 @@ ecdsa==0.13
 enum34==1.1.6; python_version<"3.5"
 ete3==3.1.1
 flask-marshmallow==0.9.0
-ipython>=4.0<6.0
+ipython>=4.0,<6.0
 itsdangerous==0.24
 marshmallow-sqlalchemy==0.13.2
 meld3==1.0.2

--- a/setup_requirements.py
+++ b/setup_requirements.py
@@ -41,7 +41,7 @@ install_requires = [
     'paramiko==2.4.1',
     'ecdsa==0.13',
     'pika==0.11.2',
-    'ipython>=4.0<6.0',  # Version of ipython non enforced, because some still prefer version 4 rather than the latest
+    'ipython>=4.0,<6.0',  # Version of ipython non enforced, because some still prefer version 4 rather than the latest
     'plumpy==0.10.6',
     'circus==0.14.0',
     'tornado==4.5.3',  # As of 2018/03/06 Tornado released v5.0 which breaks circus 0.14.0


### PR DESCRIPTION
The comma separating the upper and lower limit was missing