### PR TITLE
Implement `verdi profile show`

### DIFF
--- a/aiida/backends/djsite/utils.py
+++ b/aiida/backends/djsite/utils.py
@@ -133,8 +133,8 @@ def check_schema_version(profile):
     filepath_manage = os.path.join(os.path.dirname(filepath_utils), 'manage.py')
 
     if profile is None:
-        from aiida.common.setup import get_default_profile
-        profile = get_default_profile()
+        from aiida.common.setup import get_default_profile_name
+        profile = get_default_profile_name()
 
     if code_schema_version != db_schema_version:
         raise ConfigurationError("The code schema version is {}, but the version stored in the "

--- a/aiida/backends/profile.py
+++ b/aiida/backends/profile.py
@@ -11,7 +11,7 @@
 from __future__ import absolute_import
 from aiida.backends import settings
 from aiida.common.exceptions import InvalidOperation
-from aiida.common.setup import get_default_profile, get_profile_config
+from aiida.common.setup import get_default_profile_name, get_profile_config
 
 
 # Possible choices for backend
@@ -34,7 +34,7 @@ def load_profile(profile=None):
             raise ValueError('Error in profile loading')
     else:
         if profile is None:
-            profile = get_default_profile()
+            profile = get_default_profile_name()
 
         settings.AIIDADB_PROFILE = profile
 

--- a/aiida/backends/tests/cmdline/commands/test_profile.py
+++ b/aiida/backends/tests/cmdline/commands/test_profile.py
@@ -60,11 +60,11 @@ class TestVerdiProfileSetup(AiidaTestCase):
         :param args: list of arguments
         :param kwargs: list of keyword arguments
         """
+        import os
+        import shutil
 
         aiida_cfg.AIIDA_CONFIG_FOLDER = cls._old_aiida_config_folder
 
-        import os
-        import shutil
         if os.path.isdir(cls._new_aiida_config_folder):
             shutil.rmtree(cls._new_aiida_config_folder)
 
@@ -100,7 +100,7 @@ class TestVerdiProfileSetup(AiidaTestCase):
         from aiida.cmdline.commands.cmd_profile import profile_list
         result = self.runner.invoke(profile_list)
         self.assertIsNone(result.exception)
-        self.assertIn('Configuration folder: ' + self._new_aiida_config_folder, result.output)
+        self.assertIn('configuration folder: ' + self._new_aiida_config_folder, result.output)
         self.assertIn('* {}'.format(self.dummy_profile_list[0]), result.output)
         self.assertIn(self.dummy_profile_list[1], result.output)
 
@@ -116,9 +116,27 @@ class TestVerdiProfileSetup(AiidaTestCase):
         result = self.runner.invoke(profile_list)
 
         self.assertIsNone(result.exception)
-        self.assertIn('Configuration folder: ' + self._new_aiida_config_folder, result.output)
+        self.assertIn('configuration folder: ' + self._new_aiida_config_folder, result.output)
         self.assertIn('* {}'.format(self.dummy_profile_list[1]), result.output)
         self.assertIsNone(result.exception)
+
+    def test_show(self):
+        """
+        Test for verdi profile show command
+        """
+        from aiida.cmdline.commands.cmd_profile import profile_show
+        from aiida.common.setup import get_config
+
+        config = get_config()
+        profiles = config['profiles']
+        profile_name = self.dummy_profile_list[0]
+        profile = profiles[profile_name]
+
+        result = self.runner.invoke(profile_show, [profile_name])
+        self.assertIsNone(result.exception, result.output)
+        for key, value in profile.items():
+            self.assertIn(key.lower(), result.output)
+            self.assertIn(value, result.output)
 
     def test_delete(self):
         """
@@ -126,7 +144,7 @@ class TestVerdiProfileSetup(AiidaTestCase):
         """
         from aiida.cmdline.commands.cmd_profile import profile_delete, profile_list
 
-        ### delete single profile
+        # delete single profile
         result = self.runner.invoke(profile_delete, ["--force", self.dummy_profile_list[2]])
         self.assertIsNone(result.exception)
 
@@ -136,7 +154,7 @@ class TestVerdiProfileSetup(AiidaTestCase):
         self.assertNotIn(self.dummy_profile_list[2], result.output)
         self.assertIsNone(result.exception)
 
-        ### delete multiple profile
+        # delete multiple profile
         result = self.runner.invoke(profile_delete, ["--force", self.dummy_profile_list[3], self.dummy_profile_list[4]])
         self.assertIsNone(result.exception)
 

--- a/aiida/cmdline/commands/cmd_database.py
+++ b/aiida/cmdline/commands/cmd_database.py
@@ -46,13 +46,13 @@ def database_integrity(apply_patch):
     """
     from aiida.backends import settings
     from aiida.backends.utils import _load_dbenv_noschemacheck
-    from aiida.common.setup import get_default_profile
+    from aiida.common.setup import get_default_profile_name
     from aiida.manage.database.integrity import deduplicate_node_uuids
 
     if settings.AIIDADB_PROFILE is not None:
         profile = settings.AIIDADB_PROFILE
     else:
-        profile = get_default_profile()
+        profile = get_default_profile_name()
 
     _load_dbenv_noschemacheck(profile)
 

--- a/aiida/cmdline/params/types/__init__.py
+++ b/aiida/cmdline/params/types/__init__.py
@@ -14,6 +14,7 @@ from .node import NodeParamType
 from .nonemptystring import NonEmptyStringParamType
 from .path import AbsolutePathParamType
 from .plugin import PluginParamType
+from .profile import ProfileParamType
 from .user import UserParamType
 from .test_module import TestModuleParamType
 
@@ -21,5 +22,5 @@ __all__ = [
     'LazyChoice', 'IdentifierParamType', 'CalculationParamType', 'CodeParamType', 'ComputerParamType', 'DataParamType',
     'GroupParamType', 'NodeParamType', 'MpirunCommandParamType', 'MultipleValueParamType', 'NonEmptyStringParamType',
     'PluginParamType', 'AbsolutePathParamType', 'ShebangParamType', 'LegacyWorkflowParamType', 'UserParamType',
-    'TestModuleParamType'
+    'TestModuleParamType', 'ProfileParamType'
 ]

--- a/aiida/cmdline/params/types/profile.py
+++ b/aiida/cmdline/params/types/profile.py
@@ -1,0 +1,49 @@
+# -*- coding: utf-8 -*-
+"""Profile param type for click."""
+from __future__ import absolute_import
+import click
+
+
+class ProfileParamType(click.ParamType):
+    """The profile parameter type for click."""
+
+    name = 'profile'
+
+    def convert(self, value, param, ctx):
+        """Attempt to match the given value to a valid profile."""
+        from aiida.common.exceptions import MissingConfigurationError
+        from aiida.common.profile import Profile
+        from aiida.common.setup import get_config
+
+        try:
+            profiles = get_config()
+        except MissingConfigurationError:
+            self.fail('could not load the configuration file')
+
+        try:
+            profile = profiles['profiles'][value]
+        except KeyError:
+            self.fail('invalid profile name {}'.format(value))
+
+        return Profile(name=value, **profile)
+
+    def complete(self, ctx, incomplete):  # pylint: disable=unused-argument,no-self-use
+        """
+        Return possible completions based on an incomplete value
+
+        :returns: list of tuples of valid entry points (matching incomplete) and a description
+        """
+        from aiida.common.exceptions import MissingConfigurationError
+        from aiida.common.setup import get_config
+
+        try:
+            profiles = get_config()
+        except MissingConfigurationError:
+            return []
+
+        try:
+            profiles = profiles['profiles']
+        except KeyError:
+            return []
+
+        return [(profile, '') for profile in profiles.keys() if profile.startswith(incomplete)]

--- a/aiida/common/profile.py
+++ b/aiida/common/profile.py
@@ -33,7 +33,7 @@ def get_current_profile_name():
     """
     Return the currently configured profile name or if not set, the default profile
     """
-    return settings.AIIDADB_PROFILE or setup.get_default_profile()
+    return settings.AIIDADB_PROFILE or setup.get_default_profile_name()
 
 
 def get_current_profile_config():
@@ -41,6 +41,21 @@ def get_current_profile_config():
     Return the configuration of the currently active profile or if not set, the default profile
     """
     return setup.get_profile_config(get_current_profile_name())
+
+
+class Profile(dict):
+
+    def __init__(self, *args, **kwargs):
+        self._name = kwargs.pop('name', None)
+        super(Profile, self).__init__(*args, **kwargs)
+
+    @property
+    def name(self):
+        return self._name
+
+    @name.setter
+    def name(self, value):
+        self._name = value
 
 
 class ProfileConfig(object):

--- a/aiida/common/setup.py
+++ b/aiida/common/setup.py
@@ -295,11 +295,39 @@ def set_default_profile(profile, force_rewrite=False):
 
 def get_default_profile():
     """
+    Return the default profile from the configuration
+
+    :return: None if no default profile is found
+    """
+    from aiida.common.exceptions import ProfileConfigurationError
+
+    config = get_config()
+    default_profile = get_default_profile_name()
+
+    if default_profile is None:
+        return None
+
+    try:
+        profile = config['profiles'][default_profile]
+    except KeyError:
+        raise ProfileConfigurationError('the defined default profile {} does not exist'.format(default_profile))
+
+    return profile
+
+
+def get_default_profile_name():
+    """
     Return the default profile name from the configuration
 
     :return: None if no default profile is found
     """
-    confs = get_config()
+    from aiida.common.exceptions import MissingConfigurationError
+
+    try:
+        confs = get_config()
+    except MissingConfigurationError:
+        return None
+
     try:
         return confs['default_profile']
     except KeyError:


### PR DESCRIPTION
Fixes #2027 

This command will show the settings for a given profile, or the
default profile if no profile is specified. To facilitate this
a new click parameter type `ProfileParamType` is defined, which
provides automatic validation as well as auto complete support.