### PR TITLE
Fix 1930 transport queue py3

### DIFF
--- a/aiida/backends/testbase.py
+++ b/aiida/backends/testbase.py
@@ -15,6 +15,8 @@ import unittest
 from unittest import (
     TestSuite, defaultTestLoader as test_loader)
 
+from tornado import ioloop
+
 from aiida.backends import settings
 from aiida.backends.tests import get_db_test_list
 from aiida.common.exceptions import ConfigurationError, TestsNotAllowedError, InternalError
@@ -52,7 +54,7 @@ class AiidaTestCase(unittest.TestCase):
     """
     _class_was_setup = False
     __backend_instance = None
-    backend = None  # type: :class:`aiida.orm.backend.Backend`
+    backend = None  # type: aiida.orm.Backend
 
     @classmethod
     def get_backend_class(cls):
@@ -98,10 +100,19 @@ class AiidaTestCase(unittest.TestCase):
         cls._class_was_setup = True
 
     def setUp(self):
+        # Install a new IOLoop so that any messing up of the state of the loop is not propagated
+        # to subsequent tests.
+        # This call should come before the backend instance setup call just in case it uses the loop
+        ioloop.IOLoop().make_current()
         self.__backend_instance.setUp_method()
 
     def tearDown(self):
         self.__backend_instance.tearDown_method()
+        # Clean up the loop we created in set up.
+        # Call this after the instance tear down just in case it uses the loop
+        loop = ioloop.IOLoop.current()
+        if not loop._closing:
+            loop.close()
 
     @classmethod
     def insert_data(cls):

--- a/aiida/backends/tests/work/test_transport.py
+++ b/aiida/backends/tests/work/test_transport.py
@@ -8,9 +8,7 @@
 # For further information please visit http://www.aiida.net               #
 ###########################################################################
 from __future__ import absolute_import
-import unittest
 
-import six
 from six.moves import range
 from tornado.gen import coroutine, Return
 
@@ -18,7 +16,6 @@ from aiida.backends.testbase import AiidaTestCase
 from aiida.work.transports import TransportQueue
 
 
-@unittest.skipIf(six.PY3, "Broken on Python 3")
 class TestTransportQueue(AiidaTestCase):
     """ Tests for the transport queue """
 


### PR DESCRIPTION
Fixes #1930 

I believe that #1930 was actually not python 3 related - just an unfortunate ordering issue of the tests and impropse cleanup of the event loop.  We fixed this in the `new_engine` branch so I'm including a cherry-pick from that branch that should fix this in develop.