### PR TITLE
Implement the `get_options` method for `JobCalculation`

### DIFF
--- a/.ci/test_daemon.py
+++ b/.ci/test_daemon.py
@@ -188,10 +188,10 @@ def create_calculation(code, counter, inputval, use_cache=False):
         'retrieve_temporary_files': ['triple_value.tmp']
     })
     calc = code.new_calc()
-    calc.set_max_wallclock_seconds(5 * 60)  # 5 min
-    calc.set_resources({"num_machines": 1})
-    calc.set_withmpi(False)
-    calc.set_parser_name('simpleplugins.templatereplacer.doubler')
+    calc.set_option('max_wallclock_seconds', 5 * 60)  # 5 min
+    calc.set_option('resources', {"num_machines": 1})
+    calc.set_option('withmpi', False)
+    calc.set_option('parser_name', 'simpleplugins.templatereplacer.doubler')
 
     calc.use_parameters(parameters)
     calc.use_template(template)

--- a/aiida/backends/tests/export_and_import.py
+++ b/aiida/backends/tests/export_and_import.py
@@ -235,7 +235,7 @@ class TestSimple(AiidaTestCase):
 
             calc = JobCalculation()
             calc.set_computer(self.computer)
-            calc.set_resources({"num_machines": 1, "num_mpiprocs_per_machine": 1})
+            calc.set_option('resources', {"num_machines": 1, "num_mpiprocs_per_machine": 1})
             calc.store()
 
             calc.add_link_from(sd)
@@ -474,7 +474,7 @@ class TestSimple(AiidaTestCase):
 
             jc1 = JobCalculation()
             jc1.set_computer(self.computer)
-            jc1.set_resources({"num_machines": 1, "num_mpiprocs_per_machine": 1})
+            jc1.set_option('resources', {"num_machines": 1, "num_mpiprocs_per_machine": 1})
             jc1.set_user(user)
             jc1.label = 'jc1'
             jc1.store()
@@ -490,7 +490,7 @@ class TestSimple(AiidaTestCase):
 
             jc2 = JobCalculation()
             jc2.set_computer(self.computer)
-            jc2.set_resources({"num_machines": 1, "num_mpiprocs_per_machine": 1})
+            jc2.set_option('resources', {"num_machines": 1, "num_mpiprocs_per_machine": 1})
             jc2.label = 'jc2'
             jc2.store()
             jc2.add_link_from(sd2, label='l2')
@@ -557,7 +557,7 @@ class TestSimple(AiidaTestCase):
 
             jc1 = JobCalculation()
             jc1.set_computer(self.computer)
-            jc1.set_resources({"num_machines": 1, "num_mpiprocs_per_machine": 1})
+            jc1.set_option('resources', {"num_machines": 1, "num_mpiprocs_per_machine": 1})
             jc1.set_user(user)
             jc1.label = 'jc1'
             jc1.store()
@@ -593,7 +593,7 @@ class TestSimple(AiidaTestCase):
 
             jc2 = JobCalculation()
             jc2.set_computer(self.computer)
-            jc2.set_resources({"num_machines": 1, "num_mpiprocs_per_machine": 1})
+            jc2.set_option('resources', {"num_machines": 1, "num_mpiprocs_per_machine": 1})
             jc2.label = 'jc2'
             jc2.store()
             jc2.add_link_from(sd2_imp, label='l2')
@@ -661,7 +661,7 @@ class TestSimple(AiidaTestCase):
 
             jc1 = JobCalculation()
             jc1.set_computer(self.computer)
-            jc1.set_resources({"num_machines": 1, "num_mpiprocs_per_machine": 1})
+            jc1.set_option('resources', {"num_machines": 1, "num_mpiprocs_per_machine": 1})
             jc1.set_user(user)
             jc1.label = 'jc1'
             jc1.store()
@@ -930,7 +930,7 @@ class TestComplex(AiidaTestCase):
         try:
             calc1 = JobCalculation()
             calc1.set_computer(self.computer)
-            calc1.set_resources({"num_machines": 1, "num_mpiprocs_per_machine": 1})
+            calc1.set_option('resources', {"num_machines": 1, "num_mpiprocs_per_machine": 1})
             calc1.label = "calc1"
             calc1.store()
             calc1._set_state(u'RETRIEVING')
@@ -952,7 +952,7 @@ class TestComplex(AiidaTestCase):
 
             calc2 = JobCalculation()
             calc2.set_computer(self.computer)
-            calc2.set_resources({"num_machines": 1, "num_mpiprocs_per_machine": 1})
+            calc2.set_option('resources', {"num_machines": 1, "num_mpiprocs_per_machine": 1})
             calc2.label = "calc2"
             calc2.store()
             calc2.add_link_from(pd1, link_type=LinkType.INPUT)
@@ -1024,7 +1024,7 @@ class TestComputer(AiidaTestCase):
             calc1_label = "calc1"
             calc1 = JobCalculation()
             calc1.set_computer(self.computer)
-            calc1.set_resources({"num_machines": 1,
+            calc1.set_option('resources', {"num_machines": 1,
                                  "num_mpiprocs_per_machine": 1})
             calc1.label = calc1_label
             calc1.store()
@@ -1033,7 +1033,7 @@ class TestComputer(AiidaTestCase):
             calc2_label = "calc2"
             calc2 = JobCalculation()
             calc2.set_computer(self.computer)
-            calc2.set_resources({"num_machines": 2,
+            calc2.set_option('resources', {"num_machines": 2,
                                  "num_mpiprocs_per_machine": 2})
             calc2.label = calc2_label
             calc2.store()
@@ -1148,7 +1148,7 @@ class TestComputer(AiidaTestCase):
             calc1_label = "calc1"
             calc1 = JobCalculation()
             calc1.set_computer(self.computer)
-            calc1.set_resources({"num_machines": 1,
+            calc1.set_option('resources', {"num_machines": 1,
                                  "num_mpiprocs_per_machine": 1})
             calc1.label = calc1_label
             calc1.store()
@@ -1168,7 +1168,7 @@ class TestComputer(AiidaTestCase):
             calc2_label = "calc2"
             calc2 = JobCalculation()
             calc2.set_computer(self.computer)
-            calc2.set_resources({"num_machines": 2,
+            calc2.set_option('resources', {"num_machines": 2,
                                  "num_mpiprocs_per_machine": 2})
             calc2.label = calc2_label
             calc2.store()
@@ -1258,7 +1258,7 @@ class TestComputer(AiidaTestCase):
             calc1_label = "calc1"
             calc1 = JobCalculation()
             calc1.set_computer(self.computer)
-            calc1.set_resources({"num_machines": 1,
+            calc1.set_option('resources', {"num_machines": 1,
                                  "num_mpiprocs_per_machine": 1})
             calc1.label = calc1_label
             calc1.store()
@@ -1279,7 +1279,7 @@ class TestComputer(AiidaTestCase):
             calc2_label = "calc2"
             calc2 = JobCalculation()
             calc2.set_computer(self.computer)
-            calc2.set_resources({"num_machines": 2,
+            calc2.set_option('resources', {"num_machines": 2,
                                  "num_mpiprocs_per_machine": 2})
             calc2.label = calc2_label
             calc2.store()
@@ -1300,7 +1300,7 @@ class TestComputer(AiidaTestCase):
             calc3_label = "calc3"
             calc3 = JobCalculation()
             calc3.set_computer(self.computer)
-            calc3.set_resources({"num_machines": 2,
+            calc3.set_option('resources', {"num_machines": 2,
                                  "num_mpiprocs_per_machine": 2})
             calc3.label = calc3_label
             calc3.store()
@@ -1387,7 +1387,7 @@ class TestComputer(AiidaTestCase):
             calc1_label = "calc1"
             calc1 = JobCalculation()
             calc1.set_computer(self.computer)
-            calc1.set_resources({"num_machines": 1,
+            calc1.set_option('resources', {"num_machines": 1,
                                  "num_mpiprocs_per_machine": 1})
             calc1.label = calc1_label
             calc1.store()
@@ -1540,7 +1540,7 @@ class TestLinks(AiidaTestCase):
 
         pw1 = JobCalculation()
         pw1.set_computer(self.computer)
-        pw1.set_resources({"num_machines": 1, "num_mpiprocs_per_machine": 1})
+        pw1.set_option('resources', {"num_machines": 1, "num_mpiprocs_per_machine": 1})
         pw1.store()
 
         d3 = Int(1).store()
@@ -1548,7 +1548,7 @@ class TestLinks(AiidaTestCase):
 
         pw2 = JobCalculation()
         pw2.set_computer(self.computer)
-        pw2.set_resources({"num_machines": 1, "num_mpiprocs_per_machine": 1})
+        pw2.set_option('resources', {"num_machines": 1, "num_mpiprocs_per_machine": 1})
         pw2.store()
 
         d5 = Int(1).store()
@@ -1944,7 +1944,7 @@ class TestLinks(AiidaTestCase):
 
             jc = JobCalculation()
             jc.set_computer(self.computer)
-            jc.set_resources(
+            jc.set_option('resources',
                 {"num_machines": 1, "num_mpiprocs_per_machine": 1})
             jc.store()
 

--- a/aiida/backends/tests/parsers.py
+++ b/aiida/backends/tests/parsers.py
@@ -82,7 +82,7 @@ def output_test(pk, testname, skip_uuids_from_inputs=[]):
     from aiida.orm.importexport import export_tree
     c = load_node(pk, sub_class=JobCalculation)
     outfolder = "test_{}_{}".format(
-        c.get_parser_name().replace('.', '_'),
+        c.get_option('parser_name').replace('.', '_'),
         testname)
 
     if not is_valid_folder_name(outfolder):

--- a/aiida/backends/tests/tcodexporter.py
+++ b/aiida/backends/tests/tcodexporter.py
@@ -199,10 +199,10 @@ class TestTcodDbExporter(AiidaTestCase):
         code.store()
 
         calc = JobCalculation(computer=self.computer)
-        calc.set_resources({'num_machines': 1,
+        calc.set_option('resources', {'num_machines': 1,
                             'num_mpiprocs_per_machine': 1})
         calc.add_link_from(code, "code")
-        calc.set_environment_variables({'PATH': '/dev/null', 'USER': 'unknown'})
+        calc.set_option('environment_variables', {'PATH': '/dev/null', 'USER': 'unknown'})
 
         with tempfile.NamedTemporaryFile(mode='w+', prefix="Fe") as f:
             f.write("<UPF version=\"2.0.1\">\nelement=\"Fe\"\n")

--- a/aiida/orm/implementation/general/calculation/job/__init__.py
+++ b/aiida/orm/implementation/general/calculation/job/__init__.py
@@ -13,6 +13,7 @@ import abc
 import copy
 import datetime
 import enum
+import warnings
 
 import six
 from six.moves import range, zip
@@ -203,21 +204,25 @@ class AbstractJobCalculation(AbstractCalculation):
             raise ValidationError(
                 "No valid class/implementation found for the parser '{}'. "
                 "Set the parser to None if you do not need an automatic "
-                "parser.".format(self.get_parser_name())
+                "parser.".format(self.get_option('parser_name'))
             )
 
         computer = self.get_computer()
         s = computer.get_scheduler()
+        resources = self.get_option('resources')
+        def_cpus_machine = computer.get_default_mpiprocs_per_machine()
+        if def_cpus_machine is not None:
+            resources['default_mpiprocs_per_machine'] = def_cpus_machine
         try:
-            _ = s.create_job_resource(**self.get_resources(full=True))
+            _ = s.create_job_resource(**resources)
         except (TypeError, ValueError) as exc:
             raise ValidationError("Invalid resources for the scheduler of the "
                                   "specified computer: {}".format(exc))
 
-        if not isinstance(self.get_withmpi(), bool):
+        if not isinstance(self.get_option('withmpi', only_actually_set=False), bool):
             raise ValidationError(
                 "withmpi property must be boolean! It in instead {}"
-                "".format(str(type(self.get_withmpi())))
+                "".format(str(type(self.get_option('withmpi'))))
             )
 
     def _linking_as_output(self, dest, link_type):
@@ -286,12 +291,209 @@ class AbstractJobCalculation(AbstractCalculation):
         else:
             raise NotExistent("_raw_input_folder not created yet")
 
+    from aiida.orm.computer import Computer
+
+    options = {
+        'resources': {
+            'attribute_key': 'jobresource_params',
+            'valid_type': dict,
+            'default': {},
+            'help': 'Set the dictionary of resources to be used by the scheduler plugin, like the number of nodes, '
+                    'cpus etc. This dictionary is scheduler-plugin dependent. Look at the documentation of the '
+                    'scheduler for more details.'
+        },
+        'max_wallclock_seconds': {
+            'attribute_key': 'max_wallclock_seconds',
+            'valid_type': int,
+            'non_db': True,
+            'default': 1800,
+            'help': 'Set the wallclock in seconds asked to the scheduler',
+        },
+        'custom_scheduler_commands': {
+            'attribute_key': 'custom_scheduler_commands',
+            'valid_type': six.string_types,
+            'non_db': True,
+            'required': False,
+            'help': 'Set a (possibly multiline) string with the commands that the user wants to manually set for the '
+                    'scheduler. The difference of this option with respect to the `prepend_text` is the position in '
+                    'the scheduler submission file where such text is inserted: with this option, the string is '
+                    'inserted before any non-scheduler command',
+        },
+        'queue_name': {
+            'attribute_key': 'queue_name',
+            'valid_type': six.string_types,
+            'non_db': True,
+            'required': False,
+            'help': 'Set the name of the queue on the remote computer',
+        },
+        'account': {
+            'attribute_key': 'account',
+            'valid_type': six.string_types,
+            'non_db': True,
+            'required': False,
+            'help': 'Set the account to use in for the queue on the remote computer',
+        },
+        'qos': {
+            'attribute_key': 'qos',
+            'valid_type': six.string_types,
+            'non_db': True,
+            'required': False,
+            'help': 'Set the quality of service to use in for the queue on the remote computer',
+        },
+        'computer': {
+            'attribute_key': None,
+            'valid_type': Computer,
+            'non_db': True,
+            'required': False,
+            'help': 'Set the computer to be used by the calculation',
+        },
+        'withmpi': {
+            'attribute_key': 'withmpi',
+            'valid_type': bool,
+            'non_db': True,
+            'required': False,
+            'default': True,
+            'help': 'Set the calculation to use mpi',
+        },
+        'mpirun_extra_params': {
+            'attribute_key': 'mpirun_extra_params',
+            'valid_type': (list, tuple),
+            'non_db': True,
+            'required': False,
+            'help': 'Set the extra params to pass to the mpirun (or equivalent) command after the one provided in '
+                    'computer.mpirun_command. Example: mpirun -np 8 extra_params[0] extra_params[1] ... exec.x',
+        },
+        'import_sys_environment': {
+            'attribute_key': 'import_sys_environment',
+            'valid_type': bool,
+            'non_db': True,
+            'required': False,
+            'default': True,
+            'help': 'If set to true, the submission script will load the system environment variables',
+        },
+        'environment_variables': {
+            'attribute_key': 'custom_environment_variables',
+            'valid_type': dict,
+            'non_db': True,
+            'required': False,
+            'default': {},
+            'help': 'Set a dictionary of custom environment variables for this calculation',
+        },
+        'priority': {
+            'attribute_key': 'priority',
+            'valid_type': six.string_types[0],
+            'non_db': True,
+            'required': False,
+            'help': 'Set the priority of the job to be queued',
+        },
+        'max_memory_kb': {
+            'attribute_key': 'max_memory_kb',
+            'valid_type': int,
+            'non_db': True,
+            'required': False,
+            'help': 'Set the maximum memory (in KiloBytes) to be asked to the scheduler',
+        },
+        'prepend_text': {
+            'attribute_key': 'prepend_text',
+            'valid_type': six.string_types[0],
+            'non_db': True,
+            'required': False,
+            'help': 'Set the calculation-specific prepend text, which is going to be prepended in the scheduler-job '
+                    'script, just before the code execution',
+        },
+        'append_text': {
+            'attribute_key': 'append_text',
+            'valid_type': six.string_types[0],
+            'non_db': True,
+            'required': False,
+            'help': 'Set the calculation-specific append text, which is going to be appended in the scheduler-job '
+                    'script, just after the code execution',
+        },
+        'parser_name': {
+            'attribute_key': 'parser',
+            'valid_type': six.string_types[0],
+            'non_db': True,
+            'required': False,
+            'help': 'Set a string for the output parser. Can be None if no output plugin is available or needed',
+        }
+    }
+
+    def get_option(self, name, only_actually_set=True):
+        """
+        Retun the value of an option that was set for this JobCalculation
+
+        :param name: the option name
+        :param only_actually_set: when False will return the default value even when option had not been explicitly set
+        :return: the option value or None
+        :raises: ValueError for unknown option
+        """
+        if name not in self.options:
+            raise ValueError('unknown option {}'.format(name))
+
+        option = self.options[name]
+        attribute_key = option['attribute_key']
+        default = option.get('default', None)
+
+        attribute = self.get_attr(attribute_key, None)
+
+        if attribute is None and only_actually_set is False and default is not None:
+            attribute = default
+
+        return attribute
+
+    def set_option(self, name, value):
+        """
+        Set an option to the given value
+
+        :param name: the option name
+        :param value: the value to set
+        :raises: ValueError for unknown option
+        :raises: TypeError for values with invalid type
+        """
+        if name not in self.options:
+            raise ValueError('unknown option {}'.format(name))
+
+        option = self.options[name]
+        valid_type = option['valid_type']
+        attribute_key = option['attribute_key']
+
+        if not isinstance(value, valid_type):
+            raise TypeError('value is of invalid type {}'.format(type(value)))
+
+        self._set_attr(attribute_key, value)
+
+    def get_options(self, only_actually_set=True):
+        """
+        Return the dictionary of options set for this JobCalculation
+
+        :param only_actually_set: when False will return the default value even when option had not been explicitly set
+        :return: dictionary of the options and their values
+        """
+        options = {}
+        for name in self.options.keys():
+            value = self.get_option(name, only_actually_set=only_actually_set)
+            if value is not None:
+                options[name] = value
+
+        return options
+
+    def set_options(self, options):
+        """
+        Set the options for this JobCalculation
+
+        :param options: dictionary of option and their values to set
+        """
+        for name, value in options.items():
+            self.set_option(name, value)
+
     def set_queue_name(self, val):
         """
         Set the name of the queue on the remote computer.
 
         :param str val: the queue name
         """
+        warnings.warn(
+            'explicit option getter/setter methods are deprecated, use get_option and set_option', DeprecationWarning)
         if val is not None:
             self._set_attr('queue_name', six.text_type(val))
 
@@ -301,6 +503,8 @@ class AbstractJobCalculation(AbstractCalculation):
 
         :param str val: the account name
         """
+        warnings.warn(
+            'explicit option getter/setter methods are deprecated, use get_option and set_option', DeprecationWarning)
         if val is not None:
             self._set_attr('account', six.text_type(val))
 
@@ -310,6 +514,8 @@ class AbstractJobCalculation(AbstractCalculation):
 
         :param str val: the quality of service
         """
+        warnings.warn(
+            'explicit option getter/setter methods are deprecated, use get_option and set_option', DeprecationWarning)
         if val is not None:
             self._set_attr('qos', six.text_type(val))
 
@@ -320,6 +526,8 @@ class AbstractJobCalculation(AbstractCalculation):
 
         :param bool val: load the environment if True
         """
+        warnings.warn(
+            'explicit option getter/setter methods are deprecated, use get_option and set_option', DeprecationWarning)
         self._set_attr('import_sys_environment', bool(val))
 
     def get_import_sys_environment(self):
@@ -329,6 +537,8 @@ class AbstractJobCalculation(AbstractCalculation):
 
         :return: a boolean. If True the system environment will be load.
         """
+        warnings.warn(
+            'explicit option getter/setter methods are deprecated, use get_option and set_option', DeprecationWarning)
         return self.get_attr('import_sys_environment', True)
 
     def set_environment_variables(self, env_vars_dict):
@@ -340,6 +550,8 @@ class AbstractJobCalculation(AbstractCalculation):
         In the remote-computer submission script, it's going to export
         variables as ``export 'keys'='values'``
         """
+        warnings.warn(
+            'explicit option getter/setter methods are deprecated, use get_option and set_option', DeprecationWarning)
         if not isinstance(env_vars_dict, dict):
             raise ValueError("You have to pass a "
                              "dictionary to set_environment_variables")
@@ -362,6 +574,8 @@ class AbstractJobCalculation(AbstractCalculation):
         Return an empty dictionary if no special environment variables have
         to be set for this calculation.
         """
+        warnings.warn(
+            'explicit option getter/setter methods are deprecated, use get_option and set_option', DeprecationWarning)
         return self.get_attr('custom_environment_variables', {})
 
     def set_priority(self, val):
@@ -370,6 +584,8 @@ class AbstractJobCalculation(AbstractCalculation):
 
         :param val: the values of priority as accepted by the cluster scheduler.
         """
+        warnings.warn(
+            'explicit option getter/setter methods are deprecated, use get_option and set_option', DeprecationWarning)
         self._set_attr('priority', six.text_type(val))
 
     def set_max_memory_kb(self, val):
@@ -378,6 +594,8 @@ class AbstractJobCalculation(AbstractCalculation):
 
         :param val: an integer. Default=None
         """
+        warnings.warn(
+            'explicit option getter/setter methods are deprecated, use get_option and set_option', DeprecationWarning)
         self._set_attr('max_memory_kb', int(val))
 
     def get_max_memory_kb(self):
@@ -386,6 +604,8 @@ class AbstractJobCalculation(AbstractCalculation):
 
         :return: an integer
         """
+        warnings.warn(
+            'explicit option getter/setter methods are deprecated, use get_option and set_option', DeprecationWarning)
         return self.get_attr('max_memory_kb', None)
 
     def set_max_wallclock_seconds(self, val):
@@ -394,6 +614,8 @@ class AbstractJobCalculation(AbstractCalculation):
 
         :param val: An integer. Default=None
         """
+        warnings.warn(
+            'explicit option getter/setter methods are deprecated, use get_option and set_option', DeprecationWarning)
         self._set_attr('max_wallclock_seconds', int(val))
 
     def get_max_wallclock_seconds(self):
@@ -403,6 +625,8 @@ class AbstractJobCalculation(AbstractCalculation):
         :return: an integer
         :rtype: int
         """
+        warnings.warn(
+            'explicit option getter/setter methods are deprecated, use get_option and set_option', DeprecationWarning)
         return self.get_attr('max_wallclock_seconds', None)
 
     def set_resources(self, resources_dict):
@@ -414,6 +638,8 @@ class AbstractJobCalculation(AbstractCalculation):
         (scheduler type can be found with
         calc.get_computer().get_scheduler_type() )
         """
+        warnings.warn(
+            'explicit option getter/setter methods are deprecated, use get_option and set_option', DeprecationWarning)
         # Note: for the time being, resources are only validated during the
         # 'store' because here we are not sure that a Computer has been set
         # yet (in particular, if both computer and resources are set together
@@ -426,6 +652,8 @@ class AbstractJobCalculation(AbstractCalculation):
 
         :param val: A boolean. Default=True
         """
+        warnings.warn(
+            'explicit option getter/setter methods are deprecated, use get_option and set_option', DeprecationWarning)
         self._set_attr('withmpi', val)
 
     def get_withmpi(self):
@@ -434,6 +662,8 @@ class AbstractJobCalculation(AbstractCalculation):
 
         :return: a boolean. Default=True.
         """
+        warnings.warn(
+            'explicit option getter/setter methods are deprecated, use get_option and set_option', DeprecationWarning)
         return self.get_attr('withmpi', True)
 
     def get_resources(self, full=False):
@@ -445,6 +675,8 @@ class AbstractJobCalculation(AbstractCalculation):
 
         :return: a dictionary
         """
+        warnings.warn(
+            'explicit option getter/setter methods are deprecated, use get_option and set_option', DeprecationWarning)
         resources_dict = self.get_attr('jobresource_params', {})
 
         if full:
@@ -462,6 +694,8 @@ class AbstractJobCalculation(AbstractCalculation):
 
         :return: a string or None.
         """
+        warnings.warn(
+            'explicit option getter/setter methods are deprecated, use get_option and set_option', DeprecationWarning)
         return self.get_attr('queue_name', None)
 
     def get_account(self):
@@ -470,6 +704,8 @@ class AbstractJobCalculation(AbstractCalculation):
 
         :return: a string or None.
         """
+        warnings.warn(
+            'explicit option getter/setter methods are deprecated, use get_option and set_option', DeprecationWarning)
         return self.get_attr('account', None)
 
     def get_qos(self):
@@ -478,6 +714,8 @@ class AbstractJobCalculation(AbstractCalculation):
 
         :return: a string or None.
         """
+        warnings.warn(
+            'explicit option getter/setter methods are deprecated, use get_option and set_option', DeprecationWarning)
         return self.get_attr('qos', None)
 
     def get_priority(self):
@@ -486,6 +724,8 @@ class AbstractJobCalculation(AbstractCalculation):
 
         :return: a string or None
         """
+        warnings.warn(
+            'explicit option getter/setter methods are deprecated, use get_option and set_option', DeprecationWarning)
         return self.get_attr('priority', None)
 
     def get_prepend_text(self):
@@ -494,6 +734,8 @@ class AbstractJobCalculation(AbstractCalculation):
         which is going to be prepended in the scheduler-job script, just before
         the code execution.
         """
+        warnings.warn(
+            'explicit option getter/setter methods are deprecated, use get_option and set_option', DeprecationWarning)
         return self.get_attr("prepend_text", "")
 
     def set_prepend_text(self, val):
@@ -506,6 +748,8 @@ class AbstractJobCalculation(AbstractCalculation):
 
         :param val: a (possibly multiline) string
         """
+        warnings.warn(
+            'explicit option getter/setter methods are deprecated, use get_option and set_option', DeprecationWarning)
         self._set_attr("prepend_text", six.text_type(val))
 
     def get_append_text(self):
@@ -514,6 +758,8 @@ class AbstractJobCalculation(AbstractCalculation):
         which is going to be appended in the scheduler-job script, just after
         the code execution.
         """
+        warnings.warn(
+            'explicit option getter/setter methods are deprecated, use get_option and set_option', DeprecationWarning)
         return self.get_attr("append_text", "")
 
     def set_append_text(self, val):
@@ -524,6 +770,8 @@ class AbstractJobCalculation(AbstractCalculation):
 
         :param val: a (possibly multiline) string
         """
+        warnings.warn(
+            'explicit option getter/setter methods are deprecated, use get_option and set_option', DeprecationWarning)
         self._set_attr("append_text", six.text_type(val))
 
     def set_custom_scheduler_commands(self, val):
@@ -536,6 +784,8 @@ class AbstractJobCalculation(AbstractCalculation):
         inserted: with this method, the string is inserted before any
         non-scheduler command.
         """
+        warnings.warn(
+            'explicit option getter/setter methods are deprecated, use get_option and set_option', DeprecationWarning)
         self._set_attr("custom_scheduler_commands", six.text_type(val))
 
     def get_custom_scheduler_commands(self):
@@ -548,6 +798,8 @@ class AbstractJobCalculation(AbstractCalculation):
         :return: the custom scheduler command, or an empty string if no
           custom command was defined.
         """
+        warnings.warn(
+            'explicit option getter/setter methods are deprecated, use get_option and set_option', DeprecationWarning)
         return self.get_attr("custom_scheduler_commands", "")
 
     def get_mpirun_extra_params(self):
@@ -559,6 +811,8 @@ class AbstractJobCalculation(AbstractCalculation):
 
         Return an empty list if no parameters have been defined.
         """
+        warnings.warn(
+            'explicit option getter/setter methods are deprecated, use get_option and set_option', DeprecationWarning)
         return self.get_attr("mpirun_extra_params", [])
 
     def set_mpirun_extra_params(self, extra_params):
@@ -571,6 +825,8 @@ class AbstractJobCalculation(AbstractCalculation):
         :param extra_params: must be a list of strings, one for each
             extra parameter
         """
+        warnings.warn(
+            'explicit option getter/setter methods are deprecated, use get_option and set_option', DeprecationWarning)
         if extra_params is None:
             try:
                 self._del_attr("mpirun_extra_params")
@@ -588,6 +844,31 @@ class AbstractJobCalculation(AbstractCalculation):
                                  "set_mpirun_extra_params")
 
         self._set_attr("mpirun_extra_params", list(extra_params))
+
+    def set_parser_name(self, parser):
+        """
+        Set a string for the output parser
+        Can be None if no output plugin is available or needed.
+
+        :param parser: a string identifying the module of the parser.
+              Such module must be located within the folder 'aiida/parsers/plugins'
+        """
+        warnings.warn(
+            'explicit option getter/setter methods are deprecated, use get_option and set_option', DeprecationWarning)
+        self._set_attr('parser', parser)
+
+    def get_parser_name(self):
+        """
+        Return a string locating the module that contains
+        the output parser of this calculation, that will be searched
+        in the 'aiida/parsers/plugins' directory. None if no parser is needed/set.
+
+        :return: a string.
+        """
+        warnings.warn(
+            'explicit option getter/setter methods are deprecated, use get_option and set_option', DeprecationWarning)
+
+        return self.get_attr('parser', None)
 
     def add_link_from(self, src, label=None, link_type=LinkType.INPUT):
         """
@@ -1373,27 +1654,6 @@ class AbstractJobCalculation(AbstractCalculation):
 
         submit(ContinueJobCalculation, _calc=self)
 
-    def set_parser_name(self, parser):
-        """
-        Set a string for the output parser
-        Can be None if no output plugin is available or needed.
-
-        :param parser: a string identifying the module of the parser.
-              Such module must be located within the folder 'aiida/parsers/plugins'
-        """
-        self._set_attr('parser', parser)
-
-    def get_parser_name(self):
-        """
-        Return a string locating the module that contains
-        the output parser of this calculation, that will be searched
-        in the 'aiida/parsers/plugins' directory. None if no parser is needed/set.
-
-        :return: a string.
-        """
-
-        return self.get_attr('parser', None)
-
     def get_parserclass(self):
         """
         Return the output parser object for this calculation, or None
@@ -1404,7 +1664,7 @@ class AbstractJobCalculation(AbstractCalculation):
         """
         from aiida.parsers import ParserFactory
 
-        parser_name = self.get_parser_name()
+        parser_name = self.get_option('parser_name')
 
         if parser_name is not None:
             return ParserFactory(parser_name)
@@ -1581,17 +1841,20 @@ class AbstractJobCalculation(AbstractCalculation):
                                             [computer.get_prepend_text()] +
                                             [code.get_prepend_text() for code in codes] +
                                             [calcinfo.prepend_text,
-                                             self.get_prepend_text()] if _)
+                                             self.get_option('prepend_text')] if _)
 
         job_tmpl.append_text = "\n\n".join(_ for _ in
-                                           [self.get_append_text(),
+                                           [self.get_option('append_text'),
                                             calcinfo.append_text,
                                             code.get_append_text(),
                                             computer.get_append_text()] if _)
 
         # Set resources, also with get_default_mpiprocs_per_machine
-        resources_dict = self.get_resources(full=True)
-        job_tmpl.job_resource = s.create_job_resource(**resources_dict)
+        resources = self.get_option('resources')
+        def_cpus_machine = computer.get_default_mpiprocs_per_machine()
+        if def_cpus_machine is not None:
+            resources['default_mpiprocs_per_machine'] = def_cpus_machine
+        job_tmpl.job_resource = s.create_job_resource(**resources)
 
         subst_dict = {'tot_num_mpiprocs':
                           job_tmpl.job_resource.get_tot_num_mpiprocs()}
@@ -1600,20 +1863,8 @@ class AbstractJobCalculation(AbstractCalculation):
             subst_dict[k] = v
         mpi_args = [arg.format(**subst_dict) for arg in
                     computer.get_mpirun_command()]
-        extra_mpirun_params = self.get_mpirun_extra_params()  # this is the same for all codes in the same calc
+        extra_mpirun_params = self.get_option('mpirun_extra_params')  # this is the same for all codes in the same calc
 
-        ########################################################################
-        #         if self.get_withmpi():
-        #             job_tmpl.argv = (mpi_args + extra_mpirun_params +
-        #                              [code.get_execname()] +
-        #                              (calcinfo.cmdline_params if
-        #                               calcinfo.cmdline_params is not None else []))
-        #         else:
-        #             job_tmpl.argv = [code.get_execname()] + (
-        #                 calcinfo.cmdline_params if
-        #                 calcinfo.cmdline_params is not None else [])
-        #         job_tmpl.stdin_name = calcinfo.stdin_name
-        #         job_tmpl.stdout_name = calcinfo.stdout_name
 
         # set the codes_info
         if not isinstance(calcinfo.codes_info, (list, tuple)):
@@ -1640,7 +1891,7 @@ class AbstractJobCalculation(AbstractCalculation):
                                               "necessary to set withmpi in "
                                               "codes_info")
                 else:
-                    this_withmpi = self.get_withmpi()
+                    this_withmpi = self.get_option('withmpi')
 
             if this_withmpi:
                 this_argv = (mpi_args + extra_mpirun_params +
@@ -1675,33 +1926,33 @@ class AbstractJobCalculation(AbstractCalculation):
             job_tmpl.codes_run_mode = code_run_modes.SERIAL
         ########################################################################
 
-        custom_sched_commands = self.get_custom_scheduler_commands()
+        custom_sched_commands = self.get_option('custom_scheduler_commands')
         if custom_sched_commands:
             job_tmpl.custom_scheduler_commands = custom_sched_commands
 
-        job_tmpl.import_sys_environment = self.get_import_sys_environment()
+        job_tmpl.import_sys_environment = self.get_option('import_sys_environment')
 
-        job_tmpl.job_environment = self.get_environment_variables()
+        job_tmpl.job_environment = self.get_option('environment_variables')
 
-        queue_name = self.get_queue_name()
-        account = self.get_account()
-        qos = self.get_qos()
+        queue_name = self.get_option('queue_name')
+        account = self.get_option('account')
+        qos = self.get_option('qos')
         if queue_name is not None:
             job_tmpl.queue_name = queue_name
         if account is not None:
             job_tmpl.account = account
         if qos is not None:
             job_tmpl.qos = qos
-        priority = self.get_priority()
+        priority = self.get_option('priority')
         if priority is not None:
             job_tmpl.priority = priority
-        max_memory_kb = self.get_max_memory_kb()
+        max_memory_kb = self.get_option('max_memory_kb')
         if max_memory_kb is not None:
             job_tmpl.max_memory_kb = max_memory_kb
-        max_wallclock_seconds = self.get_max_wallclock_seconds()
+        max_wallclock_seconds = self.get_option('max_wallclock_seconds')
         if max_wallclock_seconds is not None:
             job_tmpl.max_wallclock_seconds = max_wallclock_seconds
-        max_memory_kb = self.get_max_memory_kb()
+        max_memory_kb = self.get_option('max_memory_kb')
         if max_memory_kb is not None:
             job_tmpl.max_memory_kb = max_memory_kb
 

--- a/aiida/tools/dbexporters/tcod.py
+++ b/aiida/tools/dbexporters/tcod.py
@@ -451,7 +451,7 @@ def _collect_calculation_data(calc):
         retrieved_abspath = calc.get_retrieved_node().get_abs_path()
         files_in  = _collect_files(calc._raw_input_folder.abspath)
         files_out = _collect_files(os.path.join(retrieved_abspath, 'path'))
-        this_calc['env'] = calc.get_environment_variables()
+        this_calc['env'] = calc.get_option('environment_variables')
         stdout_name = '{}.out'.format(aiida_executable_name)
         while stdout_name in [files_in,files_out]:
             stdout_name = '_{}'.format(stdout_name)
@@ -1125,7 +1125,7 @@ def deposit(what, type, author_name=None, author_email=None, url=None,
 
     cif = export_cifnode(what, store=True, **kwargs)
     calc = code.new_calc(computer=computer)
-    calc.set_resources({'num_machines': 1, 'num_mpiprocs_per_machine': 1})
+    calc.set_option('resources', {'num_machines': 1, 'num_mpiprocs_per_machine': 1})
 
     if password:
         import getpass

--- a/aiida/work/job_processes.py
+++ b/aiida/work/job_processes.py
@@ -398,58 +398,19 @@ class JobProcess(processes.Process):
     @classmethod
     def build(cls, calc_class):
         from aiida.orm.data import Data
-        from aiida.orm.computer import Computer
 
         def define(cls_, spec):
             super(JobProcess, cls_).define(spec)
 
-            # Define the 'options' inputs namespace and its input ports
             spec.input_namespace(cls.OPTIONS_INPUT_LABEL, help='various options')
-            spec.input('{}.resources'.format(cls.OPTIONS_INPUT_LABEL), valid_type=dict,
-                help='Set the dictionary of resources to be used by the scheduler plugin, like the number of nodes, '
-                     'cpus etc. This dictionary is scheduler-plugin dependent. Look at the documentation of the scheduler.')
-            spec.input('{}.max_wallclock_seconds'.format(cls.OPTIONS_INPUT_LABEL), valid_type=int, non_db=True, default=1800,
-                help='Set the wallclock in seconds asked to the scheduler')
-            spec.input('{}.custom_scheduler_commands'.format(cls.OPTIONS_INPUT_LABEL), valid_type=six.string_types, non_db=True, required=False,
-                help='Set a (possibly multiline) string with the commands that the user wants to manually set for the '
-                     'scheduler. The difference of this method with respect to the set_prepend_text is the position in the '
-                     'scheduler submission file where such text is inserted: with this method, the string is inserted before '
-                     ' any non-scheduler command')
-            spec.input('{}.queue_name'.format(cls.OPTIONS_INPUT_LABEL), valid_type=six.string_types, non_db=True, required=False,
-                help='Set the name of the queue on the remote computer')
-            spec.input('{}.account'.format(cls.OPTIONS_INPUT_LABEL), valid_type=six.string_types, non_db=True, required=False,
-                help='Set the account to use in for the queue on the remote computer')
-            spec.input('{}.qos'.format(cls.OPTIONS_INPUT_LABEL), valid_type=six.string_types, non_db=True, required=False,
-                help='Set the quality of service to use in for the queue on the remote computer')
-
-            spec.input('{}.computer'.format(cls.OPTIONS_INPUT_LABEL), valid_type=Computer, non_db=True, required=False,
-                       help='Set the computer to be used by the calculation')
-            spec.input('{}.withmpi'.format(cls.OPTIONS_INPUT_LABEL), valid_type=bool, non_db=True, required=False,
-                       help='Set the calculation to use mpi')
-            spec.input('{}.mpirun_extra_params'.format(cls.OPTIONS_INPUT_LABEL), valid_type=(list, tuple), non_db=True,
-                       required=False,
-                       help='Set the extra params to pass to the mpirun (or equivalent) command after the one provided in '
-                            'computer.mpirun_command. Example: mpirun -np 8 extra_params[0] extra_params[1] ... exec.x')
-            spec.input('{}.import_sys_environment'.format(cls.OPTIONS_INPUT_LABEL), valid_type=bool, non_db=True,
-                       required=False,
-                       help='If set to true, the submission script will load the system environment variables')
-            spec.input('{}.environment_variables'.format(cls.OPTIONS_INPUT_LABEL), valid_type=dict, non_db=True,
-                       required=False,
-                       help='Set a dictionary of custom environment variables for this calculation')
-            spec.input('{}.priority'.format(cls.OPTIONS_INPUT_LABEL), valid_type=six.string_types[0], non_db=True,
-                       required=False,
-                       help='Set the priority of the job to be queued')
-            spec.input('{}.max_memory_kb'.format(cls.OPTIONS_INPUT_LABEL), valid_type=int, non_db=True, required=False,
-                       help='Set the maximum memory (in KiloBytes) to be asked to the scheduler')
-            spec.input('{}.prepend_text'.format(cls.OPTIONS_INPUT_LABEL), valid_type=six.string_types[0], non_db=True,
-                       required=False,
-                       help='Set the calculation-specific prepend text, which is going to be prepended in the scheduler-job script, just before the code execution')
-            spec.input('{}.append_text'.format(cls.OPTIONS_INPUT_LABEL), valid_type=six.string_types[0], non_db=True,
-                       required=False,
-                       help='Set the calculation-specific append text, which is going to be appended in the scheduler-job script, just after the code execution')
-            spec.input('{}.parser_name'.format(cls.OPTIONS_INPUT_LABEL), valid_type=six.string_types[0], non_db=True,
-                       required=False,
-                       help='Set a string for the output parser. Can be None if no output plugin is available or needed')
+            for key, option in calc_class.options.items():
+                spec.input(
+                    '{}.{}'.format(cls.OPTIONS_INPUT_LABEL, key),
+                    required=option.get('required', True),
+                    valid_type=option.get('valid_type', object),  # Should match everything, as in all types are valid
+                    non_db=option.get('non_db', True),
+                    help=option.get('help', '')
+                )
 
             # Define the actual inputs based on the use methods of the calculation class
             for key, use_method in calc_class._use_methods.items():

--- a/aiida/work/process_builder.py
+++ b/aiida/work/process_builder.py
@@ -87,7 +87,7 @@ class ProcessBuilderNamespace(Mapping):
         return self._data.__repr__()
 
     def __dir__(self):
-        return sorted(set(self._valid_fields + [key for key, _ in self.__dict__ if key.startswith('_')]))
+        return sorted(set(self._valid_fields + [key for key, _ in self.__dict__.items() if key.startswith('_')]))
 
     def __iter__(self):
         for key in self._data:

--- a/aiida/work/utils.py
+++ b/aiida/work/utils.py
@@ -136,6 +136,8 @@ def exponential_backoff_retry(fct, initial_interval=10.0, max_attempts=5, logger
                 logger.warning('maximum attempts %d of calling %s, exceeded', max_attempts, coro.__name__)
                 raise
             else:
+                import traceback
+                traceback.print_exc()
                 logger.warning('iteration %d of %s excepted, retrying after %d seconds', iteration + 1, coro.__name__,
                                interval)
                 yield sleep(interval)

--- a/aiida/workflows/test.py
+++ b/aiida/workflows/test.py
@@ -123,7 +123,7 @@ def generate_calc():
     computer = Computer.get("localhost")
 
     calc = CustomCalc(computer=computer, withmpi=True)
-    calc.set_resources(
+    calc.set_option('resources',
         {"num_machines": 1, "num_mpiprocs_per_machine": 1})
     calc.store()
     calc._set_state(calc_states.FINISHED)

--- a/aiida/workflows/wf_XTiO3.py
+++ b/aiida/workflows/wf_XTiO3.py
@@ -100,8 +100,8 @@ class WorkflowXTiO3_EOS(Workflow):
         QECalc = CalculationFactory('quantumespresso.pw')
 
         calc = QECalc(computer=computer)
-        calc.set_max_wallclock_seconds(max_wallclock_seconds)
-        calc.set_resources({"num_machines": num_machines})
+        calc.set_option('max_wallclock_seconds', max_wallclock_seconds)
+        calc.set_option('resources', {"num_machines": num_machines})
         calc.store()
 
         calc.use_code(code)

--- a/aiida/workflows/wf_demo.py
+++ b/aiida/workflows/wf_demo.py
@@ -32,7 +32,7 @@ class WorkflowDemo(Workflow):
         computer = Computer.get("localhost")
 
         calc = CustomCalc(computer=computer, withmpi=True)
-        calc.set_resources({"num_machines": 1, "num_mpiprocs_per_machine": 1})
+        calc.set_option('resources', {"num_machines": 1, "num_mpiprocs_per_machine": 1})
         calc.store()
         calc._set_state(calc_states.FINISHED)
         calc._set_process_state(plumpy.ProcessState.FINISHED)
@@ -90,7 +90,7 @@ class SubWorkflowDemo(Workflow):
         computer = Computer.get("localhost")
 
         calc = CustomCalc(computer=computer, withmpi=True)
-        calc.set_resources({"num_machines": 1, "num_mpiprocs_per_machine": 1})
+        calc.set_option('resources', {"num_machines": 1, "num_mpiprocs_per_machine": 1})
         calc.store()
         calc._set_state(calc_states.FINISHED)
         calc._set_process_state(plumpy.ProcessState.FINISHED)
@@ -143,7 +143,7 @@ class BranchWorkflowDemo(Workflow):
         computer = Computer.get("localhost")
 
         calc = CustomCalc(computer=computer, withmpi=True)
-        calc.set_resources({"num_machines": 1, "num_mpiprocs_per_machine": 1})
+        calc.set_option('resources', {"num_machines": 1, "num_mpiprocs_per_machine": 1})
         calc.store()
         calc._set_state(calc_states.FINISHED)
         calc._set_process_state(plumpy.ProcessState.FINISHED)
@@ -230,7 +230,7 @@ class LoopBranchWorkflowDemo(Workflow):
         computer = Computer.get("localhost")
 
         calc = CustomCalc(computer=computer, withmpi=True)
-        calc.set_resources({"num_machines": 1, "num_mpiprocs_per_machine": 1})
+        calc.set_option('resources', {"num_machines": 1, "num_mpiprocs_per_machine": 1})
         calc.store()
         calc._set_state(calc_states.FINISHED)
         calc._set_process_state(plumpy.ProcessState.FINISHED)

--- a/docs/source/developer_guide/devel_tutorial/code_plugin_int_sum.rst
+++ b/docs/source/developer_guide/devel_tutorial/code_plugin_int_sum.rst
@@ -590,10 +590,10 @@ sample script follows (other examples can be found in the
     calc = code.new_calc()
     calc.label = "Test sum"
     calc.description = "Test calculation with the sum code"
-    calc.set_max_wallclock_seconds(30*60) # 30 min
+    calc.set_option('max_wallclock_seconds', 30*60) # 30 min
     calc.set_computer(computer)
-    calc.set_withmpi(False)
-    calc.set_resources({"num_machines": 1})
+    calc.set_option('withmpi', False)
+    calc.set_option('resources', {"num_machines": 1})
 
     calc.use_parameters(parameters)
 

--- a/docs/source/developer_guide/devel_tutorial/sum_submission.py
+++ b/docs/source/developer_guide/devel_tutorial/sum_submission.py
@@ -43,10 +43,10 @@ parameters = ParameterData(dict={'x1':2,'x2':3})
 calc = code.new_calc()
 calc.label = "Test sum"
 calc.description = "Test calculation with the sum code"
-calc.set_max_wallclock_seconds(30*60) # 30 min
+calc.set_option('max_wallclock_seconds', 30*60) # 30 min
 calc.set_computer(computer)
-calc.set_withmpi(False)
-calc.set_resources({"num_machines": 1})
+calc.set_option('withmpi', False)
+calc.set_option('resources', {"num_machines": 1})
 
 calc.use_parameters(parameters)
 

--- a/docs/source/old_workflows/index.rst
+++ b/docs/source/old_workflows/index.rst
@@ -97,7 +97,7 @@ us to understand the more sophisticated examples reported later.
             computer = Computer.get("localhost")
 
             calc = CustomCalc(computer=computer,withmpi=True)
-            calc.set_resources(num_machines=1, num_mpiprocs_per_machine=1)
+            calc.set_option('resources', num_machines=1, num_mpiprocs_per_machine=1)
             calc._set_state(calc_states.FINISHED)
             calc.store()
 
@@ -421,8 +421,8 @@ aside to the final optimal cell parameter value.
                 QECalc = CalculationFactory('quantumespresso.pw')
 
                 calc = QECalc(computer=computer)
-                calc.set_max_wallclock_seconds(max_wallclock_seconds)
-                calc.set_resources({"num_machines": num_machines, "num_mpiprocs_per_machine": num_mpiprocs_per_machine})
+                calc.set_option('max_wallclock_seconds', max_wallclock_seconds)
+                calc.set_option('resources', {"num_machines": num_machines, "num_mpiprocs_per_machine": num_mpiprocs_per_machine})
                 calc.store()
 
                 calc.use_code(code)
@@ -678,8 +678,8 @@ phonon vibrational frequncies for some XTiO3 materials, namely Ba, Sr and Pb.
                 QEPhCalc = CalculationFactory('quantumespresso.ph')
                 calc = QEPhCalc(computer=computer)
 
-                calc.set_max_wallclock_seconds(max_wallclock_seconds) # 30 min
-                calc.set_resources({"num_machines": num_machines, "num_mpiprocs_per_machine": num_mpiprocs_per_machine})
+                calc.set_option('max_wallclock_seconds', max_wallclock_seconds) # 30 min
+                calc.set_option('resources', {"num_machines": num_machines, "num_mpiprocs_per_machine": num_mpiprocs_per_machine})
                 calc.store()
 
                 calc.use_parameters(ph_parameters)

--- a/docs/source/scheduler/index.rst
+++ b/docs/source/scheduler/index.rst
@@ -102,14 +102,14 @@ In the following, the different :class:`JobResource <aiida.scheduler.datastructu
 
         from aiida.scheduler.datastructures import NodeNumberJobResource
     
-    However, in general, you will pass the fields to set directly to the :meth:`set_resources <aiida.orm.implementation.general.calculation.job.AbstractJobCalculation.set_resources>` method of a :class:`JobCalculation <aiida.orm.implementation.general.calculation.job.AbstractJobCalculation>` object. For instance::
+    However, in general, you will pass the fields to set directly to the :meth:`set_option <aiida.orm.implementation.general.calculation.job.AbstractJobCalculation.set_option>` method of a :class:`JobCalculation <aiida.orm.implementation.general.calculation.job.AbstractJobCalculation>` object with the ``resources`` key. For instance::
   
         calc = JobCalculation(computer=...) # select here a given computer configured
                                             # in AiiDA
      
         # This assumes that the computer is configured to use a scheduler with
         # job resources of type NodeNumberJobResource
-        calc.set_resources({"num_machines": 4, "num_mpiprocs_per_machine": 16})
+        calc.set_option('resources', {"num_machines": 4, "num_mpiprocs_per_machine": 16})
 
 
 .. _NodeNumberJobResource:
@@ -138,9 +138,9 @@ The same can be achieved passing the fields directly to the constructor::
 
     res = NodeNumberJobResource(num_machines=4, num_mpiprocs_per_machine=16)
 
-or, even better, directly calling the :meth:`set_resources <aiida.orm.implementation.general.calculation.job.AbstractJobCalculation.set_resources>` method of the :class:`JobCalculation <aiida.orm.implementation.general.calculation.job.AbstractJobCalculation>` class (assuming here that ``calc`` is your calculation object)::
+or, even better, directly calling the :meth:`set_option <aiida.orm.implementation.general.calculation.job.AbstractJobCalculation.set_option>` method of the :class:`JobCalculation <aiida.orm.implementation.general.calculation.job.AbstractJobCalculation>` class (assuming here that ``calc`` is your calculation object) for the ``resources`` key::
 
-    calc.set_resources({"num_machines": 4, "num_mpiprocs_per_machine": 16})
+    calc.set_option('resources', {"num_machines": 4, "num_mpiprocs_per_machine": 16})
 
 .. note:: 
     If you specify res.num_machines, res.num_mpiprocs_per_machine, and res.tot_num_mpiprocs fields (not recommended), make sure that they satisfy::
@@ -194,6 +194,6 @@ Some examples:
 
     res = ParEnvJobResource(parallel_env='mpi', tot_num_mpiprocs=64)
 
-* even better, directly calling the :meth:`set_resources <aiida.orm.implementation.general.calculation.job.AbstractJobCalculation.set_resources>` method of the :meth:`JobCalculation <aiida.orm.implementation.general.calculation.job.AbstractJobCalculation>` class (assuming here that ``calc`` is your calculation object)::
+* even better, directly calling the :meth:`set_option <aiida.orm.implementation.general.calculation.job.AbstractJobCalculation.set_option>` method of the :meth:`JobCalculation <aiida.orm.implementation.general.calculation.job.AbstractJobCalculation>` class (assuming here that ``calc`` is your calculation object) for the ``resources`` key::
 
-    calc.set_resources({"parallel_env": 'mpi', "tot_num_mpiprocs": 64})
+    calc.set_option('resources', {"parallel_env": 'mpi', "tot_num_mpiprocs": 64})

--- a/docs/source/state/calculation_state.rst
+++ b/docs/source/state/calculation_state.rst
@@ -96,24 +96,25 @@ where ``CALCULATIONPK`` is the PK of the calculation. This will open a new conne
 Setting calculation properties
 ==============================
 
-There are various methods which specify the calculation properties.
+There are various options that can be set that control the behavior of a calculation.
+They can be set through the :meth:~`.AbstractJobCalculation.set_option`` method.
 Here follows a brief documentation of their action. You can also find them in the  :class:`.AbstractJobCalculation` API reference.
 
-* ``c.set_max_memory_kb``: require explicitely the memory to be allocated to the scheduler job.
-* ``c.set_append_text``: write a set of bash commands to be executed after the call to the executable. These commands are executed only for this instance of calculations. Look also at the computer and code append_text to write bash commands for any job run on that  computer or with that code.
-* ``c.set_max_wallclock_seconds``: set (as integer) the scheduler-job wall-time in seconds.
-* ``c.set_computer``: set the computer on which the calculation is run. Unnecessary if the calculation has been created from a code.
-* ``c.set_mpirun_extra_params``: set as a list of strings the parameters to be passed to  the mpirun command.  Example: ``mpirun -np 8 extra_params[0] extra_params[1] ... exec.x`` Note: the process number is set by the resources.
-* ``c.set_custom_scheduler_commands``: set a string (even multiline) which contains  personalized job-scheduling commands. These commands are set at the beginning of the  job-scheduling script, before any non-scheduler command. (prepend_texts instead are set after all job-scheduling commands).
-* ``c.set_parser_name``: set the name of the parser to be used on the output. Typically, a plugin will have already a default plugin set, use this command to change it.
-* ``c.set_environment_variables``: set a dictionary, whose key and values will be used to  set new environment variables in the job-scheduling script before the execution of the  calculation. The dictionary is translated to: ``export 'keys'='values'``.
-* ``c.set_prepend_text``: set a string that contains bash commands, to be written in the job-scheduling script for this calculation, right before the call to the executable. (it is used for example to load modules). Note that there are also prepend text for the  computer (that are used for any job-scheduling script on the given computer) and for the code (that are used for any scheduling script using the given code), the prepend_text here is used only for this instance of the calculation: be careful in  avoiding duplication of bash commands.
-* ``c.set_extra``: pass a key and a value, to be stored in the ``Extra`` attribute table in  the database. 
-* ``c.set_extras``: like set extra, but you can pass a dictionary with multiple keys and values.
-* ``c.set_priority``: set the job-scheduler priority of the calculation (AiiDA does not  have internal priorities). The function accepts a value that depends on the scheduler. plugin (but typically is an integer).
-* ``c.set_queue_name``: pass in a string the name of the queue to use on the job-scheduler.
-* ``c.set_account``: pass in a string the name of the account/project to use on the job-scheduler.
-* ``c.set_qos``: pass in a string the name of the quality-of-service to use on the job-scheduler.
-* ``c.set_import_sys_environment``: default=True. If True, the job-scheduling script will load the environment variables.
-* ``c.set_resources``: set the resources to be used by the calculation like the number of nodes, wall-time, ..., by passing a dictionary to  this method. The keys of this dictionary, i.e. the resources, depend  on the specific scheduler plugin that has to run them. Look at the  documentation of the scheduler (type is given by: ``calc.get_computer().get_scheduler_type()``).
-* ``c.set_withmpi``: True or False, if True (the default) it will  call the executable as a parallel run.
+* ``max_memory_kb``: require explicitely the memory to be allocated to the scheduler job.
+* ``append_text``: write a set of bash commands to be executed after the call to the executable. These commands are executed only for this instance of calculations. Look also at the computer and code append_text to write bash commands for any job run on that  computer or with that code.
+* ``max_wallclock_seconds``: set (as integer) the scheduler-job wall-time in seconds.
+* ``computer``: set the computer on which the calculation is run. Unnecessary if the calculation has been created from a code.
+* ``mpirun_extra_params``: set as a list of strings the parameters to be passed to  the mpirun command.  Example: ``mpirun -np 8 extra_params[0] extra_params[1] ... exec.x`` Note: the process number is set by the resources.
+* ``custom_scheduler_commands``: set a string (even multiline) which contains  personalized job-scheduling commands. These commands are set at the beginning of the  job-scheduling script, before any non-scheduler command. (prepend_texts instead are set after all job-scheduling commands).
+* ``parser_name``: set the name of the parser to be used on the output. Typically, a plugin will have already a default plugin set, use this command to change it.
+* ``environment_variables``: set a dictionary, whose key and values will be used to  set new environment variables in the job-scheduling script before the execution of the  calculation. The dictionary is translated to: ``export 'keys'='values'``.
+* ``prepend_text``: set a string that contains bash commands, to be written in the job-scheduling script for this calculation, right before the call to the executable. (it is used for example to load modules). Note that there are also prepend text for the  computer (that are used for any job-scheduling script on the given computer) and for the code (that are used for any scheduling script using the given code), the prepend_text here is used only for this instance of the calculation: be careful in  avoiding duplication of bash commands.
+* ``extra``: pass a key and a value, to be stored in the ``Extra`` attribute table in  the database. 
+* ``extras``: like set extra, but you can pass a dictionary with multiple keys and values.
+* ``priority``: set the job-scheduler priority of the calculation (AiiDA does not  have internal priorities). The function accepts a value that depends on the scheduler. plugin (but typically is an integer).
+* ``queue_name``: pass in a string the name of the queue to use on the job-scheduler.
+* ``account``: pass in a string the name of the account/project to use on the job-scheduler.
+* ``qos``: pass in a string the name of the quality-of-service to use on the job-scheduler.
+* ``import_sys_environment``: default=True. If True, the job-scheduling script will load the environment variables.
+* ``resources``: set the resources to be used by the calculation like the number of nodes, wall-time, ..., by passing a dictionary to  this method. The keys of this dictionary, i.e. the resources, depend  on the specific scheduler plugin that has to run them. Look at the  documentation of the scheduler (type is given by: ``calc.get_computer().get_scheduler_type()``).
+* ``withmpi``: True or False, if True (the default) it will  call the executable as a parallel run.


### PR DESCRIPTION
Fixes #1533 

What is currently defined as the `options` for a `JobCalculation`, are specific
attributes that were also stored as node attributes through `set_` methods. These
were called setters and are all defined explicitly, along with the corresponding
getters. With the introduction of the `Process` paradigm, these could no longer be
called manually by the user on the calculation node, and so the `options` dictionary
was invented, to allow the user to specify these attributes.

However, after a calculation was completed, there was no easy way to retrieve this
dictionary with the collection of these attributes. Here we implement this method
the `get_options` method which by default will only return those attributes that
were explicitly set, but which can be overridden to provide the default values for
those that were not explicitly set.

The set of available options, along with their valid types, whether they are required
docstring and more, are now defined as a dictionary member of the `AbstractJobCalculation`
class. The `JobProcess` now uses this to dynamically build up the `options` port namespace
in its inputs specification, just like the rest of the input ports are build dynamically
based on the use methods.
