### PR TITLE
Update `paramiko` version requirement to `2.4.2`

### DIFF
--- a/docs/requirements_for_rtd.txt
+++ b/docs/requirements_for_rtd.txt
@@ -41,7 +41,7 @@ marshmallow-sqlalchemy==0.13.2
 meld3==1.0.2
 mock==2.0.0
 numpy==1.14.3
-paramiko==2.4.1
+paramiko==2.4.2
 passlib==1.7.1
 pathlib2==2.3.0
 pgtest==1.1.0

--- a/setup_requirements.py
+++ b/setup_requirements.py
@@ -56,7 +56,7 @@ install_requires = [
     'ete3==3.1.1',
     'uritools==2.1.0',
     'psycopg2-binary==2.7.4',
-    'paramiko==2.4.1',
+    'paramiko==2.4.2',
     'ecdsa==0.13',
     'ipython<6.0',  # Version of ipython non enforced, because some still prefer version 4 rather than the latest
 ]


### PR DESCRIPTION
Fixes #2041 

The version `2.4.1` had a high severity vulnerability CVE-2018-1000805
that has been fixed in `2.4.2`