### PR TITLE
Fix 'migration' message for default profile

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -46,7 +46,6 @@
         aiida/backends/djsite/settings/settings_profile.py|
         aiida/backends/djsite/settings/settings.py|
         aiida/backends/djsite/settings/wsgi.py|
-        aiida/backends/djsite/utils.py|
         aiida/backends/general/abstractqueries.py|
         aiida/backends/general/querybuilder_interface.py|
         aiida/backends/__init__.py|

--- a/.pylintrc
+++ b/.pylintrc
@@ -22,7 +22,7 @@ jobs=1
 
 # List of plugins (as comma separated values of python modules names) to load,
 # usually to register additional checkers.
-load-plugins=
+load-plugins=pylint_django
 
 # Pickle collected data for later comparisons.
 persistent=yes

--- a/aiida/backends/djsite/utils.py
+++ b/aiida/backends/djsite/utils.py
@@ -7,6 +7,10 @@
 # For further information on the license, see the LICENSE.txt file        #
 # For further information please visit http://www.aiida.net               #
 ###########################################################################
+"""
+This modules contains a number of utility functions specific to the
+Django backend.
+"""
 
 from __future__ import absolute_import
 import os
@@ -26,7 +30,7 @@ def load_dbenv(profile=None):
     check_schema_version()
 
 
-def _load_dbenv_noschemacheck(profile):
+def _load_dbenv_noschemacheck(profile):  # pylint: disable=unused-argument
     """
     Load the database environment (Django) WITHOUT CHECKING THE SCHEMA VERSION.
 
@@ -44,13 +48,24 @@ def _load_dbenv_noschemacheck(profile):
 
 
 def get_log_messages(obj):
+    """
+    Get a list of log messages from the database for the given
+    object (typically a Node)
+
+    :param obj: the object (typically a Node) for which you want to get
+        a list of DbLog messages
+    :return: a list of log messages. Each log message is a dictionary
+        including a 'loggername', a 'levelname', a 'message', a 'time' at
+        which the log message was issued, as well as additional 'metadata'
+    """
     from aiida.backends.djsite.db.models import DbLog
     import json
 
     extra = get_dblogger_extra(obj)
+
     # convert to list, too
-    log_messages = list(DbLog.objects.filter(**extra).order_by('time').values(
-        'loggername', 'levelname', 'message', 'metadata', 'time'))
+    log_messages = list(
+        DbLog.objects.filter(**extra).order_by('time').values('loggername', 'levelname', 'message', 'metadata', 'time'))
 
     # deserialize metadata
     for log in log_messages:
@@ -59,7 +74,7 @@ def get_log_messages(obj):
     return log_messages
 
 
-_aiida_autouser_cache = None
+_aiida_autouser_cache = None  # pylint: disable=invalid-name
 
 
 def long_field_length():
@@ -77,8 +92,9 @@ def long_field_length():
 
     if 'mysql' in settings.DATABASES['default']['ENGINE']:
         return 255
-    else:
-        return 1024
+
+    # else
+    return 1024
 
 
 def check_schema_version():
@@ -97,9 +113,8 @@ def check_schema_version():
     :raise ConfigurationError: if the two schema versions do not match.
       Otherwise, just return.
     """
-    import os
     import aiida.backends.djsite.db.models
-    from aiida.backends.utils import get_current_profile
+    from aiida.backends.settings import AIIDADB_PROFILE
     from django.db import connection
     from aiida.common.exceptions import ConfigurationError
 
@@ -119,18 +134,11 @@ def check_schema_version():
     filepath_manage = os.path.join(os.path.dirname(filepath_utils), 'manage.py')
 
     if code_schema_version != db_schema_version:
-        raise ConfigurationError(
-            "The code schema version is {}, but the version stored in the "
-            "database (DbSetting table) is {}, stopping.\n"
-            "To migrate the database to the current version, run the following commands:"
-            "\n  verdi daemon stop\n  python {} --aiida-profile={} migrate".
-                format(
-                code_schema_version,
-                db_schema_version,
-                filepath_manage,
-                get_current_profile()
-            )
-        )
+        raise ConfigurationError("The code schema version is {}, but the version stored in the "
+                                 "database (DbSetting table) is {}, stopping.\n"
+                                 "To migrate the database to the current version, run the following commands:"
+                                 "\n  verdi daemon stop\n  python {} --aiida-profile={} migrate".format(
+                                     code_schema_version, db_schema_version, filepath_manage, AIIDADB_PROFILE))
 
 
 def set_db_schema_version(version):
@@ -140,8 +148,7 @@ def set_db_schema_version(version):
     """
     from aiida.backends.utils import set_global_setting
     return set_global_setting(
-        'db|schemaversion', version,
-        description="The version of the schema used in this database.")
+        'db|schemaversion', version, description="The version of the schema used in this database.")
 
 
 def get_db_schema_version():
@@ -156,7 +163,7 @@ def get_db_schema_version():
         return None
 
 
-def delete_nodes_and_connections_django(pks_to_delete):
+def delete_nodes_and_connections_django(pks_to_delete):  # pylint: disable=invalid-name
     """
     Delete all nodes corresponding to pks in the input.
     :param pks_to_delete: A list, tuple or set of pks that should be deleted.
@@ -165,10 +172,10 @@ def delete_nodes_and_connections_django(pks_to_delete):
     from django.db.models import Q
     from aiida.backends.djsite.db import models
     with transaction.atomic():
+        # This is fixed in pylint-django>=2, but this supports only py3
+        # pylint: disable=no-member
         # Delete all links pointing to or from a given node
-        models.DbLink.objects.filter(
-            Q(input__in=pks_to_delete) |
-            Q(output__in=pks_to_delete)).delete()
+        models.DbLink.objects.filter(Q(input__in=pks_to_delete) | Q(output__in=pks_to_delete)).delete()
         # now delete nodes
         models.DbNode.objects.filter(pk__in=pks_to_delete).delete()
 
@@ -177,9 +184,9 @@ def pass_to_django_manage(argv, profile=None):
     """
     Call the corresponding django manage.py command
     """
-    from aiida.backends.utils import load_dbenv, is_dbenv_loaded
+    from aiida.backends.utils import load_dbenv as load_dbenv_, is_dbenv_loaded
     if not is_dbenv_loaded():
-        load_dbenv(profile=profile)
+        load_dbenv_(profile=profile)
 
-    import django.core.management
-    django.core.management.execute_from_command_line(argv)
+    from django.core import management
+    management.execute_from_command_line(argv)

--- a/setup_requirements.py
+++ b/setup_requirements.py
@@ -109,6 +109,7 @@ extras_require = {
         'yapf==0.23.0',
         'prospector==0.12.11',
         'pylint==1.8.4',
+        'pylint-django==0.11.1',
         'pep8-naming==0.3.3',
         'toml==0.9.4'
     ],


### PR DESCRIPTION
This fixes #2001 (actually I realised that I had a slightly outdated version of develop, and in the current one the problem of #2001 was already fixed). However, this PR still makes sense as it adds the linting/prospector support  for that file.