### PR TITLE
Improve error message for `verdi import` when archive version is incompatible

### DIFF
--- a/aiida/backends/tests/export_and_import.py
+++ b/aiida/backends/tests/export_and_import.py
@@ -279,6 +279,7 @@ class TestSimple(AiidaTestCase):
         import shutil
         import tempfile
 
+        from aiida.common import exceptions
         from aiida.orm import DataFactory
         from aiida.orm.importexport import export
 
@@ -310,7 +311,7 @@ class TestSimple(AiidaTestCase):
             self.tearDownClass()
             self.setUpClass()
 
-            with self.assertRaises(ValueError):
+            with self.assertRaises(exceptions.IncompatibleArchiveVersionError):
                 import_data(filename, silent=True)
         finally:
             # Deleting the created temporary folders

--- a/aiida/cmdline/commands/cmd_import.py
+++ b/aiida/cmdline/commands/cmd_import.py
@@ -14,6 +14,7 @@ import click
 from aiida.cmdline.commands.cmd_verdi import verdi
 from aiida.cmdline.params.options import MultipleValueOption
 from aiida.cmdline.utils import decorators, echo
+from aiida.common import exceptions
 
 
 @verdi.command('import')
@@ -31,7 +32,7 @@ def cmd_import(archives, webpages):
 
     The ARCHIVES can be specified by their relative or absolute file path, or their HTTP URL.
     """
-    # pylint: disable=too-many-branches,broad-except
+    # pylint: disable=too-many-branches,too-many-statements,broad-except
     import traceback
     from six.moves import urllib
 
@@ -64,9 +65,15 @@ def cmd_import(archives, webpages):
         echo.echo_critical('no valid exported archives were found')
 
     for archive in archives_file:
+
+        echo.echo_info('importing archive {}'.format(archive))
+
         try:
-            echo.echo_info('importing archive {}'.format(archive))
             import_data(archive)
+        except exceptions.IncompatibleArchiveVersionError as exception:
+            echo.echo_warning('{} cannot be imported: {}'.format(archive, exception))
+            echo.echo_warning('run `verdi export migrate {}` to update it'.format(archive))
+            continue
         except Exception:
             echo.echo_error('an exception occurred while importing the archive {}'.format(archive))
             echo.echo(traceback.format_exc())
@@ -75,20 +82,28 @@ def cmd_import(archives, webpages):
             echo.echo_success('imported archive {}'.format(archive))
 
     for archive in archives_url:
+
+        echo.echo_info('downloading archive {}'.format(archive))
+
         try:
-            echo.echo_info('downloading archive {}'.format(archive))
-
             response = urllib.request.urlopen(archive)
+        except Exception as exception:
+            echo.echo_warning('downloading archive {} failed: {}'.format(archive, exception))
 
-            with SandboxFolder() as temp_folder:
-                temp_file = 'importfile.tar.gz'
-                temp_folder.create_file_from_filelike(response, temp_file)
-                echo.echo_success('archive downloaded, proceeding with import')
+        with SandboxFolder() as temp_folder:
+            temp_file = 'importfile.tar.gz'
+            temp_folder.create_file_from_filelike(response, temp_file)
+            echo.echo_success('archive downloaded, proceeding with import')
+
+            try:
                 import_data(temp_folder.get_abs_path(temp_file))
-
-        except Exception:
-            echo.echo_error('an exception occurred while importing the archive {}'.format(archive))
-            echo.echo(traceback.format_exc())
-            click.confirm('do you want to continue?', abort=True)
-        else:
-            echo.echo_success('imported archive {}'.format(archive))
+            except exceptions.IncompatibleArchiveVersionError as exception:
+                echo.echo_warning('{} cannot be imported: {}'.format(archive, exception))
+                echo.echo_warning('download the archive file and run `verdi export migrate` to update it')
+                continue
+            except Exception:
+                echo.echo_error('an exception occurred while importing the archive {}'.format(archive))
+                echo.echo(traceback.format_exc())
+                click.confirm('do you want to continue?', abort=True)
+            else:
+                echo.echo_success('imported archive {}'.format(archive))

--- a/aiida/common/exceptions.py
+++ b/aiida/common/exceptions.py
@@ -260,3 +260,10 @@ class TransportTaskException(Exception):
     Raised when a TransportTask, an task to be completed by the engine that requires transport, fails
     """
     pass
+
+
+class IncompatibleArchiveVersionError(Exception):
+    """
+    Raised when trying to import an export archive with an incompatible schema version.
+    """
+    pass

--- a/aiida/orm/importexport.py
+++ b/aiida/orm/importexport.py
@@ -408,9 +408,8 @@ def import_data_dj(in_path, ignore_unknown_nodes=False,
         # PRELIMINARY CHECKS #
         ######################
         if metadata['export_version'] != expected_export_version:
-            raise ValueError("File export version is {}, but I can import only "
-                             "version {}".format(metadata['export_version'],
-                                                 expected_export_version))
+            raise exceptions.IncompatibleArchiveVersionError('Archive schema version {} is incompatible with the '
+                'currently supported schema version {}'.format(metadata['export_version'], expected_export_version))
 
         ##########################################################################
         # CREATE UUID REVERSE TABLES AND CHECK IF I HAVE ALL NODES FOR THE LINKS #
@@ -928,10 +927,8 @@ def import_data_sqla(in_path, ignore_unknown_nodes=False, silent=False):
         # PRELIMINARY CHECKS #
         ######################
         if metadata['export_version'] != expected_export_version:
-            raise ValueError("File export version is {}, but I can "
-                             "import only version {}"
-                             .format(metadata['export_version'],
-                                     expected_export_version))
+            raise exceptions.IncompatibleArchiveVersionError('Archive schema version {} is incompatible with the '
+                'currently supported schema version {}'.format(metadata['export_version'], expected_export_version))
 
         ###################################################################
         #           CREATE UUID REVERSE TABLES AND CHECK IF               #


### PR DESCRIPTION
Fixes #1947 

Since there is a known solution to this problem, i.e. running `verdi export migrate`
it is best to inform the user of this instead of dumping a stack trace.