### PR TITLE
Make `max_wallclock_seconds` option for JobCalculation optional again

### DIFF
--- a/aiida/orm/implementation/general/calculation/job/__init__.py
+++ b/aiida/orm/implementation/general/calculation/job/__init__.py
@@ -355,7 +355,7 @@ class AbstractJobCalculation(AbstractCalculation):
             'attribute_key': 'max_wallclock_seconds',
             'valid_type': int,
             'non_db': True,
-            'default': 1800,
+            'required': False,
             'help': 'Set the wallclock in seconds asked to the scheduler',
         },
         'custom_scheduler_commands': {


### PR DESCRIPTION
Fixes #1985 

This used to always be an optional option for JobCalculations but in
the recent change of the option getter and setters, it was marked
as required. Here we make the option's properties compatible with
the original definition.