### PR TITLE
Log exception if DaemonRunner fails to instantiate in `start_daemon`

### DIFF
--- a/aiida/daemon/runner.py
+++ b/aiida/daemon/runner.py
@@ -30,7 +30,11 @@ def start_daemon():
     daemon_client = DaemonClient()
     configure_logging(daemon=True, daemon_log_file=daemon_client.daemon_log_file)
 
-    runner = DaemonRunner(rmq_config=get_rmq_config(), rmq_submit=False)
+    try:
+        runner = DaemonRunner(rmq_config=get_rmq_config(), rmq_submit=False)
+    except Exception as exception:
+        logger.exception('daemon runner failed to start')
+        raise
 
     def shutdown_daemon(num, frame):
         logger.info('Received signal to shut down the daemon runner')


### PR DESCRIPTION
Fixes #2071 

If an exception occurs during instantiation of the `DaemonRunner` class
in `aiida.daemon.runner.start_daemon` the process will terminated. If
this was launched as a worker by the circus daemon, circus will simply
try to restart the worker, causing the exact same problem. Since the
exception is nog logged, the user is nonethewiser even though the
daemon appears to be running. However, it is continuously recreating
workers that instantly die.