### PR TITLE
Fix function signature of `SshTransport.copy`

### DIFF
--- a/aiida/transport/plugins/ssh.py
+++ b/aiida/transport/plugins/ssh.py
@@ -949,7 +949,7 @@ class SshTransport(aiida.transport.Transport):
         cp_flags = '-r -f'
         return self.copy(remotesource, remotedestination, dereference, cp_flags, pattern)
 
-    def copy(self, remotesource, remotedestination, dereference=False):
+    def copy(self, remotesource, remotedestination, dereference=False, pattern=None, cp_flags=None):
         """
         Copy a file or a directory from remote source to remote destination.
         Flags used: ``-r``: recursive copy; ``-f``: force, makes the command non interactive;
@@ -969,12 +969,13 @@ class SshTransport(aiida.transport.Transport):
 
         # TODO: verify that it does not re
 
-        # For the moment, these are hardcoded. They may become parameters
-        # as soon as we see the need.
-        cp_flags = '-r -f'
+        if cp_flags is None:
+            cp_flags = '-r -f'
+
+        # For the moment, this is hardcoded. May become a parameter
         cp_exe = 'cp'
 
-        ## To evaluate if we also want -p: preserves mode,ownership and timestamp
+        # To evaluate if we also want -p: preserves mode,ownership and timestamp
         if dereference:
             # use -L; --dereference is not supported on mac
             cp_flags += ' -L'
@@ -989,7 +990,7 @@ class SshTransport(aiida.transport.Transport):
                              'Found instead %s as remotedestination' % remotedestination)
 
         if self.has_magic(remotedestination):
-            raise ValueError("Pathname patterns are not allowed in the " "destination")
+            raise ValueError("Pathname patterns are not allowed in the destination")
 
         if self.has_magic(remotesource):
             to_copy_list = self.glob(remotesource)

--- a/aiida/transport/plugins/ssh.py
+++ b/aiida/transport/plugins/ssh.py
@@ -923,33 +923,13 @@ class SshTransport(aiida.transport.Transport):
             aiida_attr[key] = getattr(paramiko_attr, key)
         return aiida_attr
 
-    def copyfile(self, remotesource, remotedestination, dereference=False, pattern=None):
-        """
-        Copy a file from remote source to remote destination
-        Redirects to copy().
+    def copyfile(self, remotesource, remotedestination, dereference=False):
+        return self.copy(remotesource, remotedestination, dereference)
 
-        :param remotesource:
-        :param remotedestination:
-        :param dereference:
-        :param pattern:
-        """
-        cp_flags = '-f'
-        return self.copy(remotesource, remotedestination, dereference, cp_flags, pattern)
+    def copytree(self, remotesource, remotedestination, dereference=False):
+        return self.copy(remotesource, remotedestination, dereference, recursive=True)
 
-    def copytree(self, remotesource, remotedestination, dereference=False, pattern=None):
-        """
-        copy a folder recursively from remote source to remote destination
-        Redirects to copy()
-
-        :param remotesource:
-        :param remotedestination:
-        :param dereference:
-        :param pattern:
-        """
-        cp_flags = '-r -f'
-        return self.copy(remotesource, remotedestination, dereference, cp_flags, pattern)
-
-    def copy(self, remotesource, remotedestination, dereference=False, pattern=None, cp_flags=None):
+    def copy(self, remotesource, remotedestination, dereference=False, recursive=True):
         """
         Copy a file or a directory from remote source to remote destination.
         Flags used: ``-r``: recursive copy; ``-f``: force, makes the command non interactive;
@@ -959,18 +939,18 @@ class SshTransport(aiida.transport.Transport):
         :param remotedestination: file to copy to
         :param dereference: if True, copy content instead of copying the symlinks only
             Default = False.
+        :param recursive: if True copy directories recursively, otherwise only copy the specified file(s)
+        :type recursive: bool
         :raise IOError: if the cp execution failed.
 
         .. note:: setting dereference equal to True could cause infinite loops.
         """
         # In the majority of cases, we should deal with linux cp commands
-
         # TODO : do we need to avoid the aliases when calling cp_exe='cp'? Call directly /bin/cp?
 
-        # TODO: verify that it does not re
-
-        if cp_flags is None:
-            cp_flags = '-r -f'
+        cp_flags = '-f'
+        if recursive:
+            cp_flags += ' -r'
 
         # For the moment, this is hardcoded. May become a parameter
         cp_exe = 'cp'

--- a/aiida/transport/transport.py
+++ b/aiida/transport/transport.py
@@ -248,37 +248,45 @@ class Transport(object):
         """
         raise NotImplementedError
 
-    def copy(self, remotesource, remotedestination, *args, **kwargs):
+    def copy(self, remotesource, remotedestination, dereference=False, recursive=True):
         """
         Copy a file or a directory from remote source to remote destination
         (On the same remote machine)
 
         :param str remotesource: path of the remote source directory / file
         :param str remotedestination: path of the remote destination directory / file
+        :param dereference: if True copy the contents of any symlinks found, otherwise copy the symlinks themselves
+        :type dereference: bool
+        :param recursive: if True copy directories recursively, otherwise only copy the specified file(s)
+        :type recursive: bool
 
         :raises: IOError, if one of src or dst does not exist
         """
         raise NotImplementedError
 
-    def copyfile(self, remotesource, remotedestination, *args, **kwargs):
+    def copyfile(self, remotesource, remotedestination, dereference=False):
         """
         Copy a file from remote source to remote destination
         (On the same remote machine)
 
         :param str remotesource: path of the remote source directory / file
         :param str remotedestination: path of the remote destination directory / file
+        :param dereference: if True copy the contents of any symlinks found, otherwise copy the symlinks themselves
+        :type dereference: bool
 
         :raises IOError: if one of src or dst does not exist
         """
         raise NotImplementedError
 
-    def copytree(self, remotesource, remotedestination, *args, **kwargs):
+    def copytree(self, remotesource, remotedestination, dereference=False):
         """
         Copy a folder from remote source to remote destination
         (On the same remote machine)
 
         :param str remotesource: path of the remote source directory / file
         :param str remotedestination: path of the remote destination directory / file
+        :param dereference: if True copy the contents of any symlinks found, otherwise copy the symlinks themselves
+        :type dereference: bool
 
         :raise IOError: if one of src or dst does not exist
         """


### PR DESCRIPTION
Fixes #2062 

The internal methods `copy_file` and `copy_tree` which call through to
the `copy` method, need to be able to pass a pattern and flags for the
copy command. The `copy` signature did not correctly define these.