### PR TITLE
WIP: Fix AttributeDict YAML with recursive content

### DIFF
--- a/aiida/common/extendeddicts.py
+++ b/aiida/common/extendeddicts.py
@@ -299,4 +299,4 @@ def add_mapping_representer(tag, node_cls):
     yaml.add_representer(node_cls, representer)
     yaml.add_constructor(tag, constructor)
 
-add_mapping_representer('!!aiida:AttributeDict', AttributeDict)
+add_mapping_representer('!aiida:AttributeDict', AttributeDict)

--- a/aiida/common/extendeddicts.py
+++ b/aiida/common/extendeddicts.py
@@ -283,6 +283,10 @@ class DefaultFieldsAttributeDict(AttributeDict):
         return [_ for _ in self.keys() if _ not in self._default_fields]
 
 def add_mapping_representer(tag, node_cls):
+    """
+    Adds a YAML mapping representer and constructor to the given class, with the
+    specified tag.
+    """
     def representer(dumper, node):
         return dumper.represent_mapping(tag, node)
 

--- a/aiida/common/extendeddicts.py
+++ b/aiida/common/extendeddicts.py
@@ -11,6 +11,7 @@ from __future__ import absolute_import
 import collections
 
 import six
+import yaml
 
 from aiida.common.exceptions import ValidationError
 from aiida.common.lang import override
@@ -30,7 +31,6 @@ class Enumerate(frozenset):
     def __delattr__(self, name):
         raise AttributeError("Cannot delete attribute in Enumerate '{}'".format(
             self.__class__.__name__))
-
 
 class AttributeDict(dict):
     """
@@ -281,3 +281,18 @@ class DefaultFieldsAttributeDict(AttributeDict):
         Return the extra keys defined in the instance.
         """
         return [_ for _ in self.keys() if _ not in self._default_fields]
+
+def add_mapping_representer(tag, node_cls):
+    def representer(dumper, node):
+        return dumper.represent_mapping(tag, node)
+
+    def constructor(loader, data):
+        result = node_cls()
+        yield result
+        mapping = loader.construct_mapping(data)
+        result.update(mapping)
+
+    yaml.add_representer(node_cls, representer)
+    yaml.add_constructor(tag, constructor)
+
+add_mapping_representer('!!aiida:AttributeDict', AttributeDict)


### PR DESCRIPTION
Fixes #1981.

This adds a representer and constructor for the ``AttributeDict``, to fix YAML dumping / loading when the ``AttributeDict`` has recursive content. However, this does _not_ include subclasses of ``AttributeDict``

TODO:
- [ ] Check which subclasses of ``AttributeDict`` also need a representer / constructor.
- [ ] Add tests.
- [ ] Apply the same fix for ``plumpy.persistence.Bundle``
