### PR TITLE
Define long() in Python 3

### DIFF
--- a/aiida/backends/tests/nodes.py
+++ b/aiida/backends/tests/nodes.py
@@ -1377,12 +1377,10 @@ class TestNodeBasic(AiidaTestCase):
                                         "should be equal (since it should be "
                                         "the same node")
 
-        if six.PY2:  # In Python 3, int is always long (enough)
-            # Check that you can load it with an id of type long
-            a3 = Node.get_subclass_from_pk(long(a1.id))
-            self.assertEquals(a1.id, a3.id, "The ids of the stored and loaded node"
-                                            "should be equal (since it should be "
-                                            "the same node")
+        a3 = Node.get_subclass_from_pk(long(a1.id))
+        self.assertEquals(a1.id, a3.id, "The ids of the stored and loaded node"
+                                        "should be equal (since it should be "
+                                        "the same node")
 
         # Check that it manages to load the node even if the id is
         # passed as a string.

--- a/aiida/backends/tests/nodes.py
+++ b/aiida/backends/tests/nodes.py
@@ -29,6 +29,11 @@ from aiida.orm.utils import load_node
 from aiida.utils.capturing import Capturing
 from aiida.utils.delete_nodes import delete_nodes
 
+try:
+    long        # Python 2
+except NameError:
+    long = int  # Python 2
+
 
 class TestNodeCopyDeepcopy(AiidaTestCase):
     """Test that calling copy and deepcopy on a Node does the right thing."""


### PR DESCRIPTION
__long__ was removed in Python 3 because all __int__ are of infinite precision.