### PR TITLE
Fix proxycommand leaks

### DIFF
--- a/aiida/transport/plugins/ssh.py
+++ b/aiida/transport/plugins/ssh.py
@@ -433,6 +433,7 @@ class SshTransport(aiida.transport.Transport):
 
         self._is_open = False
         self._sftp = None
+        self._proxy = None
 
         self._machine = machine
 
@@ -484,8 +485,8 @@ class SshTransport(aiida.transport.Transport):
         connection_arguments = self._connect_args
         proxystring = connection_arguments.pop('proxy_command', None)
         if proxystring is not None:
-            proxy = _DetachedProxyCommand(proxystring)
-            connection_arguments['sock'] = proxy
+            self._proxy = _DetachedProxyCommand(proxystring)
+            connection_arguments['sock'] = self._proxy
 
         try:
             self._client.connect(self._machine, **connection_arguments)
@@ -518,6 +519,8 @@ class SshTransport(aiida.transport.Transport):
 
         self._sftp.close()
         self._client.close()
+        if self._proxy is not None:
+            self._proxy.close()
         self._is_open = False
 
     @property

--- a/aiida/transport/plugins/ssh.py
+++ b/aiida/transport/plugins/ssh.py
@@ -519,8 +519,6 @@ class SshTransport(aiida.transport.Transport):
 
         self._sftp.close()
         self._client.close()
-        if self._proxy is not None:
-            self._proxy.close()
         self._is_open = False
 
     @property

--- a/aiida/transport/util.py
+++ b/aiida/transport/util.py
@@ -13,9 +13,9 @@ from __future__ import absolute_import
 import time
 
 from paramiko import ProxyCommand
+from six.moves import range
 
 from aiida.common.extendeddicts import FixedFieldsAttributeDict
-from six.moves import range
 
 
 class FileAttribute(FixedFieldsAttributeDict):
@@ -37,8 +37,8 @@ class FileAttribute(FixedFieldsAttributeDict):
 class _DetachedProxyCommand(ProxyCommand):
     """Modifies paramiko's ProxyCommand by launching the process in a separate process group."""
 
-    def __init__(self, command_line):
-        # Note that the super().__init__ must _NOT_ be called here, otherwise
+    def __init__(self, command_line):  # pylint: disable=super-init-not-called
+        # Note that the super().__init__ MUST NOT be called here, otherwise
         # two subprocesses will be created.
         import os
         from subprocess import Popen, PIPE


### PR DESCRIPTION
Fixes #2018.

This addresses two issues:
- The constructor of ``_DetachedProxyCommand`` should _not_ call ``super``. The reason for this is that the detached version creates a _different_ subprocess. If the ``super`` is also called, two subprocesses are created.
- In the ``close`` method of ``_DetachedProxyCommand``, the subprocess is killed more aggressively, and we ``poll`` the subprocess to avoid having defunct processes.

The subprocess killing is implemented as follows:
- ``.terminate()`` the subprocess
- ``.poll()`` for 2 seconds to see if it exits
- if it hasn't, ``.kill()``, and ``.poll()`` again for 2 seconds

This part is a bit hand-wavy, but I wanted to avoid using the ``.wait()`` method. On balance I think it's better if the daemon just continues if the subprocess is really unkillable.