### PR TITLE
Restore behavior of `JobCalculation.get_option` returning default value

### DIFF
--- a/aiida/backends/tests/calculation_node.py
+++ b/aiida/backends/tests/calculation_node.py
@@ -37,6 +37,23 @@ class TestCalcNode(AiidaTestCase):
     emptydict = {}
     emptylist = []
 
+    @classmethod
+    def setUpClass(cls):
+        super(TestCalcNode, cls).setUpClass()
+        from aiida.orm import JobCalculation
+
+        cls.construction_options = {
+            'resources': {
+                'num_machines': 1,
+                'num_mpiprocs_per_machine': 1
+            }
+        }
+
+        cls.job_calculation = JobCalculation()
+        cls.job_calculation.set_computer(cls.computer)
+        cls.job_calculation.set_options(cls.construction_options)
+        cls.job_calculation.store()
+
     def test_process_state(self):
         """
         Check the properties of a newly created bare Calculation
@@ -99,3 +116,29 @@ class TestCalcNode(AiidaTestCase):
 
         with self.assertRaises(ModificationNotAllowed):
             a._del_attr(Calculation.PROCESS_STATE_KEY)
+
+    def test_job_calculation_get_option(self):
+        """Verify that options used during calculation construction can be retrieved with `get_option`."""
+        for name, attributes in self.job_calculation.options.items():
+
+            if name in self.construction_options:
+                self.assertEqual(self.job_calculation.get_option(name), self.construction_options[name])
+
+    def test_job_calculation_get_options_only_actually_set(self):
+        """Verify that `get_options only` returns explicitly set options if `only_actually_set=True`."""
+        set_options = self.job_calculation.get_options(only_actually_set=True)
+        self.assertEquals(set(set_options.keys()), set(self.construction_options.keys()))
+
+    def test_job_calculation_get_options_defaults(self):
+        """Verify that `get_options` returns all options with defaults if `only_actually_set=False`."""
+        get_options = self.job_calculation.get_options()
+
+        for name, attributes in self.job_calculation.options.items():
+
+            # If the option was specified in construction options, verify that `get_options` returns same value
+            if name in self.construction_options:
+                self.assertEqual(get_options[name], self.construction_options[name])
+
+            # Otherwise, if the option defines a default that is not `None`, verify that that is returned correctly
+            elif 'default' in attributes and attributes['default'] is not None:
+                self.assertEqual(get_options[name], attributes['default'])

--- a/aiida/backends/tests/work/test_process_builder.py
+++ b/aiida/backends/tests/work/test_process_builder.py
@@ -125,7 +125,7 @@ class TestProcessBuilder(AiidaTestCase):
 
         builder = original.get_builder_restart()
 
-        self.assertDictEqual(builder.options, original.get_options())
+        self.assertDictEqual(builder.options, original.get_options(only_actually_set=True))
 
     def test_code_get_builder(self):
         """


### PR DESCRIPTION
Fixes #2012 

Recently, the various methods to get `options` from a `JobCalculation`,
the historically called `get_*` methods, would return a default value
if the value was not explicitly set as an attribute. These methods were
recently replaced by the generic `get_option` method and the
`JobCalculation.options` dictionary, however, by default the `get_option`
would only return a value if explicitly set. One would have to set the
argument `only_actually_set` to `False` to get the default value specified
in `JobCalculation.options`, if it is defined and not `None`.

The business logic however, was always calling `get_option` with default
argument while expecting the default to be returned when not explicitly
set. In addition, certain options whose get methods used to return a
default no longer had a default defined, e.g. `append_text`.

Here we properly define defaults for the options that always had one as
defined by the old explicit get methods. In addition, the default for
the `only_actually_set` for `get_option` is changed to `False`. The
internal code in general always expects to get defaults even when not
set. Note that this required the code for `get_builder_restart` to be
adapted as that expects only those options to be set that were actually
defined by the user when constructing the `JobCalculation`.