### PR TITLE
Fix bug in the check of repository path for test profiles

### DIFF
--- a/aiida/common/setup.py
+++ b/aiida/common/setup.py
@@ -738,7 +738,7 @@ def create_configuration(profile='default'):
 
         # Check if the new repository is a test repository and if it already exists.
         if is_test_profile:
-            if TEST_KEYWORD not in os.path.basename(new_repo_path):
+            if TEST_KEYWORD not in os.path.basename(new_repo_path.rstrip('/')):
                 raise ValueError(
                     "The repository directory for test profiles should "
                     "contain the test keyword '{}'".format(TEST_KEYWORD))


### PR DESCRIPTION
Fixes #2084 

If the provided path ends with a slash, calling `os.path.basename`
will yield an empty string, even if the previous directory would
have passed the prefix check. Therefore we strip first any terminal
slashes before getting the basename.