### PR TITLE
Fixing infinite-loop in completion of interactive options

### DIFF
--- a/aiida/cmdline/commands/__init__.py
+++ b/aiida/cmdline/commands/__init__.py
@@ -16,10 +16,10 @@ import click_completion
 click_completion.init()
 
 # Import to populate the `verdi` sub commands
-from aiida.cmdline.commands import (cmd_calculation, cmd_code, cmd_comment, cmd_computer, cmd_data, cmd_database,
-                                    cmd_daemon, cmd_devel, cmd_export, cmd_graph, cmd_group, cmd_import, cmd_node,
-                                    cmd_process, cmd_profile, cmd_quicksetup, cmd_rehash, cmd_restapi, cmd_run,
-                                    cmd_setup, cmd_shell, cmd_user, cmd_work, cmd_workflow)
+from aiida.cmdline.commands import (cmd_calculation, cmd_code, cmd_comment, cmd_completioncommand, cmd_computer,
+                                    cmd_data, cmd_database, cmd_daemon, cmd_devel, cmd_export, cmd_graph, cmd_group,
+                                    cmd_import, cmd_node, cmd_process, cmd_profile, cmd_quicksetup, cmd_rehash,
+                                    cmd_restapi, cmd_run, cmd_setup, cmd_shell, cmd_user, cmd_work, cmd_workflow)
 
 # Import to populate the `verdi data` sub commands
 from aiida.cmdline.commands.cmd_data import (cmd_array, cmd_bands, cmd_cif, cmd_parameter, cmd_remote, cmd_structure,

--- a/aiida/cmdline/commands/cmd_completioncommand.py
+++ b/aiida/cmdline/commands/cmd_completioncommand.py
@@ -1,0 +1,30 @@
+# -*- coding: utf-8 -*-
+###########################################################################
+# Copyright (c), The AiiDA team. All rights reserved.                     #
+# This file is part of the AiiDA code.                                    #
+#                                                                         #
+# The code is hosted on GitHub at https://github.com/aiidateam/aiida_core #
+# For further information on the license, see the LICENSE.txt file        #
+# For further information please visit http://www.aiida.net               #
+###########################################################################
+"""
+`verdi completioncommand` command, to return the string to insert
+into the bash script to activate completion.
+"""
+from __future__ import absolute_import
+import click
+from aiida.cmdline.commands.cmd_verdi import verdi
+
+
+@verdi.command('completioncommand')
+def verdi_completioncommand():
+    """
+    Return the bash code to activate completion.
+
+    :note: this command is mainly for back-compatibility.
+        You should rather use:;
+
+            eval "$(_VERDI_COMPLETE=source verdi)"
+    """
+    from click_completion import get_auto_shell, get_code
+    click.echo(get_code(shell=get_auto_shell()))

--- a/aiida/cmdline/params/options/interactive.py
+++ b/aiida/cmdline/params/options/interactive.py
@@ -69,7 +69,6 @@ class InteractiveOption(ConditionalOption):
             passed the click context
 
         """
-
         # intercept prompt kwarg; I need to pop it before calling super
         self._prompt = kwargs.pop('prompt', None)
 
@@ -207,6 +206,15 @@ class InteractiveOption(ConditionalOption):
 
     def prompt_callback(self, ctx, param, value):
         """decide wether to initiate the prompt_loop or not"""
+
+        # From click.core.Context:
+        # if resilient_parsing is enabled then Click will
+        # parse without any interactivity or callback
+        # invocation.
+        # Therefore if this flag is set, we should not
+        # do any prompting.
+        if ctx.resilient_parsing:
+            return None
 
         # a value was given on the command line: then  just go with validation
         if value is not None:


### PR DESCRIPTION
Fixes #1802

The fix requires to skip any callback when resilient_parsing
is True (see comment in the source code).

Also, reactivating the `verdi completioncommand` for back-compatibility.
(See also discussion thread in #1810).
Note: I didn't change the docs on purpose, because I think it's
still better if people use the new syntax.
Note also that if people copy-pasted
the output of `verdi completioncommand` rather than just invoking
```
eval "$(verdi completioncommand)"
```
then they will have to change their init scripts anyway.