### PR TITLE
Fix version of `kiwipy==0.2.1`

### DIFF
--- a/docs/requirements_for_rtd.txt
+++ b/docs/requirements_for_rtd.txt
@@ -34,6 +34,7 @@ ete3==3.1.1
 flask-marshmallow==0.9.0
 ipython>=4.0,<6.0
 itsdangerous==0.24
+kiwipy==0.2.1
 marshmallow-sqlalchemy==0.13.2
 meld3==1.0.2
 mock==2.0.0

--- a/setup_requirements.py
+++ b/setup_requirements.py
@@ -43,6 +43,7 @@ install_requires = [
     'pika==0.11.2',
     'ipython>=4.0,<6.0',  # Version of ipython non enforced, because some still prefer version 4 rather than the latest
     'plumpy==0.10.6',
+    'kiwipy==0.2.1',
     'circus==0.14.0',
     'tornado==4.5.3',  # As of 2018/03/06 Tornado released v5.0 which breaks circus 0.14.0
     'chainmap; python_version<"3.5"',


### PR DESCRIPTION
Both `kiwipy` and `plumpy`, which has the former as a dependency, are
currently under active development. We need `plumpy==0.10.6` but that
has only a lower bound on `kiwipy` requirement, of which a new version
`0.3.0` was just released. This is however incompatible with `plumpy`
0.10.6 but is installed nonetheless, causing all the tests too fail.
Therefore we are temporarily fixing the version of `kiwipy` explicitly.