### PR TITLE
Revert invoke of configure after `verdi computer setup`

### DIFF
--- a/aiida/cmdline/commands/cmd_computer.py
+++ b/aiida/cmdline/commands/cmd_computer.py
@@ -215,11 +215,8 @@ def computer_setup(ctx, non_interactive, **kwargs):
     else:
         echo.echo_success('Computer<{}> {} created'.format(computer.pk, computer.name))
 
-    if not non_interactive and click.confirm('Do you want to configure the computer now?'):
-        ctx.invoke(computer_configure.commands[computer.get_transport_type()], computer=computer)
-    else:
-        echo.echo_info('Note: before the computer can be used, it has to be configured with the command:')
-        echo.echo_info('  verdi computer configure {} {}'.format(computer.get_transport_type(), computer.name))
+    echo.echo_info('Note: before the computer can be used, it has to be configured with the command:')
+    echo.echo_info('  verdi computer configure {} {}'.format(computer.get_transport_type(), computer.name))
 
 
 @verdi_computer.command('duplicate')
@@ -281,11 +278,8 @@ def computer_duplicate(ctx, computer, non_interactive, **kwargs):
     is_configured = computer.is_user_configured(backend.users.get_automatic_user())
 
     if not is_configured:
-        if not non_interactive and click.confirm('Do you want to configure the computer now?'):
-            ctx.invoke(computer_configure.commands[computer.get_transport_type()], computer=computer)
-        else:
-            echo.echo_info('Note: before the computer can be used, it has to be configured with the command:')
-            echo.echo_info('  verdi computer configure {} {}'.format(computer.get_transport_type(), computer.name))
+        echo.echo_info('Note: before the computer can be used, it has to be configured with the command:')
+        echo.echo_info('  verdi computer configure {} {}'.format(computer.get_transport_type(), computer.name))
 
 
 @verdi_computer.command('enable')


### PR DESCRIPTION
Fixes #1975 

After a successful `verdi computer setup` the computer has to be
configured. At the end of the setup command, the required command that
has to be called to configure would be printed, but this was recently
changed into a confirmation prompt, followed by a direct invocation of
the configure command. However, due to a bug, the invoked configuration
command does not prompt the user properly. While we await this bug to
be fixed, we revert to simply printing the command that the user has
to call manually.