### PR TITLE
proxy setting in verdi computer make `verdi computer test <cm>` fail

### DIFF
--- a/aiida/transport/plugins/ssh.py
+++ b/aiida/transport/plugins/ssh.py
@@ -483,7 +483,7 @@ class SshTransport(aiida.transport.Transport):
         # Open a SSHClient
         connection_arguments = self._connect_args
         proxystring = connection_arguments.pop('proxy_command', None)
-        if proxystring is not None:
+        if proxystring != '' and proxystring != 'None':
             proxy = _DetachedProxyCommand(proxystring)
             connection_arguments['sock'] = proxy
 


### PR DESCRIPTION
```python
> /home/unkcpz/Lab/pyProject/aiida_core/aiida/transport/plugins/ssh.py(487)open()
-> if proxystring is not None:                                                                                               
(Pdb) p proxystring                                                                                                          
''                                                   
(Pdb) proxystring is not None                                                    
True                                                                                                 
(Pdb) self._connect_args
{'username': u'unkcpz', 'proxy_command': u'', 'allow_agent': True, 'gss_deleg_creds': False, 'key_filename': u'/home/unkcpz/.ssh/id_rsa', 'compress': True, 'look_for_keys': True, 'timeout': 60, 'gss_kex': False, 'gss_host': u'cmp.scut.edu.cn', 'port':
22, 'gss_auth': False}
(Pdb)                                                             
```

When setting `ProxyCommand` as default, `proxystring` is `''` type `string`. And can not  compare with `None`.
I find a private method `_convert_proxy_command_fromstring()` in class `SshTransport`, but can't find caller of the method.
The commit in my change seems not the proper way to tackle this problem, but I don't know the better way to repair this. (Maybe using `_convert_proxy_command_fromstring()` here?)