### PR TITLE
Flag attribute as modified in ModelWrapper setter to properly flush

### DIFF
--- a/aiida/backends/tests/__init__.py
+++ b/aiida/backends/tests/__init__.py
@@ -84,6 +84,7 @@ db_test_list = {
         'common.datastructures': ['aiida.backends.tests.common.test_datastructures'],
         'control.computer': ['aiida.backends.tests.control.test_computer_ctrl'],
         'daemon.client': ['aiida.backends.tests.daemon.test_client'],
+        'orm.authinfo': ['aiida.backends.tests.orm.authinfo'],
         'orm.data.frozendict': ['aiida.backends.tests.orm.data.frozendict'],
         'orm.data.remote': ['aiida.backends.tests.orm.data.remote'],
         'orm.log': ['aiida.backends.tests.orm.log'],

--- a/aiida/backends/tests/orm/authinfo.py
+++ b/aiida/backends/tests/orm/authinfo.py
@@ -1,0 +1,21 @@
+# -*- coding: utf-8 -*-
+"""Unit tests for the AuthInfo ORM class."""
+from __future__ import absolute_import
+from aiida.backends.testbase import AiidaTestCase
+from aiida.control.computer import configure_computer
+
+
+class TestAuthinfo(AiidaTestCase):
+    """Unit tests for the AuthInfo ORM class."""
+
+    @classmethod
+    def setUpClass(cls, *args, **kwargs):
+        super(TestAuthinfo, cls).setUpClass(*args, **kwargs)
+        cls.auth_info = configure_computer(cls.computer)
+
+    def test_set_auth_params(self):
+        """Test the auth_params setter."""
+        auth_params = {'safe_interval': 100}
+
+        self.auth_info.set_auth_params(auth_params)
+        self.assertEqual(self.auth_info.get_auth_params(), auth_params)

--- a/aiida/control/computer.py
+++ b/aiida/control/computer.py
@@ -29,10 +29,9 @@ def configure_computer(computer, user=None, **kwargs):
     if valid_keys:
         auth_params.update(kwargs)
         authinfo.set_auth_params(auth_params)
-        from aiida.settings import BACKEND
-        if BACKEND == 'sqlalchemy':
-            authinfo._dbauthinfo.auth_params = auth_params  # pylint: disable=protected-access
-    authinfo.store()
+        authinfo.store()
+
+    return authinfo
 
 
 def get_computer_configuration(computer, user=None):


### PR DESCRIPTION
Fixes #1787 

This bug was found bceause the `computer_configure` to set auth parameters
through the `verdi computer configure` command, which calls the `computer_configure`
command from the `aiida.control.computer` module, had no persistent effect
for the SqlAlchemy backend. The unit test that has been added could not
reproduce the problem, however, the added change to flag the attribute as
modified in the `__setattr__` method of the `ModelWrapper` has fixed the
problem that appeared when configuring a computer through the command line.