### PR TITLE
Adapt installation docs for tab-completion activation

### DIFF
--- a/docs/source/install/installation.rst
+++ b/docs/source/install/installation.rst
@@ -194,18 +194,16 @@ Configure AiiDA
 
 Verdi tab-completion
 --------------------
-The ``verdi`` command line tool has many commands and options.
-To simplify its usage, there is a way to enable tab-completion for it in your bash shell.
-To do so, simply run the following command::
+The ``verdi`` command line interface has many commands and options.
+To simplify its usage, there is a way to enable tab-completion for it in your shell.
+To do so, simply add the following line to the activation script of your virtual environment (or to your shell config, e.g. ``.bashrc``)::
 
-    $ verdi completioncommand
-
-and append the result to the activation script of your virtual environment (or to your bash config, e.g. ``.bashrc``).
-Alternatively, you can accomplish the same by simply adding the following line to the activation script::
-
-    eval "$(verdi completioncommand)"
+    eval "$(_VERDI_COMPLETE=source verdi)"
 
 For the changes to apply to your current shell, make sure to source the activation script or ``.bashrc`` (depending the approach you chose).
+
+.. note::
+    This line replaces the ``eval "$(verdi completioncommand)"`` line that was used in ``aiida-core<1.0.0``.
 
 Adding AiiDA to the PATH
 ------------------------

--- a/docs/source/install/updating_installation.rst
+++ b/docs/source/install/updating_installation.rst
@@ -72,14 +72,20 @@ This updates your daemon profile and related files.
 Version migration instructions
 ==============================
 
-Updating from 0.11.* to 0.12.0
-------------------------------
-No particular changes have been introduced in ``v0.12.0`` that require specific migration operations.
+Updating from 0.12.* to 1.0
+---------------------------
+
+Configuration file
+^^^^^^^^^^^^^^^^^^
+* The tab-completion activation for ``verdi`` has changed, simply replace the ``eval "$(verdi completioncommand)"`` line in your activation script with ``eval "$(_VERDI_COMPLETE=source verdi)"``
+
+
 
 Updating from older versions
 ----------------------------
 To find the update instructions for older versions of AiiDA follow the following links to the documentation of the corresponding version:
 
+* `0.11.*`_
 * `0.10.*`_
 * `0.9.*`_
 * `0.8.* Django`_
@@ -89,7 +95,8 @@ To find the update instructions for older versions of AiiDA follow the following
 * `0.5.* Django`_
 * `0.4.* Django`_
 
-.. _0.10.*: http://aiida-core.readthedocs.io/en/v0.11.4/installation/updating.html#updating-from-0-9-to-0-10-0
+.. _0.11.*: https://aiida-core.readthedocs.io/en/v0.12.2/installation/updating.html#updating-from-0-11-to-0-12-0
+.. _0.10.*: http://aiida-core.readthedocs.io/en/v0.10.0/installation/updating.html#updating-from-0-9-to-0-10-0
 .. _0.9.*: http://aiida-core.readthedocs.io/en/v0.10.0/installation/updating.html#updating-from-0-9-to-0-10-0
 .. _0.8.* Django: http://aiida-core.readthedocs.io/en/v0.9.1/installation/index.html#updating-from-0-8-django-to-0-9-0-django
 .. _0.7.* Django: http://aiida-core.readthedocs.io/en/v0.8.1/installation/index.html#updating-from-0-7-0-django-to-0-8-0-django

--- a/docs/source/verdi/verdi_user_guide.rst
+++ b/docs/source/verdi/verdi_user_guide.rst
@@ -258,13 +258,6 @@ The ``verdi comment`` command provides a set of methods that are used to manipul
   * **update**: modify a comment
 
 
-.. _completioncommand:
-
-``verdi completioncommand``
----------------------------
-Prints the string to be copied and pasted to the ``.bashrc`` in order to allow for autocompletion of the verdi commands.
-
-
 .. _computer:
 
 ``verdi computer``


### PR DESCRIPTION
Fixes #1810 

The tab-completion for verdi is now facilitated by `click` and therewith
the procedure for activating it in the shell has changed. Here we adapt
the installation instructions to reflect this and we add a section to
the migration instructions for users that update their aiida version.