### PR TITLE
[WIP] Fix several issues with the hashing method

### DIFF
--- a/aiida/common/test_hashing.py
+++ b/aiida/common/test_hashing.py
@@ -13,6 +13,7 @@ Unittests for aiida.common.hashing:make_hash with hardcoded hash values
 
 from __future__ import absolute_import
 import unittest
+import itertools
 from datetime import datetime
 
 import six
@@ -30,26 +31,30 @@ class MakeHashTest(unittest.TestCase):
     # pylint: disable=missing-docstring,too-few-public-methods
 
     def test_builtin_types(self):
-        self.assertEqual(make_hash('something in ASCII'), '82c78710eebc41c0f0684e817944d6f08e54be54a279f9fc263f8403')
-        self.assertEqual(make_hash(42), 'f7d4da96058de015a3a6f6b98cff45a80a2852fe721b0d06a2627944')
-        self.assertEqual(make_hash(3.141), '2086094b3fbadc66b71c38281fc079d7c3978e74eb28ca7f3b966371')
-        self.assertEqual(make_hash(complex(1, 2)), '59975775040ab3a41ca969fc360f0ff1b1663d64046005a6ee68bf7b')
-        self.assertEqual(make_hash(True), '15ca7d7468e8aa86ea3db945ae856d783e2f92056550a50cb96fe7fd')
-        self.assertEqual(make_hash(None), '9a5b682a9a6a99a1d2ce4353d52062d511d418af058679d1b9b97570')
+        self.assertEqual(make_hash('something in ASCII'), u'7ada3e803dc6b66a8151c12985b0098d4f434da422bfd0740fcef562')
+        self.assertEqual(make_hash(42), u'2ab4140f3a4686f65ed84a4524bc56156e23a9e37736e273d83e99f5')
+        self.assertEqual(make_hash(3.141), u'e2f8e979916f99f6002239400f41949b94eecbaefdc064ecc51f8907')
+        self.assertEqual(make_hash(complex(1, 2)), u'1d819b8d8f2ae0a2033471f556b6f4dee7fa7fd4ca7bd1c0d0d2c70a')
+        self.assertEqual(make_hash(True), u'40f09510111ae311ce3f2406b547adcc222f8276dfe93e9f4dfc5098')
+        self.assertEqual(make_hash(None), u'2d4ca80c884a9f6dfedc579cd8072fce7918ed390bf71c1fa9fea081')
 
     def test_unicode_string(self):
         self.assertEqual(
-            make_hash(u'something still in ASCII'), '753df9fb179504652f66dd15877d393a743cbfe31d6bf6a9faed7e37')
-        # current implementation fails with real unicode:
-        # self.assertEqual(make_hash(u'öpis mit Umluut wie ä, ö, ü und emene ß 😊'), '')
+            make_hash(u'something still in ASCII'), u'7cbae2b37638c56d5fe98429d5582edc3aad061e83fa1e45d754b2d6')
+
+        self.assertEqual(
+            make_hash(u"öpis mit Umluut wie ä, ö, ü und emene ß"),
+            "524b0fb4e50f855046796751f9045d581f5758b0b91d59a6803c2535")
 
     def test_collection_with_builtin_types(self):
-        self.assertEqual(make_hash((1, 2, 3)), 'ccbd4c0c83df304a4d8fa1cb4d556f370d8d09c03b49cd069fd72598')
-        self.assertEqual(make_hash([1, 2, 3]), 'ccbd4c0c83df304a4d8fa1cb4d556f370d8d09c03b49cd069fd72598')
-        self.assertEqual(make_hash([3, 1, 2]), '401c29a918e635ab4b384e7a0ac1d189eb857bfc3e8085fe3aaa17c2')
-        self.assertEqual(make_hash({1, 2, 3}), '95467151c8099d6bef0e52588f0e651d6276fa4cad0866c710447a58')
-        self.assertEqual(make_hash({'a': 'b', 'c': 'd'}), 'ee137be5e9397e30612b6628df24be4e4913c6cc4a6be5bf85509ef3')
-        self.assertEqual(make_hash({'c': 'd', 'a': 'b'}), 'ee137be5e9397e30612b6628df24be4e4913c6cc4a6be5bf85509ef3')
+        self.assertEqual(make_hash((1, 2, 3)), '44d5ef36d5ae47a6e9aee5d910d148f1b63b6cdf073d11750159518f')
+        self.assertEqual(make_hash([1, 2, 3]), '44d5ef36d5ae47a6e9aee5d910d148f1b63b6cdf073d11750159518f')
+        self.assertEqual(make_hash([3, 1, 2]), '26e80d9e69085eca985309695732d132696c3dad6953b785e8faa963')
+        self.assertEqual(make_hash({1, 2, 3}), 'd1b190427d67bc95366a44c987e34fd68aa80716c4f45500db2bc635')
+        for perm in itertools.permutations([1, 2, 3]):
+            self.assertNotEqual(make_hash(perm), make_hash({1, 2, 3}))
+        self.assertEqual(make_hash({'a': 'b', 'c': 'd'}), 'f5a57db4d625848dba7dade0a1b64c612779bc536e3008453eb442d2')
+        self.assertEqual(make_hash({'c': 'd', 'a': 'b'}), 'f5a57db4d625848dba7dade0a1b64c612779bc536e3008453eb442d2')
 
     @unittest.skipIf(six.PY3, "Broken on Python 3")
     def test_nested_collections(self):
@@ -77,25 +82,25 @@ class MakeHashTest(unittest.TestCase):
             3: 4
         }
 
-        self.assertEqual(make_hash(obj_a), '41f1b6de377112ea0068416c00c6bb6cd2abf0133fe852fa4bb9dfbb')
-        self.assertEqual(make_hash(obj_b), '41f1b6de377112ea0068416c00c6bb6cd2abf0133fe852fa4bb9dfbb')
+        self.assertEqual(make_hash(obj_a), '28dd36897f1fcd153c71330f843e0fb28566f6b752fcdcb7fc7e0cfe')
+        self.assertEqual(make_hash(obj_b), '28dd36897f1fcd153c71330f843e0fb28566f6b752fcdcb7fc7e0cfe')
 
     def test_datetime(self):
         self.assertEqual(
-            make_hash(datetime(2018, 8, 18, 8, 18)), 'bc10b5f4152733191369a40dd96cb8992ac40ece6f0e59e77518f46f')
+            make_hash(datetime(2018, 8, 18, 8, 18)), 'b71d8e8cd775cc6bb61ba545e4674005515f9db212d8dcb9c779e915')
         self.assertEqual(
-            make_hash(datetime.utcfromtimestamp(0)), 'aaff3b5717365f5fbf4d415ae893cda13fef1b1a28cb66f381fddea2')
+            make_hash(datetime.utcfromtimestamp(0)), 'b932cff36ce23f7d3a43757d34fe935d03a083134e987c022973a35e')
 
     def test_numpy_types(self):
-        self.assertEqual(make_hash(np.float64(3.141)), '2086094b3fbadc66b71c38281fc079d7c3978e74eb28ca7f3b966371')  # pylint: disable=no-member
-        self.assertEqual(make_hash(np.int64(42)), 'f7d4da96058de015a3a6f6b98cff45a80a2852fe721b0d06a2627944')  # pylint: disable=no-member
+        self.assertEqual(make_hash(np.float64(3.141)), 'e2f8e979916f99f6002239400f41949b94eecbaefdc064ecc51f8907')  # pylint: disable=no-member
+        self.assertEqual(make_hash(np.int64(42)), '2ab4140f3a4686f65ed84a4524bc56156e23a9e37736e273d83e99f5')  # pylint: disable=no-member
 
     def test_numpy_arrays(self):
-        self.assertEqual(make_hash(np.array([1, 2, 3])), '88348823a5582f72b20b9bc51221dbbf2e52adedfa949b537f41d0f3')
+        self.assertEqual(make_hash(np.array([1, 2, 3])), '9b2bec0622bc5bedcb3d02c0b5b9d19bdbde36eec41be423715285df')
         self.assertEqual(
-            make_hash(np.array([np.float64(3.141)])), '57a640be101799c6b70ced7aa688af6dd76f0ed75007c05a97d0af6c')  # pylint: disable=no-member
+            make_hash(np.array([np.float64(3.141)])), 'e437b69603b2189abaf2fd8f2cc3d3f9fbebc537052ba3dad75e22a8')  # pylint: disable=no-member
         self.assertEqual(
-            make_hash(np.array([np.complex128(1 + 2j)])), 'eddf5fbcd94f8caf2b821ddd03c6bca1593d7029914c928c29ba25f4')  # pylint: disable=no-member
+            make_hash(np.array([np.complex128(1 + 2j)])), '37451dd77b55202142b5367f26830dfa751c208b4bb15da66d46200d')  # pylint: disable=no-member
 
     def test_unhashable_type(self):
 
@@ -113,12 +118,12 @@ class MakeHashTest(unittest.TestCase):
             fhandle.write("hello there!\n")
             fhandle.close()
 
-            self.assertEqual(make_hash(folder), '7e09b5bc4fec5b85ef85ff1679efea2c11fa1fd9212f8cb70550627b')
+            self.assertEqual(make_hash(folder), '6e5ddd16e397aa0a0154abde43d1f262c8b0f7ae388508221bbdd155')
 
             nested_obj = ['1.0.0a2', {u'array|a': [1001]}, folder, None]
-            self.assertEqual(make_hash(nested_obj), 'd7e6914da5cf7bf3c1c98cab90192362d440e2c13bd4fe04cdd71bde')
+            self.assertEqual(make_hash(nested_obj), '80d1905172f136615cbe1dded3131527d54dff7fd2d643adf63f3b49')
 
             fhandle = folder.open('file3.npy', 'wb')
             np.save(fhandle, np.arange(10))
             fhandle.close()
-            self.assertEqual(make_hash(folder), '18e28635210ec949097222567d0c8ecfbcd918af8721766e4aaecf73')
+            self.assertEqual(make_hash(folder), '4ed5bec24a050386812e6666bfab96ffee04795ca29561e115d16bcc')


### PR DESCRIPTION
Fixes #2008, #2009.

* dict items are sorted _after_ hashing, fixing the behavior for
  keys which can not be sorted
* unicode/str and str/bytes are explicitly handled, with a different
  type salt
* in general, the combination between two hashes is done via the
  method of boost::hash_combine, not by concatenating the hexdigest