### PR TITLE
Add cmdline templates to the MANIFEST.in

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,6 +2,7 @@ recursive-include aiida/common/additions/migration_tests/test_migration_files *
 recursive-include aiida/common/additions/config_migrations/test_samples/ *
 include aiida/backends/tests/export_import_test_files/*.aiida
 include aiida/backends/sqlalchemy/migrations/script.py.mako
+include aiida/cmdline/templates/*.tpl
 include aiida/common/additions/backup_script/backup_info.json.tmpl
 include examples/testdata/qepseudos/*
 include docs/source/images/*.png


### PR DESCRIPTION
Fixes #2077 

These template files are necessary for the `verdi` command line to
work and so should therefore be included in the package, which is
achieved by listing them in the manifest file.