### PR TITLE
Fix 2047  Ensure all files written by AiiDA and plugins are utf8 encoded

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -196,11 +196,9 @@
         aiida/common/profile.py|
         aiida/common/setup.py|
         aiida/common/test_extendeddicts.py|
-        aiida/common/test_folders.py|
         aiida/common/test_logging.py|
         aiida/common/test_utils.py|
         aiida/control/tests/test_postgres.py|
-        aiida/daemon/client.py|
         aiida/daemon/execmanager.py|
         aiida/daemon/runner.py|
         aiida/daemon/timestamps.py|

--- a/aiida/backends/djsite/cmdline.py
+++ b/aiida/backends/djsite/cmdline.py
@@ -13,7 +13,7 @@ from __future__ import division
 from __future__ import print_function
 from __future__ import absolute_import
 import datetime
-import json
+import aiida.utils.json as json
 
 from django.db.models import Q
 

--- a/aiida/backends/djsite/db/models.py
+++ b/aiida/backends/djsite/db/models.py
@@ -333,9 +333,9 @@ def _deserialize_attribute(mainitem, subitems, sep, original_class=None,
     :return: the deserialized value
     :raise aiida.backends.djsite.db.models.DeserializationException: if an error occurs
     """
+    import aiida.utils.json as json
     from aiida.utils.timezone import (
         is_naive, make_aware, get_current_timezone)
-    import json
 
     from aiida.common import aiidalogger
 
@@ -729,8 +729,9 @@ class DbMultipleValueAttributeBaseClass(m.Model):
           responsibility to store such entries (typically with a Django
           bulk_create() call).
         """
-        import json
         import datetime
+        
+        import aiida.utils.json as json
         from aiida.utils.timezone import is_naive, make_aware, get_current_timezone
 
         if cls._subspecifier_field_name is None:
@@ -1402,7 +1403,7 @@ class DbComputer(m.Model):
         return DjangoComputer.from_dbmodel(self, construct_backend())
 
     def _get_val_from_metadata(self, key):
-        import json
+        import aiida.utils.json as json
 
         try:
             metadata = json.loads(self.metadata)
@@ -1680,7 +1681,7 @@ class DbWorkflowData(m.Model):
     def set_value(self, arg):
         from aiida.orm.node import Node
         from aiida.common.datastructures import wf_data_value_types
-        import json
+        import aiida.utils.json as json
 
         try:
             if isinstance(arg, Node) or issubclass(arg.__class__, Node):
@@ -1697,7 +1698,8 @@ class DbWorkflowData(m.Model):
             six.reraise(ValueError, "Cannot set the parameter {}".format(self.name), sys.exc_info()[2])
 
     def get_value(self):
-        import json
+        import aiida.utils.json as json
+
         from aiida.common.datastructures import wf_data_value_types
 
         if self.value_type == wf_data_value_types.JSON:

--- a/aiida/backends/djsite/utils.py
+++ b/aiida/backends/djsite/utils.py
@@ -61,7 +61,7 @@ def get_log_messages(obj):
         which the log message was issued, as well as additional 'metadata'
     """
     from aiida.backends.djsite.db.models import DbLog
-    import json
+    import aiida.utils.json as json
 
     extra = get_dblogger_extra(obj)
 

--- a/aiida/backends/sqlalchemy/models/authinfo.py
+++ b/aiida/backends/sqlalchemy/models/authinfo.py
@@ -11,7 +11,6 @@
 from __future__ import division
 from __future__ import print_function
 from __future__ import absolute_import
-import json
 
 from sqlalchemy import ForeignKey
 from sqlalchemy.orm import relationship

--- a/aiida/backends/sqlalchemy/models/computer.py
+++ b/aiida/backends/sqlalchemy/models/computer.py
@@ -11,7 +11,6 @@
 from __future__ import division
 from __future__ import print_function
 from __future__ import absolute_import
-import json
 
 import six
 

--- a/aiida/backends/sqlalchemy/models/workflow.py
+++ b/aiida/backends/sqlalchemy/models/workflow.py
@@ -11,7 +11,6 @@
 from __future__ import division
 from __future__ import print_function
 from __future__ import absolute_import
-import json
 
 from sqlalchemy import ForeignKey
 from sqlalchemy.orm import relationship, backref
@@ -27,6 +26,7 @@ from aiida.backends.sqlalchemy.models.utils import uuid_func
 from aiida.common.datastructures import (wf_states, wf_data_types,
                                          wf_data_value_types, wf_default_call)
 from aiida.utils import timezone
+import aiida.utils.json as json
 
 
 

--- a/aiida/backends/sqlalchemy/utils.py
+++ b/aiida/backends/sqlalchemy/utils.py
@@ -21,7 +21,7 @@ try:
     json_dumps = partial(json.dumps, double_precision=15)
     json_loads = partial(json.loads, precise_float=True)
 except ImportError:
-    import json
+    import aiida.utils.json as json
 
     json_dumps = json.dumps
     json_loads = json.loads

--- a/aiida/backends/tests/backup_script.py
+++ b/aiida/backends/tests/backup_script.py
@@ -12,19 +12,19 @@ from __future__ import print_function
 from __future__ import absolute_import
 import datetime
 import importlib
-import json
 import shutil
 import sys
 import tempfile
 
 from dateutil.parser import parse
 
-from aiida.common import utils
-from aiida.common.additions.backup_script import backup_setup
-from aiida.orm.node import Node
 from aiida.backends.utils import is_dbenv_loaded, load_dbenv, BACKEND_SQLA, BACKEND_DJANGO
 from aiida.backends.settings import BACKEND
 from aiida.backends.testbase import AiidaTestCase
+from aiida.common import utils
+from aiida.common.additions.backup_script import backup_setup
+from aiida.orm.node import Node
+import aiida.utils.json as json
 
 
 if not is_dbenv_loaded():

--- a/aiida/backends/tests/backup_setup_script.py
+++ b/aiida/backends/tests/backup_setup_script.py
@@ -12,7 +12,6 @@ from __future__ import division
 from __future__ import print_function
 from __future__ import absolute_import
 import io
-import json
 import shutil
 import tempfile
 import os
@@ -21,7 +20,7 @@ from aiida.common import utils
 from aiida.common.additions.backup_script import backup_setup
 from aiida.common.additions.backup_script.backup_base import AbstractBackup
 from aiida.backends.testbase import AiidaTestCase
-
+import aiida.utils.json as json
 
 
 class TestBackupSetupScriptUnit(AiidaTestCase):

--- a/aiida/backends/tests/backup_setup_script.py
+++ b/aiida/backends/tests/backup_setup_script.py
@@ -11,6 +11,7 @@
 from __future__ import division
 from __future__ import print_function
 from __future__ import absolute_import
+import io
 import json
 import shutil
 import tempfile
@@ -120,7 +121,7 @@ class TestBackupSetupScriptIntegration(AiidaTestCase):
                             "It contains: {}.".format(backup_conf_records))
 
             # Check the content of the main backup configuration file
-            with open(os.path.join(temp_aiida_folder, "backup_info.json")
+            with io.open(os.path.join(temp_aiida_folder, "backup_info.json"), encoding='utf8'
                       ) as conf_jfile:
                 conf_cont = json.load(conf_jfile)
                 self.assertEqual(conf_cont[AbstractBackup.OLDEST_OBJECT_BK_KEY],

--- a/aiida/backends/tests/cmdline/commands/test_data.py
+++ b/aiida/backends/tests/cmdline/commands/test_data.py
@@ -11,6 +11,7 @@ from __future__ import print_function
 from __future__ import absolute_import
 from __future__ import division
 import sys
+import io
 import os
 import shutil
 import unittest
@@ -485,7 +486,7 @@ class TestVerdiDataRemote(AiidaTestCase):
         self.r = RemoteData()
         p = tempfile.mkdtemp()
         self.r.set_remote_path(p)
-        with open(p + '/file.txt', 'w') as f:
+        with io.open(p + '/file.txt', 'w', encoding='utf8') as f:
             f.write("test string")
         self.r.set_computer(comp)
         self.r.store()

--- a/aiida/backends/tests/cmdline/commands/test_data.py
+++ b/aiida/backends/tests/cmdline/commands/test_data.py
@@ -98,17 +98,14 @@ class TestVerdiDataExportable:
         }
 
         if datatype is None or datatype not in datatype_mapping.keys():
-            raise Exception("The listing of the objects {} is not supported"
-                            .format(datatype))
+            raise Exception("The listing of the objects {} is not supported".format(datatype))
 
         export_cmd = datatype_mapping[datatype]
 
         # Check that the simple command works as expected
         options = [str(ids[self.NODE_ID_STR])]
-        res = self.cli_runner.invoke(export_cmd, options,
-                                     catch_exceptions=False)
-        self.assertEquals(res.exit_code, 0, "The command did not finish "
-                                            "correctly")
+        res = self.cli_runner.invoke(export_cmd, options, catch_exceptions=False)
+        self.assertEquals(res.exit_code, 0, "The command did not finish " "correctly")
 
         dump_flags = ['-F', '--format']
         for flag in dump_flags:
@@ -137,11 +134,8 @@ class TestVerdiDataExportable:
 
                 # Try to export it again. It should fail because the
                 # file exists
-                res = self.cli_runner.invoke(export_cmd, options,
-                                             catch_exceptions=False)
-                self.assertNotEquals(res.exit_code, 0,
-                                     "The command should fail because the "
-                                     "file already exists")
+                res = self.cli_runner.invoke(export_cmd, options, catch_exceptions=False)
+                self.assertNotEquals(res.exit_code, 0, "The command should fail because the " "file already exists")
 
                 # Now we force the export of the file and it should overwrite
                 # existing files
@@ -182,12 +176,7 @@ class TestVerdiDataListable:
         from aiida.cmdline.commands.cmd_data.cmd_trajectory import LIST_PROJECT_HEADERS as p_tr
         from aiida.cmdline.commands.cmd_data.cmd_bands import LIST_PROJECT_HEADERS as p_bands
 
-        headers_mapping = {
-            CifData: p_cif,
-            StructureData: p_str,
-            TrajectoryData: p_tr,
-            BandsData: p_bands
-        }
+        headers_mapping = {CifData: p_cif, StructureData: p_str, TrajectoryData: p_tr, BandsData: p_bands}
 
         datatype_mapping = {
             CifData: cif_list,
@@ -197,8 +186,7 @@ class TestVerdiDataListable:
         }
 
         if datatype is None or datatype not in datatype_mapping.keys():
-            raise Exception("The listing of the objects {} is not supported"
-                            .format(datatype))
+            raise Exception("The listing of the objects {} is not supported".format(datatype))
 
         listing_cmd = datatype_mapping[datatype]
         project_headers = headers_mapping[datatype]
@@ -207,10 +195,8 @@ class TestVerdiDataListable:
         search_string_bytes = search_string.encode('utf-8')
 
         # Check that the normal listing works as expected
-        res = self.cli_runner.invoke(listing_cmd, [],
-                                     catch_exceptions=False)
-        self.assertIn(search_string_bytes, res.output_bytes,
-                      'The string {} was not found in the listing'
+        res = self.cli_runner.invoke(listing_cmd, [], catch_exceptions=False)
+        self.assertIn(search_string_bytes, res.output_bytes, 'The string {} was not found in the listing'
                       .format(search_string))
 
         # Check that the past days filter works as expected
@@ -218,58 +204,43 @@ class TestVerdiDataListable:
         # past_days_flags = ['-p']
         for flag in past_days_flags:
             options = [flag, '1']
-            res = self.cli_runner.invoke(listing_cmd, options,
-                                         catch_exceptions=False)
-            self.assertIn(search_string_bytes, res.output_bytes,
-                          'The string {} was not found in the listing'
+            res = self.cli_runner.invoke(listing_cmd, options, catch_exceptions=False)
+            self.assertIn(search_string_bytes, res.output_bytes, 'The string {} was not found in the listing'
                           .format(search_string))
 
             options = [flag, '0']
-            res = self.cli_runner.invoke(listing_cmd, options,
-                                         catch_exceptions=False)
-            self.assertNotIn(search_string_bytes, res.output_bytes,
-                             'A not expected string {} was found in the listing'
+            res = self.cli_runner.invoke(listing_cmd, options, catch_exceptions=False)
+            self.assertNotIn(search_string_bytes, res.output_bytes, 'A not expected string {} was found in the listing'
                              .format(search_string))
 
         # Check that the group filter works as expected
         group_flags = ['-G', '--groups']
         for flag in group_flags:
             # Non empty group
-            for non_empty in [self.NON_EMPTY_GROUP_NAME_STR,
-                              str(ids[self.NON_EMPTY_GROUP_ID_STR])]:
+            for non_empty in [self.NON_EMPTY_GROUP_NAME_STR, str(ids[self.NON_EMPTY_GROUP_ID_STR])]:
                 options = [flag, non_empty]
-                res = self.cli_runner.invoke(listing_cmd, options,
-                                             catch_exceptions=False)
-                self.assertIn(search_string_bytes, res.output_bytes,
-                              'The string {} was not found in the listing')
+                res = self.cli_runner.invoke(listing_cmd, options, catch_exceptions=False)
+                self.assertIn(search_string_bytes, res.output_bytes, 'The string {} was not found in the listing')
 
             # Empty group
-            for empty in [self.EMPTY_GROUP_NAME_STR,
-                          str(ids[self.EMPTY_GROUP_ID_STR])]:
+            for empty in [self.EMPTY_GROUP_NAME_STR, str(ids[self.EMPTY_GROUP_ID_STR])]:
                 options = [flag, empty]
-                res = self.cli_runner.invoke(listing_cmd, options,
-                                             catch_exceptions=False)
-                self.assertNotIn(
-                    search_string_bytes, res.output_bytes,
-                    'A not expected string {} was found in the listing')
+                res = self.cli_runner.invoke(listing_cmd, options, catch_exceptions=False)
+                self.assertNotIn(search_string_bytes, res.output_bytes,
+                                 'A not expected string {} was found in the listing')
 
             # Group combination
-            for non_empty in [self.NON_EMPTY_GROUP_NAME_STR,
-                              str(ids[self.NON_EMPTY_GROUP_ID_STR])]:
-                for empty in [self.EMPTY_GROUP_NAME_STR,
-                              str(ids[self.EMPTY_GROUP_ID_STR])]:
+            for non_empty in [self.NON_EMPTY_GROUP_NAME_STR, str(ids[self.NON_EMPTY_GROUP_ID_STR])]:
+                for empty in [self.EMPTY_GROUP_NAME_STR, str(ids[self.EMPTY_GROUP_ID_STR])]:
                     options = [flag, non_empty, empty]
-                    res = self.cli_runner.invoke(listing_cmd, options,
-                                                 catch_exceptions=False)
-                    self.assertIn(search_string_bytes, res.output_bytes,
-                                  'The string {} was not found in the listing')
+                    res = self.cli_runner.invoke(listing_cmd, options, catch_exceptions=False)
+                    self.assertIn(search_string_bytes, res.output_bytes, 'The string {} was not found in the listing')
 
         # Check raw flag
         raw_flags = ['-r', '--raw']
         for flag in raw_flags:
             options = [flag]
-            res = self.cli_runner.invoke(listing_cmd, options,
-                                         catch_exceptions=False)
+            res = self.cli_runner.invoke(listing_cmd, options, catch_exceptions=False)
             for header in project_headers:
                 self.assertNotIn(header.encode('utf-8'), res.output_bytes)
 
@@ -298,13 +269,10 @@ class TestVerdiData(AiidaTestCase):
         verdi data trajectory
         verdi data upf
         """
-        subcommands = ['array', 'bands', 'cif', 'parameter', 'remote',
-                       'structure', 'trajectory', 'upf']
+        subcommands = ['array', 'bands', 'cif', 'parameter', 'remote', 'structure', 'trajectory', 'upf']
         for sub_cmd in subcommands:
             output = sp.check_output(['verdi', 'data', sub_cmd, '--help'])
-            self.assertIn(
-                b'Usage:', output,
-                "Sub-command verdi data {} --help failed.".format(sub_cmd))
+            self.assertIn(b'Usage:', output, "Sub-command verdi data {} --help failed.".format(sub_cmd))
 
 
 class TestVerdiDataArray(AiidaTestCase):
@@ -325,18 +293,13 @@ class TestVerdiDataArray(AiidaTestCase):
 
     def test_arrayshowhelp(self):
         output = sp.check_output(['verdi', 'data', 'array', 'show', '--help'])
-        self.assertIn(
-            b'Usage:', output,
-            "Sub-command verdi data array show --help failed.")
+        self.assertIn(b'Usage:', output, "Sub-command verdi data array show --help failed.")
 
     def test_arrayshow(self):
         # with captured_output() as (out, err):
         options = [str(self.a.id)]
-        res = self.cli_runner.invoke(cmd_array.array_show, options,
-                                     catch_exceptions=False)
-        self.assertEquals(res.exit_code, 0,
-                          "The command did not finish "
-                          "correctly")
+        res = self.cli_runner.invoke(cmd_array.array_show, options, catch_exceptions=False)
+        self.assertEquals(res.exit_code, 0, "The command did not finish " "correctly")
 
 
 class TestVerdiDataBands(AiidaTestCase, TestVerdiDataListable):
@@ -347,10 +310,23 @@ class TestVerdiDataBands(AiidaTestCase, TestVerdiDataListable):
     @staticmethod
     def create_structure_bands():
         alat = 4.  # angstrom
-        cell = [[alat, 0., 0., ],
-                [0., alat, 0., ],
-                [0., 0., alat, ],
-                ]
+        cell = [
+            [
+                alat,
+                0.,
+                0.,
+            ],
+            [
+                0.,
+                alat,
+                0.,
+            ],
+            [
+                0.,
+                0.,
+                alat,
+            ],
+        ]
         s = StructureData(cell=cell)
         s.append_atom(position=(0., 0., 0.), symbols='Fe')
         s.append_atom(position=(alat / 2., alat / 2., alat / 2.), symbols='O')
@@ -359,10 +335,11 @@ class TestVerdiDataBands(AiidaTestCase, TestVerdiDataListable):
         @wf
         def connect_structure_bands(structure):
             alat = 4.
-            cell = np.array([[alat, 0., 0.],
-                             [0., alat, 0.],
-                             [0., 0., alat],
-                             ])
+            cell = np.array([
+                [alat, 0., 0.],
+                [0., alat, 0.],
+                [0., 0., alat],
+            ])
 
             k = KpointsData()
             k.set_cell(cell)
@@ -403,15 +380,11 @@ class TestVerdiDataBands(AiidaTestCase, TestVerdiDataListable):
 
     def test_bandsshowhelp(self):
         output = sp.check_output(['verdi', 'data', 'bands', 'show', '--help'])
-        self.assertIn(
-            b'Usage:', output,
-            "Sub-command verdi data bands show --help failed.")
+        self.assertIn(b'Usage:', output, "Sub-command verdi data bands show --help failed.")
 
     def test_bandlistshelp(self):
         output = sp.check_output(['verdi', 'data', 'bands', 'list', '--help'])
-        self.assertIn(
-            b'Usage:', output,
-            "Sub-command verdi data bands show --help failed.")
+        self.assertIn(b'Usage:', output, "Sub-command verdi data bands show --help failed.")
 
     def test_bandslist(self):
         from aiida.orm.data.array.bands import BandsData
@@ -420,17 +393,13 @@ class TestVerdiDataBands(AiidaTestCase, TestVerdiDataListable):
 
     def test_bandexporthelp(self):
         output = sp.check_output(['verdi', 'data', 'bands', 'export', '--help'])
-        self.assertIn(
-            b'Usage:', output,
-            "Sub-command verdi data bands export --help failed.")
+        self.assertIn(b'Usage:', output, "Sub-command verdi data bands export --help failed.")
 
     def test_bandsexport(self):
         options = [str(self.ids[TestVerdiDataListable.NODE_ID_STR])]
         res = self.cli_runner.invoke(cmd_bands.bands_export, options, catch_exceptions=False)
         self.assertEquals(res.exit_code, 0, 'The command did not finish correctly')
-        self.assertIn(b"[1.0, 3.0]", res.output_bytes,
-                      'The string [1.0, 3.0] was not found in the bands'
-                      'export')
+        self.assertIn(b"[1.0, 3.0]", res.output_bytes, 'The string [1.0, 3.0] was not found in the bands' 'export')
 
 
 class TestVerdiDataParameter(AiidaTestCase):
@@ -451,21 +420,15 @@ class TestVerdiDataParameter(AiidaTestCase):
 
     def test_parametershowhelp(self):
         output = sp.check_output(['verdi', 'data', 'parameter', 'show', '--help'])
-        self.assertIn(
-            b'Usage:', output,
-            "Sub-command verdi data parameter show --help failed.")
+        self.assertIn(b'Usage:', output, "Sub-command verdi data parameter show --help failed.")
 
     def test_parametershow(self):
         supported_formats = ['json_date']
         for format in supported_formats:
             options = [str(self.p.id)]
-            res = self.cli_runner.invoke(cmd_parameter.parameter_show, options,
-                                         catch_exceptions=False)
-            self.assertEquals(res.exit_code, 0,
-                              "The command verdi data parameter show did not"
-                              " finish correctly")
-        self.assertIn(b'"a": 1', res.output_bytes,
-                      'The string "a": 1 was not found in the output'
+            res = self.cli_runner.invoke(cmd_parameter.parameter_show, options, catch_exceptions=False)
+            self.assertEquals(res.exit_code, 0, "The command verdi data parameter show did not" " finish correctly")
+        self.assertIn(b'"a": 1', res.output_bytes, 'The string "a": 1 was not found in the output'
                       ' of verdi data parameter show')
 
 
@@ -486,8 +449,8 @@ class TestVerdiDataRemote(AiidaTestCase):
         self.r = RemoteData()
         p = tempfile.mkdtemp()
         self.r.set_remote_path(p)
-        with io.open(p + '/file.txt', 'w', encoding='utf8') as f:
-            f.write("test string")
+        with io.open(p + '/file.txt', 'w', encoding='utf8') as fhandle:
+            fhandle.write(u"test string")
         self.r.set_computer(comp)
         self.r.store()
 
@@ -495,17 +458,12 @@ class TestVerdiDataRemote(AiidaTestCase):
 
     def test_remoteshowhelp(self):
         output = sp.check_output(['verdi', 'data', 'remote', 'show', '--help'])
-        self.assertIn(
-            b'Usage:', output,
-            "Sub-command verdi data remote show --help failed.")
+        self.assertIn(b'Usage:', output, "Sub-command verdi data remote show --help failed.")
 
     def test_remoteshow(self):
         options = [str(self.r.id)]
-        res = self.cli_runner.invoke(cmd_remote.remote_show, options,
-                                     catch_exceptions=False)
-        self.assertEquals(res.exit_code, 0,
-                          "The command verdi data remote show did not"
-                          " finish correctly")
+        res = self.cli_runner.invoke(cmd_remote.remote_show, options, catch_exceptions=False)
+        self.assertEquals(res.exit_code, 0, "The command verdi data remote show did not" " finish correctly")
         self.assertIn(b'Remote computer name:', res.output_bytes,
                       'The string "Remote computer name:" was not found in the'
                       ' output of verdi data remote show')
@@ -515,41 +473,28 @@ class TestVerdiDataRemote(AiidaTestCase):
 
     def test_remotelshelp(self):
         output = sp.check_output(['verdi', 'data', 'remote', 'ls', '--help'])
-        self.assertIn(
-            b'Usage:', output,
-            "Sub-command verdi data remote ls --help failed.")
+        self.assertIn(b'Usage:', output, "Sub-command verdi data remote ls --help failed.")
 
     def test_remotels(self):
         options = ['--long', str(self.r.id)]
-        res = self.cli_runner.invoke(cmd_remote.remote_ls, options,
-                                     catch_exceptions=False)
-        self.assertEquals(res.exit_code, 0,
-                          "The command verdi data remote ls did not"
-                          " finish correctly")
-        self.assertIn(b'file.txt', res.output_bytes,
-                      'The file "file.txt" was not found in the output'
+        res = self.cli_runner.invoke(cmd_remote.remote_ls, options, catch_exceptions=False)
+        self.assertEquals(res.exit_code, 0, "The command verdi data remote ls did not" " finish correctly")
+        self.assertIn(b'file.txt', res.output_bytes, 'The file "file.txt" was not found in the output'
                       ' of verdi data remote ls')
 
     def test_remotecathelp(self):
         output = sp.check_output(['verdi', 'data', 'remote', 'cat', '--help'])
-        self.assertIn(
-            b'Usage:', output,
-            "Sub-command verdi data remote cat --help failed.")
+        self.assertIn(b'Usage:', output, "Sub-command verdi data remote cat --help failed.")
 
     def test_remotecat(self):
         options = [str(self.r.id), 'file.txt']
-        res = self.cli_runner.invoke(cmd_remote.remote_cat, options,
-                                     catch_exceptions=False)
-        self.assertEquals(res.exit_code, 0,
-                          "The command verdi data parameter cat did not"
-                          " finish correctly")
-        self.assertIn(b'test string', res.output_bytes,
-                      'The string "test string" was not found in the output'
+        res = self.cli_runner.invoke(cmd_remote.remote_cat, options, catch_exceptions=False)
+        self.assertEquals(res.exit_code, 0, "The command verdi data parameter cat did not" " finish correctly")
+        self.assertIn(b'test string', res.output_bytes, 'The string "test string" was not found in the output'
                       ' of verdi data remote cat file.txt')
 
 
-class TestVerdiDataTrajectory(AiidaTestCase, TestVerdiDataListable,
-                              TestVerdiDataExportable):
+class TestVerdiDataTrajectory(AiidaTestCase, TestVerdiDataListable, TestVerdiDataExportable):
 
     @staticmethod
     def create_trajectory_data():
@@ -563,33 +508,40 @@ class TestVerdiDataTrajectory(AiidaTestCase, TestVerdiDataListable,
         # I create sample data
         stepids = numpy.array([60, 70])
         times = stepids * 0.01
-        cells = numpy.array([
-            [[2., 0., 0., ],
-             [0., 2., 0., ],
-             [0., 0., 2., ]],
-            [[3., 0., 0., ],
-             [0., 3., 0., ],
-             [0., 0., 3., ]]])
+        cells = numpy.array([[[
+            2.,
+            0.,
+            0.,
+        ], [
+            0.,
+            2.,
+            0.,
+        ], [
+            0.,
+            0.,
+            2.,
+        ]], [[
+            3.,
+            0.,
+            0.,
+        ], [
+            0.,
+            3.,
+            0.,
+        ], [
+            0.,
+            0.,
+            3.,
+        ]]])
         symbols = numpy.array(['H', 'O', 'C'])
-        positions = numpy.array([
-            [[0., 0., 0.],
-             [0.5, 0.5, 0.5],
-             [1.5, 1.5, 1.5]],
-            [[0., 0., 0.],
-             [0.5, 0.5, 0.5],
-             [1.5, 1.5, 1.5]]])
-        velocities = numpy.array([
-            [[0., 0., 0.],
-             [0., 0., 0.],
-             [0., 0., 0.]],
-            [[0.5, 0.5, 0.5],
-             [0.5, 0.5, 0.5],
-             [-0.5, -0.5, -0.5]]])
+        positions = numpy.array([[[0., 0., 0.], [0.5, 0.5, 0.5], [1.5, 1.5, 1.5]], [[0., 0., 0.], [0.5, 0.5, 0.5],
+                                                                                    [1.5, 1.5, 1.5]]])
+        velocities = numpy.array([[[0., 0., 0.], [0., 0., 0.], [0., 0., 0.]], [[0.5, 0.5, 0.5], [0.5, 0.5, 0.5],
+                                                                               [-0.5, -0.5, -0.5]]])
 
         # I set the node
-        n.set_trajectory(stepids=stepids, cells=cells, symbols=symbols,
-                         positions=positions, times=times,
-                         velocities=velocities)
+        n.set_trajectory(
+            stepids=stepids, cells=cells, symbols=symbols, positions=positions, times=times, velocities=velocities)
 
         n.store()
 
@@ -611,11 +563,7 @@ class TestVerdiDataTrajectory(AiidaTestCase, TestVerdiDataListable,
     def setUpClass(cls):
         super(TestVerdiDataTrajectory, cls).setUpClass()
         new_comp = cls.backend.computers.create(
-            name='comp',
-            hostname='localhost',
-            transport_type='local',
-            scheduler_type='direct',
-            workdir='/tmp/aiida')
+            name='comp', hostname='localhost', transport_type='local', scheduler_type='direct', workdir='/tmp/aiida')
         new_comp.store()
         cls.ids = cls.create_trajectory_data()
 
@@ -629,20 +577,16 @@ class TestVerdiDataTrajectory(AiidaTestCase, TestVerdiDataListable,
 
     def test_deposithelp(self):
         res = self.runner.invoke(cmd_trajectory.trajectory_deposit, ['--help'])
-        self.assertIn(b'Usage:', res.output_bytes,
-                      'The string "Usage: " was not found in the output'
+        self.assertIn(b'Usage:', res.output_bytes, 'The string "Usage: " was not found in the output'
                       ' of verdi data trajectory deposit --help')
 
     def test_showhelp(self):
         res = self.runner.invoke(cmd_trajectory.trajectory_show, ['--help'])
-        self.assertIn(b'Usage:', res.output_bytes,
-                      'The string "Usage: " was not found in the output'
+        self.assertIn(b'Usage:', res.output_bytes, 'The string "Usage: " was not found in the output'
                       ' of verdi data trajecotry show --help')
 
     def test_list(self):
-        self.data_listing_test(
-            TrajectoryData, str(self.ids[TestVerdiDataListable.NODE_ID_STR]),
-            self.ids)
+        self.data_listing_test(TrajectoryData, str(self.ids[TestVerdiDataListable.NODE_ID_STR]), self.ids)
 
     @unittest.skipUnless(has_pycifrw(), "Unable to import PyCifRW")
     def test_export(self):
@@ -668,10 +612,23 @@ class TestVerdiDataStructure(AiidaTestCase, TestVerdiDataListable, TestVerdiData
         from aiida.orm.group import Group
 
         alat = 4.  # angstrom
-        cell = [[alat, 0., 0., ],
-                [0., alat, 0., ],
-                [0., 0., alat, ],
-                ]
+        cell = [
+            [
+                alat,
+                0.,
+                0.,
+            ],
+            [
+                0.,
+                alat,
+                0.,
+            ],
+            [
+                0.,
+                0.,
+                alat,
+            ],
+        ]
 
         # BaTiO3 cubic structure
         struc = StructureData(cell=cell)
@@ -699,11 +656,8 @@ class TestVerdiDataStructure(AiidaTestCase, TestVerdiDataListable, TestVerdiData
     @classmethod
     def setUpClass(cls):
         super(TestVerdiDataStructure, cls).setUpClass()
-        new_comp = cls.backend.computers.create(name='comp',
-                                                hostname='localhost',
-                                                transport_type='local',
-                                                scheduler_type='direct',
-                                                workdir='/tmp/aiida')
+        new_comp = cls.backend.computers.create(
+            name='comp', hostname='localhost', transport_type='local', scheduler_type='direct', workdir='/tmp/aiida')
         new_comp.store()
         cls.ids = cls.create_structure_data()
 
@@ -717,8 +671,7 @@ class TestVerdiDataStructure(AiidaTestCase, TestVerdiDataListable, TestVerdiData
 
     def test_importhelp(self):
         res = self.runner.invoke(cmd_structure.structure_import, ['--help'])
-        self.assertIn(b'Usage:', res.output_bytes,
-                      'The string "Usage: " was not found in the output'
+        self.assertIn(b'Usage:', res.output_bytes, 'The string "Usage: " was not found in the output'
                       ' of verdi data import --help')
 
     def test_import(self):
@@ -728,37 +681,39 @@ class TestVerdiDataStructure(AiidaTestCase, TestVerdiDataListable, TestVerdiData
         Fe     0.0 0.0 0.0
         O      2.0 2.0 2.0
         '''
-        with tempfile.NamedTemporaryFile(mode='w+') as f:
-            f.write(xyzcontent)
-            f.flush()
-            options = [f.name,
-                       '--format', 'xyz',
-                       '--vacuum-factor', '1.0',
-                       '--vacuum-addition', '10.0',
-                       '--pbc', '1', '1', '1',
-                       ]
-            res = self.cli_runner.invoke(cmd_structure.structure_import,
-                                         options, catch_exceptions=False)
-            self.assertIn(b'PK = None', res.output_bytes,
-                          'The string "PK = None" was not found in the output'
+        with tempfile.NamedTemporaryFile(mode='w+') as fhandle:
+            fhandle.write(xyzcontent)
+            fhandle.flush()
+            options = [
+                f.name,
+                '--format',
+                'xyz',
+                '--vacuum-factor',
+                '1.0',
+                '--vacuum-addition',
+                '10.0',
+                '--pbc',
+                '1',
+                '1',
+                '1',
+            ]
+            res = self.cli_runner.invoke(cmd_structure.structure_import, options, catch_exceptions=False)
+            self.assertIn(b'PK = None', res.output_bytes, 'The string "PK = None" was not found in the output'
                           ' of verdi data structure import with --store option.')
             options.append('--store')
-            res = self.cli_runner.invoke(cmd_structure.structure_import,
-                                         options, catch_exceptions=False)
+            res = self.cli_runner.invoke(cmd_structure.structure_import, options, catch_exceptions=False)
             self.assertIn(b'Succesfully imported', res.output_bytes,
                           'The string "Succesfully imported" was not found in the output'
                           ' of verdi data structure import.')
 
     def test_showhelp(self):
         res = self.runner.invoke(cmd_structure.structure_import, ['--help'])
-        self.assertIn(b'Usage:', res.output_bytes,
-                      'The string "Usage: " was not found in the output'
+        self.assertIn(b'Usage:', res.output_bytes, 'The string "Usage: " was not found in the output'
                       ' of verdi data show --help')
 
     def test_deposithelp(self):
         res = self.runner.invoke(cmd_structure.structure_import, ['--help'])
-        self.assertIn(b'Usage:', res.output_bytes,
-                      'The string "Usage: " was not found in the output'
+        self.assertIn(b'Usage:', res.output_bytes, 'The string "Usage: " was not found in the output'
                       ' of verdi data show --help')
 
     def test_list(self):
@@ -770,8 +725,7 @@ class TestVerdiDataStructure(AiidaTestCase, TestVerdiDataListable, TestVerdiData
 
 
 @unittest.skipUnless(has_pycifrw(), "Unable to import PyCifRW")
-class TestVerdiDataCif(AiidaTestCase, TestVerdiDataListable,
-                       TestVerdiDataExportable):
+class TestVerdiDataCif(AiidaTestCase, TestVerdiDataListable, TestVerdiDataExportable):
     valid_sample_cif_str = '''
         data_test
         _cell_length_a    10
@@ -794,14 +748,11 @@ class TestVerdiDataCif(AiidaTestCase, TestVerdiDataListable,
 
     @classmethod
     def create_cif_data(cls):
-        with tempfile.NamedTemporaryFile(mode='w+') as f:
-            filename = f.name
-            f.write(cls.valid_sample_cif_str)
-            f.flush()
-            a = CifData(file=filename,
-                        source={'version': '1234',
-                                'db_name': 'COD',
-                                'id': '0000001'})
+        with tempfile.NamedTemporaryFile(mode='w+') as fhandle:
+            filename = fhandle.name
+            fhandle.write(cls.valid_sample_cif_str)
+            fhandle.flush()
+            a = CifData(file=filename, source={'version': '1234', 'db_name': 'COD', 'id': '0000001'})
             a.store()
 
             g_ne = Group(name='non_empty_group')
@@ -821,11 +772,7 @@ class TestVerdiDataCif(AiidaTestCase, TestVerdiDataListable,
     def setUpClass(cls):
         super(TestVerdiDataCif, cls).setUpClass()
         new_comp = cls.backend.computers.create(
-            name='comp',
-            hostname='localhost',
-            transport_type='local',
-            scheduler_type='direct',
-            workdir='/tmp/aiida')
+            name='comp', hostname='localhost', transport_type='local', scheduler_type='direct', workdir='/tmp/aiida')
         new_comp.store()
 
         cls.ids = cls.create_cif_data()
@@ -850,37 +797,29 @@ class TestVerdiDataCif(AiidaTestCase, TestVerdiDataListable,
 
     def test_showhelp(self):
         options = ['--help']
-        res = self.cli_runner.invoke(cmd_cif.cif_show, options,
-                                     catch_exceptions=False)
-        self.assertIn(b'Usage:', res.output_bytes,
-                      'The string "Usage: " was not found in the output'
+        res = self.cli_runner.invoke(cmd_cif.cif_show, options, catch_exceptions=False)
+        self.assertIn(b'Usage:', res.output_bytes, 'The string "Usage: " was not found in the output'
                       ' of verdi data show help')
 
     def test_deposithelp(self):
         options = ['--help']
-        res = self.cli_runner.invoke(cmd_cif.cif_deposit, options,
-                                     catch_exceptions=False)
-        self.assertIn(b'Usage:', res.output_bytes,
-                      'The string "Usage: " was not found in the output'
+        res = self.cli_runner.invoke(cmd_cif.cif_deposit, options, catch_exceptions=False)
+        self.assertIn(b'Usage:', res.output_bytes, 'The string "Usage: " was not found in the output'
                       ' of verdi data show deposit')
 
     def test_importhelp(self):
         options = ['--help']
-        res = self.cli_runner.invoke(cmd_cif.cif_import, options,
-                                     catch_exceptions=False)
-        self.assertIn(b'Usage:', res.output_bytes,
-                      'The string "Usage: " was not found in the output'
+        res = self.cli_runner.invoke(cmd_cif.cif_import, options, catch_exceptions=False)
+        self.assertIn(b'Usage:', res.output_bytes, 'The string "Usage: " was not found in the output'
                       ' of verdi data import help')
 
     def test_import(self):
-        with tempfile.NamedTemporaryFile(mode='w+') as f:
-            f.write(self.valid_sample_cif_str)
-            f.flush()
+        with tempfile.NamedTemporaryFile(mode='w+') as fhandle:
+            fhandle.write(self.valid_sample_cif_str)
+            fhandle.flush()
             options = [f.name]
-            res = self.cli_runner.invoke(cmd_cif.cif_import, options,
-                                         catch_exceptions=False)
-            self.assertIn(b'imported uuid', res.output_bytes,
-                          'The string "imported uuid" was not found in the output'
+            res = self.cli_runner.invoke(cmd_cif.cif_import, options, catch_exceptions=False)
+            self.assertIn(b'imported uuid', res.output_bytes, 'The string "imported uuid" was not found in the output'
                           ' of verdi data import.')
 
     def test_export(self):
@@ -909,93 +848,68 @@ class TestVerdiDataUpf(AiidaTestCase):
         self.cli_runner = CliRunner()
 
     def upload_family(self):
-        options = [self.this_folder + '/' + self.pseudos_dir,
-                   "test_group",
-                   "test description"]
-        res = self.cli_runner.invoke(cmd_upf.upf_uploadfamily, options,
-                                     catch_exceptions=False)
-        self.assertIn(b'UPF files found: 3', res.output_bytes,
-                      'The string "UPF files found: 3" was not found in the'
+        options = [self.this_folder + '/' + self.pseudos_dir, "test_group", "test description"]
+        res = self.cli_runner.invoke(cmd_upf.upf_uploadfamily, options, catch_exceptions=False)
+        self.assertIn(b'UPF files found: 3', res.output_bytes, 'The string "UPF files found: 3" was not found in the'
                       ' output of verdi data upf uploadfamily')
 
     def test_uploadfamilyhelp(self):
         output = sp.check_output(['verdi', 'data', 'upf', 'uploadfamily', '--help'])
-        self.assertIn(
-            b'Usage:', output,
-            "Sub-command verdi data upf uploadfamily --help failed.")
+        self.assertIn(b'Usage:', output, "Sub-command verdi data upf uploadfamily --help failed.")
 
     def test_uploadfamily(self):
         self.upload_family()
-        options = [self.this_folder + '/' + self.pseudos_dir,
-                   "test_group",
-                   "test description",
-                   "--stop-if-existing"]
+        options = [self.this_folder + '/' + self.pseudos_dir, "test_group", "test description", "--stop-if-existing"]
         with self.assertRaises(ValueError):
-            res = self.cli_runner.invoke(cmd_upf.upf_uploadfamily, options,
-                                         catch_exceptions=False)
+            res = self.cli_runner.invoke(cmd_upf.upf_uploadfamily, options, catch_exceptions=False)
 
     def test_exportfamilyhelp(self):
         output = sp.check_output(['verdi', 'data', 'upf', 'exportfamily', '--help'])
-        self.assertIn(
-            b'Usage:', output,
-            "Sub-command verdi data upf exportfamily --help failed.")
+        self.assertIn(b'Usage:', output, "Sub-command verdi data upf exportfamily --help failed.")
 
     def test_exportfamily(self):
         self.upload_family()
 
         p = tempfile.mkdtemp()
         options = [p, 'test_group']
-        res = self.cli_runner.invoke(cmd_upf.upf_exportfamily, options,
-                                     catch_exceptions=False)
+        res = self.cli_runner.invoke(cmd_upf.upf_exportfamily, options, catch_exceptions=False)
         output = sp.check_output(['ls', p])
-        self.assertIn(
-            b'Ba.pbesol-spn-rrkjus_psl.0.2.3-tot-pslib030.UPF', output,
-            "Sub-command verdi data upf exportfamily --help failed.")
-        self.assertIn(
-            b'O.pbesol-n-rrkjus_psl.0.1-tested-pslib030.UPF', output,
-            "Sub-command verdi data upf exportfamily --help failed.")
-        self.assertIn(
-            b'Ti.pbesol-spn-rrkjus_psl.0.2.3-tot-pslib030.UPF', output,
-            "Sub-command verdi data upf exportfamily --help failed.")
+        self.assertIn(b'Ba.pbesol-spn-rrkjus_psl.0.2.3-tot-pslib030.UPF', output,
+                      "Sub-command verdi data upf exportfamily --help failed.")
+        self.assertIn(b'O.pbesol-n-rrkjus_psl.0.1-tested-pslib030.UPF', output,
+                      "Sub-command verdi data upf exportfamily --help failed.")
+        self.assertIn(b'Ti.pbesol-spn-rrkjus_psl.0.2.3-tot-pslib030.UPF', output,
+                      "Sub-command verdi data upf exportfamily --help failed.")
 
     def test_listfamilieshelp(self):
         output = sp.check_output(['verdi', 'data', 'upf', 'listfamilies', '--help'])
-        self.assertIn(
-            b'Usage:', output,
-            "Sub-command verdi data upf listfamilies --help failed.")
+        self.assertIn(b'Usage:', output, "Sub-command verdi data upf listfamilies --help failed.")
 
     def test_listfamilies(self):
         self.upload_family()
 
         options = ['-d', '-e', 'Ba']
-        res = self.cli_runner.invoke(cmd_upf.upf_listfamilies, options,
-                                     catch_exceptions=False)
+        res = self.cli_runner.invoke(cmd_upf.upf_listfamilies, options, catch_exceptions=False)
 
-        self.assertIn(b'test_group', res.output_bytes,
-                      'The string "test_group" was not found in the'
+        self.assertIn(b'test_group', res.output_bytes, 'The string "test_group" was not found in the'
                       ' output of verdi data upf listfamilies')
 
-        self.assertIn(b'test description', res.output_bytes,
-                      'The string "test_group" was not found in the'
+        self.assertIn(b'test description', res.output_bytes, 'The string "test_group" was not found in the'
                       ' output of verdi data upf listfamilies')
 
         options = ['-d', '-e', 'Fe']
-        res = self.cli_runner.invoke(cmd_upf.upf_listfamilies, options,
-                                     catch_exceptions=False)
+        res = self.cli_runner.invoke(cmd_upf.upf_listfamilies, options, catch_exceptions=False)
         self.assertIn(b'No valid UPF pseudopotential', res.output_bytes,
                       'The string "No valid UPF pseudopotential" was not'
                       ' found in the output of verdi data upf listfamilies')
 
     def test_importhelp(self):
         output = sp.check_output(['verdi', 'data', 'upf', 'import', '--help'])
-        self.assertIn(
-            b'Usage:', output,
-            "Sub-command verdi data upf listfamilies --help failed.")
+        self.assertIn(b'Usage:', output, "Sub-command verdi data upf listfamilies --help failed.")
 
     def test_import(self):
         options = [self.this_folder + '/' + self.pseudos_dir + '/' + 'Ti.pbesol-spn-rrkjus_psl.0.2.3-tot-pslib030.UPF']
         res = self.cli_runner.invoke(cmd_upf.upf_import, options, catch_exceptions=False)
 
-        self.assertIn(b'Imported', res.output_bytes,
-                      'The string "Imported" was not'
+        self.assertIn(b'Imported', res.output_bytes, 'The string "Imported" was not'
                       ' found in the output of verdi data import: {}'.format(res.output))

--- a/aiida/backends/tests/cmdline/commands/test_data.py
+++ b/aiida/backends/tests/cmdline/commands/test_data.py
@@ -726,7 +726,7 @@ class TestVerdiDataStructure(AiidaTestCase, TestVerdiDataListable, TestVerdiData
 
 @unittest.skipUnless(has_pycifrw(), "Unable to import PyCifRW")
 class TestVerdiDataCif(AiidaTestCase, TestVerdiDataListable, TestVerdiDataExportable):
-    valid_sample_cif_str = '''
+    valid_sample_cif_str = u'''
         data_test
         _cell_length_a    10
         _cell_length_b    10

--- a/aiida/backends/tests/cmdline/commands/test_data.py
+++ b/aiida/backends/tests/cmdline/commands/test_data.py
@@ -685,7 +685,7 @@ class TestVerdiDataStructure(AiidaTestCase, TestVerdiDataListable, TestVerdiData
             fhandle.write(xyzcontent)
             fhandle.flush()
             options = [
-                f.name,
+                fhandle.name,
                 '--format',
                 'xyz',
                 '--vacuum-factor',
@@ -817,7 +817,7 @@ class TestVerdiDataCif(AiidaTestCase, TestVerdiDataListable, TestVerdiDataExport
         with tempfile.NamedTemporaryFile(mode='w+') as fhandle:
             fhandle.write(self.valid_sample_cif_str)
             fhandle.flush()
-            options = [f.name]
+            options = [fhandle.name]
             res = self.cli_runner.invoke(cmd_cif.cif_import, options, catch_exceptions=False)
             self.assertIn(b'imported uuid', res.output_bytes, 'The string "imported uuid" was not found in the output'
                           ' of verdi data import.')

--- a/aiida/backends/tests/cmdline/commands/test_node.py
+++ b/aiida/backends/tests/cmdline/commands/test_node.py
@@ -19,6 +19,7 @@ from aiida.backends.testbase import AiidaTestCase
 from aiida.common.links import LinkType
 from aiida.cmdline.commands.cmd_node import node_delete, node_label, node_description, show, tree, repo_ls, repo_cat
 
+
 class TestVerdiNode(AiidaTestCase):
 
     node_labels = ('in1', 'in2', 'wf', 'slave1', 'slave2', 'outp1', 'outp2', 'outp3', 'outp4')
@@ -27,7 +28,7 @@ class TestVerdiNode(AiidaTestCase):
         """Sets up a few nodes to play around with."""
         from aiida.orm import Node
 
-        nodes = { key : Node().store() for key in self.node_labels }
+        nodes = {key: Node().store() for key in self.node_labels}
 
         nodes['wf'].add_link_from(nodes['in1'], link_type=LinkType.INPUT)
         nodes['slave1'].add_link_from(nodes['in1'], link_type=LinkType.INPUT)
@@ -90,12 +91,12 @@ class TestVerdiNode(AiidaTestCase):
         label = u"my label"
         node.label = label
         node.store()
-        
+
         # read existing label
         options = [str(node.pk), '--raw']
         result = self.runner.invoke(node_label, options)
         self.assertIsNone(result.exception)
-        self.assertEquals(result.output, label+'\n')
+        self.assertEquals(result.output, label + '\n')
 
         # set new label
         new_label = "my new label"
@@ -112,11 +113,11 @@ class TestVerdiNode(AiidaTestCase):
         description = u"my desc\nover two lines"
         node.description = description
         node.store()
-        
+
         options = [str(node.pk), '--raw']
         result = self.runner.invoke(node_description, options)
         self.assertIsNone(result.exception)
-        self.assertEquals(result.output, description+'\n')
+        self.assertEquals(result.output, description + '\n')
 
 
 class TestVerdiNodeRepo(AiidaTestCase):
@@ -128,9 +129,9 @@ class TestVerdiNodeRepo(AiidaTestCase):
 
         file_content = '''file-with-contents'''
 
-        with tempfile.NamedTemporaryFile(mode='w+') as f:
-            f.write(file_content)
-            f.flush()
+        with tempfile.NamedTemporaryFile(mode='w+') as fhandle:
+            handle.write(file_content)
+            handle.flush()
             node = SinglefileData(file=f.name)
             node.store()
 

--- a/aiida/backends/tests/cmdline/commands/test_node.py
+++ b/aiida/backends/tests/cmdline/commands/test_node.py
@@ -130,9 +130,9 @@ class TestVerdiNodeRepo(AiidaTestCase):
         file_content = '''file-with-contents'''
 
         with tempfile.NamedTemporaryFile(mode='w+') as fhandle:
-            handle.write(file_content)
-            handle.flush()
-            node = SinglefileData(file=f.name)
+            fhandle.write(file_content)
+            fhandle.flush()
+            node = SinglefileData(file=fhandle.name)
             node.store()
 
         self.node = node

--- a/aiida/backends/tests/dataclasses.py
+++ b/aiida/backends/tests/dataclasses.py
@@ -746,7 +746,7 @@ _tag   {}
             default2 = CifData(file=tmpf.name, scan_type='standard')
             self.assertEquals(default._prepare_cif(), default2._prepare_cif())
 
-            flex = CifData(file=f.name, scan_type='flex')
+            flex = CifData(file=tmpf.name, scan_type='flex')
             self.assertEquals(default._prepare_cif(), flex._prepare_cif())
 
     @unittest.skipIf(not has_pycifrw(), "Unable to import PyCifRW")

--- a/aiida/backends/tests/dataclasses.py
+++ b/aiida/backends/tests/dataclasses.py
@@ -115,11 +115,11 @@ class TestSinglefileData(AiidaTestCase):
         from aiida.orm.data.singlefile import SinglefileData
 
         file_content = 'some text ABCDE'
-        with tempfile.NamedTemporaryFile(mode='w+') as fhandle:
-            filename = fhandle.name
+        with tempfile.NamedTemporaryFile(mode='w+') as tmpf:
+            filename = tmpf.name
             basename = os.path.split(filename)[1]
-            fhandle.write(file_content)
-            fhandle.flush()
+            tmpf.write(file_content)
+            tmpf.flush()
             a = SinglefileData(file=filename)
 
         the_uuid = a.uuid
@@ -127,12 +127,12 @@ class TestSinglefileData(AiidaTestCase):
         self.assertEquals(a.get_folder_list(), [basename])
 
         with io.open(a.get_abs_path(basename), encoding='utf8') as fhandle:
-            self.assertEquals(f.read(), file_content)
+            self.assertEquals(fhandle.read(), file_content)
 
         a.store()
 
         with io.open(a.get_abs_path(basename), encoding='utf8') as fhandle:
-            self.assertEquals(f.read(), file_content)
+            self.assertEquals(fhandle.read(), file_content)
         self.assertEquals(a.get_folder_list(), [basename])
 
         b = load_node(the_uuid)
@@ -141,7 +141,7 @@ class TestSinglefileData(AiidaTestCase):
         self.assertTrue(isinstance(b, SinglefileData))
         self.assertEquals(b.get_folder_list(), [basename])
         with io.open(b.get_abs_path(basename), encoding='utf8') as fhandle:
-            self.assertEquals(f.read(), file_content)
+            self.assertEquals(fhandle.read(), file_content)
 
 
 class TestCifData(AiidaTestCase):
@@ -201,11 +201,11 @@ class TestCifData(AiidaTestCase):
         from aiida.orm.data.cif import CifData
 
         file_content = "data_test _cell_length_a 10(1)"
-        with tempfile.NamedTemporaryFile(mode='w+') as fhandle:
-            filename = fhandle.name
+        with tempfile.NamedTemporaryFile(mode='w+') as tmpf:
+            filename = tmpf.name
             basename = os.path.split(filename)[1]
-            fhandle.write(file_content)
-            fhandle.flush()
+            tmpf.write(file_content)
+            tmpf.flush()
             a = CifData(file=filename, source={'version': '1234', 'db_name': 'COD', 'id': '0000001'})
 
         # Key 'db_kind' is not allowed in source description:
@@ -217,7 +217,7 @@ class TestCifData(AiidaTestCase):
         self.assertEquals(a.get_folder_list(), [basename])
 
         with io.open(a.get_abs_path(basename), encoding='utf8') as fhandle:
-            self.assertEquals(f.read(), file_content)
+            self.assertEquals(fhandle.read(), file_content)
 
         a.store()
 
@@ -228,7 +228,7 @@ class TestCifData(AiidaTestCase):
         })
 
         with io.open(a.get_abs_path(basename), encoding='utf8') as fhandle:
-            self.assertEquals(f.read(), file_content)
+            self.assertEquals(fhandle.read(), file_content)
         self.assertEquals(a.get_folder_list(), [basename])
 
         b = load_node(the_uuid)
@@ -240,27 +240,27 @@ class TestCifData(AiidaTestCase):
             self.assertEquals(fhandle.read(), file_content)
 
         # Checking the get_or_create() method:
-        with tempfile.NamedTemporaryFile(mode='w+') as fhandle:
-            fhandle.write(file_content)
-            fhandle.flush()
-            c, created = CifData.get_or_create(f.name, store_cif=False)
+        with tempfile.NamedTemporaryFile(mode='w+') as tmpf:
+            tmpf.write(file_content)
+            tmpf.flush()
+            c, created = CifData.get_or_create(tmpf.name, store_cif=False)
 
         self.assertTrue(isinstance(c, CifData))
         self.assertTrue(not created)
 
-        with io.open(c.get_file_abs_path(), encoding='utf8') as fhandle:
+        with io.open(c.get_file_abs_path(), 'r', encoding='utf8') as fhandle:
             self.assertEquals(fhandle.read(), file_content)
 
         other_content = "data_test _cell_length_b 10(1)"
-        with tempfile.NamedTemporaryFile(mode='w+') as fhandle:
-            fhandle.write(other_content)
-            fhandle.flush()
-            c, created = CifData.get_or_create(fhandle.name, store_cif=False)
+        with tempfile.NamedTemporaryFile(mode='w+') as tmpf:
+            tmpf.write(other_content)
+            tmpf.flush()
+            c, created = CifData.get_or_create(tmpf.name, store_cif=False)
 
         self.assertTrue(isinstance(c, CifData))
         self.assertTrue(created)
 
-        with io.open(c.get_file_abs_path(), encoding='utf8') as fhandle:
+        with io.open(c.get_file_abs_path(), 'r', encoding='utf8') as fhandle:
             self.assertEquals(fhandle.read(), other_content)
 
     @unittest.skipIf(not has_pycifrw(), "Unable to import PyCifRW")
@@ -270,10 +270,10 @@ class TestCifData(AiidaTestCase):
         from aiida.orm.data.cif import CifData
 
         file_content = "data_test _cell_length_a 10(1)"
-        with tempfile.NamedTemporaryFile(mode='w+') as fhandle:
-            fhandle.write(file_content)
-            fhandle.flush()
-            a = CifData(file=f.name)
+        with tempfile.NamedTemporaryFile(mode='w+') as tmpf:
+            tmpf.write(file_content)
+            tmpf.flush()
+            a = CifData(file=tmpf.name)
 
         self.assertEquals(list(a.values.keys()), ['test'])
 
@@ -285,17 +285,17 @@ class TestCifData(AiidaTestCase):
 
         file_content_1 = "data_test _cell_length_a 10(1)"
         file_content_2 = "data_test _cell_length_a 11(1)"
-        with tempfile.NamedTemporaryFile(mode='w+') as fhandle:
-            fhandle.write(file_content_1)
-            fhandle.flush()
-            a = CifData(file=f.name)
+        with tempfile.NamedTemporaryFile(mode='w+') as tmpf:
+            tmpf.write(file_content_1)
+            tmpf.flush()
+            a = CifData(file=tmpf.name)
 
         self.assertEquals(a.values['test']['_cell_length_a'], '10(1)')
 
-        with tempfile.NamedTemporaryFile(mode='w+') as fhandle:
-            fhandle.write(file_content_2)
-            fhandle.flush()
-            a.set_file(f.name)
+        with tempfile.NamedTemporaryFile(mode='w+') as tmpf:
+            tmpf.write(file_content_2)
+            tmpf.flush()
+            a.set_file(tmpf.name)
 
         self.assertEquals(a.values['test']['_cell_length_a'], '11(1)')
 
@@ -306,8 +306,8 @@ class TestCifData(AiidaTestCase):
 
         from aiida.orm.data.cif import CifData
 
-        with tempfile.NamedTemporaryFile(mode='w+') as fhandle:
-            fhandle.write('''
+        with tempfile.NamedTemporaryFile(mode='w+') as tmpf:
+            tmpf.write('''
 data_test
 _cell_length_a    10
 _cell_length_b    10
@@ -327,8 +327,8 @@ _atom_site_fract_z
 C 0 0 0
 O 0.5 0.5 0.5
             ''')
-            fhandle.flush()
-            a = CifData(file=f.name)
+            tmpf.flush()
+            a = CifData(file=tmpf.name)
 
         with self.assertRaises(ValueError):
             a._get_aiida_structure(converter='none')
@@ -350,8 +350,8 @@ O 0.5 0.5 0.5
 
         from aiida.orm.data.cif import CifData
 
-        with tempfile.NamedTemporaryFile(mode='w+') as fhandle:
-            fhandle.write('''
+        with tempfile.NamedTemporaryFile(mode='w+') as tmpf:
+            tmpf.write('''
                 data_9012064
                 _space_group_IT_number           166
                 _symmetry_space_group_name_H-M   'R -3 m :H'
@@ -372,8 +372,8 @@ O 0.5 0.5 0.5
                 Te1 0.00000 0.00000 0.00000 0.01748
                 Te2 0.00000 0.00000 0.79030 0.01912
             ''')
-            fhandle.flush()
-            c = CifData(file=f.name)
+            tmpf.flush()
+            c = CifData(file=tmpf.name)
 
         ase = c._get_aiida_structure(converter='ase', primitive_cell=False).get_ase()
         self.assertEquals(ase.get_number_of_atoms(), 15)
@@ -397,8 +397,8 @@ O 0.5 0.5 0.5
 
         from aiida.orm.data.cif import CifData
 
-        with tempfile.NamedTemporaryFile(mode='w+') as fhandle:
-            fhandle.write('''
+        with tempfile.NamedTemporaryFile(mode='w+') as tmpf:
+            tmpf.write('''
 data_9012064
 _space_group_IT_number           166
 _symmetry_space_group_name_H-M   'R -3 m :H'
@@ -431,8 +431,8 @@ Bi 0.00000 0.00000 0.40046 0.02330
 Te1 0.00000 0.00000 0.00000 0.01748
 Te2 0.00000 0.00000 0.79030 0.01912
             ''')
-            fhandle.flush()
-            c = CifData(file=f.name)
+            tmpf.flush()
+            c = CifData(file=tmpf.name)
 
         ase = c._get_aiida_structure(converter='pymatgen', primitive_cell=False).get_ase()
         self.assertEquals(ase.get_number_of_atoms(), 15)
@@ -535,13 +535,13 @@ _tag                                    '[value]'
         import tempfile
         from aiida.orm.data.cif import CifData
 
-        with tempfile.NamedTemporaryFile(mode='w+') as fhandle:
-            fhandle.write('''
+        with tempfile.NamedTemporaryFile(mode='w+') as tmpf:
+            tmpf.write('''
 data_0
 _tag   {}
  '''.format('a' * 5000))
-            fhandle.flush()
-            _ = CifData(file=f.name)
+            tmpf.flush()
+            _ = CifData(file=tmpf.name)
 
     @unittest.skipIf(not has_ase(), "Unable to import ase")
     @unittest.skipIf(not has_pycifrw(), "Unable to import PyCifRW")
@@ -549,8 +549,8 @@ _tag   {}
         import tempfile
         from aiida.orm.data.cif import CifData
 
-        with tempfile.NamedTemporaryFile(mode='w+') as fhandle:
-            fhandle.write('''
+        with tempfile.NamedTemporaryFile(mode='w+') as tmpf:
+            tmpf.write('''
                 data_test
                 _cell_length_a    10
                 _cell_length_b    10
@@ -568,8 +568,8 @@ _tag   {}
                 _cod_database_code 0000001
                 _[local]_flags     ''
             ''')
-            fhandle.flush()
-            a = CifData(file=f.name)
+            tmpf.flush()
+            a = CifData(file=tmpf.name)
 
         b = CifData(values=a.values)
         c = CifData(values=b.values)
@@ -612,8 +612,8 @@ _tag   {}
         import tempfile
         from aiida.orm.data.cif import CifData
 
-        with tempfile.NamedTemporaryFile(mode='w+') as fhandle:
-            fhandle.write('''
+        with tempfile.NamedTemporaryFile(mode='w+') as tmpf:
+            tmpf.write('''
                 data_test
                 _cell_length_a    10
                 _cell_length_b    10
@@ -631,13 +631,13 @@ _tag   {}
                 O 0.5 0.5 0.5 .
                 H 0.75 0.75 0.75 0
             ''')
-            fhandle.flush()
-            a = CifData(file=f.name)
+            tmpf.flush()
+            a = CifData(file=tmpf.name)
 
         self.assertEqual(a.has_attached_hydrogens, False)
 
-        with tempfile.NamedTemporaryFile(mode='w+') as fhandle:
-            fhandle.write('''
+        with tempfile.NamedTemporaryFile(mode='w+') as tmpf:
+            tmpf.write('''
                 data_test
                 _cell_length_a    10
                 _cell_length_b    10
@@ -655,8 +655,8 @@ _tag   {}
                 O 0.5 0.5 0.5 1
                 H 0.75 0.75 0.75 0
             ''')
-            fhandle.flush()
-            a = CifData(file=f.name)
+            tmpf.flush()
+            a = CifData(file=tmpf.name)
 
         self.assertEqual(a.has_attached_hydrogens, True)
 
@@ -671,8 +671,8 @@ _tag   {}
         from aiida.orm.data.cif import CifData, refine_inline
         import tempfile
 
-        with tempfile.NamedTemporaryFile(mode='w+') as fhandle:
-            fhandle.write('''
+        with tempfile.NamedTemporaryFile(mode='w+') as tmpf:
+            tmpf.write('''
                 data_test
                 _cell_length_a    10
                 _cell_length_b    10
@@ -689,8 +689,8 @@ _tag   {}
                 O 0.25 0.5 0.5
                 O 0.75 0.5 0.5
             ''')
-            fhandle.flush()
-            a = CifData(file=f.name)
+            tmpf.flush()
+            a = CifData(file=tmpf.name)
 
         ret_dict = refine_inline(a)
         b = ret_dict['cif']
@@ -701,13 +701,13 @@ _tag   {}
             '-y,-x,-z', 'y,x,z', '-x,y,-z', 'x,-y,z', 'y,x,-z', '-y,-x,z'
         ])
 
-        with tempfile.NamedTemporaryFile(mode='w+') as fhandle:
-            fhandle.write('''
+        with tempfile.NamedTemporaryFile(mode='w+') as tmpf:
+            tmpf.write('''
                 data_a
                 data_b
             ''')
-            fhandle.flush()
-            c = CifData(file=f.name)
+            tmpf.flush()
+            c = CifData(file=tmpf.name)
 
         with self.assertRaises(ValueError):
             ret_dict = refine_inline(c)
@@ -738,12 +738,12 @@ _tag   {}
         import tempfile
         from aiida.orm.data.cif import CifData
 
-        with tempfile.NamedTemporaryFile(mode='w+') as fhandle:
-            fhandle.write(self.valid_sample_cif_str)
-            fhandle.flush()
+        with tempfile.NamedTemporaryFile(mode='w+') as tmpf:
+            tmpf.write(self.valid_sample_cif_str)
+            tmpf.flush()
 
-            default = CifData(file=f.name)
-            default2 = CifData(file=f.name, scan_type='standard')
+            default = CifData(file=tmpf.name)
+            default2 = CifData(file=tmpf.name, scan_type='standard')
             self.assertEquals(default._prepare_cif(), default2._prepare_cif())
 
             flex = CifData(file=f.name, scan_type='flex')
@@ -759,9 +759,9 @@ _tag   {}
         import tempfile
         from aiida.orm.data.cif import CifData
 
-        with tempfile.NamedTemporaryFile(mode='w+') as fhandle:
-            fhandle.write(self.valid_sample_cif_str)
-            fhandle.flush()
+        with tempfile.NamedTemporaryFile(mode='w+') as tmpf:
+            tmpf.write(self.valid_sample_cif_str)
+            tmpf.flush()
 
             # empty cifdata should be possible
             a = CifData()
@@ -771,7 +771,7 @@ _tag   {}
                 a.filename
 
             #now it has
-            a.set_file(f.name)
+            a.set_file(tmpf.name)
             a.filename
 
             a.store()
@@ -784,16 +784,16 @@ _tag   {}
         import tempfile
         from aiida.orm.data.cif import CifData
 
-        with tempfile.NamedTemporaryFile(mode='w+') as fhandle:
-            fhandle.write(self.valid_sample_cif_str)
-            fhandle.flush()
+        with tempfile.NamedTemporaryFile(mode='w+') as tmpf:
+            tmpf.write(self.valid_sample_cif_str)
+            tmpf.flush()
 
             # this will parse the cif
-            eager = CifData(file=f.name, parse_policy='eager')
+            eager = CifData(file=tmpf.name, parse_policy='eager')
             self.assertIsNot(eager._values, None)
 
             # this should not parse the cif
-            lazy = CifData(file=f.name, parse_policy='lazy')
+            lazy = CifData(file=tmpf.name, parse_policy='lazy')
             self.assertIs(lazy._values, None)
 
             # also lazy-loaded nodes should be storable
@@ -811,20 +811,20 @@ _tag   {}
         import tempfile
         from aiida.orm.data.cif import CifData
 
-        with tempfile.NamedTemporaryFile(mode='w+') as fhandle:
-            fhandle.write(self.valid_sample_cif_str)
-            fhandle.flush()
+        with tempfile.NamedTemporaryFile(mode='w+') as tmpf:
+            tmpf.write(self.valid_sample_cif_str)
+            tmpf.flush()
 
-            a = CifData(file=f.name)
+            a = CifData(file=tmpf.name)
             f1 = a.get_formulae()
             self.assertIsNot(f1, None)
 
-        with tempfile.NamedTemporaryFile(mode='w+') as fhandle:
-            fhandle.write(self.valid_sample_cif_str_2)
-            fhandle.flush()
+        with tempfile.NamedTemporaryFile(mode='w+') as tmpf:
+            tmpf.write(self.valid_sample_cif_str_2)
+            tmpf.flush()
 
             # this should reset formulae and spacegroup_numbers
-            a.set_file(f.name)
+            a.set_file(tmpf.name)
             self.assertIs(a.get_attr('formulae'), None)
             self.assertIs(a.get_attr('spacegroup_numbers'), None)
 
@@ -839,7 +839,7 @@ _tag   {}
             with self.assertRaises(AttributeError):
                 a.filename
             #now it has
-            a.set_file(f.name)
+            a.set_file(tmpf.name)
             a.parse()
             a.filename
 
@@ -2362,8 +2362,8 @@ class TestStructureDataFromPymatgen(AiidaTestCase):
 
         import tempfile
 
-        with tempfile.NamedTemporaryFile(mode='w+', suffix=".cif") as fhandle:
-            fhandle.write("""data_9011963
+        with tempfile.NamedTemporaryFile(mode='w+', suffix=".cif") as tmpf:
+            tmpf.write("""data_9011963
                 _space_group_IT_number           166
                 _symmetry_space_group_name_Hall  '-R 3 2"'
                 _symmetry_space_group_name_H-M   'R -3 m :H'
@@ -2388,8 +2388,8 @@ class TestStructureDataFromPymatgen(AiidaTestCase):
                 Te2 0.00000 0.00000 0.21180 0.66667 0.02343 B 1
                 Se2 0.00000 0.00000 0.21180 0.33333 0.02343 B 2
                 """)
-            fhandle.flush()
-            pymatgen_parser = CifParser(f.name)
+            tmpf.flush()
+            pymatgen_parser = CifParser(tmpf.name)
             pymatgen_struct = pymatgen_parser.get_structures()[0]
 
         structs_to_test = [StructureData(pymatgen=pymatgen_struct), StructureData(pymatgen_structure=pymatgen_struct)]
@@ -2434,16 +2434,16 @@ class TestStructureDataFromPymatgen(AiidaTestCase):
 
         import tempfile
 
-        with tempfile.NamedTemporaryFile(mode='w+', suffix=".xyz") as fhandle:
-            fhandle.write("""5
+        with tempfile.NamedTemporaryFile(mode='w+', suffix=".xyz") as tmpf:
+            tmpf.write("""5
                 H4 C1
                 C 0.000000 0.000000 0.000000
                 H 0.000000 0.000000 1.089000
                 H 1.026719 0.000000 -0.363000
                 H -0.513360 -0.889165 -0.363000
                 H -0.513360 0.889165 -0.363000""")
-            fhandle.flush()
-            pymatgen_xyz = XYZ.from_file(f.name)
+            tmpf.flush()
+            pymatgen_xyz = XYZ.from_file(tmpf.name)
             pymatgen_mol = pymatgen_xyz.molecule
 
         for struct in [StructureData(pymatgen=pymatgen_mol), StructureData(pymatgen_molecule=pymatgen_mol)]:

--- a/aiida/backends/tests/dataclasses.py
+++ b/aiida/backends/tests/dataclasses.py
@@ -13,6 +13,7 @@ Tests for specific subclasses of Data
 from __future__ import print_function
 from __future__ import absolute_import
 from __future__ import division
+import io
 import unittest
 
 from six.moves import range
@@ -127,12 +128,12 @@ class TestSinglefileData(AiidaTestCase):
 
         self.assertEquals(a.get_folder_list(), [basename])
 
-        with open(a.get_abs_path(basename)) as f:
+        with io.open(a.get_abs_path(basename), encoding='utf8') as f:
             self.assertEquals(f.read(), file_content)
 
         a.store()
 
-        with open(a.get_abs_path(basename)) as f:
+        with io.open(a.get_abs_path(basename), encoding='utf8') as f:
             self.assertEquals(f.read(), file_content)
         self.assertEquals(a.get_folder_list(), [basename])
 
@@ -141,7 +142,7 @@ class TestSinglefileData(AiidaTestCase):
         # I check the retrieved object
         self.assertTrue(isinstance(b, SinglefileData))
         self.assertEquals(b.get_folder_list(), [basename])
-        with open(b.get_abs_path(basename)) as f:
+        with io.open(b.get_abs_path(basename), encoding='utf8') as f:
             self.assertEquals(f.read(), file_content)
 
 
@@ -219,7 +220,7 @@ class TestCifData(AiidaTestCase):
 
         self.assertEquals(a.get_folder_list(), [basename])
 
-        with open(a.get_abs_path(basename)) as f:
+        with io.open(a.get_abs_path(basename), encoding='utf8') as f:
             self.assertEquals(f.read(), file_content)
 
         a.store()
@@ -230,7 +231,7 @@ class TestCifData(AiidaTestCase):
             'version': '1234',
         })
 
-        with open(a.get_abs_path(basename)) as f:
+        with io.open(a.get_abs_path(basename), encoding='utf8') as f:
             self.assertEquals(f.read(), file_content)
         self.assertEquals(a.get_folder_list(), [basename])
 
@@ -239,7 +240,7 @@ class TestCifData(AiidaTestCase):
         # I check the retrieved object
         self.assertTrue(isinstance(b, CifData))
         self.assertEquals(b.get_folder_list(), [basename])
-        with open(b.get_abs_path(basename)) as f:
+        with io.open(b.get_abs_path(basename), encoding='utf8') as f:
             self.assertEquals(f.read(), file_content)
 
         # Checking the get_or_create() method:
@@ -251,7 +252,7 @@ class TestCifData(AiidaTestCase):
         self.assertTrue(isinstance(c, CifData))
         self.assertTrue(not created)
 
-        with open(c.get_file_abs_path()) as f:
+        with io.open(c.get_file_abs_path(), encoding='utf8') as f:
             self.assertEquals(f.read(), file_content)
 
         other_content = "data_test _cell_length_b 10(1)"
@@ -263,7 +264,7 @@ class TestCifData(AiidaTestCase):
         self.assertTrue(isinstance(c, CifData))
         self.assertTrue(created)
 
-        with open(c.get_file_abs_path()) as f:
+        with io.open(c.get_file_abs_path(), encoding='utf8') as f:
             self.assertEquals(f.read(), other_content)
 
     @unittest.skipIf(not has_pycifrw(), "Unable to import PyCifRW")
@@ -3463,7 +3464,7 @@ class TestTrajectoryData(AiidaTestCase):
             files_created = [] # In case there is an exception
             try:
                 files_created = n.export(filename, fileformat=format)
-                with open(filename) as f:
+                with io.open(filename, encoding='utf8') as f:
                     filedata = f.read()
             finally:
                 for file in files_created:
@@ -4282,7 +4283,7 @@ class TestBandsData(AiidaTestCase):
             files_created = [] # In case there is an exception
             try:
                 files_created = b.export(filename, fileformat=format)
-                with open(filename) as f:
+                with io.open(filename, encoding='utf8') as f:
                     filedata = f.read()
             finally:
                 for file in files_created:

--- a/aiida/backends/tests/dataclasses.py
+++ b/aiida/backends/tests/dataclasses.py
@@ -36,6 +36,7 @@ def has_seekpath():
     except ImportError:
         return False
 
+
 def to_list_of_lists(lofl):
     """
     Converts an iterable of iterables to a list of lists, needed
@@ -46,6 +47,7 @@ def to_list_of_lists(lofl):
     :return: a list of lists
     """
     return [[el for el in l] for l in lofl]
+
 
 def simplify(string):
     """
@@ -67,11 +69,7 @@ class TestCalcStatus(AiidaTestCase):
 
         # Use the AiidaTestCase test computer
 
-        c = JobCalculation(computer=self.computer,
-                           resources={
-                               'num_machines': 1,
-                               'num_mpiprocs_per_machine': 1}
-                           )
+        c = JobCalculation(computer=self.computer, resources={'num_machines': 1, 'num_mpiprocs_per_machine': 1})
         # Should be in the NEW state before storing
         self.assertEquals(c.get_state(), calc_states.NEW)
 
@@ -117,23 +115,23 @@ class TestSinglefileData(AiidaTestCase):
         from aiida.orm.data.singlefile import SinglefileData
 
         file_content = 'some text ABCDE'
-        with tempfile.NamedTemporaryFile(mode='w+') as f:
-            filename = f.name
+        with tempfile.NamedTemporaryFile(mode='w+') as fhandle:
+            filename = fhandle.name
             basename = os.path.split(filename)[1]
-            f.write(file_content)
-            f.flush()
+            fhandle.write(file_content)
+            fhandle.flush()
             a = SinglefileData(file=filename)
 
         the_uuid = a.uuid
 
         self.assertEquals(a.get_folder_list(), [basename])
 
-        with io.open(a.get_abs_path(basename), encoding='utf8') as f:
+        with io.open(a.get_abs_path(basename), encoding='utf8') as fhandle:
             self.assertEquals(f.read(), file_content)
 
         a.store()
 
-        with io.open(a.get_abs_path(basename), encoding='utf8') as f:
+        with io.open(a.get_abs_path(basename), encoding='utf8') as fhandle:
             self.assertEquals(f.read(), file_content)
         self.assertEquals(a.get_folder_list(), [basename])
 
@@ -142,7 +140,7 @@ class TestSinglefileData(AiidaTestCase):
         # I check the retrieved object
         self.assertTrue(isinstance(b, SinglefileData))
         self.assertEquals(b.get_folder_list(), [basename])
-        with io.open(b.get_abs_path(basename), encoding='utf8') as f:
+        with io.open(b.get_abs_path(basename), encoding='utf8') as fhandle:
             self.assertEquals(f.read(), file_content)
 
 
@@ -154,6 +152,7 @@ class TestCifData(AiidaTestCase):
     from aiida.orm.data.structure import has_ase, has_pymatgen, has_spglib, \
         get_pymatgen_version
     
+    from distutils.version import StrictVersion
 
     valid_sample_cif_str = '''
         data_test
@@ -202,15 +201,12 @@ class TestCifData(AiidaTestCase):
         from aiida.orm.data.cif import CifData
 
         file_content = "data_test _cell_length_a 10(1)"
-        with tempfile.NamedTemporaryFile(mode='w+') as f:
-            filename = f.name
+        with tempfile.NamedTemporaryFile(mode='w+') as fhandle:
+            filename = fhandle.name
             basename = os.path.split(filename)[1]
-            f.write(file_content)
-            f.flush()
-            a = CifData(file=filename,
-                        source={'version': '1234',
-                                'db_name': 'COD',
-                                'id': '0000001'})
+            fhandle.write(file_content)
+            fhandle.flush()
+            a = CifData(file=filename, source={'version': '1234', 'db_name': 'COD', 'id': '0000001'})
 
         # Key 'db_kind' is not allowed in source description:
         with self.assertRaises(KeyError):
@@ -220,7 +216,7 @@ class TestCifData(AiidaTestCase):
 
         self.assertEquals(a.get_folder_list(), [basename])
 
-        with io.open(a.get_abs_path(basename), encoding='utf8') as f:
+        with io.open(a.get_abs_path(basename), encoding='utf8') as fhandle:
             self.assertEquals(f.read(), file_content)
 
         a.store()
@@ -231,7 +227,7 @@ class TestCifData(AiidaTestCase):
             'version': '1234',
         })
 
-        with io.open(a.get_abs_path(basename), encoding='utf8') as f:
+        with io.open(a.get_abs_path(basename), encoding='utf8') as fhandle:
             self.assertEquals(f.read(), file_content)
         self.assertEquals(a.get_folder_list(), [basename])
 
@@ -240,32 +236,32 @@ class TestCifData(AiidaTestCase):
         # I check the retrieved object
         self.assertTrue(isinstance(b, CifData))
         self.assertEquals(b.get_folder_list(), [basename])
-        with io.open(b.get_abs_path(basename), encoding='utf8') as f:
-            self.assertEquals(f.read(), file_content)
+        with io.open(b.get_abs_path(basename), encoding='utf8') as fhandle:
+            self.assertEquals(fhandle.read(), file_content)
 
         # Checking the get_or_create() method:
-        with tempfile.NamedTemporaryFile(mode='w+') as f:
-            f.write(file_content)
-            f.flush()
+        with tempfile.NamedTemporaryFile(mode='w+') as fhandle:
+            fhandle.write(file_content)
+            fhandle.flush()
             c, created = CifData.get_or_create(f.name, store_cif=False)
 
         self.assertTrue(isinstance(c, CifData))
         self.assertTrue(not created)
 
-        with io.open(c.get_file_abs_path(), encoding='utf8') as f:
-            self.assertEquals(f.read(), file_content)
+        with io.open(c.get_file_abs_path(), encoding='utf8') as fhandle:
+            self.assertEquals(fhandle.read(), file_content)
 
         other_content = "data_test _cell_length_b 10(1)"
-        with tempfile.NamedTemporaryFile(mode='w+') as f:
-            f.write(other_content)
-            f.flush()
-            c, created = CifData.get_or_create(f.name, store_cif=False)
+        with tempfile.NamedTemporaryFile(mode='w+') as fhandle:
+            fhandle.write(other_content)
+            fhandle.flush()
+            c, created = CifData.get_or_create(fhandle.name, store_cif=False)
 
         self.assertTrue(isinstance(c, CifData))
         self.assertTrue(created)
 
-        with io.open(c.get_file_abs_path(), encoding='utf8') as f:
-            self.assertEquals(f.read(), other_content)
+        with io.open(c.get_file_abs_path(), encoding='utf8') as fhandle:
+            self.assertEquals(fhandle.read(), other_content)
 
     @unittest.skipIf(not has_pycifrw(), "Unable to import PyCifRW")
     def test_parse_cifdata(self):
@@ -274,9 +270,9 @@ class TestCifData(AiidaTestCase):
         from aiida.orm.data.cif import CifData
 
         file_content = "data_test _cell_length_a 10(1)"
-        with tempfile.NamedTemporaryFile(mode='w+') as f:
-            f.write(file_content)
-            f.flush()
+        with tempfile.NamedTemporaryFile(mode='w+') as fhandle:
+            fhandle.write(file_content)
+            fhandle.flush()
             a = CifData(file=f.name)
 
         self.assertEquals(list(a.values.keys()), ['test'])
@@ -289,16 +285,16 @@ class TestCifData(AiidaTestCase):
 
         file_content_1 = "data_test _cell_length_a 10(1)"
         file_content_2 = "data_test _cell_length_a 11(1)"
-        with tempfile.NamedTemporaryFile(mode='w+') as f:
-            f.write(file_content_1)
-            f.flush()
+        with tempfile.NamedTemporaryFile(mode='w+') as fhandle:
+            fhandle.write(file_content_1)
+            fhandle.flush()
             a = CifData(file=f.name)
 
         self.assertEquals(a.values['test']['_cell_length_a'], '10(1)')
 
-        with tempfile.NamedTemporaryFile(mode='w+') as f:
-            f.write(file_content_2)
-            f.flush()
+        with tempfile.NamedTemporaryFile(mode='w+') as fhandle:
+            fhandle.write(file_content_2)
+            fhandle.flush()
             a.set_file(f.name)
 
         self.assertEquals(a.values['test']['_cell_length_a'], '11(1)')
@@ -310,8 +306,8 @@ class TestCifData(AiidaTestCase):
 
         from aiida.orm.data.cif import CifData
 
-        with tempfile.NamedTemporaryFile(mode='w+') as f:
-            f.write('''
+        with tempfile.NamedTemporaryFile(mode='w+') as fhandle:
+            fhandle.write('''
 data_test
 _cell_length_a    10
 _cell_length_b    10
@@ -331,7 +327,7 @@ _atom_site_fract_z
 C 0 0 0
 O 0.5 0.5 0.5
             ''')
-            f.flush()
+            fhandle.flush()
             a = CifData(file=f.name)
 
         with self.assertRaises(ValueError):
@@ -354,8 +350,8 @@ O 0.5 0.5 0.5
 
         from aiida.orm.data.cif import CifData
 
-        with tempfile.NamedTemporaryFile(mode='w+') as f:
-            f.write('''
+        with tempfile.NamedTemporaryFile(mode='w+') as fhandle:
+            fhandle.write('''
                 data_9012064
                 _space_group_IT_number           166
                 _symmetry_space_group_name_H-M   'R -3 m :H'
@@ -376,18 +372,16 @@ O 0.5 0.5 0.5
                 Te1 0.00000 0.00000 0.00000 0.01748
                 Te2 0.00000 0.00000 0.79030 0.01912
             ''')
-            f.flush()
+            fhandle.flush()
             c = CifData(file=f.name)
 
-        ase = c._get_aiida_structure(converter='ase',
-                                     primitive_cell=False).get_ase()
+        ase = c._get_aiida_structure(converter='ase', primitive_cell=False).get_ase()
         self.assertEquals(ase.get_number_of_atoms(), 15)
 
         ase = c._get_aiida_structure(converter='ase').get_ase()
         self.assertEquals(ase.get_number_of_atoms(), 15)
 
-        ase = c._get_aiida_structure(converter='ase',
-                                     primitive_cell=True, subtrans_included=False).get_ase()
+        ase = c._get_aiida_structure(converter='ase', primitive_cell=True, subtrans_included=False).get_ase()
         self.assertEquals(ase.get_number_of_atoms(), 5)
 
     @unittest.skipIf(not has_ase(), "Unable to import ase")
@@ -403,8 +397,8 @@ O 0.5 0.5 0.5
 
         from aiida.orm.data.cif import CifData
 
-        with tempfile.NamedTemporaryFile(mode='w+') as f:
-            f.write('''
+        with tempfile.NamedTemporaryFile(mode='w+') as fhandle:
+            fhandle.write('''
 data_9012064
 _space_group_IT_number           166
 _symmetry_space_group_name_H-M   'R -3 m :H'
@@ -437,18 +431,16 @@ Bi 0.00000 0.00000 0.40046 0.02330
 Te1 0.00000 0.00000 0.00000 0.01748
 Te2 0.00000 0.00000 0.79030 0.01912
             ''')
-            f.flush()
+            fhandle.flush()
             c = CifData(file=f.name)
 
-        ase = c._get_aiida_structure(converter='pymatgen',
-                                     primitive_cell=False).get_ase()
+        ase = c._get_aiida_structure(converter='pymatgen', primitive_cell=False).get_ase()
         self.assertEquals(ase.get_number_of_atoms(), 15)
 
         ase = c._get_aiida_structure(converter='pymatgen').get_ase()
         self.assertEquals(ase.get_number_of_atoms(), 15)
 
-        ase = c._get_aiida_structure(converter='pymatgen',
-                                     primitive_cell=True).get_ase()
+        ase = c._get_aiida_structure(converter='pymatgen', primitive_cell=True).get_ase()
         self.assertEquals(ase.get_number_of_atoms(), 5)
 
     @unittest.skipIf(not has_pycifrw(), "Unable to import PyCifRW")
@@ -459,21 +451,20 @@ Te2 0.00000 0.00000 0.79030 0.01912
         from aiida.orm.data.cif import pycifrw_from_cif
         import re
 
-        datablocks = [
-            {
-                '_atom_site_label': ['A', 'B', 'C'],
-                '_atom_site_occupancy': [1.0, 0.5, 0.5],
-                '_publ_section_title': 'Test CIF'
-            }
-        ]
+        datablocks = [{
+            '_atom_site_label': ['A', 'B', 'C'],
+            '_atom_site_occupancy': [1.0, 0.5, 0.5],
+            '_publ_section_title': 'Test CIF'
+        }]
         with HiddenPrints():
             lines = pycifrw_from_cif(datablocks).WriteOut().split('\n')
         non_comments = []
         for line in lines:
             if not re.search('^#', line):
                 non_comments.append(line)
-        self.assertEquals(simplify("\n".join(non_comments)),
-                          simplify('''
+        self.assertEquals(
+            simplify("\n".join(non_comments)),
+            simplify('''
 data_0
 loop_
   _atom_site_label
@@ -497,8 +488,9 @@ _publ_section_title                     'Test CIF'
         for line in lines:
             if not re.search('^#', line):
                 non_comments.append(line)
-        self.assertEquals(simplify("\n".join(non_comments)),
-                          simplify('''
+        self.assertEquals(
+            simplify("\n".join(non_comments)),
+            simplify('''
 data_0
 loop_
   _atom_site_label
@@ -518,19 +510,17 @@ _publ_section_title                     'Test CIF'
         from aiida.orm.data.cif import pycifrw_from_cif
         import re
 
-        datablocks = [
-            {
-                '_tag': '[value]',
-            }
-        ]
+        datablocks = [{
+            '_tag': '[value]',
+        }]
         with HiddenPrints():
             lines = pycifrw_from_cif(datablocks).WriteOut().split('\n')
         non_comments = []
         for line in lines:
             if not re.search('^#', line):
                 non_comments.append(line)
-        self.assertEquals(simplify("\n".join(non_comments)),
-                          simplify('''
+        self.assertEquals(
+            simplify("\n".join(non_comments)), simplify('''
 data_0
 _tag                                    '[value]'
 '''))
@@ -545,12 +535,12 @@ _tag                                    '[value]'
         import tempfile
         from aiida.orm.data.cif import CifData
 
-        with tempfile.NamedTemporaryFile(mode='w+') as f:
-            f.write('''
+        with tempfile.NamedTemporaryFile(mode='w+') as fhandle:
+            fhandle.write('''
 data_0
 _tag   {}
- '''.format('a'*5000))
-            f.flush()
+ '''.format('a' * 5000))
+            fhandle.flush()
             _ = CifData(file=f.name)
 
     @unittest.skipIf(not has_ase(), "Unable to import ase")
@@ -559,8 +549,8 @@ _tag   {}
         import tempfile
         from aiida.orm.data.cif import CifData
 
-        with tempfile.NamedTemporaryFile(mode='w+') as f:
-            f.write('''
+        with tempfile.NamedTemporaryFile(mode='w+') as fhandle:
+            fhandle.write('''
                 data_test
                 _cell_length_a    10
                 _cell_length_b    10
@@ -578,7 +568,7 @@ _tag   {}
                 _cod_database_code 0000001
                 _[local]_flags     ''
             ''')
-            f.flush()
+            fhandle.flush()
             a = CifData(file=f.name)
 
         b = CifData(values=a.values)
@@ -592,35 +582,25 @@ _tag   {}
     def test_symop_string_from_symop_matrix_tr(self):
         from aiida.orm.data.cif import symop_string_from_symop_matrix_tr
 
-        self.assertEquals(
-            symop_string_from_symop_matrix_tr(
-                [[1, 0, 0], [0, 1, 0], [0, 0, 1]]), "x,y,z")
+        self.assertEquals(symop_string_from_symop_matrix_tr([[1, 0, 0], [0, 1, 0], [0, 0, 1]]), "x,y,z")
+
+        self.assertEquals(symop_string_from_symop_matrix_tr([[1, 0, 0], [0, -1, 0], [0, 1, 1]]), "x,-y,y+z")
 
         self.assertEquals(
-            symop_string_from_symop_matrix_tr(
-                [[1, 0, 0], [0, -1, 0], [0, 1, 1]]), "x,-y,y+z")
-
-        self.assertEquals(
-            symop_string_from_symop_matrix_tr(
-                [[-1, 0, 0], [0, 1, 0], [0, 0, 1]], [1, -1, 0]), "-x+1,y-1,z")
+            symop_string_from_symop_matrix_tr([[-1, 0, 0], [0, 1, 0], [0, 0, 1]], [1, -1, 0]), "-x+1,y-1,z")
 
     def test_parse_formula(self):
         from aiida.orm.data.cif import parse_formula
 
-        self.assertEqual(parse_formula("C H"),
-                         {'C': 1, 'H': 1})
+        self.assertEqual(parse_formula("C H"), {'C': 1, 'H': 1})
 
-        self.assertEqual(parse_formula("C5 H1"),
-                         {'C': 5, 'H': 1})
+        self.assertEqual(parse_formula("C5 H1"), {'C': 5, 'H': 1})
 
-        self.assertEqual(parse_formula("Ca5 Ho"),
-                         {'Ca': 5, 'Ho': 1})
+        self.assertEqual(parse_formula("Ca5 Ho"), {'Ca': 5, 'Ho': 1})
 
-        self.assertEqual(parse_formula("H0.5 O"),
-                         {'H': 0.5, 'O': 1})
+        self.assertEqual(parse_formula("H0.5 O"), {'H': 0.5, 'O': 1})
 
-        self.assertEqual(parse_formula("C0 O0"),
-                         {'C': 0, 'O': 0})
+        self.assertEqual(parse_formula("C0 O0"), {'C': 0, 'O': 0})
 
         # Invalid literal for float()
         with self.assertRaises(ValueError):
@@ -632,8 +612,8 @@ _tag   {}
         import tempfile
         from aiida.orm.data.cif import CifData
 
-        with tempfile.NamedTemporaryFile(mode='w+') as f:
-            f.write('''
+        with tempfile.NamedTemporaryFile(mode='w+') as fhandle:
+            fhandle.write('''
                 data_test
                 _cell_length_a    10
                 _cell_length_b    10
@@ -651,13 +631,13 @@ _tag   {}
                 O 0.5 0.5 0.5 .
                 H 0.75 0.75 0.75 0
             ''')
-            f.flush()
+            fhandle.flush()
             a = CifData(file=f.name)
 
         self.assertEqual(a.has_attached_hydrogens, False)
 
-        with tempfile.NamedTemporaryFile(mode='w+') as f:
-            f.write('''
+        with tempfile.NamedTemporaryFile(mode='w+') as fhandle:
+            fhandle.write('''
                 data_test
                 _cell_length_a    10
                 _cell_length_b    10
@@ -675,7 +655,7 @@ _tag   {}
                 O 0.5 0.5 0.5 1
                 H 0.75 0.75 0.75 0
             ''')
-            f.flush()
+            fhandle.flush()
             a = CifData(file=f.name)
 
         self.assertEqual(a.has_attached_hydrogens, True)
@@ -691,8 +671,8 @@ _tag   {}
         from aiida.orm.data.cif import CifData, refine_inline
         import tempfile
 
-        with tempfile.NamedTemporaryFile(mode='w+') as f:
-            f.write('''
+        with tempfile.NamedTemporaryFile(mode='w+') as fhandle:
+            fhandle.write('''
                 data_test
                 _cell_length_a    10
                 _cell_length_b    10
@@ -709,7 +689,7 @@ _tag   {}
                 O 0.25 0.5 0.5
                 O 0.75 0.5 0.5
             ''')
-            f.flush()
+            fhandle.flush()
             a = CifData(file=f.name)
 
         ret_dict = refine_inline(a)
@@ -717,29 +697,16 @@ _tag   {}
         self.assertEqual(list(b.values.keys()), ['test'])
         self.assertEqual(b.values['test']['_chemical_formula_sum'], 'C O2')
         self.assertEqual(b.values['test']['_symmetry_equiv_pos_as_xyz'], [
-            'x,y,z',
-            '-x,-y,-z',
-            '-y,x,z',
-            'y,-x,-z',
-            '-x,-y,z',
-            'x,y,-z',
-            'y,-x,z',
-            '-y,x,-z',
-            'x,-y,-z',
-            '-x,y,z',
-            '-y,-x,-z',
-            'y,x,z',
-            '-x,y,-z',
-            'x,-y,z',
-            'y,x,-z',
-            '-y,-x,z'])
+            'x,y,z', '-x,-y,-z', '-y,x,z', 'y,-x,-z', '-x,-y,z', 'x,y,-z', 'y,-x,z', '-y,x,-z', 'x,-y,-z', '-x,y,z',
+            '-y,-x,-z', 'y,x,z', '-x,y,-z', 'x,-y,z', 'y,x,-z', '-y,-x,z'
+        ])
 
-        with tempfile.NamedTemporaryFile(mode='w+') as f:
-            f.write('''
+        with tempfile.NamedTemporaryFile(mode='w+') as fhandle:
+            fhandle.write('''
                 data_a
                 data_b
             ''')
-            f.flush()
+            fhandle.flush()
             c = CifData(file=f.name)
 
         with self.assertRaises(ValueError):
@@ -751,17 +718,13 @@ _tag   {}
     def test_parse_formula(self):
         from aiida.orm.data.cif import parse_formula
 
-        self.assertEqual(parse_formula("C H"),
-                         {'C': 1, 'H': 1})
+        self.assertEqual(parse_formula("C H"), {'C': 1, 'H': 1})
 
-        self.assertEqual(parse_formula("C5 H1"),
-                         {'C': 5, 'H': 1})
+        self.assertEqual(parse_formula("C5 H1"), {'C': 5, 'H': 1})
 
-        self.assertEqual(parse_formula("Ca5 Ho"),
-                         {'Ca': 5, 'Ho': 1})
+        self.assertEqual(parse_formula("Ca5 Ho"), {'Ca': 5, 'Ho': 1})
 
-        self.assertEqual(parse_formula("H0.5 O"),
-                         {'H': 0.5, 'O': 1})
+        self.assertEqual(parse_formula("H0.5 O"), {'H': 0.5, 'O': 1})
 
         # Invalid literal for float()
         with self.assertRaises(ValueError):
@@ -775,9 +738,9 @@ _tag   {}
         import tempfile
         from aiida.orm.data.cif import CifData
 
-        with tempfile.NamedTemporaryFile(mode='w+') as f:
-            f.write(self.valid_sample_cif_str)
-            f.flush()
+        with tempfile.NamedTemporaryFile(mode='w+') as fhandle:
+            fhandle.write(self.valid_sample_cif_str)
+            fhandle.flush()
 
             default = CifData(file=f.name)
             default2 = CifData(file=f.name, scan_type='standard')
@@ -796,9 +759,9 @@ _tag   {}
         import tempfile
         from aiida.orm.data.cif import CifData
 
-        with tempfile.NamedTemporaryFile(mode='w+') as f:
-            f.write(self.valid_sample_cif_str)
-            f.flush()
+        with tempfile.NamedTemporaryFile(mode='w+') as fhandle:
+            fhandle.write(self.valid_sample_cif_str)
+            fhandle.flush()
 
             # empty cifdata should be possible
             a = CifData()
@@ -821,9 +784,9 @@ _tag   {}
         import tempfile
         from aiida.orm.data.cif import CifData
 
-        with tempfile.NamedTemporaryFile(mode='w+') as f:
-            f.write(self.valid_sample_cif_str)
-            f.flush()
+        with tempfile.NamedTemporaryFile(mode='w+') as fhandle:
+            fhandle.write(self.valid_sample_cif_str)
+            fhandle.flush()
 
             # this will parse the cif
             eager = CifData(file=f.name, parse_policy='eager')
@@ -840,7 +803,6 @@ _tag   {}
             lazy.values
             self.assertIsNot(lazy._values, None)
 
-
     @unittest.skipIf(not has_pycifrw(), "Unable to import PyCifRW")
     def test_set_file(self):
         """
@@ -849,17 +811,17 @@ _tag   {}
         import tempfile
         from aiida.orm.data.cif import CifData
 
-        with tempfile.NamedTemporaryFile(mode='w+') as f:
-            f.write(self.valid_sample_cif_str)
-            f.flush()
+        with tempfile.NamedTemporaryFile(mode='w+') as fhandle:
+            fhandle.write(self.valid_sample_cif_str)
+            fhandle.flush()
 
             a = CifData(file=f.name)
             f1 = a.get_formulae()
             self.assertIsNot(f1, None)
 
-        with tempfile.NamedTemporaryFile(mode='w+') as f:
-            f.write(self.valid_sample_cif_str_2)
-            f.flush()
+        with tempfile.NamedTemporaryFile(mode='w+') as fhandle:
+            fhandle.write(self.valid_sample_cif_str_2)
+            fhandle.flush()
 
             # this should reset formulae and spacegroup_numbers
             a.set_file(f.name)
@@ -882,6 +844,7 @@ _tag   {}
             a.filename
 
         self.assertNotEquals(f1, f2)
+
 
 class TestKindValidSymbols(AiidaTestCase):
     """
@@ -923,6 +886,7 @@ class TestKindValidSymbols(AiidaTestCase):
         from aiida.orm.data.structure import Kind
 
         _ = Kind(symbols=['X'])
+
 
 class TestSiteValidWeights(AiidaTestCase):
     """
@@ -976,8 +940,7 @@ class TestSiteValidWeights(AiidaTestCase):
         from aiida.orm.data.structure import Kind
 
         with self.assertRaises(ValueError):
-            _ = Kind(symbols=['Ba', 'C'],
-                     weights=[0.5, 0.6])
+            _ = Kind(symbols=['Ba', 'C'], weights=[0.5, 0.6])
 
     def test_sum_one_weights(self):
         """
@@ -985,8 +948,7 @@ class TestSiteValidWeights(AiidaTestCase):
         """
         from aiida.orm.data.structure import Kind
 
-        _ = Kind(symbols=['Ba', 'C'],
-                 weights=[1. / 3., 2. / 3.])
+        _ = Kind(symbols=['Ba', 'C'], weights=[1. / 3., 2. / 3.])
 
     def test_sum_less_one_weights(self):
         """
@@ -994,8 +956,7 @@ class TestSiteValidWeights(AiidaTestCase):
         """
         from aiida.orm.data.structure import Kind
 
-        _ = Kind(symbols=['Ba', 'C'],
-                 weights=[1. / 3., 1. / 3.])
+        _ = Kind(symbols=['Ba', 'C'], weights=[1. / 3., 1. / 3.])
 
     def test_none(self):
         """
@@ -1017,8 +978,7 @@ class TestKindTestGeneral(AiidaTestCase):
         """
         from aiida.orm.data.structure import Kind
 
-        a = Kind(symbols=['Ba', 'C'],
-                 weights=[1. / 3., 2. / 3.])
+        a = Kind(symbols=['Ba', 'C'], weights=[1. / 3., 2. / 3.])
         self.assertTrue(a.is_alloy())
         self.assertFalse(a.has_vacancies())
 
@@ -1028,8 +988,7 @@ class TestKindTestGeneral(AiidaTestCase):
         """
         from aiida.orm.data.structure import Kind
 
-        a = Kind(symbols=['Ba', 'C'],
-                 weights=[1. / 3., 1. / 3.])
+        a = Kind(symbols=['Ba', 'C'], weights=[1. / 3., 1. / 3.])
         self.assertTrue(a.is_alloy())
         self.assertTrue(a.has_vacancies())
 
@@ -1040,8 +999,7 @@ class TestKindTestGeneral(AiidaTestCase):
         from aiida.orm.data.structure import Kind
 
         with self.assertRaises(ValueError):
-            _ = Kind(position=[0., 0., 0.], symbols=['Ba'],
-                     weights=[1.])
+            _ = Kind(position=[0., 0., 0.], symbols=['Ba'], weights=[1.])
 
     def test_simple(self):
         """
@@ -1072,19 +1030,19 @@ class TestKindTestGeneral(AiidaTestCase):
 
         a = Kind(symbols='X')
         self.assertEqual(a.name, 'X')
-        
+
         a = Kind(symbols=('Si', 'Ge'), weights=(1. / 3., 2. / 3.))
         self.assertEqual(a.name, 'GeSi')
 
         a = Kind(symbols=('Si', 'X'), weights=(1. / 3., 2. / 3.))
         self.assertEqual(a.name, 'SiX')
-        
+
         a = Kind(symbols=('Si', 'Ge'), weights=(0.4, 0.5))
         self.assertEqual(a.name, 'GeSiX')
 
         a = Kind(symbols=('Si', 'X'), weights=(0.4, 0.5))
         self.assertEqual(a.name, 'SiXX')
-        
+
         # Manually setting the name of the species
         a.name = 'newstring'
         self.assertEqual(a.name, 'newstring')
@@ -1101,11 +1059,8 @@ class TestKindTestMasses(AiidaTestCase):
         """
         from aiida.orm.data.structure import Kind, _atomic_masses
 
-        a = Kind(symbols=['Ba', 'C'],
-                 weights=[1. / 3., 2. / 3.])
-        self.assertAlmostEqual(a.mass,
-                               (_atomic_masses['Ba'] +
-                                2. * _atomic_masses['C']) / 3.)
+        a = Kind(symbols=['Ba', 'C'], weights=[1. / 3., 2. / 3.])
+        self.assertAlmostEqual(a.mass, (_atomic_masses['Ba'] + 2. * _atomic_masses['C']) / 3.)
 
     def test_sum_less_one_masses(self):
         """
@@ -1113,11 +1068,8 @@ class TestKindTestMasses(AiidaTestCase):
         """
         from aiida.orm.data.structure import Kind, _atomic_masses
 
-        a = Kind(symbols=['Ba', 'C'],
-                 weights=[1. / 3., 1. / 3.])
-        self.assertAlmostEqual(a.mass,
-                               (_atomic_masses['Ba'] +
-                                _atomic_masses['C']) / 2.)
+        a = Kind(symbols=['Ba', 'C'], weights=[1. / 3., 1. / 3.])
+        self.assertAlmostEqual(a.mass, (_atomic_masses['Ba'] + _atomic_masses['C']) / 2.)
 
     def test_sum_less_one_singleelem(self):
         """
@@ -1126,8 +1078,7 @@ class TestKindTestMasses(AiidaTestCase):
         from aiida.orm.data.structure import Kind, _atomic_masses
 
         a = Kind(symbols=['Ba'])
-        self.assertAlmostEqual(a.mass,
-                               _atomic_masses['Ba'])
+        self.assertAlmostEqual(a.mass, _atomic_masses['Ba'])
 
     def test_manual_mass(self):
         """
@@ -1135,9 +1086,7 @@ class TestKindTestMasses(AiidaTestCase):
         """
         from aiida.orm.data.structure import Kind
 
-        a = Kind(symbols=['Ba', 'C'],
-                 weights=[1. / 3., 1. / 3.],
-                 mass=1000.)
+        a = Kind(symbols=['Ba', 'C'], weights=[1. / 3., 1. / 3.], mass=1000.)
         self.assertAlmostEqual(a.mass, 1000.)
 
 
@@ -1300,8 +1249,7 @@ class TestStructureData(AiidaTestCase):
         # belong to the same kind)
         self.assertEquals(len(a.kinds), 2)
 
-        a.append_atom(position=(0.5, 1., 1.5), symbols=['O', 'C'],
-                      weights=[0.5, 0.5])
+        a.append_atom(position=(0.5, 1., 1.5), symbols=['O', 'C'], weights=[0.5, 0.5])
         self.assertTrue(a.is_alloy())
         self.assertFalse(a.has_vacancies())
 
@@ -1336,8 +1284,7 @@ class TestStructureData(AiidaTestCase):
         # belong to the same kind)
         self.assertEquals(len(a.kinds), 2)
 
-        a.append_atom(position=(0.5, 1., 1.5), symbols=['O', 'C'],
-                      weights=[0.5, 0.5])
+        a.append_atom(position=(0.5, 1., 1.5), symbols=['O', 'C'], weights=[0.5, 0.5])
         self.assertTrue(a.is_alloy())
         self.assertFalse(a.has_vacancies())
 
@@ -1349,7 +1296,7 @@ class TestStructureData(AiidaTestCase):
         a.append_atom(position=(0.5, 1., 1.5), symbols=['X'], weights=[0.5])
         self.assertFalse(a.is_alloy())
         self.assertTrue(a.has_vacancies())
-        
+
     def test_kind_1(self):
         """
         Test the management of kinds (automatic detection of kind of
@@ -1365,8 +1312,7 @@ class TestStructureData(AiidaTestCase):
 
         self.assertEqual(len(a.kinds), 2)  # I should only have two types
         # I check for the default names of kinds
-        self.assertEqual(set(k.name for k in a.kinds),
-                         set(('Ba', 'Ti')))
+        self.assertEqual(set(k.name for k in a.kinds), set(('Ba', 'Ti')))
 
     def test_kind_1_unknown(self):
         """
@@ -1383,9 +1329,8 @@ class TestStructureData(AiidaTestCase):
 
         self.assertEqual(len(a.kinds), 2)  # I should only have two types
         # I check for the default names of kinds
-        self.assertEqual(set(k.name for k in a.kinds),
-                         set(('X', 'Ti')))
-        
+        self.assertEqual(set(k.name for k in a.kinds), set(('X', 'Ti')))
+
     def test_kind_2(self):
         """
         Test the management of kinds (manual specification of kind name).
@@ -1400,8 +1345,7 @@ class TestStructureData(AiidaTestCase):
 
         kind_list = a.kinds
         self.assertEqual(len(kind_list), 3)  # I should have now three kinds
-        self.assertEqual(set(k.name for k in kind_list),
-                         set(('Ba1', 'Ba2', 'Ti')))
+        self.assertEqual(set(k.name for k in kind_list), set(('Ba1', 'Ba2', 'Ti')))
 
     def test_kind_2_unknown(self):
         """
@@ -1418,9 +1362,8 @@ class TestStructureData(AiidaTestCase):
 
         kind_list = a.kinds
         self.assertEqual(len(kind_list), 3)  # I should have now three kinds
-        self.assertEqual(set(k.name for k in kind_list),
-                         set(('X1', 'X2', 'Ti')))
-        
+        self.assertEqual(set(k.name for k in kind_list), set(('X1', 'X2', 'Ti')))
+
     def test_kind_3(self):
         """
         Test the management of kinds (adding an atom with different mass).
@@ -1432,12 +1375,10 @@ class TestStructureData(AiidaTestCase):
         a.append_atom(position=(0., 0., 0.), symbols=['Ba'], mass=100.)
         with self.assertRaises(ValueError):
             # Shouldn't allow, I am adding two sites with the same name 'Ba'
-            a.append_atom(position=(0.5, 0.5, 0.5), symbols=['Ba'],
-                          mass=101., name='Ba')
+            a.append_atom(position=(0.5, 0.5, 0.5), symbols=['Ba'], mass=101., name='Ba')
 
             # now it should work because I am using a different kind name
-        a.append_atom(position=(0.5, 0.5, 0.5),
-                      symbols=['Ba'], mass=101., name='Ba2')
+        a.append_atom(position=(0.5, 0.5, 0.5), symbols=['Ba'], mass=101., name='Ba2')
 
         a.append_atom(position=(1., 1., 1.), symbols=['Ti'])
 
@@ -1457,19 +1398,17 @@ class TestStructureData(AiidaTestCase):
         a.append_atom(position=(0., 0., 0.), symbols=['X'], mass=100.)
         with self.assertRaises(ValueError):
             # Shouldn't allow, I am adding two sites with the same name 'Ba'
-            a.append_atom(position=(0.5, 0.5, 0.5), symbols=['X'],
-                          mass=101., name='X')
+            a.append_atom(position=(0.5, 0.5, 0.5), symbols=['X'], mass=101., name='X')
 
             # now it should work because I am using a different kind name
-        a.append_atom(position=(0.5, 0.5, 0.5),
-                      symbols=['X'], mass=101., name='X2')
+        a.append_atom(position=(0.5, 0.5, 0.5), symbols=['X'], mass=101., name='X2')
 
         a.append_atom(position=(1., 1., 1.), symbols=['Ti'])
 
         self.assertEqual(len(a.kinds), 3)  # I should have now three types
         self.assertEqual(len(a.sites), 3)  # and 3 sites
         self.assertEqual(set(k.name for k in a.kinds), set(('X', 'X2', 'Ti')))
-        
+
     def test_kind_4(self):
         """
         Test the management of kind (adding an atom with different symbols
@@ -1479,32 +1418,26 @@ class TestStructureData(AiidaTestCase):
 
         a = StructureData(cell=((2., 0., 0.), (0., 2., 0.), (0., 0., 2.)))
 
-        a.append_atom(position=(0., 0., 0.), symbols=['Ba', 'Ti'],
-                      weights=(1., 0.), name='mytype')
+        a.append_atom(position=(0., 0., 0.), symbols=['Ba', 'Ti'], weights=(1., 0.), name='mytype')
 
         with self.assertRaises(ValueError):
             # Shouldn't allow, different weights
-            a.append_atom(position=(0.5, 0.5, 0.5), symbols=['Ba', 'Ti'],
-                          weights=(0.9, 0.1), name='mytype')
+            a.append_atom(position=(0.5, 0.5, 0.5), symbols=['Ba', 'Ti'], weights=(0.9, 0.1), name='mytype')
 
         with self.assertRaises(ValueError):
             # Shouldn't allow, different weights (with vacancy)
-            a.append_atom(position=(0.5, 0.5, 0.5), symbols=['Ba', 'Ti'],
-                          weights=(0.8, 0.1), name='mytype')
+            a.append_atom(position=(0.5, 0.5, 0.5), symbols=['Ba', 'Ti'], weights=(0.8, 0.1), name='mytype')
 
         with self.assertRaises(ValueError):
             # Shouldn't allow, different symbols list
-            a.append_atom(position=(0.5, 0.5, 0.5), symbols=['Ba'],
-                          name='mytype')
+            a.append_atom(position=(0.5, 0.5, 0.5), symbols=['Ba'], name='mytype')
 
         with self.assertRaises(ValueError):
             # Shouldn't allow, different symbols list
-            a.append_atom(position=(0.5, 0.5, 0.5), symbols=['Si', 'Ti'],
-                          weights=(1., 0.), name='mytype')
+            a.append_atom(position=(0.5, 0.5, 0.5), symbols=['Si', 'Ti'], weights=(1., 0.), name='mytype')
 
             # should allow because every property is identical
-        a.append_atom(position=(0., 0., 0.), symbols=['Ba', 'Ti'],
-                      weights=(1., 0.), name='mytype')
+        a.append_atom(position=(0., 0., 0.), symbols=['Ba', 'Ti'], weights=(1., 0.), name='mytype')
 
         self.assertEquals(len(a.kinds), 1)
 
@@ -1517,35 +1450,29 @@ class TestStructureData(AiidaTestCase):
 
         a = StructureData(cell=((2., 0., 0.), (0., 2., 0.), (0., 0., 2.)))
 
-        a.append_atom(position=(0., 0., 0.), symbols=['X', 'Ti'],
-                      weights=(1., 0.), name='mytype')
+        a.append_atom(position=(0., 0., 0.), symbols=['X', 'Ti'], weights=(1., 0.), name='mytype')
 
         with self.assertRaises(ValueError):
             # Shouldn't allow, different weights
-            a.append_atom(position=(0.5, 0.5, 0.5), symbols=['X', 'Ti'],
-                          weights=(0.9, 0.1), name='mytype')
+            a.append_atom(position=(0.5, 0.5, 0.5), symbols=['X', 'Ti'], weights=(0.9, 0.1), name='mytype')
 
         with self.assertRaises(ValueError):
             # Shouldn't allow, different weights (with vacancy)
-            a.append_atom(position=(0.5, 0.5, 0.5), symbols=['X', 'Ti'],
-                          weights=(0.8, 0.1), name='mytype')
+            a.append_atom(position=(0.5, 0.5, 0.5), symbols=['X', 'Ti'], weights=(0.8, 0.1), name='mytype')
 
         with self.assertRaises(ValueError):
             # Shouldn't allow, different symbols list
-            a.append_atom(position=(0.5, 0.5, 0.5), symbols=['X'],
-                          name='mytype')
+            a.append_atom(position=(0.5, 0.5, 0.5), symbols=['X'], name='mytype')
 
         with self.assertRaises(ValueError):
             # Shouldn't allow, different symbols list
-            a.append_atom(position=(0.5, 0.5, 0.5), symbols=['Si', 'Ti'],
-                          weights=(1., 0.), name='mytype')
+            a.append_atom(position=(0.5, 0.5, 0.5), symbols=['Si', 'Ti'], weights=(1., 0.), name='mytype')
 
             # should allow because every property is identical
-        a.append_atom(position=(0., 0., 0.), symbols=['X', 'Ti'],
-                      weights=(1., 0.), name='mytype')
+        a.append_atom(position=(0., 0., 0.), symbols=['X', 'Ti'], weights=(1., 0.), name='mytype')
 
         self.assertEquals(len(a.kinds), 1)
-        
+
     def test_kind_5(self):
         """
         Test the management of kinds (automatic creation of new kind
@@ -1563,15 +1490,13 @@ class TestStructureData(AiidaTestCase):
         a.append_atom(position=(1., 1., 1.), symbols='Ti', name='Ti2')
         # The name already exists, but the properties are different!
         with self.assertRaises(ValueError):
-            a.append_atom(position=(1., 1., 1.), symbols='Ti', mass=100.,
-                          name='Ti2')
+            a.append_atom(position=(1., 1., 1.), symbols='Ti', mass=100., name='Ti2')
         # Should not complain, should create a new type
         a.append_atom(position=(0., 0., 0.), symbols='Ba', mass=150.)
 
         # There should be 4 kinds, the automatic name for the last one
         # should be Ba1
-        self.assertEquals([k.name for k in a.kinds],
-                          ['Ba', 'Ti', 'Ti2', 'Ba1'])
+        self.assertEquals([k.name for k in a.kinds], ['Ba', 'Ti', 'Ti2', 'Ba1'])
         self.assertEquals(len(a.sites), 5)
 
     def test_kind_5_unknown(self):
@@ -1592,17 +1517,15 @@ class TestStructureData(AiidaTestCase):
         a.append_atom(position=(1., 1., 1.), symbols='Ti', name='Ti2')
         # The name already exists, but the properties are different!
         with self.assertRaises(ValueError):
-            a.append_atom(position=(1., 1., 1.), symbols='Ti', mass=100.,
-                          name='Ti2')
+            a.append_atom(position=(1., 1., 1.), symbols='Ti', mass=100., name='Ti2')
         # Should not complain, should create a new type
         a.append_atom(position=(0., 0., 0.), symbols='X', mass=150.)
 
         # There should be 4 kinds, the automatic name for the last one
         # should be Ba1
-        self.assertEquals([k.name for k in a.kinds],
-                          ['X', 'Ti', 'Ti2', 'X1'])
+        self.assertEquals([k.name for k in a.kinds], ['X', 'Ti', 'Ti2', 'X1'])
         self.assertEquals(len(a.sites), 5)
-        
+
     def test_kind_5_bis(self):
         """
         Test the management of kinds (automatic creation of new kind
@@ -1623,13 +1546,10 @@ class TestStructureData(AiidaTestCase):
         # I expect only two species, the first one with name 'Fe', mass 12,
         # and referencing the first three atoms; the second with name
         # 'Fe1', mass = elements[26]['mass'], and referencing the last two atoms
-        self.assertEquals(
-            set([(k.name, k.mass) for k in s.kinds]),
-            set([('Fe', 12.0), ('Fe1', elements[26]['mass'])]))
+        self.assertEquals(set([(k.name, k.mass) for k in s.kinds]), set([('Fe', 12.0), ('Fe1', elements[26]['mass'])]))
 
         kind_of_each_site = [site.kind_name for site in s.sites]
-        self.assertEquals(kind_of_each_site,
-                          ['Fe', 'Fe', 'Fe', 'Fe1', 'Fe1'])
+        self.assertEquals(kind_of_each_site, ['Fe', 'Fe', 'Fe', 'Fe1', 'Fe1'])
 
     def test_kind_5_bis_unknown(self):
         """
@@ -1652,14 +1572,11 @@ class TestStructureData(AiidaTestCase):
         # I expect only two species, the first one with name 'X', mass 12,
         # and referencing the first three atoms; the second with name
         # 'X', mass = elements[0]['mass'], and referencing the last two atoms
-        self.assertEquals(
-            set([(k.name, k.mass) for k in s.kinds]),
-            set([('X', 12.0), ('X1', elements[0]['mass'])]))
+        self.assertEquals(set([(k.name, k.mass) for k in s.kinds]), set([('X', 12.0), ('X1', elements[0]['mass'])]))
 
         kind_of_each_site = [site.kind_name for site in s.sites]
-        self.assertEquals(kind_of_each_site,
-                          ['X', 'X', 'X', 'X1', 'X1'])
-        
+        self.assertEquals(kind_of_each_site, ['X', 'X', 'X', 'X1', 'X1'])
+
     @unittest.skipIf(not has_ase(), "Unable to import ase")
     def test_kind_5_bis_ase(self):
         """
@@ -1668,8 +1585,7 @@ class TestStructureData(AiidaTestCase):
         from aiida.orm.data.structure import StructureData
         import ase
 
-        asecell = ase.Atoms('Fe5',
-                            cell=((6., 0., 0.), (0., 6., 0.), (0., 0., 6.)))
+        asecell = ase.Atoms('Fe5', cell=((6., 0., 0.), (0., 6., 0.), (0., 0., 6.)))
         asecell.set_positions([
             [0, 0, 0],
             [1, 0, 0],
@@ -1687,13 +1603,10 @@ class TestStructureData(AiidaTestCase):
         # I expect only two species, the first one with name 'Fe', mass 12,
         # and referencing the first three atoms; the second with name
         # 'Fe1', mass = elements[26]['mass'], and referencing the last two atoms
-        self.assertEquals(
-            set([(k.name, k.mass) for k in s.kinds]),
-            set([('Fe', 12.0), ('Fe1', asecell[3].mass)]))
+        self.assertEquals(set([(k.name, k.mass) for k in s.kinds]), set([('Fe', 12.0), ('Fe1', asecell[3].mass)]))
 
         kind_of_each_site = [site.kind_name for site in s.sites]
-        self.assertEquals(kind_of_each_site,
-                          ['Fe', 'Fe', 'Fe', 'Fe1', 'Fe1'])
+        self.assertEquals(kind_of_each_site, ['Fe', 'Fe', 'Fe', 'Fe1', 'Fe1'])
 
     @unittest.skipIf(not has_ase(), "Unable to import ase")
     def test_kind_5_bis_ase_unknown(self):
@@ -1703,8 +1616,7 @@ class TestStructureData(AiidaTestCase):
         from aiida.orm.data.structure import StructureData
         import ase
 
-        asecell = ase.Atoms('X5',
-                            cell=((6., 0., 0.), (0., 6., 0.), (0., 0., 6.)))
+        asecell = ase.Atoms('X5', cell=((6., 0., 0.), (0., 6., 0.), (0., 0., 6.)))
         asecell.set_positions([
             [0, 0, 0],
             [1, 0, 0],
@@ -1722,14 +1634,11 @@ class TestStructureData(AiidaTestCase):
         # I expect only two species, the first one with name 'X', mass 12,
         # and referencing the first three atoms; the second with name
         # 'X1', mass = elements[26]['mass'], and referencing the last two atoms
-        self.assertEquals(
-            set([(k.name, k.mass) for k in s.kinds]),
-            set([('X', 12.0), ('X1', asecell[3].mass)]))
+        self.assertEquals(set([(k.name, k.mass) for k in s.kinds]), set([('X', 12.0), ('X1', asecell[3].mass)]))
 
         kind_of_each_site = [site.kind_name for site in s.sites]
-        self.assertEquals(kind_of_each_site,
-                          ['X', 'X', 'X', 'X1', 'X1'])
-        
+        self.assertEquals(kind_of_each_site, ['X', 'X', 'X', 'X1', 'X1'])
+
     def test_kind_6(self):
         """
         Test the returning of kinds from the string name (most of the code
@@ -1749,8 +1658,7 @@ class TestStructureData(AiidaTestCase):
         a.append_atom(position=(0., 0., 0.), symbols='Ba', mass=150.)
         # There should be 4 kinds, the automatic name for the last one
         # should be Ba1 (same check of test_kind_5
-        self.assertEquals([k.name for k in a.kinds],
-                          ['Ba', 'Ti', 'Ti2', 'Ba1'])
+        self.assertEquals([k.name for k in a.kinds], ['Ba', 'Ti', 'Ti2', 'Ba1'])
         #############################
         # Here I start the real tests
         # No such kind
@@ -1779,8 +1687,7 @@ class TestStructureData(AiidaTestCase):
         a.append_atom(position=(0., 0., 0.), symbols='X', mass=150.)
         # There should be 4 kinds, the automatic name for the last one
         # should be Ba1 (same check of test_kind_5
-        self.assertEquals([k.name for k in a.kinds],
-                          ['X', 'Ti', 'Ti2', 'X1'])
+        self.assertEquals([k.name for k in a.kinds], ['X', 'Ti', 'Ti2', 'X1'])
         #############################
         # Here I start the real tests
         # No such kind
@@ -1789,7 +1696,7 @@ class TestStructureData(AiidaTestCase):
         k = a.get_kind('X1')
         self.assertEqual(k.symbols, ('X',))
         self.assertAlmostEqual(k.mass, 150.)
-        
+
     def test_kind_7(self):
         """
         Test the functions returning the list of kinds, symbols, ...
@@ -1803,8 +1710,7 @@ class TestStructureData(AiidaTestCase):
         # The name does not exist
         a.append_atom(position=(0., 0., 0.), symbols='Ti', name='Ti2')
         # The name already exists, but the properties are identical => OK
-        a.append_atom(position=(0., 0., 0.), symbols=['O', 'H'],
-                      weights=[0.9, 0.1], mass=15.)
+        a.append_atom(position=(0., 0., 0.), symbols=['O', 'H'], weights=[0.9, 0.1], mass=15.)
 
         self.assertEquals(a.get_symbols_set(), set(['Ba', 'Ti', 'O', 'H']))
 
@@ -1822,11 +1728,10 @@ class TestStructureData(AiidaTestCase):
         # The name does not exist
         a.append_atom(position=(0., 0., 0.), symbols='X', name='X2')
         # The name already exists, but the properties are identical => OK
-        a.append_atom(position=(0., 0., 0.), symbols=['O', 'H'],
-                      weights=[0.9, 0.1], mass=15.)
+        a.append_atom(position=(0., 0., 0.), symbols=['O', 'H'], weights=[0.9, 0.1], mass=15.)
 
         self.assertEquals(a.get_symbols_set(), set(['Ba', 'X', 'O', 'H']))
-        
+
     @unittest.skipIf(not has_ase(), "Unable to import ase")
     @unittest.skipIf(not has_spglib(), "Unable to import spglib")
     def test_kind_8(self):
@@ -1846,8 +1751,7 @@ class TestStructureData(AiidaTestCase):
         sym.pop('translations')
         self.assertEquals(b.get_chemical_symbols(), ['C'])
         self.assertEquals(b.cell.tolist(), [[10, 0, 0], [0, 10, 0], [0, 0, 5]])
-        self.assertEquals(sym,
-                          {'hall': '-P 4 2', 'hm': 'P4/mmm', 'tables': 123})
+        self.assertEquals(sym, {'hall': '-P 4 2', 'hm': 'P4/mmm', 'tables': 123})
 
         a = ase.Atoms(cell=[10, 2 * math.sqrt(75), 10])
         a.append(ase.Atom('C', [0, 0, 0]))
@@ -1856,10 +1760,8 @@ class TestStructureData(AiidaTestCase):
         sym.pop('rotations')
         sym.pop('translations')
         self.assertEquals(b.get_chemical_symbols(), ['C'])
-        self.assertEquals(numpy.round(b.cell, 2).tolist(),
-                          [[10, 0, 0], [-5, 8.66, 0], [0, 0, 10]])
-        self.assertEquals(sym,
-                          {'hall': '-P 6 2', 'hm': 'P6/mmm', 'tables': 191})
+        self.assertEquals(numpy.round(b.cell, 2).tolist(), [[10, 0, 0], [-5, 8.66, 0], [0, 0, 10]])
+        self.assertEquals(sym, {'hall': '-P 6 2', 'hm': 'P6/mmm', 'tables': 191})
 
         a = ase.Atoms(cell=[[10, 0, 0], [-10, 10, 0], [0, 0, 10]])
         a.append(ase.Atom('C', [5, 5, 5]))
@@ -1869,10 +1771,8 @@ class TestStructureData(AiidaTestCase):
         sym.pop('translations')
         self.assertEquals(b.get_chemical_symbols(), ['C', 'F'])
         self.assertEquals(b.cell.tolist(), [[10, 0, 0], [0, 10, 0], [0, 0, 10]])
-        self.assertEquals(b.get_scaled_positions().tolist(),
-                          [[0.5, 0.5, 0.5], [0, 0, 0]])
-        self.assertEquals(sym,
-                          {'hall': '-P 4 2 3', 'hm': 'Pm-3m', 'tables': 221})
+        self.assertEquals(b.get_scaled_positions().tolist(), [[0.5, 0.5, 0.5], [0, 0, 0]])
+        self.assertEquals(sym, {'hall': '-P 4 2 3', 'hm': 'Pm-3m', 'tables': 221})
 
         a = ase.Atoms(cell=[[10, 0, 0], [-10, 10, 0], [0, 0, 10]])
         a.append(ase.Atom('C', [0, 0, 0]))
@@ -1882,18 +1782,15 @@ class TestStructureData(AiidaTestCase):
         sym.pop('translations')
         self.assertEquals(b.get_chemical_symbols(), ['C', 'F'])
         self.assertEquals(b.cell.tolist(), [[10, 0, 0], [0, 10, 0], [0, 0, 10]])
-        self.assertEquals(b.get_scaled_positions().tolist(),
-                          [[0, 0, 0], [0.5, 0.5, 0.5]])
-        self.assertEquals(sym,
-                          {'hall': '-P 4 2 3', 'hm': 'Pm-3m', 'tables': 221})
+        self.assertEquals(b.get_scaled_positions().tolist(), [[0, 0, 0], [0.5, 0.5, 0.5]])
+        self.assertEquals(sym, {'hall': '-P 4 2 3', 'hm': 'Pm-3m', 'tables': 221})
 
         a = ase.Atoms(cell=[[12.132, 0, 0], [0, 6.0606, 0], [0, 0, 8.0956]])
         a.append(ase.Atom('Ba', [1.5334848, 1.3999986, 2.00042276]))
         b, sym = ase_refine_cell(a)
         sym.pop('rotations')
         sym.pop('translations')
-        self.assertEquals(b.cell.tolist(),
-                          [[6.0606, 0, 0], [0, 8.0956, 0], [0, 0, 12.132]])
+        self.assertEquals(b.cell.tolist(), [[6.0606, 0, 0], [0, 8.0956, 0], [0, 0, 12.132]])
         self.assertEquals(b.get_scaled_positions().tolist(), [[0, 0, 0]])
 
         a = ase.Atoms(cell=[10, 10, 10])
@@ -1904,21 +1801,15 @@ class TestStructureData(AiidaTestCase):
         sym.pop('rotations')
         sym.pop('translations')
         self.assertEquals(b.get_chemical_symbols(), ['C', 'O'])
-        self.assertEquals(sym,
-                          {'hall': '-P 4 2', 'hm': 'P4/mmm', 'tables': 123})
+        self.assertEquals(sym, {'hall': '-P 4 2', 'hm': 'P4/mmm', 'tables': 123})
 
         # Generated from COD entry 1507756
         # (http://www.crystallography.net/cod/1507756.cif@87343)
         from ase.spacegroup import crystal
-        a = crystal(['Ba', 'Ti', 'O', 'O'],
-                    [
-                        [0, 0, 0],
-                        [0.5, 0.5, 0.482],
-                        [0.5, 0.5, 0.016],
-                        [0.5, 0, 0.515]
-                    ],
-                    cell=[3.9999, 3.9999, 4.0170],
-                    spacegroup=99)
+        a = crystal(
+            ['Ba', 'Ti', 'O', 'O'], [[0, 0, 0], [0.5, 0.5, 0.482], [0.5, 0.5, 0.016], [0.5, 0, 0.515]],
+            cell=[3.9999, 3.9999, 4.0170],
+            spacegroup=99)
         b, sym = ase_refine_cell(a)
         sym.pop('rotations')
         sym.pop('translations')
@@ -1931,16 +1822,10 @@ class TestStructureData(AiidaTestCase):
         """
         from aiida.orm.data.structure import get_formula
 
-        self.assertEquals(get_formula(['Ba', 'Ti'] + ['O'] * 3),
-                          'BaO3Ti')
-        self.assertEquals(get_formula(['Ba', 'Ti', 'C'] + ['O'] * 3,
-                                      separator=" "),
-                          'C Ba O3 Ti')
-        self.assertEquals(get_formula(['H'] * 6 + ['C'] * 6),
-                          'C6H6')
-        self.assertEquals(get_formula(['H'] * 6 + ['C'] * 6,
-                                      mode="hill_compact"),
-                          'CH')
+        self.assertEquals(get_formula(['Ba', 'Ti'] + ['O'] * 3), 'BaO3Ti')
+        self.assertEquals(get_formula(['Ba', 'Ti', 'C'] + ['O'] * 3, separator=" "), 'C Ba O3 Ti')
+        self.assertEquals(get_formula(['H'] * 6 + ['C'] * 6), 'C6H6')
+        self.assertEquals(get_formula(['H'] * 6 + ['C'] * 6, mode="hill_compact"), 'CH')
         self.assertEquals(get_formula((['Ba', 'Ti'] + ['O'] * 3) * 2 + \
                                       ['Ba'] + ['Ti'] * 2 + ['O'] * 3,
                                       mode="group"),
@@ -1957,12 +1842,8 @@ class TestStructureData(AiidaTestCase):
                                       ['Ba'] + ['Ti'] * 2 + ['O'] * 3,
                                       mode="reduce", separator=", "),
                           'Ba, Ti, O3, Ba, Ti, O3, Ba, Ti2, O3')
-        self.assertEquals(get_formula((['Ba', 'Ti'] + ['O'] * 3) * 2,
-                                      mode="count"),
-                          'Ba2Ti2O6')
-        self.assertEquals(get_formula((['Ba', 'Ti'] + ['O'] * 3) * 2,
-                                      mode="count_compact"),
-                          'BaTiO3')
+        self.assertEquals(get_formula((['Ba', 'Ti'] + ['O'] * 3) * 2, mode="count"), 'Ba2Ti2O6')
+        self.assertEquals(get_formula((['Ba', 'Ti'] + ['O'] * 3) * 2, mode="count_compact"), 'BaTiO3')
 
     def test_get_formula_unknown(self):
         """
@@ -1970,16 +1851,10 @@ class TestStructureData(AiidaTestCase):
         """
         from aiida.orm.data.structure import get_formula
 
-        self.assertEquals(get_formula(['Ba', 'Ti'] + ['X'] * 3),
-                          'BaTiX3')
-        self.assertEquals(get_formula(['Ba', 'Ti', 'C'] + ['X'] * 3,
-                                      separator=" "),
-                          'C Ba Ti X3')
-        self.assertEquals(get_formula(['X'] * 6 + ['C'] * 6),
-                          'C6X6')
-        self.assertEquals(get_formula(['X'] * 6 + ['C'] * 6,
-                                      mode="hill_compact"),
-                          'CX')
+        self.assertEquals(get_formula(['Ba', 'Ti'] + ['X'] * 3), 'BaTiX3')
+        self.assertEquals(get_formula(['Ba', 'Ti', 'C'] + ['X'] * 3, separator=" "), 'C Ba Ti X3')
+        self.assertEquals(get_formula(['X'] * 6 + ['C'] * 6), 'C6X6')
+        self.assertEquals(get_formula(['X'] * 6 + ['C'] * 6, mode="hill_compact"), 'CX')
         self.assertEquals(get_formula((['Ba', 'Ti'] + ['X'] * 3) * 2 + \
                                       ['Ba'] + ['X'] * 2 + ['O'] * 3,
                                       mode="group"),
@@ -1996,13 +1871,9 @@ class TestStructureData(AiidaTestCase):
                                       ['Ba'] + ['Ti'] * 2 + ['X'] * 3,
                                       mode="reduce", separator=", "),
                           'Ba, Ti, X3, Ba, Ti, X3, Ba, Ti2, X3')
-        self.assertEquals(get_formula((['Ba', 'Ti'] + ['O'] * 3) * 2,
-                                      mode="count"),
-                          'Ba2Ti2O6')
-        self.assertEquals(get_formula((['Ba', 'Ti'] + ['X'] * 3) * 2,
-                                      mode="count_compact"),
-                          'BaTiX3')
-        
+        self.assertEquals(get_formula((['Ba', 'Ti'] + ['O'] * 3) * 2, mode="count"), 'Ba2Ti2O6')
+        self.assertEquals(get_formula((['Ba', 'Ti'] + ['X'] * 3) * 2, mode="count_compact"), 'BaTiX3')
+
     @unittest.skipIf(not has_ase(), "Unable to import ase")
     @unittest.skipIf(not has_pycifrw(), "Unable to import PyCifRW")
     def test_get_cif(self):
@@ -2024,8 +1895,9 @@ class TestStructureData(AiidaTestCase):
         for line in lines:
             if not re.search('^#', line):
                 non_comments.append(line)
-        self.assertEquals(simplify("\n".join(non_comments)),
-                          simplify("""
+        self.assertEquals(
+            simplify("\n".join(non_comments)),
+            simplify("""
 data_0
 loop_
   _atom_site_label
@@ -2227,7 +2099,6 @@ class TestStructureDataReload(AiidaTestCase):
         for i in range(3):
             self.assertAlmostEqual(b.sites[1].position[i], 1.)
 
-
     def test_clone(self):
         """
         Start from a StructureData object, clone it and see if it is preserved
@@ -2292,10 +2163,10 @@ class TestStructureDataFromAse(AiidaTestCase):
         import ase
 
         a = ase.Atoms('SiGe', cell=(1., 2., 3.), pbc=(True, False, False))
-        a.set_positions(
-            ((0., 0., 0.),
-             (0.5, 0.7, 0.9),)
-        )
+        a.set_positions((
+            (0., 0., 0.),
+            (0.5, 0.7, 0.9),
+        ))
         a[1].mass = 110.2
 
         b = StructureData(ase=a)
@@ -2320,24 +2191,21 @@ class TestStructureDataFromAse(AiidaTestCase):
         import ase
 
         a = ase.Atoms('Si4Ge4', cell=(1., 2., 3.), pbc=(True, False, False))
-        a.set_positions(
-            ((0.0, 0.0, 0.0),
-             (0.1, 0.1, 0.1),
-             (0.2, 0.2, 0.2),
-             (0.3, 0.3, 0.3),
-             (0.4, 0.4, 0.4),
-             (0.5, 0.5, 0.5),
-             (0.6, 0.6, 0.6),
-             (0.7, 0.7, 0.7),
-             )
-        )
+        a.set_positions((
+            (0.0, 0.0, 0.0),
+            (0.1, 0.1, 0.1),
+            (0.2, 0.2, 0.2),
+            (0.3, 0.3, 0.3),
+            (0.4, 0.4, 0.4),
+            (0.5, 0.5, 0.5),
+            (0.6, 0.6, 0.6),
+            (0.7, 0.7, 0.7),
+        ))
 
         a.set_tags((0, 1, 2, 3, 4, 5, 6, 7))
 
         b = StructureData(ase=a)
-        self.assertEquals([k.name for k in b.kinds],
-                          ["Si", "Si1", "Si2", "Si3",
-                           "Ge4", "Ge5", "Ge6", "Ge7"])
+        self.assertEquals([k.name for k in b.kinds], ["Si", "Si1", "Si2", "Si3", "Ge4", "Ge5", "Ge6", "Ge7"])
         c = b.get_ase()
 
         a_tags = list(a.get_tags())
@@ -2354,13 +2222,12 @@ class TestStructureDataFromAse(AiidaTestCase):
         import ase
 
         a = ase.Atoms('Si4', cell=(1., 2., 3.), pbc=(True, False, False))
-        a.set_positions(
-            ((0.0, 0.0, 0.0),
-             (0.1, 0.1, 0.1),
-             (0.2, 0.2, 0.2),
-             (0.3, 0.3, 0.3),
-             )
-        )
+        a.set_positions((
+            (0.0, 0.0, 0.0),
+            (0.1, 0.1, 0.1),
+            (0.2, 0.2, 0.2),
+            (0.3, 0.3, 0.3),
+        ))
 
         a.set_tags((0, 1, 0, 1))
         a[2].mass = 100.
@@ -2404,14 +2271,10 @@ class TestStructureDataFromAse(AiidaTestCase):
 
         # Just to be sure that the species were saved with the correct name
         # in the first place
-        self.assertEquals([k.name for k in a.kinds],
-                          ['Ba', 'Ba1', 'Cu', 'Cu2', 'Cu_my',
-                           'a_name', 'Fe', 'cu1'])
+        self.assertEquals([k.name for k in a.kinds], ['Ba', 'Ba1', 'Cu', 'Cu2', 'Cu_my', 'a_name', 'Fe', 'cu1'])
 
         b = a.get_ase()
-        self.assertEquals(b.get_chemical_symbols(), ['Ba', 'Ba', 'Cu',
-                                                     'Cu', 'Cu', 'Cu',
-                                                     'Cu', 'Cu'])
+        self.assertEquals(b.get_chemical_symbols(), ['Ba', 'Ba', 'Cu', 'Cu', 'Cu', 'Cu', 'Cu', 'Cu'])
         self.assertEquals(list(b.get_tags()), [0, 1, 0, 2, 3, 4, 5, 6])
 
     @unittest.skipIf(not has_ase(), "Unable to import ase")
@@ -2431,9 +2294,9 @@ class TestStructureDataFromAse(AiidaTestCase):
         self.assertEquals(kindnames, set(['Fe', 'Fe1', 'Fe4']))
         # check roundtrip ASE -> StructureData -> ASE
         atoms2 = s.get_ase()
-        self.assertEquals(list(atoms2.get_tags()),list(atoms.get_tags()))
-        self.assertEquals(list(atoms2.get_chemical_symbols()),list(atoms.get_chemical_symbols()))
-        self.assertEquals(atoms2.get_chemical_formula(),'Fe5')
+        self.assertEquals(list(atoms2.get_tags()), list(atoms.get_tags()))
+        self.assertEquals(list(atoms2.get_chemical_symbols()), list(atoms.get_chemical_symbols()))
+        self.assertEquals(atoms2.get_chemical_formula(), 'Fe5')
 
     @unittest.skipIf(not has_ase(), "Unable to import ase")
     def test_conversion_of_types_5(self):
@@ -2453,9 +2316,9 @@ class TestStructureDataFromAse(AiidaTestCase):
         self.assertEquals(kindnames, set(['Fe', 'Fe1', 'Fe4']))
         # check roundtrip ASE -> StructureData -> ASE
         atoms2 = s.get_ase()
-        self.assertEquals(list(atoms2.get_tags()),list(atoms.get_tags()))
-        self.assertEquals(list(atoms2.get_chemical_symbols()),list(atoms.get_chemical_symbols()))
-        self.assertEquals(atoms2.get_chemical_formula(),'Fe5')
+        self.assertEquals(list(atoms2.get_tags()), list(atoms.get_tags()))
+        self.assertEquals(list(atoms2.get_chemical_symbols()), list(atoms.get_chemical_symbols()))
+        self.assertEquals(atoms2.get_chemical_formula(), 'Fe5')
 
     @unittest.skipIf(not has_ase(), "Unable to import ase")
     def test_conversion_of_types_6(self):
@@ -2464,21 +2327,20 @@ class TestStructureDataFromAse(AiidaTestCase):
         """
         from aiida.orm.data.structure import StructureData
 
-        a = StructureData(cell=[[4,0,0],[0,4,0],[0,0,4]])
-        a.append_atom(position=(0,0,0), symbols='Ni', name='Ni1')
-        a.append_atom(position=(2,2,2), symbols='Ni', name='Ni2')
-        a.append_atom(position=(1,0,1), symbols='Cl', name='Cl')
-        a.append_atom(position=(1,3,1), symbols='Cl', name='Cl')
-        
+        a = StructureData(cell=[[4, 0, 0], [0, 4, 0], [0, 0, 4]])
+        a.append_atom(position=(0, 0, 0), symbols='Ni', name='Ni1')
+        a.append_atom(position=(2, 2, 2), symbols='Ni', name='Ni2')
+        a.append_atom(position=(1, 0, 1), symbols='Cl', name='Cl')
+        a.append_atom(position=(1, 3, 1), symbols='Cl', name='Cl')
+
         b = a.get_ase()
-        self.assertEquals(b.get_chemical_symbols(), ['Ni', 'Ni', 'Cl','Cl'])
+        self.assertEquals(b.get_chemical_symbols(), ['Ni', 'Ni', 'Cl', 'Cl'])
         self.assertEquals(list(b.get_tags()), [1, 2, 0, 0])
-        
+
         c = StructureData(ase=b)
-        self.assertEquals(c.get_site_kindnames(), ['Ni1', 'Ni2', 'Cl','Cl'])
+        self.assertEquals(c.get_site_kindnames(), ['Ni1', 'Ni2', 'Cl', 'Cl'])
         self.assertEquals([k.symbol for k in c.kinds], ['Ni', 'Ni', 'Cl'])
-        self.assertEquals([s.position for s in c.sites],
-                          [(0.,0.,0.),(2.,2.,2.),(1.,0.,1.),(1.,3.,1.)])
+        self.assertEquals([s.position for s in c.sites], [(0., 0., 0.), (2., 2., 2.), (1., 0., 1.), (1., 3., 1.)])
 
 
 class TestStructureDataFromPymatgen(AiidaTestCase):
@@ -2500,8 +2362,8 @@ class TestStructureDataFromPymatgen(AiidaTestCase):
 
         import tempfile
 
-        with tempfile.NamedTemporaryFile(mode='w+', suffix=".cif") as f:
-            f.write("""data_9011963
+        with tempfile.NamedTemporaryFile(mode='w+', suffix=".cif") as fhandle:
+            fhandle.write("""data_9011963
                 _space_group_IT_number           166
                 _symmetry_space_group_name_Hall  '-R 3 2"'
                 _symmetry_space_group_name_H-M   'R -3 m :H'
@@ -2526,24 +2388,24 @@ class TestStructureDataFromPymatgen(AiidaTestCase):
                 Te2 0.00000 0.00000 0.21180 0.66667 0.02343 B 1
                 Se2 0.00000 0.00000 0.21180 0.33333 0.02343 B 2
                 """)
-            f.flush()
+            fhandle.flush()
             pymatgen_parser = CifParser(f.name)
             pymatgen_struct = pymatgen_parser.get_structures()[0]
 
-        structs_to_test = [StructureData(pymatgen=pymatgen_struct),
-                           StructureData(pymatgen_structure=pymatgen_struct)]
+        structs_to_test = [StructureData(pymatgen=pymatgen_struct), StructureData(pymatgen_structure=pymatgen_struct)]
 
         for struct in structs_to_test:
-            self.assertEquals(struct.get_site_kindnames(),
-                              ['Bi', 'Bi', 'SeTe', 'SeTe', 'SeTe'])
+            self.assertEquals(struct.get_site_kindnames(), ['Bi', 'Bi', 'SeTe', 'SeTe', 'SeTe'])
 
             # Pymatgen's Composition does not guarantee any particular ordering of the kinds,
             # see the definition of its internal datatype at
             #   pymatgen/core/composition.py#L135 (d4fe64c18a52949a4e22bfcf7b45de5b87242c51)
-            self.assertEquals([sorted(x.symbols) for x in struct.kinds],
-                              [['Bi',], ['Se', 'Te']])
-            self.assertEquals([sorted(x.weights) for x in struct.kinds],
-                              [[1.0,], [0.33333, 0.66667]])
+            self.assertEquals([sorted(x.symbols) for x in struct.kinds], [[
+                'Bi',
+            ], ['Se', 'Te']])
+            self.assertEquals([sorted(x.weights) for x in struct.kinds], [[
+                1.0,
+            ], [0.33333, 0.66667]])
 
         struct = StructureData(pymatgen_structure=pymatgen_struct)
 
@@ -2572,38 +2434,26 @@ class TestStructureDataFromPymatgen(AiidaTestCase):
 
         import tempfile
 
-        with tempfile.NamedTemporaryFile(mode='w+', suffix=".xyz") as f:
-            f.write("""5
+        with tempfile.NamedTemporaryFile(mode='w+', suffix=".xyz") as fhandle:
+            fhandle.write("""5
                 H4 C1
                 C 0.000000 0.000000 0.000000
                 H 0.000000 0.000000 1.089000
                 H 1.026719 0.000000 -0.363000
                 H -0.513360 -0.889165 -0.363000
                 H -0.513360 0.889165 -0.363000""")
-            f.flush()
+            fhandle.flush()
             pymatgen_xyz = XYZ.from_file(f.name)
             pymatgen_mol = pymatgen_xyz.molecule
 
-        for struct in [StructureData(pymatgen=pymatgen_mol),
-                       StructureData(pymatgen_molecule=pymatgen_mol)]:
-            self.assertEquals(struct.get_site_kindnames(),
-                              ['H', 'H', 'H', 'H', 'C'])
+        for struct in [StructureData(pymatgen=pymatgen_mol), StructureData(pymatgen_molecule=pymatgen_mol)]:
+            self.assertEquals(struct.get_site_kindnames(), ['H', 'H', 'H', 'H', 'C'])
             self.assertEquals(struct.pbc, (False, False, False))
-            self.assertEquals(
-                [round(x, 2) for x in list(struct.sites[0].position)],
-                [5.77, 5.89, 6.81])
-            self.assertEquals(
-                [round(x, 2) for x in list(struct.sites[1].position)],
-                [6.8, 5.89, 5.36])
-            self.assertEquals(
-                [round(x, 2) for x in list(struct.sites[2].position)],
-                [5.26, 5.0, 5.36])
-            self.assertEquals(
-                [round(x, 2) for x in list(struct.sites[3].position)],
-                [5.26, 6.78, 5.36])
-            self.assertEquals(
-                [round(x, 2) for x in list(struct.sites[4].position)],
-                [5.77, 5.89, 5.73])
+            self.assertEquals([round(x, 2) for x in list(struct.sites[0].position)], [5.77, 5.89, 6.81])
+            self.assertEquals([round(x, 2) for x in list(struct.sites[1].position)], [6.8, 5.89, 5.36])
+            self.assertEquals([round(x, 2) for x in list(struct.sites[2].position)], [5.26, 5.0, 5.36])
+            self.assertEquals([round(x, 2) for x in list(struct.sites[3].position)], [5.26, 6.78, 5.36])
+            self.assertEquals([round(x, 2) for x in list(struct.sites[4].position)], [5.77, 5.89, 5.73])
 
     @unittest.skipIf(not has_pymatgen(), "Unable to import pymatgen")
     def test_partial_occ_and_spin(self):
@@ -2613,28 +2463,26 @@ class TestStructureDataFromPymatgen(AiidaTestCase):
         """
         from aiida.orm.data.structure import StructureData
         import pymatgen
-        
-        Fe_spin_up = pymatgen.structure.Specie('Fe',0,properties={'spin':1})
-        Mn_spin_up = pymatgen.structure.Specie('Mn',0,properties={'spin':1})
-        Fe_spin_down = pymatgen.structure.Specie('Fe',0,properties={'spin':-1})
-        Mn_spin_down = pymatgen.structure.Specie('Mn',0,properties={'spin':-1})
-        FeMn1 = pymatgen.Composition({Fe_spin_up:0.5,Mn_spin_up:0.5})
-        FeMn2 = pymatgen.Composition({Fe_spin_down:0.5,Mn_spin_down:0.5})
-        a = pymatgen.structure.Structure(lattice=[[4,0,0],[0,4,0],[0,0,4]],
-                                         species=[FeMn1,FeMn2],
-                                         coords=[[0,0,0],[0.5,0.5,0.5]])
-                
-        with self.assertRaises(ValueError): 
-            StructureData(pymatgen=a)
-        
-        # same, with vacancies
-        Fe1 = pymatgen.Composition({Fe_spin_up:0.5})
-        Fe2 = pymatgen.Composition({Fe_spin_down:0.5})
-        a = pymatgen.structure.Structure(lattice=[[4,0,0],[0,4,0],[0,0,4]],
-                                         species=[Fe1,Fe2],
-                                         coords=[[0,0,0],[0.5,0.5,0.5]])
 
-        with self.assertRaises(ValueError): 
+        Fe_spin_up = pymatgen.structure.Specie('Fe', 0, properties={'spin': 1})
+        Mn_spin_up = pymatgen.structure.Specie('Mn', 0, properties={'spin': 1})
+        Fe_spin_down = pymatgen.structure.Specie('Fe', 0, properties={'spin': -1})
+        Mn_spin_down = pymatgen.structure.Specie('Mn', 0, properties={'spin': -1})
+        FeMn1 = pymatgen.Composition({Fe_spin_up: 0.5, Mn_spin_up: 0.5})
+        FeMn2 = pymatgen.Composition({Fe_spin_down: 0.5, Mn_spin_down: 0.5})
+        a = pymatgen.structure.Structure(
+            lattice=[[4, 0, 0], [0, 4, 0], [0, 0, 4]], species=[FeMn1, FeMn2], coords=[[0, 0, 0], [0.5, 0.5, 0.5]])
+
+        with self.assertRaises(ValueError):
+            StructureData(pymatgen=a)
+
+        # same, with vacancies
+        Fe1 = pymatgen.Composition({Fe_spin_up: 0.5})
+        Fe2 = pymatgen.Composition({Fe_spin_down: 0.5})
+        a = pymatgen.structure.Structure(
+            lattice=[[4, 0, 0], [0, 4, 0], [0, 0, 4]], species=[Fe1, Fe2], coords=[[0, 0, 0], [0.5, 0.5, 0.5]])
+
+        with self.assertRaises(ValueError):
             StructureData(pymatgen=a)
 
     @unittest.skipIf(not has_pymatgen(), "Unable to import pymatgen")
@@ -2650,10 +2498,7 @@ class TestStructureDataFromPymatgen(AiidaTestCase):
         Mg2 = pymatgen.structure.Composition({'Mg': 0.25})
 
         a = pymatgen.structure.Structure(
-            lattice=[[4, 0, 0], [0, 4, 0], [0, 0, 4]],
-            species=[Mg1, Mg2],
-            coords=[[0, 0, 0], [0.5, 0.5, 0.5]]
-        )
+            lattice=[[4, 0, 0], [0, 4, 0], [0, 0, 4]], species=[Mg1, Mg2], coords=[[0, 0, 0], [0.5, 0.5, 0.5]])
 
         structure = StructureData(pymatgen=a)
 
@@ -2672,8 +2517,7 @@ class TestStructureDataFromPymatgen(AiidaTestCase):
         a = pymatgen.structure.Structure(
             lattice=[[4, 0, 0], [0, 4, 0], [0, 0, 4]],
             species=[alloy_one, alloy_two],
-            coords=[[0, 0, 0], [0.5, 0.5, 0.5]]
-        )
+            coords=[[0, 0, 0], [0.5, 0.5, 0.5]])
 
         structure = StructureData(pymatgen=a)
 
@@ -2711,15 +2555,13 @@ class TestPymatgenFromStructureData(AiidaTestCase):
         from aiida.orm.data.structure import StructureData
         import ase
 
-        aseatoms = ase.Atoms('Si4', cell=(1., 2., 3.),
-                             pbc=(True, True, True))
-        aseatoms.set_scaled_positions(
-            ((0.0, 0.0, 0.0),
-             (0.1, 0.1, 0.1),
-             (0.2, 0.2, 0.2),
-             (0.3, 0.3, 0.3),
-             )
-        )
+        aseatoms = ase.Atoms('Si4', cell=(1., 2., 3.), pbc=(True, True, True))
+        aseatoms.set_scaled_positions((
+            (0.0, 0.0, 0.0),
+            (0.1, 0.1, 0.1),
+            (0.2, 0.2, 0.2),
+            (0.3, 0.3, 0.3),
+        ))
 
         a_struct = StructureData(ase=aseatoms)
         p_struct = a_struct.get_pymatgen_structure()
@@ -2729,11 +2571,7 @@ class TestPymatgenFromStructureData(AiidaTestCase):
         for i in range(len(coord_array)):
             coord_array[i] = [round(x, 2) for x in coord_array[i]]
 
-        self.assertEquals(coord_array,
-                          [[0.0, 0.0, 0.0],
-                           [0.1, 0.1, 0.1],
-                           [0.2, 0.2, 0.2],
-                           [0.3, 0.3, 0.3]])
+        self.assertEquals(coord_array, [[0.0, 0.0, 0.0], [0.1, 0.1, 0.1], [0.2, 0.2, 0.2], [0.3, 0.3, 0.3]])
 
     @unittest.skipIf(not has_ase(), "Unable to import ase")
     @unittest.skipIf(not has_pymatgen(), "Unable to import pymatgen")
@@ -2745,25 +2583,20 @@ class TestPymatgenFromStructureData(AiidaTestCase):
         from aiida.orm.data.structure import StructureData
         import ase
 
-        aseatoms = ase.Atoms('Si4', cell=(10, 10, 10),
-                             pbc=(True, True, True))
-        aseatoms.set_scaled_positions(
-            ((0.0, 0.0, 0.0),
-             (0.1, 0.1, 0.1),
-             (0.2, 0.2, 0.2),
-             (0.3, 0.3, 0.3),
-             )
-        )
+        aseatoms = ase.Atoms('Si4', cell=(10, 10, 10), pbc=(True, True, True))
+        aseatoms.set_scaled_positions((
+            (0.0, 0.0, 0.0),
+            (0.1, 0.1, 0.1),
+            (0.2, 0.2, 0.2),
+            (0.3, 0.3, 0.3),
+        ))
 
         a_struct = StructureData(ase=aseatoms)
         p_mol = a_struct.get_pymatgen_molecule()
 
         p_mol_dict = p_mol.as_dict()
         self.assertEquals([x['xyz'] for x in p_mol_dict['sites']],
-                          [[0.0, 0.0, 0.0],
-                           [1.0, 1.0, 1.0],
-                           [2.0, 2.0, 2.0],
-                           [3.0, 3.0, 3.0]])
+                          [[0.0, 0.0, 0.0], [1.0, 1.0, 1.0], [2.0, 2.0, 2.0], [3.0, 3.0, 3.0]])
 
     @unittest.skipIf(not has_pymatgen(), "Unable to import pymatgen")
     def test_roundtrip(self):
@@ -2773,22 +2606,22 @@ class TestPymatgenFromStructureData(AiidaTestCase):
         """
         from aiida.orm.data.structure import StructureData
 
-        a = StructureData(cell=[[5.6,0,0],[0,5.6,0],[0,0,5.6]])
-        a.append_atom(position=(0,0,0), symbols='Cl')
-        a.append_atom(position=(2.8,0,2.8), symbols='Cl')
-        a.append_atom(position=(0,2.8,2.8), symbols='Cl')
-        a.append_atom(position=(2.8,2.8,0), symbols='Cl')
-        a.append_atom(position=(2.8,2.8,2.8), symbols='Na')
-        a.append_atom(position=(2.8,0,0), symbols='Na')
-        a.append_atom(position=(0,2.8,0), symbols='Na')
-        a.append_atom(position=(0,0,2.8), symbols='Na')
-        
+        a = StructureData(cell=[[5.6, 0, 0], [0, 5.6, 0], [0, 0, 5.6]])
+        a.append_atom(position=(0, 0, 0), symbols='Cl')
+        a.append_atom(position=(2.8, 0, 2.8), symbols='Cl')
+        a.append_atom(position=(0, 2.8, 2.8), symbols='Cl')
+        a.append_atom(position=(2.8, 2.8, 0), symbols='Cl')
+        a.append_atom(position=(2.8, 2.8, 2.8), symbols='Na')
+        a.append_atom(position=(2.8, 0, 0), symbols='Na')
+        a.append_atom(position=(0, 2.8, 0), symbols='Na')
+        a.append_atom(position=(0, 0, 2.8), symbols='Na')
+
         b = a.get_pymatgen()
         c = StructureData(pymatgen=b)
-        self.assertEquals(c.get_site_kindnames(), ['Cl','Cl','Cl','Cl','Na','Na','Na','Na'])
-        self.assertEquals([k.symbol for k in c.kinds], ['Cl','Na'])
-        self.assertEquals([s.position for s in c.sites],
-                          [(0.,0.,0.),(2.8,0,2.8),(0,2.8,2.8),(2.8,2.8,0),(2.8,2.8,2.8),(2.8,0,0),(0,2.8,0),(0,0,2.8)])
+        self.assertEquals(c.get_site_kindnames(), ['Cl', 'Cl', 'Cl', 'Cl', 'Na', 'Na', 'Na', 'Na'])
+        self.assertEquals([k.symbol for k in c.kinds], ['Cl', 'Na'])
+        self.assertEquals([s.position for s in c.sites], [(0., 0., 0.), (2.8, 0, 2.8), (0, 2.8, 2.8), (2.8, 2.8, 0),
+                                                          (2.8, 2.8, 2.8), (2.8, 0, 0), (0, 2.8, 0), (0, 0, 2.8)])
 
     @unittest.skipIf(not has_pymatgen(), "Unable to import pymatgen")
     def test_roundtrip_kindnames(self):
@@ -2798,25 +2631,25 @@ class TestPymatgenFromStructureData(AiidaTestCase):
         """
         from aiida.orm.data.structure import StructureData
 
-        a = StructureData(cell=[[5.6,0,0],[0,5.6,0],[0,0,5.6]])
-        a.append_atom(position=(0,0,0), symbols='Cl',name='Cl')
-        a.append_atom(position=(2.8,0,2.8), symbols='Cl',name='Cl10')
-        a.append_atom(position=(0,2.8,2.8), symbols='Cl',name='Cla')
-        a.append_atom(position=(2.8,2.8,0), symbols='Cl',name='cl_x')
-        a.append_atom(position=(2.8,2.8,2.8), symbols='Na',name='Na1')
-        a.append_atom(position=(2.8,0,0), symbols='Na',name='Na2')
-        a.append_atom(position=(0,2.8,0), symbols='Na',name='Na_Na')
-        a.append_atom(position=(0,0,2.8), symbols='Na',name='Na4')
-        
+        a = StructureData(cell=[[5.6, 0, 0], [0, 5.6, 0], [0, 0, 5.6]])
+        a.append_atom(position=(0, 0, 0), symbols='Cl', name='Cl')
+        a.append_atom(position=(2.8, 0, 2.8), symbols='Cl', name='Cl10')
+        a.append_atom(position=(0, 2.8, 2.8), symbols='Cl', name='Cla')
+        a.append_atom(position=(2.8, 2.8, 0), symbols='Cl', name='cl_x')
+        a.append_atom(position=(2.8, 2.8, 2.8), symbols='Na', name='Na1')
+        a.append_atom(position=(2.8, 0, 0), symbols='Na', name='Na2')
+        a.append_atom(position=(0, 2.8, 0), symbols='Na', name='Na_Na')
+        a.append_atom(position=(0, 0, 2.8), symbols='Na', name='Na4')
+
         b = a.get_pymatgen()
         self.assertEquals([site.properties['kind_name'] for site in b.sites],
-                         ['Cl','Cl10','Cla','cl_x','Na1','Na2','Na_Na','Na4'])
-        
+                          ['Cl', 'Cl10', 'Cla', 'cl_x', 'Na1', 'Na2', 'Na_Na', 'Na4'])
+
         c = StructureData(pymatgen=b)
-        self.assertEquals(c.get_site_kindnames(), ['Cl','Cl10','Cla','cl_x','Na1','Na2','Na_Na','Na4'])
-        self.assertEquals(c.get_symbols_set(), set(['Cl','Na']))
-        self.assertEquals([s.position for s in c.sites],
-                          [(0.,0.,0.),(2.8,0,2.8),(0,2.8,2.8),(2.8,2.8,0),(2.8,2.8,2.8),(2.8,0,0),(0,2.8,0),(0,0,2.8)])
+        self.assertEquals(c.get_site_kindnames(), ['Cl', 'Cl10', 'Cla', 'cl_x', 'Na1', 'Na2', 'Na_Na', 'Na4'])
+        self.assertEquals(c.get_symbols_set(), set(['Cl', 'Na']))
+        self.assertEquals([s.position for s in c.sites], [(0., 0., 0.), (2.8, 0, 2.8), (0, 2.8, 2.8), (2.8, 2.8, 0),
+                                                          (2.8, 2.8, 2.8), (2.8, 0, 0), (0, 2.8, 0), (0, 0, 2.8)])
 
     @unittest.skipIf(not has_pymatgen(), "Unable to import pymatgen")
     def test_roundtrip_spins(self):
@@ -2826,26 +2659,25 @@ class TestPymatgenFromStructureData(AiidaTestCase):
         """
         from aiida.orm.data.structure import StructureData
 
-        a = StructureData(cell=[[5.6,0,0],[0,5.6,0],[0,0,5.6]])
-        a.append_atom(position=(0,0,0), symbols='Mn',name='Mn1')
-        a.append_atom(position=(2.8,0,2.8), symbols='Mn',name='Mn1')
-        a.append_atom(position=(0,2.8,2.8), symbols='Mn',name='Mn1')
-        a.append_atom(position=(2.8,2.8,0), symbols='Mn',name='Mn1')
-        a.append_atom(position=(2.8,2.8,2.8), symbols='Mn',name='Mn2')
-        a.append_atom(position=(2.8,0,0), symbols='Mn',name='Mn2')
-        a.append_atom(position=(0,2.8,0), symbols='Mn',name='Mn2')
-        a.append_atom(position=(0,0,2.8), symbols='Mn',name='Mn2')
-        
+        a = StructureData(cell=[[5.6, 0, 0], [0, 5.6, 0], [0, 0, 5.6]])
+        a.append_atom(position=(0, 0, 0), symbols='Mn', name='Mn1')
+        a.append_atom(position=(2.8, 0, 2.8), symbols='Mn', name='Mn1')
+        a.append_atom(position=(0, 2.8, 2.8), symbols='Mn', name='Mn1')
+        a.append_atom(position=(2.8, 2.8, 0), symbols='Mn', name='Mn1')
+        a.append_atom(position=(2.8, 2.8, 2.8), symbols='Mn', name='Mn2')
+        a.append_atom(position=(2.8, 0, 0), symbols='Mn', name='Mn2')
+        a.append_atom(position=(0, 2.8, 0), symbols='Mn', name='Mn2')
+        a.append_atom(position=(0, 0, 2.8), symbols='Mn', name='Mn2')
+
         b = a.get_pymatgen(add_spin=True)
         # check the spins
-        self.assertEquals([s.as_dict()['properties']['spin'] for s in b.species],
-                          [-1, -1, -1, -1, 1, 1, 1, 1])
+        self.assertEquals([s.as_dict()['properties']['spin'] for s in b.species], [-1, -1, -1, -1, 1, 1, 1, 1])
         # back to StructureData
         c = StructureData(pymatgen=b)
-        self.assertEquals(c.get_site_kindnames(), ['Mn1','Mn1','Mn1','Mn1','Mn2','Mn2','Mn2','Mn2'])
-        self.assertEquals([k.symbol for k in c.kinds], ['Mn','Mn'])
-        self.assertEquals([s.position for s in c.sites],
-                          [(0.,0.,0.),(2.8,0,2.8),(0,2.8,2.8),(2.8,2.8,0),(2.8,2.8,2.8),(2.8,0,0),(0,2.8,0),(0,0,2.8)])
+        self.assertEquals(c.get_site_kindnames(), ['Mn1', 'Mn1', 'Mn1', 'Mn1', 'Mn2', 'Mn2', 'Mn2', 'Mn2'])
+        self.assertEquals([k.symbol for k in c.kinds], ['Mn', 'Mn'])
+        self.assertEquals([s.position for s in c.sites], [(0., 0., 0.), (2.8, 0, 2.8), (0, 2.8, 2.8), (2.8, 2.8, 0),
+                                                          (2.8, 2.8, 2.8), (2.8, 0, 0), (0, 2.8, 0), (0, 0, 2.8)])
 
     @unittest.skipIf(not has_pymatgen(), "Unable to import pymatgen")
     def test_roundtrip_partial_occ(self):
@@ -2855,57 +2687,65 @@ class TestPymatgenFromStructureData(AiidaTestCase):
         """
         from aiida.orm.data.structure import StructureData
 
-        a = StructureData(cell=[[4.0, 0.0, 0.0],
-                                [-2., 3.5, 0.0],
-                                [0.0, 0.0, 16.]])
-        a.append_atom(position=(0.0,0.0,13.5), symbols='Mn')
-        a.append_atom(position=(0.0,0.0,2.6), symbols='Mn')
-        a.append_atom(position=(0.0,0.0,5.5), symbols='Mn')
-        a.append_atom(position=(0.0,0.0,11.), symbols='Mn')
-        a.append_atom(position=(2.,1.,12.), symbols='Mn',weights=0.8)
-        a.append_atom(position=(0.0,2.2,4.), symbols='Mn',weights=0.8)
-        a.append_atom(position=(0.0,2.2,12.),symbols='Si')
-        a.append_atom(position=(2.,1.,4.),symbols='Si')
-        a.append_atom(position=(2.,1.,15.),symbols='N')
-        a.append_atom(position=(0.0,2.2,1.5),symbols='N')
-        a.append_atom(position=(0.0,2.2,7.),symbols='N')
-        a.append_atom(position=(2.,1.,9.5),symbols='N')
-        
+        a = StructureData(cell=[[4.0, 0.0, 0.0], [-2., 3.5, 0.0], [0.0, 0.0, 16.]])
+        a.append_atom(position=(0.0, 0.0, 13.5), symbols='Mn')
+        a.append_atom(position=(0.0, 0.0, 2.6), symbols='Mn')
+        a.append_atom(position=(0.0, 0.0, 5.5), symbols='Mn')
+        a.append_atom(position=(0.0, 0.0, 11.), symbols='Mn')
+        a.append_atom(position=(2., 1., 12.), symbols='Mn', weights=0.8)
+        a.append_atom(position=(0.0, 2.2, 4.), symbols='Mn', weights=0.8)
+        a.append_atom(position=(0.0, 2.2, 12.), symbols='Si')
+        a.append_atom(position=(2., 1., 4.), symbols='Si')
+        a.append_atom(position=(2., 1., 15.), symbols='N')
+        a.append_atom(position=(0.0, 2.2, 1.5), symbols='N')
+        a.append_atom(position=(0.0, 2.2, 7.), symbols='N')
+        a.append_atom(position=(2., 1., 9.5), symbols='N')
+
         # a few checks on the structure kinds and symbols
-        self.assertEquals(a.get_symbols_set(),set(['Mn', 'Si', 'N']))
+        self.assertEquals(a.get_symbols_set(), set(['Mn', 'Si', 'N']))
         self.assertEquals(a.get_site_kindnames(),
-                          ['Mn','Mn','Mn','Mn','MnX','MnX','Si','Si','N','N','N','N'])
-        self.assertEquals(a.get_formula(),'Mn4N4Si2{Mn0.80X0.20}2')
-        
+                          ['Mn', 'Mn', 'Mn', 'Mn', 'MnX', 'MnX', 'Si', 'Si', 'N', 'N', 'N', 'N'])
+        self.assertEquals(a.get_formula(), 'Mn4N4Si2{Mn0.80X0.20}2')
+
         b = a.get_pymatgen()
         # check the partial occupancies
-        self.assertEquals([s.as_dict() for s in b.species_and_occu],
-                          [{'Mn':1.0},{'Mn':1.0},{'Mn':1.0},{'Mn':1.0},
-                           {'Mn':0.8},{'Mn':0.8},{'Si':1.0},{'Si':1.0},
-                           {'N':1.0},{'N':1.0},{'N':1.0},{'N':1.0}])
-                           
+        self.assertEquals([s.as_dict() for s in b.species_and_occu], [{
+            'Mn': 1.0
+        }, {
+            'Mn': 1.0
+        }, {
+            'Mn': 1.0
+        }, {
+            'Mn': 1.0
+        }, {
+            'Mn': 0.8
+        }, {
+            'Mn': 0.8
+        }, {
+            'Si': 1.0
+        }, {
+            'Si': 1.0
+        }, {
+            'N': 1.0
+        }, {
+            'N': 1.0
+        }, {
+            'N': 1.0
+        }, {
+            'N': 1.0
+        }])
+
         # back to StructureData
         c = StructureData(pymatgen=b)
-        self.assertEquals(c.cell,[[4., 0.0, 0.0],
-                                  [-2., 3.5, 0.0],
-                                  [0.0, 0.0, 16.]])
-        self.assertEquals(c.get_symbols_set(),set(['Mn', 'Si', 'N']))
+        self.assertEquals(c.cell, [[4., 0.0, 0.0], [-2., 3.5, 0.0], [0.0, 0.0, 16.]])
+        self.assertEquals(c.get_symbols_set(), set(['Mn', 'Si', 'N']))
         self.assertEquals(c.get_site_kindnames(),
-                          ['Mn','Mn','Mn','Mn','MnX','MnX','Si','Si','N','N','N','N'])
-        self.assertEquals(c.get_formula(),'Mn4N4Si2{Mn0.80X0.20}2')
+                          ['Mn', 'Mn', 'Mn', 'Mn', 'MnX', 'MnX', 'Si', 'Si', 'N', 'N', 'N', 'N'])
+        self.assertEquals(c.get_formula(), 'Mn4N4Si2{Mn0.80X0.20}2')
         self.assertEquals([s.position for s in c.sites],
-                          [(0.0, 0.0, 13.5),
-                           (0.0, 0.0, 2.6),
-                           (0.0, 0.0, 5.5),
-                           (0.0, 0.0, 11.),
-                           (2., 1., 12.),
-                           (0.0, 2.2, 4.),
-                           (0.0, 2.2, 12.),
-                           (2., 1., 4.),
-                           (2., 1., 15.),
-                           (0.0, 2.2, 1.5),
-                           (0.0, 2.2, 7.),
-                           (2., 1., 9.5)])
+                          [(0.0, 0.0, 13.5), (0.0, 0.0, 2.6), (0.0, 0.0, 5.5), (0.0, 0.0, 11.), (2., 1., 12.),
+                           (0.0, 2.2, 4.), (0.0, 2.2, 12.), (2., 1., 4.), (2., 1., 15.), (0.0, 2.2, 1.5),
+                           (0.0, 2.2, 7.), (2., 1., 9.5)])
 
     @unittest.skipIf(not has_pymatgen(), "Unable to import pymatgen")
     def test_partial_occ_and_spin(self):
@@ -2914,33 +2754,33 @@ class TestPymatgenFromStructureData(AiidaTestCase):
         This should raise a ValueError.
         """
         from aiida.orm.data.structure import StructureData
-        
-        a = StructureData(cell=[[4,0,0],[0,4,0],[0,0,4]])
-        a.append_atom(position=(0,0,0), symbols=('Fe','Al'),weights=(0.8,0.2),name='FeAl1')
-        a.append_atom(position=(2,2,2), symbols=('Fe','Al'),weights=(0.8,0.2),name='FeAl2')
-        
+
+        a = StructureData(cell=[[4, 0, 0], [0, 4, 0], [0, 0, 4]])
+        a.append_atom(position=(0, 0, 0), symbols=('Fe', 'Al'), weights=(0.8, 0.2), name='FeAl1')
+        a.append_atom(position=(2, 2, 2), symbols=('Fe', 'Al'), weights=(0.8, 0.2), name='FeAl2')
+
         # a few checks on the structure kinds and symbols
-        self.assertEquals(a.get_symbols_set(),set(['Fe', 'Al']))
-        self.assertEquals(a.get_site_kindnames(),['FeAl1','FeAl2'])
-        self.assertEquals(a.get_formula(),'{Al0.20Fe0.80}2')
-        
-        with self.assertRaises(ValueError): 
+        self.assertEquals(a.get_symbols_set(), set(['Fe', 'Al']))
+        self.assertEquals(a.get_site_kindnames(), ['FeAl1', 'FeAl2'])
+        self.assertEquals(a.get_formula(), '{Al0.20Fe0.80}2')
+
+        with self.assertRaises(ValueError):
             a.get_pymatgen(add_spin=True)
-        
+
         # same, with vacancies
-        a = StructureData(cell=[[4,0,0],[0,4,0],[0,0,4]])
-        a.append_atom(position=(0,0,0), symbols='Fe',weights=0.8,name='FeX1')
-        a.append_atom(position=(2,2,2), symbols='Fe',weights=0.8,name='FeX2')
-        
+        a = StructureData(cell=[[4, 0, 0], [0, 4, 0], [0, 0, 4]])
+        a.append_atom(position=(0, 0, 0), symbols='Fe', weights=0.8, name='FeX1')
+        a.append_atom(position=(2, 2, 2), symbols='Fe', weights=0.8, name='FeX2')
+
         # a few checks on the structure kinds and symbols
-        self.assertEquals(a.get_symbols_set(),set(['Fe']))
-        self.assertEquals(a.get_site_kindnames(),['FeX1','FeX2'])
-        self.assertEquals(a.get_formula(),'{Fe0.80X0.20}2')
-        
-        with self.assertRaises(ValueError): 
+        self.assertEquals(a.get_symbols_set(), set(['Fe']))
+        self.assertEquals(a.get_site_kindnames(), ['FeX1', 'FeX2'])
+        self.assertEquals(a.get_formula(), '{Fe0.80X0.20}2')
+
+        with self.assertRaises(ValueError):
             a.get_pymatgen(add_spin=True)
-        
-        
+
+
 class TestArrayData(AiidaTestCase):
     """
     Tests the ArrayData objects.
@@ -2966,8 +2806,7 @@ class TestArrayData(AiidaTestCase):
         n.set_array('third', third)
 
         # Check if the arrays are there
-        self.assertEquals(set(['first', 'second', 'third']),
-                          set(n.arraynames()))
+        self.assertEquals(set(['first', 'second', 'third']), set(n.arraynames()))
         self.assertAlmostEquals(abs(first - n.get_array('first')).max(), 0.)
         self.assertAlmostEquals(abs(second - n.get_array('second')).max(), 0.)
         self.assertAlmostEquals(abs(third - n.get_array('third')).max(), 0.)
@@ -3085,33 +2924,40 @@ class TestTrajectoryData(AiidaTestCase):
         # I create sample data
         stepids = numpy.array([60, 70])
         times = stepids * 0.01
-        cells = numpy.array([
-            [[2., 0., 0., ],
-             [0., 2., 0., ],
-             [0., 0., 2., ]],
-            [[3., 0., 0., ],
-             [0., 3., 0., ],
-             [0., 0., 3., ]]])
+        cells = numpy.array([[[
+            2.,
+            0.,
+            0.,
+        ], [
+            0.,
+            2.,
+            0.,
+        ], [
+            0.,
+            0.,
+            2.,
+        ]], [[
+            3.,
+            0.,
+            0.,
+        ], [
+            0.,
+            3.,
+            0.,
+        ], [
+            0.,
+            0.,
+            3.,
+        ]]])
         symbols = numpy.array(['H', 'O', 'C'])
-        positions = numpy.array([
-            [[0., 0., 0.],
-             [0.5, 0.5, 0.5],
-             [1.5, 1.5, 1.5]],
-            [[0., 0., 0.],
-             [0.5, 0.5, 0.5],
-             [1.5, 1.5, 1.5]]])
-        velocities = numpy.array([
-            [[0., 0., 0.],
-             [0., 0., 0.],
-             [0., 0., 0.]],
-            [[0.5, 0.5, 0.5],
-             [0.5, 0.5, 0.5],
-             [-0.5, -0.5, -0.5]]])
+        positions = numpy.array([[[0., 0., 0.], [0.5, 0.5, 0.5], [1.5, 1.5, 1.5]], [[0., 0., 0.], [0.5, 0.5, 0.5],
+                                                                                    [1.5, 1.5, 1.5]]])
+        velocities = numpy.array([[[0., 0., 0.], [0., 0., 0.], [0., 0., 0.]], [[0.5, 0.5, 0.5], [0.5, 0.5, 0.5],
+                                                                               [-0.5, -0.5, -0.5]]])
 
         # I set the node
-        n.set_trajectory(stepids=stepids, cells=cells, symbols=symbols,
-                         positions=positions, times=times,
-                         velocities=velocities)
+        n.set_trajectory(
+            stepids=stepids, cells=cells, symbols=symbols, positions=positions, times=times, velocities=velocities)
 
         # Generic checks
         self.assertEqual(n.numsites, 3)
@@ -3140,8 +2986,7 @@ class TestTrajectoryData(AiidaTestCase):
 
         ########################################################
         # I set the node, this time without times or velocities (the same node)
-        n.set_trajectory(stepids=stepids, cells=cells, symbols=symbols,
-                         positions=positions)
+        n.set_trajectory(stepids=stepids, cells=cells, symbols=symbols, positions=positions)
         # Generic checks
         self.assertEqual(n.numsites, 3)
         self.assertEqual(n.numsteps, 2)
@@ -3154,8 +2999,7 @@ class TestTrajectoryData(AiidaTestCase):
 
         # Same thing, but for a new node
         n = TrajectoryData()
-        n.set_trajectory(stepids=stepids, cells=cells, symbols=symbols,
-                         positions=positions)
+        n.set_trajectory(stepids=stepids, cells=cells, symbols=symbols, positions=positions)
         # Generic checks
         self.assertEqual(n.numsites, 3)
         self.assertEqual(n.numsteps, 2)
@@ -3168,8 +3012,7 @@ class TestTrajectoryData(AiidaTestCase):
 
         ########################################################
         # I set the node, this time without velocities (the same node)
-        n.set_trajectory(stepids=stepids, cells=cells, symbols=symbols,
-                         positions=positions, times=times)
+        n.set_trajectory(stepids=stepids, cells=cells, symbols=symbols, positions=positions, times=times)
         # Generic checks
         self.assertEqual(n.numsites, 3)
         self.assertEqual(n.numsteps, 2)
@@ -3182,8 +3025,7 @@ class TestTrajectoryData(AiidaTestCase):
 
         # Same thing, but for a new node
         n = TrajectoryData()
-        n.set_trajectory(stepids=stepids, cells=cells, symbols=symbols,
-                         positions=positions, times=times)
+        n.set_trajectory(stepids=stepids, cells=cells, symbols=symbols, positions=positions, times=times)
         # Generic checks
         self.assertEqual(n.numsites, 3)
         self.assertEqual(n.numsteps, 2)
@@ -3264,41 +3106,47 @@ class TestTrajectoryData(AiidaTestCase):
         # I create sample data
         stepids = numpy.array([60, 70])
         times = stepids * 0.01
-        cells = numpy.array([
-            [[2., 0., 0., ],
-             [0., 2., 0., ],
-             [0., 0., 2., ]],
-            [[3., 0., 0., ],
-             [0., 3., 0., ],
-             [0., 0., 3., ]]])
+        cells = numpy.array([[[
+            2.,
+            0.,
+            0.,
+        ], [
+            0.,
+            2.,
+            0.,
+        ], [
+            0.,
+            0.,
+            2.,
+        ]], [[
+            3.,
+            0.,
+            0.,
+        ], [
+            0.,
+            3.,
+            0.,
+        ], [
+            0.,
+            0.,
+            3.,
+        ]]])
         symbols = numpy.array(['H', 'O', 'C'])
-        positions = numpy.array([
-            [[0., 0., 0.],
-             [0.5, 0.5, 0.5],
-             [1.5, 1.5, 1.5]],
-            [[0., 0., 0.],
-             [0.5, 0.5, 0.5],
-             [1.5, 1.5, 1.5]]])
-        velocities = numpy.array([
-            [[0., 0., 0.],
-             [0., 0., 0.],
-             [0., 0., 0.]],
-            [[0.5, 0.5, 0.5],
-             [0.5, 0.5, 0.5],
-             [-0.5, -0.5, -0.5]]])
+        positions = numpy.array([[[0., 0., 0.], [0.5, 0.5, 0.5], [1.5, 1.5, 1.5]], [[0., 0., 0.], [0.5, 0.5, 0.5],
+                                                                                    [1.5, 1.5, 1.5]]])
+        velocities = numpy.array([[[0., 0., 0.], [0., 0., 0.], [0., 0., 0.]], [[0.5, 0.5, 0.5], [0.5, 0.5, 0.5],
+                                                                               [-0.5, -0.5, -0.5]]])
 
         # I set the node
-        n.set_trajectory(stepids=stepids, cells=cells, symbols=symbols,
-                         positions=positions, times=times,
-                         velocities=velocities)
+        n.set_trajectory(
+            stepids=stepids, cells=cells, symbols=symbols, positions=positions, times=times, velocities=velocities)
 
         from_step = n.get_step_structure(1)
         from_get_aiida_structure = n._get_aiida_structure(index=1)
 
         for struc in [from_step, from_get_aiida_structure]:
             self.assertEqual(len(struc.sites), 3)  # 3 sites
-            self.assertAlmostEqual(
-                abs(numpy.array(struc.cell) - cells[1]).sum(), 0)
+            self.assertAlmostEqual(abs(numpy.array(struc.cell) - cells[1]).sum(), 0)
             newpos = numpy.array([s.position for s in struc.sites])
             self.assertAlmostEqual(abs(newpos - positions[1]).sum(), 0)
             newkinds = [s.kind_name for s in struc.sites]
@@ -3332,20 +3180,17 @@ class TestTrajectoryData(AiidaTestCase):
 
             # Checks
             self.assertEqual(len(struc.sites), 3)  # 3 sites
-            self.assertAlmostEqual(
-                abs(numpy.array(struc.cell) - cells[1]).sum(), 0)
+            self.assertAlmostEqual(abs(numpy.array(struc.cell) - cells[1]).sum(), 0)
             newpos = numpy.array([s.position for s in struc.sites])
             self.assertAlmostEqual(abs(newpos - positions[1]).sum(), 0)
             newkinds = [s.kind_name for s in struc.sites]
             # Kinds are in the same order as given in the custm_kinds list
             self.assertEqual(newkinds, symbols.tolist())
-            newatomtypes = [struc.get_kind(s.kind_name).symbols[0] for s in
-                            struc.sites]
+            newatomtypes = [struc.get_kind(s.kind_name).symbols[0] for s in struc.sites]
             # Atoms remain in the same order as given in the positions list
             self.assertEqual(newatomtypes, ['He', 'Os', 'Cu'])
             # Check the mass of the kind of the second atom ('O' _> symbol Os, mass 100)
-            self.assertAlmostEqual(
-                struc.get_kind(struc.sites[1].kind_name).mass, 100.)
+            self.assertAlmostEqual(struc.get_kind(struc.sites[1].kind_name).mass, 100.)
 
     def test_conversion_from_structurelist(self):
         """
@@ -3355,23 +3200,34 @@ class TestTrajectoryData(AiidaTestCase):
         from aiida.orm.data.structure import StructureData
         from aiida.orm.data.array.trajectory import TrajectoryData
 
-        cells = [
-            [[2., 0., 0., ],
-             [0., 2., 0., ],
-             [0., 0., 2., ]],
-            [[3., 0., 0., ],
-             [0., 3., 0., ],
-             [0., 0., 3., ]]
-        ]
+        cells = [[[
+            2.,
+            0.,
+            0.,
+        ], [
+            0.,
+            2.,
+            0.,
+        ], [
+            0.,
+            0.,
+            2.,
+        ]], [[
+            3.,
+            0.,
+            0.,
+        ], [
+            0.,
+            3.,
+            0.,
+        ], [
+            0.,
+            0.,
+            3.,
+        ]]]
         symbols = [['H', 'O', 'C'], ['H', 'O', 'C']]
-        positions = [
-            [[0., 0., 0.],
-             [0.5, 0.5, 0.5],
-             [1.5, 1.5, 1.5]],
-            [[0., 0., 0.],
-             [0.75, 0.75, 0.75],
-             [1.25, 1.25, 1.25]]
-        ]
+        positions = [[[0., 0., 0.], [0.5, 0.5, 0.5], [1.5, 1.5, 1.5]], [[0., 0., 0.], [0.75, 0.75, 0.75],
+                                                                        [1.25, 1.25, 1.25]]]
         structurelist = []
         for i in range(0, 2):
             struct = StructureData(cell=cells[i])
@@ -3410,42 +3266,48 @@ class TestTrajectoryData(AiidaTestCase):
         # I create sample data
         stepids = numpy.array([60, 70])
         times = stepids * 0.01
-        cells = numpy.array([
-            [[2., 0., 0., ],
-             [0., 2., 0., ],
-             [0., 0., 2., ]],
-            [[3., 0., 0., ],
-             [0., 3., 0., ],
-             [0., 0., 3., ]]])
+        cells = numpy.array([[[
+            2.,
+            0.,
+            0.,
+        ], [
+            0.,
+            2.,
+            0.,
+        ], [
+            0.,
+            0.,
+            2.,
+        ]], [[
+            3.,
+            0.,
+            0.,
+        ], [
+            0.,
+            3.,
+            0.,
+        ], [
+            0.,
+            0.,
+            3.,
+        ]]])
         symbols = numpy.array(['H', 'O', 'C'])
-        positions = numpy.array([
-            [[0., 0., 0.],
-             [0.5, 0.5, 0.5],
-             [1.5, 1.5, 1.5]],
-            [[0., 0., 0.],
-             [0.5, 0.5, 0.5],
-             [1.5, 1.5, 1.5]]])
-        velocities = numpy.array([
-            [[0., 0., 0.],
-             [0., 0., 0.],
-             [0., 0., 0.]],
-            [[0.5, 0.5, 0.5],
-             [0.5, 0.5, 0.5],
-             [-0.5, -0.5, -0.5]]])
+        positions = numpy.array([[[0., 0., 0.], [0.5, 0.5, 0.5], [1.5, 1.5, 1.5]], [[0., 0., 0.], [0.5, 0.5, 0.5],
+                                                                                    [1.5, 1.5, 1.5]]])
+        velocities = numpy.array([[[0., 0., 0.], [0., 0., 0.], [0., 0., 0.]], [[0.5, 0.5, 0.5], [0.5, 0.5, 0.5],
+                                                                               [-0.5, -0.5, -0.5]]])
 
         # I set the node
-        n.set_trajectory(stepids=stepids, cells=cells, symbols=symbols,
-                         positions=positions, times=times,
-                         velocities=velocities)
-
+        n.set_trajectory(
+            stepids=stepids, cells=cells, symbols=symbols, positions=positions, times=times, velocities=velocities)
 
         # define a cell
         alat = 4.
-        cell = numpy.array([[alat, 0., 0.],
-                            [0., alat, 0.],
-                            [0., 0., alat],
-                            ])
-
+        cell = numpy.array([
+            [alat, 0., 0.],
+            [0., alat, 0.],
+            [0., 0., alat],
+        ])
 
         # It is not obvious how to check that the bands are correct.
         # I just check, for a few formats, that the file is correctly
@@ -3461,11 +3323,11 @@ class TestTrajectoryData(AiidaTestCase):
         else:
             formats_to_test = ['xsf']
         for format in formats_to_test:
-            files_created = [] # In case there is an exception
+            files_created = []  # In case there is an exception
             try:
                 files_created = n.export(filename, fileformat=format)
-                with io.open(filename, encoding='utf8') as f:
-                    filedata = f.read()
+                with io.open(filename, encoding='utf8') as fhandle:
+                    filedata = fhandle.read()
             finally:
                 for file in files_created:
                     if os.path.exists(file):
@@ -3523,7 +3385,6 @@ class TestKpointsData(AiidaTestCase):
         kpoints_03.set_kpoints_path(format_03)
         kpoints_04.set_kpoints_path(format_04)
 
-
     def test_mesh(self):
         """
         Check the methods to set and retrieve a mesh.
@@ -3538,8 +3399,7 @@ class TestKpointsData(AiidaTestCase):
         k.set_kpoints_mesh(input_mesh)
         mesh, offset = k.get_kpoints_mesh()
         self.assertEqual(mesh, list(input_mesh))
-        self.assertEqual(offset,
-                         [0., 0., 0.])  # must be a tuple of three 0 by default
+        self.assertEqual(offset, [0., 0., 0.])  # must be a tuple of three 0 by default
 
         # a too long list should fail
         with self.assertRaises(ValueError):
@@ -3570,11 +3430,12 @@ class TestKpointsData(AiidaTestCase):
 
         k = KpointsData()
 
-        input_klist = numpy.array([(0.0, 0.0, 0.0),
-                                   (0.2, 0.0, 0.0),
-                                   (0.0, 0.2, 0.0),
-                                   (0.0, 0.0, 0.2),
-                                   ])
+        input_klist = numpy.array([
+            (0.0, 0.0, 0.0),
+            (0.2, 0.0, 0.0),
+            (0.0, 0.2, 0.0),
+            (0.0, 0.0, 0.2),
+        ])
 
         # set kpoints list
         k.set_kpoints(input_klist)
@@ -3619,18 +3480,20 @@ class TestKpointsData(AiidaTestCase):
 
         k = KpointsData()
 
-        input_klist = numpy.array([(0.0, 0.0, 0.0),
-                                   (0.2, 0.0, 0.0),
-                                   (0.0, 0.2, 0.0),
-                                   (0.0, 0.0, 0.2),
-                                   ])
+        input_klist = numpy.array([
+            (0.0, 0.0, 0.0),
+            (0.2, 0.0, 0.0),
+            (0.0, 0.2, 0.0),
+            (0.0, 0.0, 0.2),
+        ])
 
         # define a cell
         alat = 4.
-        cell = numpy.array([[alat, 0., 0.],
-                            [0., alat, 0.],
-                            [0., 0., alat],
-                            ])
+        cell = numpy.array([
+            [alat, 0., 0.],
+            [0., alat, 0.],
+            [0., 0., alat],
+        ])
 
         k.set_cell(cell)
 
@@ -3654,46 +3517,53 @@ class TestKpointsData(AiidaTestCase):
         """
         from aiida.orm.data.array.kpoints import KpointsData
         import numpy
-        
+
         k = KpointsData()
-        
+
         # shouldn't get anything wiothout having set the cell
         with self.assertRaises(ValueError):
             k.set_kpoints_path()
-        
+
         # define a cell
         alat = 4.
-        cell = numpy.array([[alat, 0., 0.],
-                            [0., alat, 0.],
-                            [0., 0., alat],
-                            ])
-        
+        cell = numpy.array([
+            [alat, 0., 0.],
+            [0., alat, 0.],
+            [0., 0., alat],
+        ])
+
         k.set_cell(cell)
         k.set_kpoints_path()
         # something should be retrieved
         klist = k.get_kpoints()
-        
+
         # test the various formats for specifying the path
-        k.set_kpoints_path([('G','M'),
-                            ])
-        k.set_kpoints_path([('G','M',30),
-                            ])
-        k.set_kpoints_path([('G',(0.,0.,0.),'M',(1.,1.,1.)),
-                            ])
-        k.set_kpoints_path([('G',(0.,0.,0.),'M',(1.,1.,1.),30),
-                            ])
+        k.set_kpoints_path([
+            ('G', 'M'),
+        ])
+        k.set_kpoints_path([
+            ('G', 'M', 30),
+        ])
+        k.set_kpoints_path([
+            ('G', (0., 0., 0.), 'M', (1., 1., 1.)),
+        ])
+        k.set_kpoints_path([
+            ('G', (0., 0., 0.), 'M', (1., 1., 1.), 30),
+        ])
 
         # at least 2 points per segment
         with self.assertRaises(ValueError):
-            k.set_kpoints_path([('G','M',1),
-                                ])
+            k.set_kpoints_path([
+                ('G', 'M', 1),
+            ])
         with self.assertRaises(ValueError):
-            k.set_kpoints_path([('G',(0.,0.,0.),'M',(1.,1.,1.),1),
-                                ])
-        
+            k.set_kpoints_path([
+                ('G', (0., 0., 0.), 'M', (1., 1., 1.), 1),
+            ])
+
         # try to set points with a spacing
         k.set_kpoints_path(kpoint_distance=0.1)
-        
+
         # try to modify after storage
         k.store()
         with self.assertRaises(ModificationNotAllowed):
@@ -3726,21 +3596,38 @@ class TestKpointsData(AiidaTestCase):
         structure = StructureData(cell=cell)
 
         # test the various formats for specifying the path
-        get_explicit_kpoints_path(structure, method='legacy', value=[('G','M'),])
-        get_explicit_kpoints_path(structure, method='legacy', value=[('G','M',30),])
-        get_explicit_kpoints_path(structure, method='legacy', value=[('G',(0.,0.,0.),'M',(1.,1.,1.)),])
-        get_explicit_kpoints_path(structure, method='legacy', value=[('G',(0.,0.,0.),'M',(1.,1.,1.),30),])
+        get_explicit_kpoints_path(
+            structure, method='legacy', value=[
+                ('G', 'M'),
+            ])
+        get_explicit_kpoints_path(
+            structure, method='legacy', value=[
+                ('G', 'M', 30),
+            ])
+        get_explicit_kpoints_path(
+            structure, method='legacy', value=[
+                ('G', (0., 0., 0.), 'M', (1., 1., 1.)),
+            ])
+        get_explicit_kpoints_path(
+            structure, method='legacy', value=[
+                ('G', (0., 0., 0.), 'M', (1., 1., 1.), 30),
+            ])
 
         # at least 2 points per segment
         with self.assertRaises(ValueError):
-            get_explicit_kpoints_path(structure, method='legacy', value=[('G','M',1),])
+            get_explicit_kpoints_path(
+                structure, method='legacy', value=[
+                    ('G', 'M', 1),
+                ])
 
         with self.assertRaises(ValueError):
-            get_explicit_kpoints_path(structure, method='legacy', value=[('G',(0.,0.,0.),'M',(1.,1.,1.),1),])
+            get_explicit_kpoints_path(
+                structure, method='legacy', value=[
+                    ('G', (0., 0., 0.), 'M', (1., 1., 1.), 1),
+                ])
 
         # try to set points with a spacing
         get_explicit_kpoints_path(structure, method='legacy', kpoint_distance=0.1)
-
 
     def test_tetra_x(self):
         """
@@ -3749,13 +3636,13 @@ class TestKpointsData(AiidaTestCase):
         import numpy
         from aiida.orm import DataFactory
         alat = 1.5
-        cell_x = [[alat,0,0],[0,1,0],[0,0,1]]
+        cell_x = [[alat, 0, 0], [0, 1, 0], [0, 0, 1]]
         K = DataFactory('array.kpoints')
         k = K()
         k.set_cell(cell_x)
         points = k.get_special_points(cartesian=True)
 
-        self.assertAlmostEqual(points[0]['Z'][0], numpy.pi/alat)
+        self.assertAlmostEqual(points[0]['Z'][0], numpy.pi / alat)
         self.assertAlmostEqual(points[0]['Z'][1], 0.)
 
     def test_tetra_z(self):
@@ -3765,13 +3652,13 @@ class TestKpointsData(AiidaTestCase):
         import numpy
         from aiida.orm import DataFactory
         alat = 1.5
-        cell_x = [[1,0,0],[0,1,0],[0,0,alat]]
+        cell_x = [[1, 0, 0], [0, 1, 0], [0, 0, alat]]
         K = DataFactory('array.kpoints')
         k = K()
         k.set_cell(cell_x)
         points = k.get_special_points(cartesian=True)
 
-        self.assertAlmostEqual(points[0]['Z'][2], numpy.pi/alat )
+        self.assertAlmostEqual(points[0]['Z'][2], numpy.pi / alat)
         self.assertAlmostEqual(points[0]['Z'][0], 0.)
 
     def test_tetra_z_wrapper_legacy(self):
@@ -3786,7 +3673,7 @@ class TestKpointsData(AiidaTestCase):
         from aiida.tools.data.array.kpoints import get_kpoints_path
 
         alat = 1.5
-        cell_x = [[1,0,0],[0,1,0],[0,0,alat]]
+        cell_x = [[1, 0, 0], [0, 1, 0], [0, 0, alat]]
         s = StructureData(cell=cell_x)
         result = get_kpoints_path(s, method='legacy', cartesian=True)
 
@@ -3795,7 +3682,7 @@ class TestKpointsData(AiidaTestCase):
         point_coords = result['parameters'].dict.point_coords
         path = result['parameters'].dict.path
 
-        self.assertAlmostEqual(point_coords['Z'][2], numpy.pi/alat )
+        self.assertAlmostEqual(point_coords['Z'][2], numpy.pi / alat)
         self.assertAlmostEqual(point_coords['Z'][0], 0.)
 
 
@@ -3810,9 +3697,8 @@ class TestSpglibTupleConversion(AiidaTestCase):
 
         cell = np.array([[4., 1., 0.], [0., 4., 0.], [0., 0., 4.]])
 
-        relcoords = np.array([[0.09493671, 0., 0.], [0.59493671, 0.5, 0.5],
-                              [0.59493671, 0.5, 0.], [0.59493671, 0., 0.5],
-                              [0.09493671, 0.5, 0.5]])
+        relcoords = np.array([[0.09493671, 0., 0.], [0.59493671, 0.5, 0.5], [0.59493671, 0.5, 0.],
+                              [0.59493671, 0., 0.5], [0.09493671, 0.5, 0.5]])
 
         abscoords = np.dot(cell.T, relcoords.T).T
 
@@ -3820,16 +3706,10 @@ class TestSpglibTupleConversion(AiidaTestCase):
 
         struc = spglib_tuple_to_structure((cell, relcoords, numbers))
 
+        self.assertAlmostEqual(np.sum(np.abs(np.array(struc.cell) - np.array(cell))), 0.)
         self.assertAlmostEqual(
-            np.sum(np.abs(np.array(struc.cell) - np.array(cell))), 0.)
-        self.assertAlmostEqual(
-            np.sum(
-                np.abs(
-                    np.array([site.position
-                              for site in struc.sites]) - np.array(abscoords))),
-            0.)
-        self.assertEqual([site.kind_name for site in struc.sites],
-                         ['Ba', 'Ti', 'O', 'O', 'O'])
+            np.sum(np.abs(np.array([site.position for site in struc.sites]) - np.array(abscoords))), 0.)
+        self.assertEqual([site.kind_name for site in struc.sites], ['Ba', 'Ti', 'O', 'O', 'O'])
 
     def test_complex1_to_aiida(self):
         """
@@ -3841,51 +3721,25 @@ class TestSpglibTupleConversion(AiidaTestCase):
 
         cell = np.array([[4., 1., 0.], [0., 4., 0.], [0., 0., 4.]])
 
-        relcoords = np.array([[0.09493671, 0., 0.], [0.59493671, 0.5, 0.5], [
-            0.59493671, 0.5, 0.
-        ], [0.59493671, 0., 0.5], [0.09493671, 0.5, 0.5],
-                              [0.09493671, 0.5, 0.5], [0.09493671, 0.5, 0.5],
-                              [0.09493671, 0.5, 0.5], [0.09493671, 0.5, 0.5]])
+        relcoords = np.array([[0.09493671, 0., 0.], [0.59493671, 0.5, 0.5], [0.59493671, 0.5, 0.],
+                              [0.59493671, 0., 0.5], [0.09493671, 0.5, 0.5], [0.09493671, 0.5, 0.5],
+                              [0.09493671, 0.5, 0.5], [0.09493671, 0.5, 0.5], [0.09493671, 0.5, 0.5]])
 
         abscoords = np.dot(cell.T, relcoords.T).T
 
         numbers = [56, 22, 8, 8, 8, 56000, 200000, 200001, 56001]
 
-        kind_info = {
-            'Ba': 56,
-            'Ba2': 56000,
-            'Ba3': 56001,
-            'BaTi': 200000,
-            'BaTi2': 200001,
-            'O': 8,
-            'Ti': 22
-        }
+        kind_info = {'Ba': 56, 'Ba2': 56000, 'Ba3': 56001, 'BaTi': 200000, 'BaTi2': 200001, 'O': 8, 'Ti': 22}
 
-        kind_info_wrong = {
-            'Ba': 56,
-            'Ba2': 56000,
-            'Ba3': 56002,
-            'BaTi': 200000,
-            'BaTi2': 200001,
-            'O': 8,
-            'Ti': 22
-        }
+        kind_info_wrong = {'Ba': 56, 'Ba2': 56000, 'Ba3': 56002, 'BaTi': 200000, 'BaTi2': 200001, 'O': 8, 'Ti': 22}
 
         kinds = [
             Kind(name='Ba', symbols="Ba"),
             Kind(name='Ti', symbols="Ti"),
             Kind(name='O', symbols="O"),
             Kind(name='Ba2', symbols="Ba", mass=100.),
-            Kind(
-                name='BaTi',
-                symbols=("Ba", "Ti"),
-                weights=(0.5, 0.5),
-                mass=100.),
-            Kind(
-                name='BaTi2',
-                symbols=("Ba", "Ti"),
-                weights=(0.4, 0.6),
-                mass=100.),
+            Kind(name='BaTi', symbols=("Ba", "Ti"), weights=(0.5, 0.5), mass=100.),
+            Kind(name='BaTi2', symbols=("Ba", "Ti"), weights=(0.4, 0.6), mass=100.),
             Kind(name='Ba3', symbols="Ba", mass=100.)
         ]
 
@@ -3894,54 +3748,31 @@ class TestSpglibTupleConversion(AiidaTestCase):
             Kind(name='Ti', symbols="Ti"),
             Kind(name='O', symbols="O"),
             Kind(name='Ba2', symbols="Ba", mass=100.),
-            Kind(
-                name='BaTi',
-                symbols=("Ba", "Ti"),
-                weights=(0.5, 0.5),
-                mass=100.),
-            Kind(
-                name='BaTi2',
-                symbols=("Ba", "Ti"),
-                weights=(0.4, 0.6),
-                mass=100.),
+            Kind(name='BaTi', symbols=("Ba", "Ti"), weights=(0.5, 0.5), mass=100.),
+            Kind(name='BaTi2', symbols=("Ba", "Ti"), weights=(0.4, 0.6), mass=100.),
             Kind(name='Ba4', symbols="Ba", mass=100.)
         ]
 
         # Must specify also kind_info and kinds
         with self.assertRaises(ValueError):
-            struc = spglib_tuple_to_structure(
-                (cell, relcoords, numbers),)
+            struc = spglib_tuple_to_structure((cell, relcoords, numbers),)
 
         # There is no kind_info for one of the numbers
         with self.assertRaises(ValueError):
-            struc = spglib_tuple_to_structure(
-                (cell, relcoords, numbers),
-                kind_info=kind_info_wrong,
-                kinds=kinds)
+            struc = spglib_tuple_to_structure((cell, relcoords, numbers), kind_info=kind_info_wrong, kinds=kinds)
 
         # There is no kind in the kinds for one of the labels
         # specified in kind_info
         with self.assertRaises(ValueError):
-            struc = spglib_tuple_to_structure(
-                (cell, relcoords, numbers),
-                kind_info=kind_info,
-                kinds=kinds_wrong)
+            struc = spglib_tuple_to_structure((cell, relcoords, numbers), kind_info=kind_info, kinds=kinds_wrong)
 
-        struc = spglib_tuple_to_structure(
-            (cell, relcoords, numbers), kind_info=kind_info, kinds=kinds)
+        struc = spglib_tuple_to_structure((cell, relcoords, numbers), kind_info=kind_info, kinds=kinds)
 
+        self.assertAlmostEqual(np.sum(np.abs(np.array(struc.cell) - np.array(cell))), 0.)
         self.assertAlmostEqual(
-            np.sum(np.abs(np.array(struc.cell) - np.array(cell))), 0.)
-        self.assertAlmostEqual(
-            np.sum(
-                np.abs(
-                    np.array([site.position
-                              for site in struc.sites]) - np.array(abscoords))),
-            0.)
-        self.assertEqual(
-            [site.kind_name for site in struc.sites],
-            ['Ba', 'Ti', 'O', 'O', 'O', 'Ba2', 'BaTi', 'BaTi2', 'Ba3'])
-
+            np.sum(np.abs(np.array([site.position for site in struc.sites]) - np.array(abscoords))), 0.)
+        self.assertEqual([site.kind_name for site in struc.sites],
+                         ['Ba', 'Ti', 'O', 'O', 'O', 'Ba2', 'BaTi', 'BaTi2', 'Ba3'])
 
     def test_from_aiida(self):
         """
@@ -3959,12 +3790,7 @@ class TestSpglibTupleConversion(AiidaTestCase):
         struc.append_atom(symbols='O', position=(-1, -2, -4))
         struc.append_kind(Kind(name='Ba2', symbols="Ba", mass=100.))
         struc.append_site(Site(kind_name='Ba2', position=[3, 2, 1]))
-        struc.append_kind(
-            Kind(
-                name='Test',
-                symbols=["Ba", "Ti"],
-                weights=[0.2, 0.4],
-                mass=120.))
+        struc.append_kind(Kind(name='Test', symbols=["Ba", "Ti"], weights=[0.2, 0.4], mass=120.))
         struc.append_site(Site(kind_name='Test', position=[3, 5, 1]))
 
         struc_tuple, kind_info, kinds = structure_to_spglib_tuple(struc)
@@ -3972,10 +3798,8 @@ class TestSpglibTupleConversion(AiidaTestCase):
         abscoords = np.array([_.position for _ in struc.sites])
         struc_relpos = np.dot(np.linalg.inv(cell.T), abscoords.T).T
 
-        self.assertAlmostEqual(
-            np.sum(np.abs(np.array(struc.cell) - np.array(struc_tuple[0]))), 0.)
-        self.assertAlmostEqual(
-            np.sum(np.abs(np.array(struc_tuple[1]) - struc_relpos)), 0.)
+        self.assertAlmostEqual(np.sum(np.abs(np.array(struc.cell) - np.array(struc_tuple[0]))), 0.)
+        self.assertAlmostEqual(np.sum(np.abs(np.array(struc_tuple[1]) - struc_relpos)), 0.)
 
         expected_kind_info = [kind_info[site.kind_name] for site in struc.sites]
         self.assertEqual(struc_tuple[2], expected_kind_info)
@@ -3996,30 +3820,20 @@ class TestSpglibTupleConversion(AiidaTestCase):
         struc.append_atom(symbols='O', position=(-1, -2, -4))
         struc.append_kind(Kind(name='Ba2', symbols="Ba", mass=100.))
         struc.append_site(Site(kind_name='Ba2', position=[3, 2, 1]))
-        struc.append_kind(
-            Kind(
-                name='Test',
-                symbols=["Ba", "Ti"],
-                weights=[0.2, 0.4],
-                mass=120.))
+        struc.append_kind(Kind(name='Test', symbols=["Ba", "Ti"], weights=[0.2, 0.4], mass=120.))
         struc.append_site(Site(kind_name='Test', position=[3, 5, 1]))
 
         struc_tuple, kind_info, kinds = structure_to_spglib_tuple(struc)
         roundtrip_struc = spglib_tuple_to_structure(struc_tuple, kind_info, kinds)
 
-        self.assertAlmostEqual(
-            np.sum(
-                np.abs(np.array(struc.cell) - np.array(roundtrip_struc.cell))),
-            0.)
-        self.assertEqual(
-            struc.get_attr('kinds'), roundtrip_struc.get_attr('kinds'))
-        self.assertEqual([_.kind_name for _ in struc.sites],
-                         [_.kind_name for _ in roundtrip_struc.sites])
+        self.assertAlmostEqual(np.sum(np.abs(np.array(struc.cell) - np.array(roundtrip_struc.cell))), 0.)
+        self.assertEqual(struc.get_attr('kinds'), roundtrip_struc.get_attr('kinds'))
+        self.assertEqual([_.kind_name for _ in struc.sites], [_.kind_name for _ in roundtrip_struc.sites])
         self.assertEqual(
             np.sum(
                 np.abs(
-                    np.array([_.position for _ in struc.sites]) -
-                    np.array([_.position for _ in roundtrip_struc.sites]))), 0.)
+                    np.array([_.position for _ in struc.sites]) - np.array([_.position
+                                                                            for _ in roundtrip_struc.sites]))), 0.)
 
 
 class TestSeekpathExplicitPath(AiidaTestCase):
@@ -4031,20 +3845,14 @@ class TestSeekpathExplicitPath(AiidaTestCase):
 
         from aiida.tools import get_explicit_kpoints_path
 
-        structure = DataFactory('structure')(
-            cell=[[4, 0, 0], [0, 4, 0], [0, 0, 6]])
+        structure = DataFactory('structure')(cell=[[4, 0, 0], [0, 4, 0], [0, 0, 6]])
         structure.append_atom(symbols='Ba', position=[0, 0, 0])
         structure.append_atom(symbols='Ti', position=[2, 2, 3])
         structure.append_atom(symbols='O', position=[2, 2, 0])
         structure.append_atom(symbols='O', position=[2, 0, 3])
         structure.append_atom(symbols='O', position=[0, 2, 3])
 
-        params = {
-            'with_time_reversal': True,
-            'reference_distance': 0.025,
-            'recipe': 'hpkot',
-            'threshold': 1.e-7
-        }
+        params = {'with_time_reversal': True, 'reference_distance': 0.025, 'recipe': 'hpkot', 'threshold': 1.e-7}
 
         return_value = get_explicit_kpoints_path(structure, method='seekpath', **params)
         retdict = return_value['parameters'].get_dict()
@@ -4054,15 +3862,12 @@ class TestSeekpathExplicitPath(AiidaTestCase):
         self.assertAlmostEqual(retdict['volume_original_wrt_prim'], 1.0)
         self.assertEqual(
             to_list_of_lists(retdict['explicit_segments']),
-            [[0, 31], [30, 61], [60, 104], [103, 123], [122, 153], [152, 183],
-             [182, 226], [226, 246], [246, 266]])
+            [[0, 31], [30, 61], [60, 104], [103, 123], [122, 153], [152, 183], [182, 226], [226, 246], [246, 266]])
 
         ret_k = return_value['explicit_kpoints']
         self.assertEqual(
-            to_list_of_lists(ret_k.labels),
-            [[0, 'GAMMA'], [30, 'X'], [60, 'M'], [103, 'GAMMA'], [122, 'Z'],
-             [152, 'R'], [182, 'A'], [225, 'Z'], [226, 'X'], [245, 'R'],
-             [246, 'M'], [265, 'A']])
+            to_list_of_lists(ret_k.labels), [[0, 'GAMMA'], [30, 'X'], [60, 'M'], [103, 'GAMMA'], [122, 'Z'], [152, 'R'],
+                                             [182, 'A'], [225, 'Z'], [226, 'X'], [245, 'R'], [246, 'M'], [265, 'A']])
         kpts = ret_k.get_kpoints(cartesian=False)
         highsympoints_relcoords = [kpts[idx] for idx, label in ret_k.labels]
         self.assertAlmostEqual(
@@ -4087,28 +3892,22 @@ class TestSeekpathExplicitPath(AiidaTestCase):
         ret_prims = return_value['primitive_structure']
         ret_convs = return_value['conv_structure']
         # The primitive structure should be the same as the one I input
-        self.assertAlmostEqual(
-            np.sum(np.abs(np.array(structure.cell) - np.array(ret_prims.cell))),
-            0.)
-        self.assertEqual([_.kind_name for _ in structure.sites],
-                         [_.kind_name for _ in ret_prims.sites])
+        self.assertAlmostEqual(np.sum(np.abs(np.array(structure.cell) - np.array(ret_prims.cell))), 0.)
+        self.assertEqual([_.kind_name for _ in structure.sites], [_.kind_name for _ in ret_prims.sites])
         self.assertEqual(
             np.sum(
                 np.abs(
-                    np.array([_.position for _ in structure.sites]) -
-                    np.array([_.position for _ in ret_prims.sites]))), 0.)
+                    np.array([_.position for _ in structure.sites]) - np.array([_.position for _ in ret_prims.sites]))),
+            0.)
 
         # Also the conventional structure should be the same as the one I input
-        self.assertAlmostEqual(
-            np.sum(np.abs(np.array(structure.cell) - np.array(ret_convs.cell))),
-            0.)
-        self.assertEqual([_.kind_name for _ in structure.sites],
-                         [_.kind_name for _ in ret_convs.sites])
+        self.assertAlmostEqual(np.sum(np.abs(np.array(structure.cell) - np.array(ret_convs.cell))), 0.)
+        self.assertEqual([_.kind_name for _ in structure.sites], [_.kind_name for _ in ret_convs.sites])
         self.assertEqual(
             np.sum(
                 np.abs(
-                    np.array([_.position for _ in structure.sites]) -
-                    np.array([_.position for _ in ret_convs.sites]))), 0.)
+                    np.array([_.position for _ in structure.sites]) - np.array([_.position for _ in ret_convs.sites]))),
+            0.)
 
 
 class TestSeekpathPath(AiidaTestCase):
@@ -4120,19 +3919,14 @@ class TestSeekpathPath(AiidaTestCase):
 
         from aiida.tools import get_kpoints_path
 
-        structure = DataFactory('structure')(
-            cell=[[4, 0, 0], [0, 4, 0], [0, 0, 6]])
+        structure = DataFactory('structure')(cell=[[4, 0, 0], [0, 4, 0], [0, 0, 6]])
         structure.append_atom(symbols='Ba', position=[0, 0, 0])
         structure.append_atom(symbols='Ti', position=[2, 2, 3])
         structure.append_atom(symbols='O', position=[2, 2, 0])
         structure.append_atom(symbols='O', position=[2, 0, 3])
         structure.append_atom(symbols='O', position=[0, 2, 3])
 
-        params = {
-            'with_time_reversal': True,
-            'recipe': 'hpkot',
-            'threshold': 1.e-7
-        }
+        params = {'with_time_reversal': True, 'recipe': 'hpkot', 'threshold': 1.e-7}
 
         return_value = get_kpoints_path(structure, method='seekpath', **params)
         retdict = return_value['parameters'].get_dict()
@@ -4144,9 +3938,8 @@ class TestSeekpathPath(AiidaTestCase):
         self.assertEqual(retdict['bravais_lattice'], 'tP')
         self.assertEqual(retdict['bravais_lattice_extended'], 'tP1')
         self.assertEqual(
-            to_list_of_lists(retdict['path']),
-            [['GAMMA', 'X'], ['X', 'M'], ['M', 'GAMMA'], ['GAMMA', 'Z'],
-             ['Z', 'R'], ['R', 'A'], ['A', 'Z'], ['X', 'R'], ['M', 'A']])
+            to_list_of_lists(retdict['path']), [['GAMMA', 'X'], ['X', 'M'], ['M', 'GAMMA'], ['GAMMA', 'Z'], ['Z', 'R'],
+                                                ['R', 'A'], ['A', 'Z'], ['X', 'R'], ['M', 'A']])
 
         self.assertEqual(
             retdict['point_coords'], {
@@ -4161,41 +3954,35 @@ class TestSeekpathPath(AiidaTestCase):
         self.assertAlmostEqual(
             np.sum(
                 np.abs(
-                    np.array(retdict['inverse_primitive_transformation_matrix'])
-                    - np.array([[1, 0, 0], [0, 1, 0], [0, 0, 1]]))), 0.)
+                    np.array(retdict['inverse_primitive_transformation_matrix']) -
+                    np.array([[1, 0, 0], [0, 1, 0], [0, 0, 1]]))), 0.)
 
         ret_prims = return_value['primitive_structure']
         ret_convs = return_value['conv_structure']
         # The primitive structure should be the same as the one I input
-        self.assertAlmostEqual(
-            np.sum(np.abs(np.array(structure.cell) - np.array(ret_prims.cell))),
-            0.)
-        self.assertEqual([_.kind_name for _ in structure.sites],
-                         [_.kind_name for _ in ret_prims.sites])
+        self.assertAlmostEqual(np.sum(np.abs(np.array(structure.cell) - np.array(ret_prims.cell))), 0.)
+        self.assertEqual([_.kind_name for _ in structure.sites], [_.kind_name for _ in ret_prims.sites])
         self.assertEqual(
             np.sum(
                 np.abs(
-                    np.array([_.position for _ in structure.sites]) -
-                    np.array([_.position for _ in ret_prims.sites]))), 0.)
+                    np.array([_.position for _ in structure.sites]) - np.array([_.position for _ in ret_prims.sites]))),
+            0.)
 
         # Also the conventional structure should be the same as the one I input
-        self.assertAlmostEqual(
-            np.sum(np.abs(np.array(structure.cell) - np.array(ret_convs.cell))),
-            0.)
-        self.assertEqual([_.kind_name for _ in structure.sites],
-                         [_.kind_name for _ in ret_convs.sites])
+        self.assertAlmostEqual(np.sum(np.abs(np.array(structure.cell) - np.array(ret_convs.cell))), 0.)
+        self.assertEqual([_.kind_name for _ in structure.sites], [_.kind_name for _ in ret_convs.sites])
         self.assertEqual(
             np.sum(
                 np.abs(
-                    np.array([_.position for _ in structure.sites]) -
-                    np.array([_.position for _ in ret_convs.sites]))), 0.)
+                    np.array([_.position for _ in structure.sites]) - np.array([_.position for _ in ret_convs.sites]))),
+            0.)
 
 
 class TestBandsData(AiidaTestCase):
     """
     Tests the BandsData objects.
     """
-    
+
     def test_band(self):
         """
         Check the methods to set and retrieve a mesh.
@@ -4203,38 +3990,39 @@ class TestBandsData(AiidaTestCase):
         from aiida.orm.data.array.bands import BandsData
         from aiida.orm.data.array.kpoints import KpointsData
         import numpy
-        
+
         # define a cell
         alat = 4.
-        cell = numpy.array([[alat, 0., 0.],
-                            [0., alat, 0.],
-                            [0., 0., alat],
-                            ])
-        
+        cell = numpy.array([
+            [alat, 0., 0.],
+            [0., alat, 0.],
+            [0., 0., alat],
+        ])
+
         k = KpointsData()
         k.set_cell(cell)
         k.set_kpoints_path()
-        
+
         b = BandsData()
         b.set_kpointsdata(k)
-        self.assertTrue( numpy.array_equal(b.cell,k.cell) )
-        
-        input_bands = numpy.array([numpy.ones(4) for i in range(k.get_kpoints().shape[0]) ]) 
+        self.assertTrue(numpy.array_equal(b.cell, k.cell))
+
+        input_bands = numpy.array([numpy.ones(4) for i in range(k.get_kpoints().shape[0])])
         input_occupations = input_bands
-        
+
         b.set_bands(input_bands, occupations=input_occupations, units='ev')
         b.set_bands(input_bands, units='ev')
         b.set_bands(input_bands, occupations=input_occupations)
         with self.assertRaises(TypeError):
             b.set_bands(occupations=input_occupations, units='ev')
-        
+
         b.set_bands(input_bands, occupations=input_occupations, units='ev')
-        bands,occupations = b.get_bands(also_occupations=True)
-        
-        self.assertTrue( numpy.array_equal(bands,input_bands) )
-        self.assertTrue( numpy.array_equal(occupations,input_occupations) )
-        self.assertTrue( b.units=='ev' )
-        
+        bands, occupations = b.get_bands(also_occupations=True)
+
+        self.assertTrue(numpy.array_equal(bands, input_bands))
+        self.assertTrue(numpy.array_equal(occupations, input_occupations))
+        self.assertTrue(b.units == 'ev')
+
         b.store()
         with self.assertRaises(ModificationNotAllowed):
             b.set_bands(bands)
@@ -4251,10 +4039,11 @@ class TestBandsData(AiidaTestCase):
 
         # define a cell
         alat = 4.
-        cell = numpy.array([[alat, 0., 0.],
-                            [0., alat, 0.],
-                            [0., 0., alat],
-                            ])
+        cell = numpy.array([
+            [alat, 0., 0.],
+            [0., alat, 0.],
+            [0., 0., alat],
+        ])
 
         k = KpointsData()
         k.set_cell(cell)
@@ -4265,7 +4054,7 @@ class TestBandsData(AiidaTestCase):
 
         # 4 bands with linearly increasing energies, it does not make sense
         # but is good for testing
-        input_bands = numpy.array([numpy.ones(4)*i for i in range(k.get_kpoints().shape[0]) ])
+        input_bands = numpy.array([numpy.ones(4) * i for i in range(k.get_kpoints().shape[0])])
 
         b.set_bands(input_bands, units='eV')
 
@@ -4278,13 +4067,12 @@ class TestBandsData(AiidaTestCase):
         os.close(handle)
         os.remove(filename)
 
-        for format in ['agr', 'agr_batch', 'json', 'mpl_singlefile',
-                       'dat_blocks', 'dat_multicolumn']:
-            files_created = [] # In case there is an exception
+        for format in ['agr', 'agr_batch', 'json', 'mpl_singlefile', 'dat_blocks', 'dat_multicolumn']:
+            files_created = []  # In case there is an exception
             try:
                 files_created = b.export(filename, fileformat=format)
-                with io.open(filename, encoding='utf8') as f:
-                    filedata = f.read()
+                with io.open(filename, encoding='utf8') as fhandle:
+                    filedata = fhandle.read()
             finally:
                 for file in files_created:
                     if os.path.exists(file):

--- a/aiida/backends/tests/dbimporters.py
+++ b/aiida/backends/tests/dbimporters.py
@@ -13,6 +13,7 @@ Tests for subclasses of DbImporter, DbSearchResults and DbEntry
 from __future__ import print_function
 from __future__ import absolute_import
 from __future__ import division
+import io
 import unittest
 
 import six
@@ -265,10 +266,10 @@ class TestNnincDbImporter(AiidaTestCase):
         results = NnincSearchResults([{'id': upf}])
         entry = results.at(0)
 
-        with open(os.path.join(
+        with io.open(os.path.join(
                 os.path.split(aiida.__file__)[0], os.pardir,
                 "examples", "testdata", "qepseudos", "{}.UPF".format(upf))
-                , 'r') as f:
+                , 'r', encoding='utf8') as f:
             entry._contents = f.read()
 
         upfnode = entry.get_upf_node()

--- a/aiida/backends/tests/export_and_import.py
+++ b/aiida/backends/tests/export_and_import.py
@@ -14,7 +14,7 @@ Tests for the export and import routines.
 from __future__ import division
 from __future__ import print_function
 from __future__ import absolute_import
-
+import io
 import six
 from six.moves import range, zip
 
@@ -299,12 +299,12 @@ class TestSimple(AiidaTestCase):
             with tarfile.open(filename, "r:gz", format=tarfile.PAX_FORMAT) as tar:
                 tar.extractall(unpack_tmp_folder)
 
-            with open(os.path.join(unpack_tmp_folder,
-                                   'metadata.json'), 'r') as f:
+            with io.open(os.path.join(unpack_tmp_folder,
+                                   'metadata.json'), 'r', encoding='utf8') as f:
                 metadata = json.load(f)
             metadata['export_version'] = 0.0
-            with open(os.path.join(unpack_tmp_folder,
-                                   'metadata.json'), 'w') as f:
+            with io.open(os.path.join(unpack_tmp_folder,
+                                   'metadata.json', encoding='utf8'), 'w') as f:
                 json.dump(metadata, f)
 
             with tarfile.open(filename, "w:gz", format=tarfile.PAX_FORMAT) as tar:
@@ -351,14 +351,14 @@ class TestSimple(AiidaTestCase):
                     filename, "r:gz", format=tarfile.PAX_FORMAT) as tar:
                 tar.extractall(unpack.abspath)
 
-            with open(unpack.get_abs_path('data.json'), 'r') as f:
+            with io.open(unpack.get_abs_path('data.json'), 'r', encoding='utf8') as f:
                 metadata = json.load(f)
             metadata['links_uuid'].append({
                 'output': sd.uuid,
                 'input': 'non-existing-uuid',
                 'label': 'parent'
             })
-            with open(unpack.get_abs_path('data.json'), 'w') as f:
+            with io.open(unpack.get_abs_path('data.json'), 'w', encoding='utf8') as f:
                 json.dump(metadata, f)
 
             with tarfile.open(

--- a/aiida/backends/tests/export_and_import.py
+++ b/aiida/backends/tests/export_and_import.py
@@ -21,6 +21,7 @@ from six.moves import range, zip
 from aiida.backends.testbase import AiidaTestCase
 from aiida.orm.importexport import import_data
 
+
 class TestSpecificImport(AiidaTestCase):
 
     def setUp(self):
@@ -176,6 +177,7 @@ class TestSpecificImport(AiidaTestCase):
             qb.append(Calculation, output_of='remote')
             self.assertGreater(len(qb.all()), 0)
 
+
 class TestSimple(AiidaTestCase):
 
     def setUp(self):
@@ -303,9 +305,11 @@ class TestSimple(AiidaTestCase):
                                    'metadata.json'), 'r', encoding='utf8') as fhandle:
                 metadata = json.load(fhandle)
             metadata['export_version'] = 0.0
-            with io.open(os.path.join(unpack_tmp_folder,
-                                   'metadata.json'), 'wb', encoding=None) as fhandle:
-                json.dump(metadata, fhandle, ensure_ascii=False)
+
+            with io.open(os.path.join(unpack_tmp_folder, 'metadata.json'),
+                         'w', encoding='utf-8') as fhandle:
+                fhandle.write(six.text_type(json.dumps(
+                    metadata, ensure_ascii=False)))
 
             with tarfile.open(filename, "w:gz", format=tarfile.PAX_FORMAT) as tar:
                 tar.add(unpack_tmp_folder, arcname="")
@@ -358,8 +362,11 @@ class TestSimple(AiidaTestCase):
                 'input': 'non-existing-uuid',
                 'label': 'parent'
             })
-            with io.open(unpack.get_abs_path('data.json'), 'wb', encoding=None) as fhandle:
-                json.dump(metadata, fhandle, ensure_ascii=False)
+
+            with io.open(unpack.get_abs_path('data.json'), 'w',
+                             encoding='utf-8') as fhandle:
+                fhandle.write(six.text_type(json.dumps(
+                    metadata, ensure_ascii=False)))
 
             with tarfile.open(
                     filename, "w:gz", format=tarfile.PAX_FORMAT) as tar:

--- a/aiida/backends/tests/export_and_import.py
+++ b/aiida/backends/tests/export_and_import.py
@@ -305,7 +305,7 @@ class TestSimple(AiidaTestCase):
             metadata['export_version'] = 0.0
             with io.open(os.path.join(unpack_tmp_folder,
                                    'metadata.json'), 'wb', encoding=None) as fhandle:
-                json.dump(metadata, fhandle)
+                json.dump(metadata, fhandle, ensure_ascii=False)
 
             with tarfile.open(filename, "w:gz", format=tarfile.PAX_FORMAT) as tar:
                 tar.add(unpack_tmp_folder, arcname="")
@@ -359,7 +359,7 @@ class TestSimple(AiidaTestCase):
                 'label': 'parent'
             })
             with io.open(unpack.get_abs_path('data.json'), 'wb', encoding=None) as fhandle:
-                json.dump(metadata, fhandle)
+                json.dump(metadata, fhandle, ensure_ascii=False)
 
             with tarfile.open(
                     filename, "w:gz", format=tarfile.PAX_FORMAT) as tar:

--- a/aiida/backends/tests/export_and_import.py
+++ b/aiida/backends/tests/export_and_import.py
@@ -300,12 +300,12 @@ class TestSimple(AiidaTestCase):
                 tar.extractall(unpack_tmp_folder)
 
             with io.open(os.path.join(unpack_tmp_folder,
-                                   'metadata.json'), 'r', encoding='utf8') as f:
-                metadata = json.load(f)
+                                   'metadata.json'), 'r', encoding='utf8') as fhandle:
+                metadata = json.load(fhandle)
             metadata['export_version'] = 0.0
             with io.open(os.path.join(unpack_tmp_folder,
-                                   'metadata.json', encoding='utf8'), 'w') as f:
-                json.dump(metadata, f)
+                                   'metadata.json'), 'wb', encoding=None) as fhandle:
+                json.dump(metadata, fhandle)
 
             with tarfile.open(filename, "w:gz", format=tarfile.PAX_FORMAT) as tar:
                 tar.add(unpack_tmp_folder, arcname="")
@@ -351,15 +351,15 @@ class TestSimple(AiidaTestCase):
                     filename, "r:gz", format=tarfile.PAX_FORMAT) as tar:
                 tar.extractall(unpack.abspath)
 
-            with io.open(unpack.get_abs_path('data.json'), 'r', encoding='utf8') as f:
-                metadata = json.load(f)
+            with io.open(unpack.get_abs_path('data.json'), 'r', encoding='utf8') as fhandle:
+                metadata = json.load(fhandle)
             metadata['links_uuid'].append({
                 'output': sd.uuid,
                 'input': 'non-existing-uuid',
                 'label': 'parent'
             })
-            with io.open(unpack.get_abs_path('data.json'), 'w', encoding='utf8') as f:
-                json.dump(metadata, f)
+            with io.open(unpack.get_abs_path('data.json'), 'wb', encoding=None) as fhandle:
+                json.dump(metadata, fhandle)
 
             with tarfile.open(
                     filename, "w:gz", format=tarfile.PAX_FORMAT) as tar:

--- a/aiida/backends/tests/export_and_import.py
+++ b/aiida/backends/tests/export_and_import.py
@@ -277,7 +277,6 @@ class TestSimple(AiidaTestCase):
         """
         Test the check for the export format version.
         """
-        import json
         import tarfile
         import os
         import shutil
@@ -286,6 +285,8 @@ class TestSimple(AiidaTestCase):
         from aiida.common import exceptions
         from aiida.orm import DataFactory
         from aiida.orm.importexport import export
+        import aiida.utils.json as json
+
 
         # Creating a folder for the import/export files
         export_file_tmp_folder = tempfile.mkdtemp()
@@ -307,9 +308,8 @@ class TestSimple(AiidaTestCase):
             metadata['export_version'] = 0.0
 
             with io.open(os.path.join(unpack_tmp_folder, 'metadata.json'),
-                         'w', encoding='utf-8') as fhandle:
-                fhandle.write(six.text_type(json.dumps(
-                    metadata, ensure_ascii=False)))
+                         'wb') as fhandle:
+                json.dump(metadata, fhandle)
 
             with tarfile.open(filename, "w:gz", format=tarfile.PAX_FORMAT) as tar:
                 tar.add(unpack_tmp_folder, arcname="")
@@ -328,7 +328,6 @@ class TestSimple(AiidaTestCase):
         """
         Test importing of nodes, that have links to unknown nodes.
         """
-        import json
         import tarfile
         import os
         import shutil
@@ -338,6 +337,7 @@ class TestSimple(AiidaTestCase):
         from aiida.common.folders import SandboxFolder
         from aiida.orm.data.structure import StructureData
         from aiida.orm import load_node
+        import aiida.utils.json as json
 
         # Creating a folder for the import/export files
         temp_folder = tempfile.mkdtemp()
@@ -363,10 +363,8 @@ class TestSimple(AiidaTestCase):
                 'label': 'parent'
             })
 
-            with io.open(unpack.get_abs_path('data.json'), 'w',
-                             encoding='utf-8') as fhandle:
-                fhandle.write(six.text_type(json.dumps(
-                    metadata, ensure_ascii=False)))
+            with io.open(unpack.get_abs_path('data.json'), 'wb') as fhandle:
+                json.dump(metadata, fhandle)
 
             with tarfile.open(
                     filename, "w:gz", format=tarfile.PAX_FORMAT) as tar:

--- a/aiida/backends/tests/generic.py
+++ b/aiida/backends/tests/generic.py
@@ -38,7 +38,7 @@ class TestCode(AiidaTestCase):
         with tempfile.NamedTemporaryFile(mode='w+') as fhandle:
             fhandle.write("#/bin/bash\n\necho test run\n")
             fhandle.flush()
-            code.add_path(f.name, 'test.sh')
+            code.add_path(fhandle.name, 'test.sh')
 
         code.store()
         self.assertTrue(code.can_run_on(self.computer))
@@ -71,7 +71,7 @@ class TestCode(AiidaTestCase):
         with tempfile.NamedTemporaryFile(mode='w+') as fhandle:
             fhandle.write("#/bin/bash\n\necho test run\n")
             fhandle.flush()
-            code.add_path(f.name, 'test.sh')
+            code.add_path(fhandle.name, 'test.sh')
 
         with self.assertRaises(ValidationError):
             # There are files inside

--- a/aiida/backends/tests/generic.py
+++ b/aiida/backends/tests/generic.py
@@ -35,9 +35,9 @@ class TestCode(AiidaTestCase):
             # No file with name test.sh
             code.store()
 
-        with tempfile.NamedTemporaryFile(mode='w+') as f:
-            f.write("#/bin/bash\n\necho test run\n")
-            f.flush()
+        with tempfile.NamedTemporaryFile(mode='w+') as fhandle:
+            fhandle.write("#/bin/bash\n\necho test run\n")
+            fhandle.flush()
             code.add_path(f.name, 'test.sh')
 
         code.store()
@@ -68,9 +68,9 @@ class TestCode(AiidaTestCase):
             _ = Code(remote_computer_exec=('localhost', '/bin/ls'))
 
         code = Code(remote_computer_exec=(self.computer, '/bin/ls'))
-        with tempfile.NamedTemporaryFile(mode='w+') as f:
-            f.write("#/bin/bash\n\necho test run\n")
-            f.flush()
+        with tempfile.NamedTemporaryFile(mode='w+') as fhandle:
+            fhandle.write("#/bin/bash\n\necho test run\n")
+            fhandle.flush()
             code.add_path(f.name, 'test.sh')
 
         with self.assertRaises(ValidationError):
@@ -86,9 +86,12 @@ class TestCode(AiidaTestCase):
         self.assertEquals(code.get_execname(), '/bin/ls')
 
         self.assertTrue(code.can_run_on(self.computer))
-        othercomputer = self.backend.computers.create(name='another_localhost', hostname='localhost',
-                                                      transport_type='local', scheduler_type='pbspro',
-                                                      workdir='/tmp/aiida').store()
+        othercomputer = self.backend.computers.create(
+            name='another_localhost',
+            hostname='localhost',
+            transport_type='local',
+            scheduler_type='pbspro',
+            workdir='/tmp/aiida').store()
         self.assertFalse(code.can_run_on(othercomputer))
 
 
@@ -138,14 +141,12 @@ class TestGroupHashing(AiidaTestCase):
 
         # Search for the UUID of the stored group
         qb = QueryBuilder()
-        qb.append(Group, project=['uuid'],
-                  filters={'name': {'==': 'test_group'}})
+        qb.append(Group, project=['uuid'], filters={'name': {'==': 'test_group'}})
         [uuid] = qb.first()
 
         # Look the node with the previously returned UUID
         qb = QueryBuilder()
-        qb.append(Group, project=['id'],
-                  filters={'uuid': {'==': uuid}})
+        qb.append(Group, project=['id'], filters={'uuid': {'==': uuid}})
         # Check that the query doesn't fail
         qb.all()
         # And that the results are correct
@@ -266,13 +267,11 @@ class TestGroups(AiidaTestCase):
         g.add_nodes([n7, n8.dbnode])
 
         # Check
-        self.assertEquals(set([_.pk for _ in [n1, n2, n3, n4, n5, n6, n7, n8]]),
-                          set([_.pk for _ in g.nodes]))
+        self.assertEquals(set([_.pk for _ in [n1, n2, n3, n4, n5, n6, n7, n8]]), set([_.pk for _ in g.nodes]))
 
         # Try to add a node that is already present: there should be no problem
         g.add_nodes(n1)
-        self.assertEquals(set([_.pk for _ in [n1, n2, n3, n4, n5, n6, n7, n8]]),
-                          set([_.pk for _ in g.nodes]))
+        self.assertEquals(set([_.pk for _ in [n1, n2, n3, n4, n5, n6, n7, n8]]), set([_.pk for _ in g.nodes]))
 
         # Cleanup
         g.delete()
@@ -298,41 +297,33 @@ class TestGroups(AiidaTestCase):
         # Add initial nodes
         g.add_nodes([n1, n2, n3, n4, n5, n6, n7, n8])
         # Check
-        self.assertEquals(set([_.pk for _ in [n1, n2, n3, n4, n5, n6, n7, n8]]),
-                          set([_.pk for _ in g.nodes]))
+        self.assertEquals(set([_.pk for _ in [n1, n2, n3, n4, n5, n6, n7, n8]]), set([_.pk for _ in g.nodes]))
 
         # Remove a node that is not in the group: nothing should happen
         # (same behavior of Django)
         g.remove_nodes(n_out)
         # Re-check
-        self.assertEquals(set([_.pk for _ in [n1, n2, n3, n4, n5, n6, n7, n8]]),
-                          set([_.pk for _ in g.nodes]))
+        self.assertEquals(set([_.pk for _ in [n1, n2, n3, n4, n5, n6, n7, n8]]), set([_.pk for _ in g.nodes]))
 
         # Remove one Node and check
         g.remove_nodes(n4)
-        self.assertEquals(set([_.pk for _ in [n1, n2, n3, n5, n6, n7, n8]]),
-                          set([_.pk for _ in g.nodes]))
+        self.assertEquals(set([_.pk for _ in [n1, n2, n3, n5, n6, n7, n8]]), set([_.pk for _ in g.nodes]))
         # Remove one DbNode and check
         g.remove_nodes(n7.dbnode)
-        self.assertEquals(set([_.pk for _ in [n1, n2, n3, n5, n6, n8]]),
-                          set([_.pk for _ in g.nodes]))
+        self.assertEquals(set([_.pk for _ in [n1, n2, n3, n5, n6, n8]]), set([_.pk for _ in g.nodes]))
         # Remove a list of Nodes and check
         g.remove_nodes([n1, n8])
-        self.assertEquals(set([_.pk for _ in [n2, n3, n5, n6]]),
-                          set([_.pk for _ in g.nodes]))
+        self.assertEquals(set([_.pk for _ in [n2, n3, n5, n6]]), set([_.pk for _ in g.nodes]))
         # Remove a list of Nodes and check
         g.remove_nodes([n1, n8])
-        self.assertEquals(set([_.pk for _ in [n2, n3, n5, n6]]),
-                          set([_.pk for _ in g.nodes]))
+        self.assertEquals(set([_.pk for _ in [n2, n3, n5, n6]]), set([_.pk for _ in g.nodes]))
         # Remove a list of DbNodes and check
         g.remove_nodes([n2.dbnode, n5.dbnode])
-        self.assertEquals(set([_.pk for _ in [n3, n6]]),
-                          set([_.pk for _ in g.nodes]))
+        self.assertEquals(set([_.pk for _ in [n3, n6]]), set([_.pk for _ in g.nodes]))
 
         # Remove a mixed list of Nodes and DbNodes and check
         g.remove_nodes([n3, n6.dbnode])
-        self.assertEquals(set(),
-                          set([_.pk for _ in g.nodes]))
+        self.assertEquals(set(), set([_.pk for _ in g.nodes]))
 
         # Cleanup
         g.delete()
@@ -447,6 +438,7 @@ class TestDbExtras(AiidaTestCase):
 
 
 class TestBool(AiidaTestCase):
+
     def test_bool_conversion(self):
         from aiida.orm.data.bool import Bool
         for val in [True, False]:

--- a/aiida/backends/tests/inline_calculation.py
+++ b/aiida/backends/tests/inline_calculation.py
@@ -11,6 +11,7 @@
 from __future__ import division
 from __future__ import print_function
 from __future__ import absolute_import
+import io
 from aiida.backends.testbase import AiidaTestCase
 from aiida.common.caching import enable_caching
 from aiida.orm.calculation.inline import make_inline, InlineCalculation
@@ -99,7 +100,7 @@ class TestInlineCalculation(AiidaTestCase):
         # into memory, which should be exactly this test file
         function_source_file = node.function_source_file
 
-        with open(function_source_file) as handle:
+        with io.open(function_source_file, encoding='utf8') as handle:
             function_source_code = handle.readlines()
 
         # Get the attributes that should be stored in the node

--- a/aiida/backends/tests/nodes.py
+++ b/aiida/backends/tests/nodes.py
@@ -613,17 +613,17 @@ class TestNodeBasic(AiidaTestCase):
         file_content = 'some text ABCDE'
         file_content_different = 'other values 12345'
 
-        with tempfile.NamedTemporaryFile(mode='w+') as fhandle:
-            fhandle.write(file_content)
-            fhandle.flush()
-            a.add_path(f.name, 'file1.txt')
-            a.add_path(f.name, 'file2.txt')
+        with tempfile.NamedTemporaryFile(mode='w+') as tmpf:
+            tmpf.write(file_content)
+            tmpf.flush()
+            a.add_path(tmpf.name, 'file1.txt')
+            a.add_path(tmpf.name, 'file2.txt')
 
         self.assertEquals(set(a.get_folder_list()), set(['file1.txt', 'file2.txt']))
         with io.open(a.get_abs_path('file1.txt'), encoding='utf8') as fhandle:
-            self.assertEquals(f.read(), file_content)
+            self.assertEquals(fhandle.read(), file_content)
         with io.open(a.get_abs_path('file2.txt'), encoding='utf8') as fhandle:
-            self.assertEquals(f.read(), file_content)
+            self.assertEquals(fhandle.read(), file_content)
 
         b = a.clone()
         self.assertNotEquals(a.uuid, b.uuid)
@@ -631,30 +631,30 @@ class TestNodeBasic(AiidaTestCase):
         # Check that the content is there
         self.assertEquals(set(b.get_folder_list()), set(['file1.txt', 'file2.txt']))
         with io.open(b.get_abs_path('file1.txt'), encoding='utf8') as fhandle:
-            self.assertEquals(f.read(), file_content)
+            self.assertEquals(fhandle.read(), file_content)
         with io.open(b.get_abs_path('file2.txt'), encoding='utf8') as fhandle:
-            self.assertEquals(f.read(), file_content)
+            self.assertEquals(fhandle.read(), file_content)
 
         # I overwrite a file and create a new one in the clone only
-        with tempfile.NamedTemporaryFile(mode='w+') as fhandle:
-            fhandle.write(file_content_different)
-            fhandle.flush()
-            b.add_path(f.name, 'file2.txt')
-            b.add_path(f.name, 'file3.txt')
+        with tempfile.NamedTemporaryFile(mode='w+') as tmpf:
+            tmpf.write(file_content_different)
+            tmpf.flush()
+            b.add_path(tmpf.name, 'file2.txt')
+            b.add_path(tmpf.name, 'file3.txt')
 
         # I check the new content, and that the old one has not changed
         self.assertEquals(set(a.get_folder_list()), set(['file1.txt', 'file2.txt']))
         with io.open(a.get_abs_path('file1.txt'), encoding='utf8') as fhandle:
-            self.assertEquals(f.read(), file_content)
+            self.assertEquals(fhandle.read(), file_content)
         with io.open(a.get_abs_path('file2.txt'), encoding='utf8') as fhandle:
-            self.assertEquals(f.read(), file_content)
+            self.assertEquals(fhandle.read(), file_content)
         self.assertEquals(set(b.get_folder_list()), set(['file1.txt', 'file2.txt', 'file3.txt']))
         with io.open(b.get_abs_path('file1.txt'), encoding='utf8') as fhandle:
-            self.assertEquals(f.read(), file_content)
+            self.assertEquals(fhandle.read(), file_content)
         with io.open(b.get_abs_path('file2.txt'), encoding='utf8') as fhandle:
-            self.assertEquals(f.read(), file_content_different)
+            self.assertEquals(fhandle.read(), file_content_different)
         with io.open(b.get_abs_path('file3.txt'), encoding='utf8') as fhandle:
-            self.assertEquals(f.read(), file_content_different)
+            self.assertEquals(fhandle.read(), file_content_different)
 
         # This should in principle change the location of the files,
         # so I recheck
@@ -663,25 +663,25 @@ class TestNodeBasic(AiidaTestCase):
         # I now clone after storing
         c = a.clone()
         # I overwrite a file and create a new one in the clone only
-        with tempfile.NamedTemporaryFile(mode='w+') as fhandle:
-            fhandle.write(file_content_different)
-            fhandle.flush()
-            c.add_path(f.name, 'file1.txt')
-            c.add_path(f.name, 'file4.txt')
+        with tempfile.NamedTemporaryFile(mode='w+') as tmpf:
+            tmpf.write(file_content_different)
+            tmpf.flush()
+            c.add_path(tmpf.name, 'file1.txt')
+            c.add_path(tmpf.name, 'file4.txt')
 
         self.assertEquals(set(a.get_folder_list()), set(['file1.txt', 'file2.txt']))
         with io.open(a.get_abs_path('file1.txt'), encoding='utf8') as fhandle:
-            self.assertEquals(f.read(), file_content)
+            self.assertEquals(fhandle.read(), file_content)
         with io.open(a.get_abs_path('file2.txt'), encoding='utf8') as fhandle:
-            self.assertEquals(f.read(), file_content)
+            self.assertEquals(fhandle.read(), file_content)
 
         self.assertEquals(set(c.get_folder_list()), set(['file1.txt', 'file2.txt', 'file4.txt']))
         with io.open(c.get_abs_path('file1.txt'), encoding='utf8') as fhandle:
-            self.assertEquals(f.read(), file_content_different)
+            self.assertEquals(fhandle.read(), file_content_different)
         with io.open(c.get_abs_path('file2.txt'), encoding='utf8') as fhandle:
-            self.assertEquals(f.read(), file_content)
+            self.assertEquals(fhandle.read(), file_content)
         with io.open(c.get_abs_path('file4.txt'), encoding='utf8') as fhandle:
-            self.assertEquals(f.read(), file_content_different)
+            self.assertEquals(fhandle.read(), file_content_different)
 
     def test_folders(self):
         """
@@ -707,8 +707,8 @@ class TestNodeBasic(AiidaTestCase):
         # create a folder structure to copy around
         tree_1 = os.path.join(directory, 'tree_1')
         os.makedirs(tree_1)
-        file_content = 'some text ABCDE'
-        file_content_different = 'other values 12345'
+        file_content = u'some text ABCDE'
+        file_content_different = u'other values 12345'
         with io.open(os.path.join(tree_1, 'file1.txt'), 'w', encoding='utf8') as fhandle:
             fhandle.write(file_content)
         os.mkdir(os.path.join(tree_1, 'dir1'))
@@ -726,9 +726,9 @@ class TestNodeBasic(AiidaTestCase):
         self.assertEquals(set(a.get_folder_list('tree_1')), set(['file1.txt', 'dir1']))
         self.assertEquals(set(a.get_folder_list(os.path.join('tree_1', 'dir1'))), set(['dir2', 'file2.txt']))
         with io.open(a.get_abs_path(os.path.join('tree_1', 'file1.txt')), encoding='utf8') as fhandle:
-            self.assertEquals(f.read(), file_content)
+            self.assertEquals(fhandle.read(), file_content)
         with io.open(a.get_abs_path(os.path.join('tree_1', 'dir1', 'file2.txt')), encoding='utf8') as fhandle:
-            self.assertEquals(f.read(), file_content)
+            self.assertEquals(fhandle.read(), file_content)
 
         # try to exit from the folder
         with self.assertRaises(ValueError):
@@ -743,9 +743,9 @@ class TestNodeBasic(AiidaTestCase):
         self.assertEquals(set(b.get_folder_list('tree_1')), set(['file1.txt', 'dir1']))
         self.assertEquals(set(b.get_folder_list(os.path.join('tree_1', 'dir1'))), set(['dir2', 'file2.txt']))
         with io.open(b.get_abs_path(os.path.join('tree_1', 'file1.txt')), encoding='utf8') as fhandle:
-            self.assertEquals(f.read(), file_content)
+            self.assertEquals(fhandle.read(), file_content)
         with io.open(b.get_abs_path(os.path.join('tree_1', 'dir1', 'file2.txt')), encoding='utf8') as fhandle:
-            self.assertEquals(f.read(), file_content)
+            self.assertEquals(fhandle.read(), file_content)
 
         # I overwrite a file and create a new one in the copy only
         dir3 = os.path.join(directory, 'dir3')
@@ -756,10 +756,10 @@ class TestNodeBasic(AiidaTestCase):
         with self.assertRaises(ValueError):
             b.add_path('dir3', os.path.join('tree_1', 'dir3'))
 
-        with tempfile.NamedTemporaryFile(mode='w+') as fhandle:
-            fhandle.write(file_content_different)
-            fhandle.flush()
-            b.add_path(f.name, 'file3.txt')
+        with tempfile.NamedTemporaryFile(mode='w+') as tmpf:
+            tmpf.write(file_content_different)
+            tmpf.flush()
+            b.add_path(tmpf.name, 'file3.txt')
 
         # I check the new content, and that the old one has not changed
         # old
@@ -767,17 +767,17 @@ class TestNodeBasic(AiidaTestCase):
         self.assertEquals(set(a.get_folder_list('tree_1')), set(['file1.txt', 'dir1']))
         self.assertEquals(set(a.get_folder_list(os.path.join('tree_1', 'dir1'))), set(['dir2', 'file2.txt']))
         with io.open(a.get_abs_path(os.path.join('tree_1', 'file1.txt')), encoding='utf8') as fhandle:
-            self.assertEquals(f.read(), file_content)
+            self.assertEquals(fhandle.read(), file_content)
         with io.open(a.get_abs_path(os.path.join('tree_1', 'dir1', 'file2.txt')), encoding='utf8') as fhandle:
-            self.assertEquals(f.read(), file_content)
+            self.assertEquals(fhandle.read(), file_content)
         # new
         self.assertEquals(set(b.get_folder_list('.')), set(['tree_1', 'file3.txt']))
         self.assertEquals(set(b.get_folder_list('tree_1')), set(['file1.txt', 'dir1', 'dir3']))
         self.assertEquals(set(b.get_folder_list(os.path.join('tree_1', 'dir1'))), set(['dir2', 'file2.txt']))
         with io.open(b.get_abs_path(os.path.join('tree_1', 'file1.txt')), encoding='utf8') as fhandle:
-            self.assertEquals(f.read(), file_content)
+            self.assertEquals(fhandle.read(), file_content)
         with io.open(b.get_abs_path(os.path.join('tree_1', 'dir1', 'file2.txt')), encoding='utf8') as fhandle:
-            self.assertEquals(f.read(), file_content)
+            self.assertEquals(fhandle.read(), file_content)
 
         # This should in principle change the location of the files,
         # so I recheck
@@ -787,11 +787,11 @@ class TestNodeBasic(AiidaTestCase):
         c = a.clone()
         # I overwrite a file, create a new one and remove a directory
         # in the copy only
-        with tempfile.NamedTemporaryFile(mode='w+') as fhandle:
-            fhandle.write(file_content_different)
-            fhandle.flush()
-            c.add_path(f.name, os.path.join('tree_1', 'file1.txt'))
-            c.add_path(f.name, os.path.join('tree_1', 'dir1', 'file4.txt'))
+        with tempfile.NamedTemporaryFile(mode='w+') as tmpf:
+            tmpf.write(file_content_different)
+            tmpf.flush()
+            c.add_path(tmpf.name, os.path.join('tree_1', 'file1.txt'))
+            c.add_path(tmpf.name, os.path.join('tree_1', 'dir1', 'file4.txt'))
         c.remove_path(os.path.join('tree_1', 'dir1', 'dir2'))
 
         # check old
@@ -799,18 +799,18 @@ class TestNodeBasic(AiidaTestCase):
         self.assertEquals(set(a.get_folder_list('tree_1')), set(['file1.txt', 'dir1']))
         self.assertEquals(set(a.get_folder_list(os.path.join('tree_1', 'dir1'))), set(['dir2', 'file2.txt']))
         with io.open(a.get_abs_path(os.path.join('tree_1', 'file1.txt')), encoding='utf8') as fhandle:
-            self.assertEquals(f.read(), file_content)
+            self.assertEquals(fhandle.read(), file_content)
         with io.open(a.get_abs_path(os.path.join('tree_1', 'dir1', 'file2.txt')), encoding='utf8') as fhandle:
-            self.assertEquals(f.read(), file_content)
+            self.assertEquals(fhandle.read(), file_content)
 
         # check new
         self.assertEquals(set(c.get_folder_list('.')), set(['tree_1']))
         self.assertEquals(set(c.get_folder_list('tree_1')), set(['file1.txt', 'dir1']))
         self.assertEquals(set(c.get_folder_list(os.path.join('tree_1', 'dir1'))), set(['file2.txt', 'file4.txt']))
         with io.open(c.get_abs_path(os.path.join('tree_1', 'file1.txt'))) as fhandle:
-            self.assertEquals(f.read(), file_content_different)
+            self.assertEquals(fhandle.read(), file_content_different)
         with io.open(c.get_abs_path(os.path.join('tree_1', 'dir1', 'file2.txt')), encoding='utf8') as fhandle:
-            self.assertEquals(f.read(), file_content)
+            self.assertEquals(fhandle.read(), file_content)
 
         # garbage cleaning
         shutil.rmtree(directory)
@@ -1865,8 +1865,8 @@ class TestSubNodesAndLinks(AiidaTestCase):
 
         # I create some objects
         d1 = Data().store()
-        with tempfile.NamedTemporaryFile('w+') as fhandle:
-            d2 = SinglefileData(file=f.name).store()
+        with tempfile.NamedTemporaryFile('w+') as tmpf:
+            d2 = SinglefileData(file=tmpf.name).store()
 
         code = Code()
         code._set_remote()

--- a/aiida/backends/tests/nodes.py
+++ b/aiida/backends/tests/nodes.py
@@ -14,6 +14,7 @@ from __future__ import division
 from __future__ import absolute_import
 from __future__ import print_function
 import copy
+import io
 import unittest
 
 import six
@@ -654,9 +655,9 @@ class TestNodeBasic(AiidaTestCase):
 
         self.assertEquals(
             set(a.get_folder_list()), set(['file1.txt', 'file2.txt']))
-        with open(a.get_abs_path('file1.txt')) as f:
+        with io.open(a.get_abs_path('file1.txt'), encoding='utf8') as f:
             self.assertEquals(f.read(), file_content)
-        with open(a.get_abs_path('file2.txt')) as f:
+        with io.open(a.get_abs_path('file2.txt'), encoding='utf8') as f:
             self.assertEquals(f.read(), file_content)
 
         b = a.clone()
@@ -665,9 +666,9 @@ class TestNodeBasic(AiidaTestCase):
         # Check that the content is there
         self.assertEquals(
             set(b.get_folder_list()), set(['file1.txt', 'file2.txt']))
-        with open(b.get_abs_path('file1.txt')) as f:
+        with io.open(b.get_abs_path('file1.txt'), encoding='utf8') as f:
             self.assertEquals(f.read(), file_content)
-        with open(b.get_abs_path('file2.txt')) as f:
+        with io.open(b.get_abs_path('file2.txt'), encoding='utf8') as f:
             self.assertEquals(f.read(), file_content)
 
         # I overwrite a file and create a new one in the clone only
@@ -680,18 +681,18 @@ class TestNodeBasic(AiidaTestCase):
         # I check the new content, and that the old one has not changed
         self.assertEquals(
             set(a.get_folder_list()), set(['file1.txt', 'file2.txt']))
-        with open(a.get_abs_path('file1.txt')) as f:
+        with io.open(a.get_abs_path('file1.txt'), encoding='utf8') as f:
             self.assertEquals(f.read(), file_content)
-        with open(a.get_abs_path('file2.txt')) as f:
+        with io.open(a.get_abs_path('file2.txt'), encoding='utf8') as f:
             self.assertEquals(f.read(), file_content)
         self.assertEquals(
             set(b.get_folder_list()),
             set(['file1.txt', 'file2.txt', 'file3.txt']))
-        with open(b.get_abs_path('file1.txt')) as f:
+        with io.open(b.get_abs_path('file1.txt'), encoding='utf8') as f:
             self.assertEquals(f.read(), file_content)
-        with open(b.get_abs_path('file2.txt')) as f:
+        with io.open(b.get_abs_path('file2.txt'), encoding='utf8') as f:
             self.assertEquals(f.read(), file_content_different)
-        with open(b.get_abs_path('file3.txt')) as f:
+        with io.open(b.get_abs_path('file3.txt'), encoding='utf8') as f:
             self.assertEquals(f.read(), file_content_different)
 
         # This should in principle change the location of the files,
@@ -709,19 +710,19 @@ class TestNodeBasic(AiidaTestCase):
 
         self.assertEquals(
             set(a.get_folder_list()), set(['file1.txt', 'file2.txt']))
-        with open(a.get_abs_path('file1.txt')) as f:
+        with io.open(a.get_abs_path('file1.txt'), encoding='utf8') as f:
             self.assertEquals(f.read(), file_content)
-        with open(a.get_abs_path('file2.txt')) as f:
+        with io.open(a.get_abs_path('file2.txt'), encoding='utf8') as f:
             self.assertEquals(f.read(), file_content)
 
         self.assertEquals(
             set(c.get_folder_list()),
             set(['file1.txt', 'file2.txt', 'file4.txt']))
-        with open(c.get_abs_path('file1.txt')) as f:
+        with io.open(c.get_abs_path('file1.txt'), encoding='utf8') as f:
             self.assertEquals(f.read(), file_content_different)
-        with open(c.get_abs_path('file2.txt')) as f:
+        with io.open(c.get_abs_path('file2.txt'), encoding='utf8') as f:
             self.assertEquals(f.read(), file_content)
-        with open(c.get_abs_path('file4.txt')) as f:
+        with io.open(c.get_abs_path('file4.txt'), encoding='utf8') as f:
             self.assertEquals(f.read(), file_content_different)
 
     def test_folders(self):
@@ -750,11 +751,11 @@ class TestNodeBasic(AiidaTestCase):
         os.makedirs(tree_1)
         file_content = 'some text ABCDE'
         file_content_different = 'other values 12345'
-        with open(os.path.join(tree_1, 'file1.txt'), 'w') as f:
+        with io.open(os.path.join(tree_1, 'file1.txt'), 'w', encoding='utf8') as f:
             f.write(file_content)
         os.mkdir(os.path.join(tree_1, 'dir1'))
         os.mkdir(os.path.join(tree_1, 'dir1', 'dir2'))
-        with open(os.path.join(tree_1, 'dir1', 'file2.txt'), 'w') as f:
+        with io.open(os.path.join(tree_1, 'dir1', 'file2.txt'), 'w', encoding='utf8') as f:
             f.write(file_content)
         os.mkdir(os.path.join(tree_1, 'dir1', 'dir2', 'dir3'))
 
@@ -769,10 +770,10 @@ class TestNodeBasic(AiidaTestCase):
         self.assertEquals(
             set(a.get_folder_list(os.path.join('tree_1', 'dir1'))),
             set(['dir2', 'file2.txt']))
-        with open(a.get_abs_path(os.path.join('tree_1', 'file1.txt'))) as f:
+        with io.open(a.get_abs_path(os.path.join('tree_1', 'file1.txt')), encoding='utf8') as f:
             self.assertEquals(f.read(), file_content)
-        with open(a.get_abs_path(os.path.join('tree_1', 'dir1',
-                                              'file2.txt'))) as f:
+        with io.open(a.get_abs_path(os.path.join('tree_1', 'dir1',
+                                              'file2.txt')), encoding='utf8') as f:
             self.assertEquals(f.read(), file_content)
 
         # try to exit from the folder
@@ -790,10 +791,10 @@ class TestNodeBasic(AiidaTestCase):
         self.assertEquals(
             set(b.get_folder_list(os.path.join('tree_1', 'dir1'))),
             set(['dir2', 'file2.txt']))
-        with open(b.get_abs_path(os.path.join('tree_1', 'file1.txt'))) as f:
+        with io.open(b.get_abs_path(os.path.join('tree_1', 'file1.txt')), encoding='utf8') as f:
             self.assertEquals(f.read(), file_content)
-        with open(b.get_abs_path(os.path.join('tree_1', 'dir1',
-                                              'file2.txt'))) as f:
+        with io.open(b.get_abs_path(os.path.join('tree_1', 'dir1',
+                                              'file2.txt')), encoding='utf8') as f:
             self.assertEquals(f.read(), file_content)
 
         # I overwrite a file and create a new one in the copy only
@@ -818,10 +819,10 @@ class TestNodeBasic(AiidaTestCase):
         self.assertEquals(
             set(a.get_folder_list(os.path.join('tree_1', 'dir1'))),
             set(['dir2', 'file2.txt']))
-        with open(a.get_abs_path(os.path.join('tree_1', 'file1.txt'))) as f:
+        with io.open(a.get_abs_path(os.path.join('tree_1', 'file1.txt')), encoding='utf8') as f:
             self.assertEquals(f.read(), file_content)
-        with open(a.get_abs_path(os.path.join('tree_1', 'dir1',
-                                              'file2.txt'))) as f:
+        with io.open(a.get_abs_path(os.path.join('tree_1', 'dir1',
+                                              'file2.txt')), encoding='utf8') as f:
             self.assertEquals(f.read(), file_content)
         # new
         self.assertEquals(
@@ -832,10 +833,10 @@ class TestNodeBasic(AiidaTestCase):
         self.assertEquals(
             set(b.get_folder_list(os.path.join('tree_1', 'dir1'))),
             set(['dir2', 'file2.txt']))
-        with open(b.get_abs_path(os.path.join('tree_1', 'file1.txt'))) as f:
+        with io.open(b.get_abs_path(os.path.join('tree_1', 'file1.txt')), encoding='utf8') as f:
             self.assertEquals(f.read(), file_content)
-        with open(b.get_abs_path(os.path.join('tree_1', 'dir1',
-                                              'file2.txt'))) as f:
+        with io.open(b.get_abs_path(os.path.join('tree_1', 'dir1',
+                                              'file2.txt')), encoding='utf8') as f:
             self.assertEquals(f.read(), file_content)
 
         # This should in principle change the location of the files,
@@ -860,10 +861,10 @@ class TestNodeBasic(AiidaTestCase):
         self.assertEquals(
             set(a.get_folder_list(os.path.join('tree_1', 'dir1'))),
             set(['dir2', 'file2.txt']))
-        with open(a.get_abs_path(os.path.join('tree_1', 'file1.txt'))) as f:
+        with io.open(a.get_abs_path(os.path.join('tree_1', 'file1.txt')), encoding='utf8') as f:
             self.assertEquals(f.read(), file_content)
-        with open(a.get_abs_path(os.path.join('tree_1', 'dir1',
-                                              'file2.txt'))) as f:
+        with io.open(a.get_abs_path(os.path.join('tree_1', 'dir1',
+                                              'file2.txt')), encoding='utf8') as f:
             self.assertEquals(f.read(), file_content)
 
         # check new
@@ -873,10 +874,10 @@ class TestNodeBasic(AiidaTestCase):
         self.assertEquals(
             set(c.get_folder_list(os.path.join('tree_1', 'dir1'))),
             set(['file2.txt', 'file4.txt']))
-        with open(c.get_abs_path(os.path.join('tree_1', 'file1.txt'))) as f:
+        with io.open(c.get_abs_path(os.path.join('tree_1', 'file1.txt'))) as f:
             self.assertEquals(f.read(), file_content_different)
-        with open(c.get_abs_path(os.path.join('tree_1', 'dir1',
-                                              'file2.txt'))) as f:
+        with io.open(c.get_abs_path(os.path.join('tree_1', 'dir1',
+                                              'file2.txt')), encoding='utf8') as f:
             self.assertEquals(f.read(), file_content)
 
         # garbage cleaning

--- a/aiida/backends/tests/nodes.py
+++ b/aiida/backends/tests/nodes.py
@@ -62,10 +62,7 @@ class TestNodeHashing(AiidaTestCase):
         return n
 
     def test_simple_equal_nodes(self):
-        attributes = [
-            (1.0, 1.1, 1.2),
-            ({'a': 'b', 'c': 'd'}, [1, 2, 3], {4, 1, 2})
-        ]
+        attributes = [(1.0, 1.1, 1.2), ({'a': 'b', 'c': 'd'}, [1, 2, 3], {4, 1, 2})]
         for attr in attributes:
             n1 = self.create_simple_node(*attr)
             n2 = self.create_simple_node(*attr)
@@ -85,14 +82,12 @@ class TestNodeHashing(AiidaTestCase):
 
         # Search for the UUID of the stored node
         qb = QueryBuilder()
-        qb.append(Node, project=['uuid'],
-                  filters={'id': {'==': n.id}})
+        qb.append(Node, project=['uuid'], filters={'id': {'==': n.id}})
         [uuid] = qb.first()
 
         # Look the node with the previously returned UUID
         qb = QueryBuilder()
-        qb.append(Node, project=['id'],
-                  filters={'uuid': {'==': uuid}})
+        qb.append(Node, project=['id'], filters={'uuid': {'==': uuid}})
 
         # Check that the query doesn't fail
         qb.all()
@@ -104,7 +99,7 @@ class TestNodeHashing(AiidaTestCase):
     def create_folderdata_with_empty_file():
         from aiida.orm.data.folder import FolderData
         res = FolderData()
-        with res.folder.get_subfolder('path').open('name', 'w') as f:
+        with res.folder.get_subfolder('path').open('name', 'w') as fhandle:
             pass
         return res
 
@@ -120,9 +115,7 @@ class TestNodeHashing(AiidaTestCase):
         f2 = self.create_folderdata_with_empty_folder()
 
         assert (
-                f1.folder.get_subfolder('path').get_content_list() ==
-                f2.folder.get_subfolder('path').get_content_list()
-        )
+            f1.folder.get_subfolder('path').get_content_list() == f2.folder.get_subfolder('path').get_content_list())
         assert f1.get_hash() != f2.get_hash()
 
     def test_folder_same(self):
@@ -155,10 +148,7 @@ class TestNodeHashing(AiidaTestCase):
     def test_unequal_arrays(self):
         import numpy as np
         from aiida.orm.data.array import ArrayData
-        arrays = [
-            (np.zeros(1001), np.zeros(1005)),
-            (np.array([1, 2, 3]), np.array([2, 3, 4]))
-        ]
+        arrays = [(np.zeros(1001), np.zeros(1005)), (np.array([1, 2, 3]), np.array([2, 3, 4]))]
 
         def create_arraydata(arr):
             a = ArrayData()
@@ -216,16 +206,9 @@ class TestQueryWithAiidaObjects(AiidaTestCase):
         from aiida.orm import (JobCalculation, CalculationFactory, DataFactory)
 
         extra_name = self.__class__.__name__ + "/test_with_subclasses"
-        calc_params = {
-            'computer': self.computer,
-            'resources': {
-                'num_machines': 1,
-                'num_mpiprocs_per_machine': 1
-            }
-        }
+        calc_params = {'computer': self.computer, 'resources': {'num_machines': 1, 'num_mpiprocs_per_machine': 1}}
 
-        TemplateReplacerCalc = CalculationFactory(
-            'simpleplugins.templatereplacer')
+        TemplateReplacerCalc = CalculationFactory('simpleplugins.templatereplacer')
         ParameterData = DataFactory('parameter')
 
         a1 = JobCalculation(**calc_params).store()
@@ -259,9 +242,7 @@ class TestQueryWithAiidaObjects(AiidaTestCase):
         qb = QueryBuilder()
         qb.append(Node, filters={'extras': {'has_key': extra_name}})
         results = [_ for [_] in qb.all()]
-        self.assertEquals(
-            set([i.pk for i in results]),
-            set([a1.pk, a2.pk, a3.pk, a4.pk, a5.pk]))
+        self.assertEquals(set([i.pk for i in results]), set([a1.pk, a2.pk, a3.pk, a4.pk, a5.pk]))
 
         # Same query, but by the Data class
         qb = QueryBuilder()
@@ -277,12 +258,7 @@ class TestQueryWithAiidaObjects(AiidaTestCase):
 
         # Same query, but by the TemplateReplacerCalc subclass
         qb = QueryBuilder()
-        qb.append(
-            TemplateReplacerCalc, filters={
-                'extras': {
-                    'has_key': extra_name
-                }
-            })
+        qb.append(TemplateReplacerCalc, filters={'extras': {'has_key': extra_name}})
         results = [_ for [_] in qb.all()]
         self.assertEquals(set([i.pk for i in results]), set([a2.pk]))
 
@@ -299,21 +275,15 @@ class TestQueryWithAiidaObjects(AiidaTestCase):
 
         # I check that I get the correct links
         self.assertEquals(set([n.uuid for n in a1.get_inputs()]), set([]))
-        self.assertEquals(
-            set([n.uuid for n in a1.get_outputs()]), set([a2.uuid]))
+        self.assertEquals(set([n.uuid for n in a1.get_outputs()]), set([a2.uuid]))
 
-        self.assertEquals(
-            set([n.uuid for n in a2.get_inputs()]), set([a1.uuid]))
-        self.assertEquals(
-            set([n.uuid for n in a2.get_outputs()]), set([a3.uuid, a4.uuid]))
+        self.assertEquals(set([n.uuid for n in a2.get_inputs()]), set([a1.uuid]))
+        self.assertEquals(set([n.uuid for n in a2.get_outputs()]), set([a3.uuid, a4.uuid]))
 
-        self.assertEquals(
-            set([n.uuid for n in a3.get_inputs()]), set([a2.uuid]))
-        self.assertEquals(
-            set([n.uuid for n in a3.get_outputs()]), set([a4.uuid]))
+        self.assertEquals(set([n.uuid for n in a3.get_inputs()]), set([a2.uuid]))
+        self.assertEquals(set([n.uuid for n in a3.get_outputs()]), set([a4.uuid]))
 
-        self.assertEquals(
-            set([n.uuid for n in a4.get_inputs()]), set([a2.uuid, a3.uuid]))
+        self.assertEquals(set([n.uuid for n in a4.get_inputs()]), set([a2.uuid, a3.uuid]))
         self.assertEquals(set([n.uuid for n in a4.get_outputs()]), set([]))
 
 
@@ -550,8 +520,7 @@ class TestNodeBasic(AiidaTestCase):
             attribute = {semi_long_string: value}
             key_len = len(semi_long_string)
 
-            max_len = models.DbAttribute._meta.get_field_by_name('key')[
-                0].max_length
+            max_len = models.DbAttribute._meta.get_field_by_name('key')[0].max_length
 
             while key_len < 2 * max_len:
                 # Create a deep, recursive attribute
@@ -562,15 +531,12 @@ class TestNodeBasic(AiidaTestCase):
 
             n.store()
 
-            all_keys = models.DbAttribute.objects.filter(
-                dbnode=n.dbnode).values_list(
-                'key', flat=True)
+            all_keys = models.DbAttribute.objects.filter(dbnode=n.dbnode).values_list('key', flat=True)
 
             print(max(len(i) for i in all_keys))
 
     def test_datetime_attribute(self):
-        from aiida.utils.timezone import (get_current_timezone, is_naive,
-                                          make_aware, now)
+        from aiida.utils.timezone import (get_current_timezone, is_naive, make_aware, now)
 
         a = Node()
 
@@ -647,52 +613,47 @@ class TestNodeBasic(AiidaTestCase):
         file_content = 'some text ABCDE'
         file_content_different = 'other values 12345'
 
-        with tempfile.NamedTemporaryFile(mode='w+') as f:
-            f.write(file_content)
-            f.flush()
+        with tempfile.NamedTemporaryFile(mode='w+') as fhandle:
+            fhandle.write(file_content)
+            fhandle.flush()
             a.add_path(f.name, 'file1.txt')
             a.add_path(f.name, 'file2.txt')
 
-        self.assertEquals(
-            set(a.get_folder_list()), set(['file1.txt', 'file2.txt']))
-        with io.open(a.get_abs_path('file1.txt'), encoding='utf8') as f:
+        self.assertEquals(set(a.get_folder_list()), set(['file1.txt', 'file2.txt']))
+        with io.open(a.get_abs_path('file1.txt'), encoding='utf8') as fhandle:
             self.assertEquals(f.read(), file_content)
-        with io.open(a.get_abs_path('file2.txt'), encoding='utf8') as f:
+        with io.open(a.get_abs_path('file2.txt'), encoding='utf8') as fhandle:
             self.assertEquals(f.read(), file_content)
 
         b = a.clone()
         self.assertNotEquals(a.uuid, b.uuid)
 
         # Check that the content is there
-        self.assertEquals(
-            set(b.get_folder_list()), set(['file1.txt', 'file2.txt']))
-        with io.open(b.get_abs_path('file1.txt'), encoding='utf8') as f:
+        self.assertEquals(set(b.get_folder_list()), set(['file1.txt', 'file2.txt']))
+        with io.open(b.get_abs_path('file1.txt'), encoding='utf8') as fhandle:
             self.assertEquals(f.read(), file_content)
-        with io.open(b.get_abs_path('file2.txt'), encoding='utf8') as f:
+        with io.open(b.get_abs_path('file2.txt'), encoding='utf8') as fhandle:
             self.assertEquals(f.read(), file_content)
 
         # I overwrite a file and create a new one in the clone only
-        with tempfile.NamedTemporaryFile(mode='w+') as f:
-            f.write(file_content_different)
-            f.flush()
+        with tempfile.NamedTemporaryFile(mode='w+') as fhandle:
+            fhandle.write(file_content_different)
+            fhandle.flush()
             b.add_path(f.name, 'file2.txt')
             b.add_path(f.name, 'file3.txt')
 
         # I check the new content, and that the old one has not changed
-        self.assertEquals(
-            set(a.get_folder_list()), set(['file1.txt', 'file2.txt']))
-        with io.open(a.get_abs_path('file1.txt'), encoding='utf8') as f:
+        self.assertEquals(set(a.get_folder_list()), set(['file1.txt', 'file2.txt']))
+        with io.open(a.get_abs_path('file1.txt'), encoding='utf8') as fhandle:
             self.assertEquals(f.read(), file_content)
-        with io.open(a.get_abs_path('file2.txt'), encoding='utf8') as f:
+        with io.open(a.get_abs_path('file2.txt'), encoding='utf8') as fhandle:
             self.assertEquals(f.read(), file_content)
-        self.assertEquals(
-            set(b.get_folder_list()),
-            set(['file1.txt', 'file2.txt', 'file3.txt']))
-        with io.open(b.get_abs_path('file1.txt'), encoding='utf8') as f:
+        self.assertEquals(set(b.get_folder_list()), set(['file1.txt', 'file2.txt', 'file3.txt']))
+        with io.open(b.get_abs_path('file1.txt'), encoding='utf8') as fhandle:
             self.assertEquals(f.read(), file_content)
-        with io.open(b.get_abs_path('file2.txt'), encoding='utf8') as f:
+        with io.open(b.get_abs_path('file2.txt'), encoding='utf8') as fhandle:
             self.assertEquals(f.read(), file_content_different)
-        with io.open(b.get_abs_path('file3.txt'), encoding='utf8') as f:
+        with io.open(b.get_abs_path('file3.txt'), encoding='utf8') as fhandle:
             self.assertEquals(f.read(), file_content_different)
 
         # This should in principle change the location of the files,
@@ -702,27 +663,24 @@ class TestNodeBasic(AiidaTestCase):
         # I now clone after storing
         c = a.clone()
         # I overwrite a file and create a new one in the clone only
-        with tempfile.NamedTemporaryFile(mode='w+') as f:
-            f.write(file_content_different)
-            f.flush()
+        with tempfile.NamedTemporaryFile(mode='w+') as fhandle:
+            fhandle.write(file_content_different)
+            fhandle.flush()
             c.add_path(f.name, 'file1.txt')
             c.add_path(f.name, 'file4.txt')
 
-        self.assertEquals(
-            set(a.get_folder_list()), set(['file1.txt', 'file2.txt']))
-        with io.open(a.get_abs_path('file1.txt'), encoding='utf8') as f:
+        self.assertEquals(set(a.get_folder_list()), set(['file1.txt', 'file2.txt']))
+        with io.open(a.get_abs_path('file1.txt'), encoding='utf8') as fhandle:
             self.assertEquals(f.read(), file_content)
-        with io.open(a.get_abs_path('file2.txt'), encoding='utf8') as f:
+        with io.open(a.get_abs_path('file2.txt'), encoding='utf8') as fhandle:
             self.assertEquals(f.read(), file_content)
 
-        self.assertEquals(
-            set(c.get_folder_list()),
-            set(['file1.txt', 'file2.txt', 'file4.txt']))
-        with io.open(c.get_abs_path('file1.txt'), encoding='utf8') as f:
+        self.assertEquals(set(c.get_folder_list()), set(['file1.txt', 'file2.txt', 'file4.txt']))
+        with io.open(c.get_abs_path('file1.txt'), encoding='utf8') as fhandle:
             self.assertEquals(f.read(), file_content_different)
-        with io.open(c.get_abs_path('file2.txt'), encoding='utf8') as f:
+        with io.open(c.get_abs_path('file2.txt'), encoding='utf8') as fhandle:
             self.assertEquals(f.read(), file_content)
-        with io.open(c.get_abs_path('file4.txt'), encoding='utf8') as f:
+        with io.open(c.get_abs_path('file4.txt'), encoding='utf8') as fhandle:
             self.assertEquals(f.read(), file_content_different)
 
     def test_folders(self):
@@ -751,12 +709,12 @@ class TestNodeBasic(AiidaTestCase):
         os.makedirs(tree_1)
         file_content = 'some text ABCDE'
         file_content_different = 'other values 12345'
-        with io.open(os.path.join(tree_1, 'file1.txt'), 'w', encoding='utf8') as f:
-            f.write(file_content)
+        with io.open(os.path.join(tree_1, 'file1.txt'), 'w', encoding='utf8') as fhandle:
+            fhandle.write(file_content)
         os.mkdir(os.path.join(tree_1, 'dir1'))
         os.mkdir(os.path.join(tree_1, 'dir1', 'dir2'))
-        with io.open(os.path.join(tree_1, 'dir1', 'file2.txt'), 'w', encoding='utf8') as f:
-            f.write(file_content)
+        with io.open(os.path.join(tree_1, 'dir1', 'file2.txt'), 'w', encoding='utf8') as fhandle:
+            fhandle.write(file_content)
         os.mkdir(os.path.join(tree_1, 'dir1', 'dir2', 'dir3'))
 
         # add the tree to the node
@@ -765,15 +723,11 @@ class TestNodeBasic(AiidaTestCase):
 
         # verify if the node has the structure I expect
         self.assertEquals(set(a.get_folder_list()), set(['tree_1']))
-        self.assertEquals(
-            set(a.get_folder_list('tree_1')), set(['file1.txt', 'dir1']))
-        self.assertEquals(
-            set(a.get_folder_list(os.path.join('tree_1', 'dir1'))),
-            set(['dir2', 'file2.txt']))
-        with io.open(a.get_abs_path(os.path.join('tree_1', 'file1.txt')), encoding='utf8') as f:
+        self.assertEquals(set(a.get_folder_list('tree_1')), set(['file1.txt', 'dir1']))
+        self.assertEquals(set(a.get_folder_list(os.path.join('tree_1', 'dir1'))), set(['dir2', 'file2.txt']))
+        with io.open(a.get_abs_path(os.path.join('tree_1', 'file1.txt')), encoding='utf8') as fhandle:
             self.assertEquals(f.read(), file_content)
-        with io.open(a.get_abs_path(os.path.join('tree_1', 'dir1',
-                                              'file2.txt')), encoding='utf8') as f:
+        with io.open(a.get_abs_path(os.path.join('tree_1', 'dir1', 'file2.txt')), encoding='utf8') as fhandle:
             self.assertEquals(f.read(), file_content)
 
         # try to exit from the folder
@@ -786,15 +740,11 @@ class TestNodeBasic(AiidaTestCase):
 
         # Check that the content is there
         self.assertEquals(set(b.get_folder_list('.')), set(['tree_1']))
-        self.assertEquals(
-            set(b.get_folder_list('tree_1')), set(['file1.txt', 'dir1']))
-        self.assertEquals(
-            set(b.get_folder_list(os.path.join('tree_1', 'dir1'))),
-            set(['dir2', 'file2.txt']))
-        with io.open(b.get_abs_path(os.path.join('tree_1', 'file1.txt')), encoding='utf8') as f:
+        self.assertEquals(set(b.get_folder_list('tree_1')), set(['file1.txt', 'dir1']))
+        self.assertEquals(set(b.get_folder_list(os.path.join('tree_1', 'dir1'))), set(['dir2', 'file2.txt']))
+        with io.open(b.get_abs_path(os.path.join('tree_1', 'file1.txt')), encoding='utf8') as fhandle:
             self.assertEquals(f.read(), file_content)
-        with io.open(b.get_abs_path(os.path.join('tree_1', 'dir1',
-                                              'file2.txt')), encoding='utf8') as f:
+        with io.open(b.get_abs_path(os.path.join('tree_1', 'dir1', 'file2.txt')), encoding='utf8') as fhandle:
             self.assertEquals(f.read(), file_content)
 
         # I overwrite a file and create a new one in the copy only
@@ -806,37 +756,27 @@ class TestNodeBasic(AiidaTestCase):
         with self.assertRaises(ValueError):
             b.add_path('dir3', os.path.join('tree_1', 'dir3'))
 
-        with tempfile.NamedTemporaryFile(mode='w+') as f:
-            f.write(file_content_different)
-            f.flush()
+        with tempfile.NamedTemporaryFile(mode='w+') as fhandle:
+            fhandle.write(file_content_different)
+            fhandle.flush()
             b.add_path(f.name, 'file3.txt')
 
         # I check the new content, and that the old one has not changed
         # old
         self.assertEquals(set(a.get_folder_list('.')), set(['tree_1']))
-        self.assertEquals(
-            set(a.get_folder_list('tree_1')), set(['file1.txt', 'dir1']))
-        self.assertEquals(
-            set(a.get_folder_list(os.path.join('tree_1', 'dir1'))),
-            set(['dir2', 'file2.txt']))
-        with io.open(a.get_abs_path(os.path.join('tree_1', 'file1.txt')), encoding='utf8') as f:
+        self.assertEquals(set(a.get_folder_list('tree_1')), set(['file1.txt', 'dir1']))
+        self.assertEquals(set(a.get_folder_list(os.path.join('tree_1', 'dir1'))), set(['dir2', 'file2.txt']))
+        with io.open(a.get_abs_path(os.path.join('tree_1', 'file1.txt')), encoding='utf8') as fhandle:
             self.assertEquals(f.read(), file_content)
-        with io.open(a.get_abs_path(os.path.join('tree_1', 'dir1',
-                                              'file2.txt')), encoding='utf8') as f:
+        with io.open(a.get_abs_path(os.path.join('tree_1', 'dir1', 'file2.txt')), encoding='utf8') as fhandle:
             self.assertEquals(f.read(), file_content)
         # new
-        self.assertEquals(
-            set(b.get_folder_list('.')), set(['tree_1', 'file3.txt']))
-        self.assertEquals(
-            set(b.get_folder_list('tree_1')), set(['file1.txt', 'dir1',
-                                                   'dir3']))
-        self.assertEquals(
-            set(b.get_folder_list(os.path.join('tree_1', 'dir1'))),
-            set(['dir2', 'file2.txt']))
-        with io.open(b.get_abs_path(os.path.join('tree_1', 'file1.txt')), encoding='utf8') as f:
+        self.assertEquals(set(b.get_folder_list('.')), set(['tree_1', 'file3.txt']))
+        self.assertEquals(set(b.get_folder_list('tree_1')), set(['file1.txt', 'dir1', 'dir3']))
+        self.assertEquals(set(b.get_folder_list(os.path.join('tree_1', 'dir1'))), set(['dir2', 'file2.txt']))
+        with io.open(b.get_abs_path(os.path.join('tree_1', 'file1.txt')), encoding='utf8') as fhandle:
             self.assertEquals(f.read(), file_content)
-        with io.open(b.get_abs_path(os.path.join('tree_1', 'dir1',
-                                              'file2.txt')), encoding='utf8') as f:
+        with io.open(b.get_abs_path(os.path.join('tree_1', 'dir1', 'file2.txt')), encoding='utf8') as fhandle:
             self.assertEquals(f.read(), file_content)
 
         # This should in principle change the location of the files,
@@ -847,37 +787,29 @@ class TestNodeBasic(AiidaTestCase):
         c = a.clone()
         # I overwrite a file, create a new one and remove a directory
         # in the copy only
-        with tempfile.NamedTemporaryFile(mode='w+') as f:
-            f.write(file_content_different)
-            f.flush()
+        with tempfile.NamedTemporaryFile(mode='w+') as fhandle:
+            fhandle.write(file_content_different)
+            fhandle.flush()
             c.add_path(f.name, os.path.join('tree_1', 'file1.txt'))
             c.add_path(f.name, os.path.join('tree_1', 'dir1', 'file4.txt'))
         c.remove_path(os.path.join('tree_1', 'dir1', 'dir2'))
 
         # check old
         self.assertEquals(set(a.get_folder_list('.')), set(['tree_1']))
-        self.assertEquals(
-            set(a.get_folder_list('tree_1')), set(['file1.txt', 'dir1']))
-        self.assertEquals(
-            set(a.get_folder_list(os.path.join('tree_1', 'dir1'))),
-            set(['dir2', 'file2.txt']))
-        with io.open(a.get_abs_path(os.path.join('tree_1', 'file1.txt')), encoding='utf8') as f:
+        self.assertEquals(set(a.get_folder_list('tree_1')), set(['file1.txt', 'dir1']))
+        self.assertEquals(set(a.get_folder_list(os.path.join('tree_1', 'dir1'))), set(['dir2', 'file2.txt']))
+        with io.open(a.get_abs_path(os.path.join('tree_1', 'file1.txt')), encoding='utf8') as fhandle:
             self.assertEquals(f.read(), file_content)
-        with io.open(a.get_abs_path(os.path.join('tree_1', 'dir1',
-                                              'file2.txt')), encoding='utf8') as f:
+        with io.open(a.get_abs_path(os.path.join('tree_1', 'dir1', 'file2.txt')), encoding='utf8') as fhandle:
             self.assertEquals(f.read(), file_content)
 
         # check new
         self.assertEquals(set(c.get_folder_list('.')), set(['tree_1']))
-        self.assertEquals(
-            set(c.get_folder_list('tree_1')), set(['file1.txt', 'dir1']))
-        self.assertEquals(
-            set(c.get_folder_list(os.path.join('tree_1', 'dir1'))),
-            set(['file2.txt', 'file4.txt']))
-        with io.open(c.get_abs_path(os.path.join('tree_1', 'file1.txt'))) as f:
+        self.assertEquals(set(c.get_folder_list('tree_1')), set(['file1.txt', 'dir1']))
+        self.assertEquals(set(c.get_folder_list(os.path.join('tree_1', 'dir1'))), set(['file2.txt', 'file4.txt']))
+        with io.open(c.get_abs_path(os.path.join('tree_1', 'file1.txt'))) as fhandle:
             self.assertEquals(f.read(), file_content_different)
-        with io.open(c.get_abs_path(os.path.join('tree_1', 'dir1',
-                                              'file2.txt')), encoding='utf8') as f:
+        with io.open(c.get_abs_path(os.path.join('tree_1', 'dir1', 'file2.txt')), encoding='utf8') as fhandle:
             self.assertEquals(f.read(), file_content)
 
         # garbage cleaning
@@ -984,9 +916,8 @@ class TestNodeBasic(AiidaTestCase):
         n2.set_extra('samename', 1)
 
     def test_settings_methods(self):
-        from aiida.backends.utils import (
-            get_global_setting_description, get_global_setting,
-            set_global_setting, del_global_setting)
+        from aiida.backends.utils import (get_global_setting_description, get_global_setting, set_global_setting,
+                                          del_global_setting)
 
         set_global_setting(key="aaa", value={'b': 'c'}, description="pippo")
 
@@ -1027,10 +958,7 @@ class TestNodeBasic(AiidaTestCase):
         a.store()
 
         # I now set extras
-        extras_to_set = {
-            'bool': 'some non-boolean value',
-            'some_other_name': 987
-        }
+        extras_to_set = {'bool': 'some non-boolean value', 'some_other_name': 987}
 
         for k, v in extras_to_set.items():
             a.set_extra(k, v)
@@ -1303,11 +1231,10 @@ class TestNodeBasic(AiidaTestCase):
             self.assertTrue(time > before)
             self.assertTrue(time < after)
 
-        self.assertEquals([(i['user__email'], i['content'])
-                           for i in comments], [
-                              (self.user_email, 'text'),
-                              (self.user_email, 'text2'),
-                          ])
+        self.assertEquals([(i['user__email'], i['content']) for i in comments], [
+            (self.user_email, 'text'),
+            (self.user_email, 'text2'),
+        ])
 
     def test_code_loading_from_string(self):
         """
@@ -1331,16 +1258,13 @@ class TestNodeBasic(AiidaTestCase):
         q_code_1 = Code.get_from_string(code1.label)
         self.assertEquals(q_code_1.id, code1.id)
         self.assertEquals(q_code_1.label, code1.label)
-        self.assertEquals(q_code_1.get_remote_exec_path(),
-                          code1.get_remote_exec_path())
+        self.assertEquals(q_code_1.get_remote_exec_path(), code1.get_remote_exec_path())
 
         # Test that the code2 can be loaded correctly with its label
-        q_code_2 = Code.get_from_string(code2.label + '@' +
-                                        self.computer.get_name())
+        q_code_2 = Code.get_from_string(code2.label + '@' + self.computer.get_name())
         self.assertEquals(q_code_2.id, code2.id)
         self.assertEquals(q_code_2.label, code2.label)
-        self.assertEquals(q_code_2.get_remote_exec_path(),
-                          code2.get_remote_exec_path())
+        self.assertEquals(q_code_2.get_remote_exec_path(), code2.get_remote_exec_path())
 
         # Calling get_from_string for a non string type raises exception
         with self.assertRaises(InputValidationError):
@@ -1371,22 +1295,22 @@ class TestNodeBasic(AiidaTestCase):
         # Check that you can load it with a simple integer id.
         a2 = Node.get_subclass_from_pk(a1.id)
         self.assertEquals(a1.id, a2.id, "The ids of the stored and loaded node"
-                                        "should be equal (since it should be "
-                                        "the same node")
+                          "should be equal (since it should be "
+                          "the same node")
 
         if six.PY2:  # In Python 3, int is always long (enough)
             # Check that you can load it with an id of type long
             a3 = Node.get_subclass_from_pk(long(a1.id))
             self.assertEquals(a1.id, a3.id, "The ids of the stored and loaded node"
-                                            "should be equal (since it should be "
-                                            "the same node")
+                              "should be equal (since it should be "
+                              "the same node")
 
         # Check that it manages to load the node even if the id is
         # passed as a string.
         a4 = Node.get_subclass_from_pk(str(a1.id))
         self.assertEquals(a1.id, a4.id, "The ids of the stored and loaded node"
-                                        "should be equal (since it should be "
-                                        "the same node")
+                          "should be equal (since it should be "
+                          "the same node")
 
         # Check that a ValueError exception is raised when a string that can
         # not be casted to integer is passed.
@@ -1428,30 +1352,25 @@ class TestNodeBasic(AiidaTestCase):
         q_code_1 = Code.get(label=code1.label)
         self.assertEquals(q_code_1.id, code1.id)
         self.assertEquals(q_code_1.label, code1.label)
-        self.assertEquals(q_code_1.get_remote_exec_path(),
-                          code1.get_remote_exec_path())
+        self.assertEquals(q_code_1.get_remote_exec_path(), code1.get_remote_exec_path())
 
         # Test that the code1 can be loaded correctly with its id/pk
         q_code_1 = Code.get(code1.id)
         self.assertEquals(q_code_1.id, code1.id)
         self.assertEquals(q_code_1.label, code1.label)
-        self.assertEquals(q_code_1.get_remote_exec_path(),
-                          code1.get_remote_exec_path())
+        self.assertEquals(q_code_1.get_remote_exec_path(), code1.get_remote_exec_path())
 
         # Test that the code2 can be loaded correctly with its label and computername
-        q_code_2 = Code.get(
-            label=code2.label, machinename=self.computer.get_name())
+        q_code_2 = Code.get(label=code2.label, machinename=self.computer.get_name())
         self.assertEquals(q_code_2.id, code2.id)
         self.assertEquals(q_code_2.label, code2.label)
-        self.assertEquals(q_code_2.get_remote_exec_path(),
-                          code2.get_remote_exec_path())
+        self.assertEquals(q_code_2.get_remote_exec_path(), code2.get_remote_exec_path())
 
         # Test that the code2 can be loaded correctly with its id/pk
         q_code_2 = Code.get(code2.id)
         self.assertEquals(q_code_2.id, code2.id)
         self.assertEquals(q_code_2.label, code2.label)
-        self.assertEquals(q_code_2.get_remote_exec_path(),
-                          code2.get_remote_exec_path())
+        self.assertEquals(q_code_2.get_remote_exec_path(), code2.get_remote_exec_path())
 
         # Test that the lookup of a nonexistent code works as expected
         with self.assertRaises(NotExistent):
@@ -1480,8 +1399,7 @@ class TestNodeBasic(AiidaTestCase):
         q_code_4 = Code.get(code4.label)
         self.assertEquals(q_code_4.id, code1.id)
         self.assertEquals(q_code_4.label, code1.label)
-        self.assertEquals(q_code_4.get_remote_exec_path(),
-                          code1.get_remote_exec_path())
+        self.assertEquals(q_code_4.get_remote_exec_path(), code1.get_remote_exec_path())
 
     def test_code_description(self):
         """
@@ -1576,10 +1494,7 @@ class TestNodeBasic(AiidaTestCase):
         from aiida.orm import (JobCalculation, CalculationFactory)
 
         ###### for calculation
-        calc_params = {
-            'computer': self.computer,
-            'resources': {'num_machines': 1, 'num_mpiprocs_per_machine': 1}
-        }
+        calc_params = {'computer': self.computer, 'resources': {'num_machines': 1, 'num_mpiprocs_per_machine': 1}}
 
         TemplateReplacerCalc = CalculationFactory('simpleplugins.templatereplacer')
         testcalc = TemplateReplacerCalc(**calc_params).store()
@@ -1653,8 +1568,7 @@ class TestSubNodesAndLinks(AiidaTestCase):
 
         self.assertEqual(endnode.get_inputs(only_in_db=True), [])
         self.assertEqual(
-            set([(i[0], i[1].uuid)
-                 for i in endnode.get_inputs(also_labels=True)]),
+            set([(i[0], i[1].uuid) for i in endnode.get_inputs(also_labels=True)]),
             set([("N1", n1.uuid), ("N2", n2.uuid)]))
 
         # Endnode not stored yet, n3 and n4 already stored
@@ -1664,39 +1578,27 @@ class TestSubNodesAndLinks(AiidaTestCase):
 
         self.assertEqual(endnode.get_inputs(only_in_db=True), [])
         self.assertEqual(
-            set([(i[0], i[1].uuid)
-                 for i in endnode.get_inputs(also_labels=True)]),
-            set([("N1", n1.uuid), ("N2", n2.uuid), ("N3", n3.uuid), ("N4",
-                                                                     n4.uuid)]))
+            set([(i[0], i[1].uuid) for i in endnode.get_inputs(also_labels=True)]),
+            set([("N1", n1.uuid), ("N2", n2.uuid), ("N3", n3.uuid), ("N4", n4.uuid)]))
 
         # Some parent nodes are not stored yet
         with self.assertRaises(ModificationNotAllowed):
             endnode.store()
 
+        self.assertEqual(set([(i[0], i[1].uuid) for i in endnode.get_inputs(only_in_db=True, also_labels=True)]), set())
         self.assertEqual(
-            set([(i[0], i[1].uuid)
-                 for i in endnode.get_inputs(only_in_db=True, also_labels=True)
-                 ]), set())
-        self.assertEqual(
-            set([(i[0], i[1].uuid)
-                 for i in endnode.get_inputs(also_labels=True)]),
-            set([("N1", n1.uuid), ("N2", n2.uuid), ("N3", n3.uuid), ("N4",
-                                                                     n4.uuid)]))
+            set([(i[0], i[1].uuid) for i in endnode.get_inputs(also_labels=True)]),
+            set([("N1", n1.uuid), ("N2", n2.uuid), ("N3", n3.uuid), ("N4", n4.uuid)]))
 
         # This will also store n1 and n2!
         endnode.store_all()
 
         self.assertEqual(
-            set([(i[0], i[1].uuid)
-                 for i in endnode.get_inputs(only_in_db=True, also_labels=True)
-                 ]),
-            set([("N1", n1.uuid), ("N2", n2.uuid), ("N3", n3.uuid), ("N4",
-                                                                     n4.uuid)]))
+            set([(i[0], i[1].uuid) for i in endnode.get_inputs(only_in_db=True, also_labels=True)]),
+            set([("N1", n1.uuid), ("N2", n2.uuid), ("N3", n3.uuid), ("N4", n4.uuid)]))
         self.assertEqual(
-            set([(i[0], i[1].uuid)
-                 for i in endnode.get_inputs(also_labels=True)]),
-            set([("N1", n1.uuid), ("N2", n2.uuid), ("N3", n3.uuid), ("N4",
-                                                                     n4.uuid)]))
+            set([(i[0], i[1].uuid) for i in endnode.get_inputs(also_labels=True)]),
+            set([("N1", n1.uuid), ("N2", n2.uuid), ("N3", n3.uuid), ("N4", n4.uuid)]))
 
     def test_store_with_unstored_parents(self):
         """
@@ -1722,12 +1624,10 @@ class TestSubNodesAndLinks(AiidaTestCase):
         endnode.store()
 
         self.assertEqual(
-            set([(i[0], i[1].uuid)
-                 for i in endnode.get_inputs(only_in_db=True, also_labels=True)
-                 ]), set([("N1", n1.uuid), ("N2", n2.uuid)]))
+            set([(i[0], i[1].uuid) for i in endnode.get_inputs(only_in_db=True, also_labels=True)]),
+            set([("N1", n1.uuid), ("N2", n2.uuid)]))
         self.assertEqual(
-            set([(i[0], i[1].uuid)
-                 for i in endnode.get_inputs(also_labels=True)]),
+            set([(i[0], i[1].uuid) for i in endnode.get_inputs(also_labels=True)]),
             set([("N1", n1.uuid), ("N2", n2.uuid)]))
 
     def test_storeall_with_unstored_grandparents(self):
@@ -1750,13 +1650,8 @@ class TestSubNodesAndLinks(AiidaTestCase):
         endnode.store_all()
 
         # Check the parents...
-        self.assertEqual(
-            set([(i[0], i[1].uuid) for i in n2.get_inputs(also_labels=True)]),
-            set([("N1", n1.uuid)]))
-        self.assertEqual(
-            set([(i[0], i[1].uuid)
-                 for i in endnode.get_inputs(also_labels=True)]),
-            set([("N2", n2.uuid)]))
+        self.assertEqual(set([(i[0], i[1].uuid) for i in n2.get_inputs(also_labels=True)]), set([("N1", n1.uuid)]))
+        self.assertEqual(set([(i[0], i[1].uuid) for i in endnode.get_inputs(also_labels=True)]), set([("N2", n2.uuid)]))
 
     def test_has_children_has_parents(self):
         """
@@ -1772,14 +1667,10 @@ class TestSubNodesAndLinks(AiidaTestCase):
         # Create a link between these 2 nodes, link type CREATE so we track the provenance
         n2.add_link_from(n1, "N1", link_type=LinkType.CREATE)
 
-        self.assertTrue(n1.has_children, "It should be true since n2 is the "
-                                         "child of n1.")
-        self.assertFalse(n1.has_parents, "It should be false since n1 doesn't "
-                                         "have any parents.")
-        self.assertFalse(n2.has_children, "It should be false since n2 "
-                                          "doesn't have any children.")
-        self.assertTrue(n2.has_parents, "It should be true since n1 is the "
-                                        "parent of n2.")
+        self.assertTrue(n1.has_children, "It should be true since n2 is the " "child of n1.")
+        self.assertFalse(n1.has_parents, "It should be false since n1 doesn't " "have any parents.")
+        self.assertFalse(n2.has_children, "It should be false since n2 " "doesn't have any children.")
+        self.assertTrue(n2.has_parents, "It should be true since n1 is the " "parent of n2.")
 
     def test_use_code(self):
         from aiida.orm import JobCalculation
@@ -1789,18 +1680,8 @@ class TestSubNodesAndLinks(AiidaTestCase):
 
         code = Code(remote_computer_exec=(computer, '/bin/true'))  # .store()
 
-        unstoredcalc = JobCalculation(
-            computer=computer,
-            resources={
-                'num_machines': 1,
-                'num_mpiprocs_per_machine': 1
-            })
-        calc = JobCalculation(
-            computer=computer,
-            resources={
-                'num_machines': 1,
-                'num_mpiprocs_per_machine': 1
-            }).store()
+        unstoredcalc = JobCalculation(computer=computer, resources={'num_machines': 1, 'num_mpiprocs_per_machine': 1})
+        calc = JobCalculation(computer=computer, resources={'num_machines': 1, 'num_mpiprocs_per_machine': 1}).store()
 
         # calc is not stored, and also code is not
         unstoredcalc.use_code(code)
@@ -1828,8 +1709,7 @@ class TestSubNodesAndLinks(AiidaTestCase):
 
         # I check with a string, with an object and with the computer pk/id
         calc = JobCalculation(
-            computer=self.computer,
-            resources={
+            computer=self.computer, resources={
                 'num_machines': 1,
                 'num_mpiprocs_per_machine': 1
             }).store()
@@ -1837,8 +1717,7 @@ class TestSubNodesAndLinks(AiidaTestCase):
             # I should get an error if I ask for a computer id/pk that doesn't
             # exist
             _ = JobCalculation(
-                computer=self.computer.id + 100000,
-                resources={
+                computer=self.computer.id + 100000, resources={
                     'num_machines': 2,
                     'num_mpiprocs_per_machine': 1
                 }).store()
@@ -1890,9 +1769,7 @@ class TestSubNodesAndLinks(AiidaTestCase):
         n10.add_link_from(n9)
 
         all_labels = [_[0] for _ in n10.get_inputs(also_labels=True)]
-        self.assertEquals(
-            len(set(all_labels)),
-            len(all_labels), "There are duplicate links, that are not expected")
+        self.assertEquals(len(set(all_labels)), len(all_labels), "There are duplicate links, that are not expected")
 
     @unittest.skip("Skipping while we solve issue #301")
     def test_link_replace(self):
@@ -1909,24 +1786,14 @@ class TestSubNodesAndLinks(AiidaTestCase):
 
         # I can replace the link and check that it was replaced
         n3._replace_link_from(n2, label='the_label')
-        the_parent = [
-            _[1].uuid for _ in n3.get_inputs(also_labels=True)
-            if _[0] == 'the_label'
-        ]
-        self.assertEquals(
-            len(the_parent), 1,
-            "There are multiple input links with the same label (the_label)!")
+        the_parent = [_[1].uuid for _ in n3.get_inputs(also_labels=True) if _[0] == 'the_label']
+        self.assertEquals(len(the_parent), 1, "There are multiple input links with the same label (the_label)!")
         self.assertEquals(n2.uuid, the_parent[0])
 
         # _replace_link_from should work also if there is no previous link
         n2._replace_link_from(n1, label='the_label_2')
-        the_parent_2 = [
-            _[1].uuid for _ in n3.get_inputs(also_labels=True)
-            if _[0] == 'the_label_2'
-        ]
-        self.assertEquals(
-            len(the_parent_2), 1,
-            "There are multiple input links with the same label (the_label_2)!")
+        the_parent_2 = [_[1].uuid for _ in n3.get_inputs(also_labels=True) if _[0] == 'the_label_2']
+        self.assertEquals(len(the_parent_2), 1, "There are multiple input links with the same label (the_label_2)!")
         self.assertEquals(n1.uuid, the_parent_2[0])
 
     def test_link_with_unstored(self):
@@ -1961,18 +1828,16 @@ class TestSubNodesAndLinks(AiidaTestCase):
             ('l1', n1.uuid),
         ]))
         n3_in_links = [(l, n.uuid) for l, n in n3.get_inputs_dict().items()]
-        self.assertEquals(
-            sorted(n3_in_links), sorted([
-                ('l2', n2.uuid),
-                ('l3', n1.uuid),
-            ]))
+        self.assertEquals(sorted(n3_in_links), sorted([
+            ('l2', n2.uuid),
+            ('l3', n1.uuid),
+        ]))
 
         n1_out_links = [(l, n.pk) for l, n in n1.get_outputs(also_labels=True)]
-        self.assertEquals(
-            sorted(n1_out_links), sorted([
-                ('l1', n2.pk),
-                ('l3', n3.pk),
-            ]))
+        self.assertEquals(sorted(n1_out_links), sorted([
+            ('l1', n2.pk),
+            ('l3', n3.pk),
+        ]))
         n2_out_links = [(l, n.pk) for l, n in n2.get_outputs(also_labels=True)]
         self.assertEquals(sorted(n2_out_links), sorted([('l2', n3.pk)]))
 
@@ -2000,7 +1865,7 @@ class TestSubNodesAndLinks(AiidaTestCase):
 
         # I create some objects
         d1 = Data().store()
-        with tempfile.NamedTemporaryFile('w+') as f:
+        with tempfile.NamedTemporaryFile('w+') as fhandle:
             d2 = SinglefileData(file=f.name).store()
 
         code = Code()
@@ -2014,22 +1879,19 @@ class TestSubNodesAndLinks(AiidaTestCase):
         with self.assertRaises(ValueError):
             # I need to save the localhost entry first
             _ = JobCalculation(
-                computer=unsavedcomputer,
-                resources={
+                computer=unsavedcomputer, resources={
                     'num_machines': 1,
                     'num_mpiprocs_per_machine': 1
                 }).store()
 
         # Load calculations with two different ways
         calc = JobCalculation(
-            computer=self.computer,
-            resources={
+            computer=self.computer, resources={
                 'num_machines': 1,
                 'num_mpiprocs_per_machine': 1
             }).store()
         calc2 = JobCalculation(
-            computer=self.computer,
-            resources={
+            computer=self.computer, resources={
                 'num_machines': 1,
                 'num_mpiprocs_per_machine': 1
             }).store()
@@ -2059,14 +1921,12 @@ class TestSubNodesAndLinks(AiidaTestCase):
             calc.add_link_from(calc2)
 
         calc_a = JobCalculation(
-            computer=self.computer,
-            resources={
+            computer=self.computer, resources={
                 'num_machines': 1,
                 'num_mpiprocs_per_machine': 1
             }).store()
         calc_b = JobCalculation(
-            computer=self.computer,
-            resources={
+            computer=self.computer, resources={
                 'num_machines': 1,
                 'num_mpiprocs_per_machine': 1
             }).store()
@@ -2096,12 +1956,8 @@ class TestSubNodesAndLinks(AiidaTestCase):
             calc_a.use_code(code)
 
         calculation_inputs = calc.get_inputs()
-        inputs_type_data = [
-            i for i in calculation_inputs if isinstance(i, Data)
-        ]
-        inputs_type_code = [
-            i for i in calculation_inputs if isinstance(i, Code)
-        ]
+        inputs_type_data = [i for i in calculation_inputs if isinstance(i, Data)]
+        inputs_type_code = [i for i in calculation_inputs if isinstance(i, Code)]
 
         # This calculation has three inputs (2 data and one code)
         self.assertEquals(len(calculation_inputs), 3)
@@ -2118,14 +1974,12 @@ class TestSubNodesAndLinks(AiidaTestCase):
         d1 = Data().store()
 
         calc = JobCalculation(
-            computer=self.computer,
-            resources={
+            computer=self.computer, resources={
                 'num_machines': 1,
                 'num_mpiprocs_per_machine': 1
             }).store()
         calc2 = JobCalculation(
-            computer=self.computer,
-            resources={
+            computer=self.computer, resources={
                 'num_machines': 1,
                 'num_mpiprocs_per_machine': 1
             }).store()

--- a/aiida/backends/tests/orm/data/remote.py
+++ b/aiida/backends/tests/orm/data/remote.py
@@ -11,6 +11,7 @@ from __future__ import division
 from __future__ import print_function
 from __future__ import absolute_import
 import errno
+import io
 import os
 import shutil
 import tempfile
@@ -37,7 +38,7 @@ class TestRemoteData(AiidaTestCase):
         self.remote = RemoteData(computer=self.computer)
         self.remote.set_remote_path(self.tmp_path)
 
-        with open(os.path.join(self.tmp_path, 'file.txt'), 'w') as handle:
+        with io.open(os.path.join(self.tmp_path, 'file.txt'), 'w', encoding='utf8') as handle:
             handle.write('test string')
 
         self.remote.set_computer(self.computer)

--- a/aiida/backends/tests/orm/data/remote.py
+++ b/aiida/backends/tests/orm/data/remote.py
@@ -38,8 +38,8 @@ class TestRemoteData(AiidaTestCase):
         self.remote = RemoteData(computer=self.computer)
         self.remote.set_remote_path(self.tmp_path)
 
-        with io.open(os.path.join(self.tmp_path, 'file.txt'), 'w', encoding='utf8') as handle:
-            handle.write('test string')
+        with io.open(os.path.join(self.tmp_path, 'file.txt'), 'w', encoding='utf8') as fhandle:
+            fhandle.write(u'test string')
 
         self.remote.set_computer(self.computer)
         self.remote.store()

--- a/aiida/backends/tests/parsers.py
+++ b/aiida/backends/tests/parsers.py
@@ -109,8 +109,8 @@ def output_test(pk, testname, skip_uuids_from_inputs=[]):
     export_tree(to_export, folder=folder, also_parents=False, also_calc_outputs=False)
 
     # Create an empty checks file
-    with io.open(os.path.join(outfolder, '_aiida_checks.json', encoding='utf8'), 'w') as fhandle:
-        json.dump({}, f)
+    with io.open(os.path.join(outfolder, '_aiida_checks.json'), 'w', encoding=None) as fhandle:
+        json.dump({}, fhandle)
 
     for path, dirlist, filelist in os.walk(outfolder):
         if len(dirlist) == 0 and len(filelist) == 0:

--- a/aiida/backends/tests/parsers.py
+++ b/aiida/backends/tests/parsers.py
@@ -77,7 +77,7 @@ def output_test(pk, testname, skip_uuids_from_inputs=[]):
         skipped
     """
     import os
-    import json
+    import aiida.utils.json as json
 
     from aiida.common.folders import Folder
     from aiida.orm import JobCalculation
@@ -109,8 +109,8 @@ def output_test(pk, testname, skip_uuids_from_inputs=[]):
     export_tree(to_export, folder=folder, also_parents=False, also_calc_outputs=False)
 
     # Create an empty checks file
-    with io.open(os.path.join(outfolder, '_aiida_checks.json'), 'w', encoding='utf8') as fhandle:
-        fhandle.write(six.text_type(json.dumps({}, ensure_ascii=False)))
+    with io.open(os.path.join(outfolder, '_aiida_checks.json'), 'wb') as fhandle:
+        json.dump({}, fhandle)
 
     for path, dirlist, filelist in os.walk(outfolder):
         if len(dirlist) == 0 and len(filelist) == 0:
@@ -173,7 +173,7 @@ class TestParsers(AiidaTestCase):
     def read_test(self, outfolder):
         import os
         import importlib
-        import json
+        import aiida.utils.json as json
 
         from aiida.orm import JobCalculation
         from aiida.orm.utils import load_node

--- a/aiida/backends/tests/parsers.py
+++ b/aiida/backends/tests/parsers.py
@@ -14,7 +14,7 @@ Tests for specific subclasses of Data
 from __future__ import division
 from __future__ import print_function
 from __future__ import absolute_import
-
+import io
 import six
 from six.moves import range
 
@@ -111,12 +111,12 @@ def output_test(pk, testname, skip_uuids_from_inputs=[]):
                 also_calc_outputs=False)
 
     # Create an empty checks file
-    with open(os.path.join(outfolder, '_aiida_checks.json'), 'w') as f:
+    with io.open(os.path.join(outfolder, '_aiida_checks.json', encoding='utf8'), 'w') as f:
         json.dump({}, f)
 
     for path, dirlist, filelist in os.walk(outfolder):
         if len(dirlist) == 0 and len(filelist) == 0:
-            with open("{}/.gitignore".format(path), 'w') as f:
+            with io.open("{}/.gitignore".format(path), 'w', encoding='utf8') as f:
                 f.write("# This is a placeholder file, used to make git "
                         "store an empty folder")
                 f.flush()
@@ -196,7 +196,7 @@ class TestParsers(AiidaTestCase):
         retrieved = calc.out.retrieved
 
         try:
-            with open(os.path.join(outfolder, '_aiida_checks.json')) as f:
+            with io.open(os.path.join(outfolder, '_aiida_checks.json', encoding='utf8')) as f:
                 tests = json.load(f)
         except IOError:
             raise ValueError("This test does not provide a check file!")

--- a/aiida/backends/tests/parsers.py
+++ b/aiida/backends/tests/parsers.py
@@ -109,8 +109,8 @@ def output_test(pk, testname, skip_uuids_from_inputs=[]):
     export_tree(to_export, folder=folder, also_parents=False, also_calc_outputs=False)
 
     # Create an empty checks file
-    with io.open(os.path.join(outfolder, '_aiida_checks.json'), 'wb', encoding=None) as fhandle:
-        json.dump({}, fhandle, ensure_ascii=False)
+    with io.open(os.path.join(outfolder, '_aiida_checks.json'), 'w', encoding='utf8') as fhandle:
+        fhandle.write(six.text_type(json.dumps({}, ensure_ascii=False)))
 
     for path, dirlist, filelist in os.walk(outfolder):
         if len(dirlist) == 0 and len(filelist) == 0:

--- a/aiida/backends/tests/parsers.py
+++ b/aiida/backends/tests/parsers.py
@@ -109,8 +109,8 @@ def output_test(pk, testname, skip_uuids_from_inputs=[]):
     export_tree(to_export, folder=folder, also_parents=False, also_calc_outputs=False)
 
     # Create an empty checks file
-    with io.open(os.path.join(outfolder, '_aiida_checks.json'), 'w', encoding=None) as fhandle:
-        json.dump({}, fhandle)
+    with io.open(os.path.join(outfolder, '_aiida_checks.json'), 'wb', encoding=None) as fhandle:
+        json.dump({}, fhandle, ensure_ascii=False)
 
     for path, dirlist, filelist in os.walk(outfolder):
         if len(dirlist) == 0 and len(filelist) == 0:

--- a/aiida/backends/tests/restapi.py
+++ b/aiida/backends/tests/restapi.py
@@ -14,7 +14,6 @@ Unittests for REST API
 from __future__ import division
 from __future__ import print_function
 from __future__ import absolute_import
-import json
 
 from aiida.backends.testbase import AiidaTestCase
 from aiida.common.links import LinkType
@@ -24,6 +23,7 @@ from aiida.orm.computer import Computer
 from aiida.orm.data import Data
 from aiida.orm.querybuilder import QueryBuilder
 from aiida.restapi.api import App, AiidaApi
+import aiida.utils.json as json
 
 StructureData = DataFactory('structure')  # pylint: disable=invalid-name
 CifData = DataFactory('cif')  # pylint: disable=invalid-name

--- a/aiida/backends/tests/tcodexporter.py
+++ b/aiida/backends/tests/tcodexporter.py
@@ -78,7 +78,7 @@ class TestTcodDbExporter(AiidaTestCase):
         """Testing the collection of files from file tree."""
         from aiida.tools.dbexporters.tcod import _collect_files
         from aiida.common.folders import SandboxFolder
-        from six.moves import cStringIO as StringIO
+        from six.moves import StringIO as StringIO
 
         sf = SandboxFolder()
         sf.get_subfolder('out', create=True)
@@ -87,17 +87,17 @@ class TestTcodDbExporter(AiidaTestCase):
         sf.get_subfolder('save/1', create=True)
         sf.get_subfolder('save/2', create=True)
 
-        f = StringIO("test")
+        f = StringIO(u"test")
         sf.create_file_from_filelike(f, 'aiida.in')
-        f = StringIO("test")
+        f = StringIO(u"test")
         sf.create_file_from_filelike(f, 'aiida.out')
-        f = StringIO("test")
+        f = StringIO(u"test")
         sf.create_file_from_filelike(f, '_aiidasubmit.sh')
-        f = StringIO("test")
+        f = StringIO(u"test")
         sf.create_file_from_filelike(f, '_.out')
-        f = StringIO("test")
+        f = StringIO(u"test")
         sf.create_file_from_filelike(f, 'out/out')
-        f = StringIO("test")
+        f = StringIO(u"test")
         sf.create_file_from_filelike(f, 'save/1/log.log')
 
         md5 = '098f6bcd4621d373cade4e832627b4f6'

--- a/aiida/backends/tests/tcodexporter.py
+++ b/aiida/backends/tests/tcodexporter.py
@@ -137,8 +137,8 @@ class TestTcodDbExporter(AiidaTestCase):
         from aiida.common.datastructures import calc_states
         import tempfile
 
-        with tempfile.NamedTemporaryFile(mode='w+') as f:
-            f.write('''
+        with tempfile.NamedTemporaryFile(mode='w+') as tmpf:
+            tmpf.write('''
                 data_test
                 _cell_length_a    10
                 _cell_length_b    10
@@ -154,18 +154,18 @@ class TestTcodDbExporter(AiidaTestCase):
                 C 0 0 0
                 O 0.5 0.5 0.5
             ''')
-            f.flush()
-            a = CifData(file=f.name)
+            tmpf.flush()
+            a = CifData(file=tmpf.name)
 
         c = a._get_aiida_structure()
         c.store()
         pd = ParameterData()
 
         code = Code(local_executable='test.sh')
-        with tempfile.NamedTemporaryFile(mode='w+') as f:
-            f.write("#/bin/bash\n\necho test run\n")
-            f.flush()
-            code.add_path(f.name, 'test.sh')
+        with tempfile.NamedTemporaryFile(mode='w+') as tmpf:
+            tmpf.write("#/bin/bash\n\necho test run\n")
+            tmpf.flush()
+            code.add_path(tmpf.name, 'test.sh')
 
         code.store()
 
@@ -175,35 +175,35 @@ class TestTcodDbExporter(AiidaTestCase):
         calc.add_link_from(code, "code")
         calc.set_option('environment_variables', {'PATH': '/dev/null', 'USER': 'unknown'})
 
-        with tempfile.NamedTemporaryFile(mode='w+', prefix="Fe") as f:
-            f.write("<UPF version=\"2.0.1\">\nelement=\"Fe\"\n")
-            f.flush()
-            upf = UpfData(file=f.name)
+        with tempfile.NamedTemporaryFile(mode='w+', prefix="Fe") as tmpf:
+            tmpf.write("<UPF version=\"2.0.1\">\nelement=\"Fe\"\n")
+            tmpf.flush()
+            upf = UpfData(file=tmpf.name)
             upf.store()
             calc.add_link_from(upf, "upf")
 
-        with tempfile.NamedTemporaryFile(mode='w+') as f:
-            f.write("data_test")
-            f.flush()
-            cif = CifData(file=f.name)
+        with tempfile.NamedTemporaryFile(mode='w+') as tmpf:
+            tmpf.write("data_test")
+            tmpf.flush()
+            cif = CifData(file=tmpf.name)
             cif.store()
             calc.add_link_from(cif, "cif")
 
         calc.store()
         calc._set_state(calc_states.TOSUBMIT)
-        with SandboxFolder() as f:
-            calc._store_raw_input_folder(f.abspath)
+        with SandboxFolder() as fhandle:
+            calc._store_raw_input_folder(fhandle.abspath)
 
         fd = FolderData()
         with io.open(fd._get_folder_pathsubfolder.get_abs_path(
-                calc._SCHED_OUTPUT_FILE), 'w', encoding='utf8') as f:
-            f.write("standard output")
-            f.flush()
+                calc._SCHED_OUTPUT_FILE), 'w', encoding='utf8') as fhandle:
+            fhandle.write("standard output")
+            fhandle.flush()
 
         with io.open(fd._get_folder_pathsubfolder.get_abs_path(
-                calc._SCHED_ERROR_FILE), 'w', encoding='uft8') as f:
-            f.write("standard error")
-            f.flush()
+                calc._SCHED_ERROR_FILE), 'w', encoding='uft8') as fhandle:
+            fhandle.write("standard error")
+            fhandle.flush()
 
         fd.store()
         calc._set_state(calc_states.PARSING)
@@ -235,8 +235,8 @@ class TestTcodDbExporter(AiidaTestCase):
         from aiida.tools.dbexporters.tcod import export_values
         import tempfile
 
-        with tempfile.NamedTemporaryFile(mode='w+') as f:
-            f.write('''
+        with tempfile.NamedTemporaryFile(mode='w+') as tmpf:
+            tmpf.write('''
                 data_test
                 _cell_length_a    10
                 _cell_length_b    10
@@ -252,8 +252,8 @@ class TestTcodDbExporter(AiidaTestCase):
                 C 0 0 0
                 O 0.5 0.5 0.5
             ''')
-            f.flush()
-            a = CifData(file=f.name)
+            tmpf.flush()
+            a = CifData(file=tmpf.name)
 
         s = a._get_aiida_structure(store=True)
         val = export_values(s)

--- a/aiida/backends/tests/tcodexporter.py
+++ b/aiida/backends/tests/tcodexporter.py
@@ -13,6 +13,7 @@ Tests for TestTcodDbExporter
 from __future__ import division
 from __future__ import print_function
 from __future__ import absolute_import
+import io
 import unittest
 
 import six
@@ -194,13 +195,13 @@ class TestTcodDbExporter(AiidaTestCase):
             calc._store_raw_input_folder(f.abspath)
 
         fd = FolderData()
-        with open(fd._get_folder_pathsubfolder.get_abs_path(
-                calc._SCHED_OUTPUT_FILE), 'w') as f:
+        with io.open(fd._get_folder_pathsubfolder.get_abs_path(
+                calc._SCHED_OUTPUT_FILE), 'w', encoding='utf8') as f:
             f.write("standard output")
             f.flush()
 
-        with open(fd._get_folder_pathsubfolder.get_abs_path(
-                calc._SCHED_ERROR_FILE), 'w') as f:
+        with io.open(fd._get_folder_pathsubfolder.get_abs_path(
+                calc._SCHED_ERROR_FILE), 'w', encoding='uft8') as f:
             f.write("standard error")
             f.flush()
 

--- a/aiida/backends/tests/tcodexporter.py
+++ b/aiida/backends/tests/tcodexporter.py
@@ -198,12 +198,10 @@ class TestTcodDbExporter(AiidaTestCase):
         with io.open(fd._get_folder_pathsubfolder.get_abs_path(
                 calc._SCHED_OUTPUT_FILE), 'w', encoding='utf8') as fhandle:
             fhandle.write(u"standard output")
-            fhandle.flush()
 
         with io.open(fd._get_folder_pathsubfolder.get_abs_path(
                 calc._SCHED_ERROR_FILE), 'w', encoding='utf8') as fhandle:
             fhandle.write(u"standard error")
-            fhandle.flush()
 
         fd.store()
         calc._set_state(calc_states.PARSING)

--- a/aiida/backends/tests/tcodexporter.py
+++ b/aiida/backends/tests/tcodexporter.py
@@ -197,12 +197,12 @@ class TestTcodDbExporter(AiidaTestCase):
         fd = FolderData()
         with io.open(fd._get_folder_pathsubfolder.get_abs_path(
                 calc._SCHED_OUTPUT_FILE), 'w', encoding='utf8') as fhandle:
-            fhandle.write("standard output")
+            fhandle.write(u"standard output")
             fhandle.flush()
 
         with io.open(fd._get_folder_pathsubfolder.get_abs_path(
-                calc._SCHED_ERROR_FILE), 'w', encoding='uft8') as fhandle:
-            fhandle.write("standard error")
+                calc._SCHED_ERROR_FILE), 'w', encoding='utf8') as fhandle:
+            fhandle.write(u"standard error")
             fhandle.flush()
 
         fd.store()

--- a/aiida/backends/tests/test_caching_config.py
+++ b/aiida/backends/tests/test_caching_config.py
@@ -38,9 +38,9 @@ class CacheConfigTest(unittest.TestCase):
                 'disabled': ['aiida.orm.calculation.job.simpleplugins.templatereplacer.TemplatereplacerCalculation', 'aiida.orm.data.bool.Bool']
             }
         }
-        with tempfile.NamedTemporaryFile() as tf, io.open(tf.name, 'w', encoding='utf8') as of:
-            yaml.dump(self.config_reference, of)
-            configure(config_file=tf.name)
+        with tempfile.NamedTemporaryFile() as tmpf:
+            yaml.dump(self.config_reference, tmpf)
+            configure(config_file=tmpf.name)
 
     def tearDown(self):
         configure()

--- a/aiida/backends/tests/test_caching_config.py
+++ b/aiida/backends/tests/test_caching_config.py
@@ -39,7 +39,7 @@ class CacheConfigTest(unittest.TestCase):
             }
         }
         with tempfile.NamedTemporaryFile() as tmpf:
-            yaml.dump(self.config_reference, tmpf)
+            yaml.dump(self.config_reference, tmpf, encoding='utf-8')
             configure(config_file=tmpf.name)
 
     def tearDown(self):

--- a/aiida/backends/tests/test_caching_config.py
+++ b/aiida/backends/tests/test_caching_config.py
@@ -10,6 +10,7 @@
 from __future__ import division
 from __future__ import print_function
 from __future__ import absolute_import
+import io
 import unittest
 import tempfile
 
@@ -37,7 +38,7 @@ class CacheConfigTest(unittest.TestCase):
                 'disabled': ['aiida.orm.calculation.job.simpleplugins.templatereplacer.TemplatereplacerCalculation', 'aiida.orm.data.bool.Bool']
             }
         }
-        with tempfile.NamedTemporaryFile() as tf, open(tf.name, 'w') as of:
+        with tempfile.NamedTemporaryFile() as tf, io.open(tf.name, 'w', encoding='utf8') as of:
             yaml.dump(self.config_reference, of)
             configure(config_file=tf.name)
 

--- a/aiida/backends/tests/utils/test_serialize.py
+++ b/aiida/backends/tests/utils/test_serialize.py
@@ -10,10 +10,12 @@
 from __future__ import division
 from __future__ import print_function
 from __future__ import absolute_import
-import json
+
 from aiida.orm import Group, Node
 from aiida.utils.serialize import serialize_data, deserialize_data
 from aiida.backends.testbase import AiidaTestCase
+import aiida.utils.json as json
+
 
 
 class TestSerialize(AiidaTestCase):

--- a/aiida/cmdline/commands/cmd_calculation.py
+++ b/aiida/cmdline/commands/cmd_calculation.py
@@ -185,9 +185,9 @@ def calculation_logshow(calculations):
 @decorators.with_dbenv()
 def calculation_plugins(entry_point):
     """Print a list of registered calculation plugins or details of a specific calculation plugin."""
-    import json
     from aiida.common.exceptions import LoadingPluginFailed, MissingPluginError
     from aiida.plugins.entry_point import get_entry_point_names, load_entry_point
+    import aiida.utils.json as json
 
     if entry_point:
         try:

--- a/aiida/cmdline/commands/cmd_computer.py
+++ b/aiida/cmdline/commands/cmd_computer.py
@@ -12,6 +12,7 @@
 from __future__ import division
 from __future__ import print_function
 from __future__ import absolute_import
+import io
 import sys
 from functools import partial
 from six.moves import zip
@@ -169,7 +170,7 @@ def _computer_create_temp_file(transport, scheduler, authinfo):  # pylint: disab
     os.close(handle)
     try:
         transport.getfile(remote_file_path, destfile)
-        with open(destfile) as dfile:
+        with io.open(destfile, encoding='utf8') as dfile:
             read_string = dfile.read()
         echo.echo("      [Retrieved]")
         if read_string != file_content:

--- a/aiida/cmdline/commands/cmd_data/cmd_export.py
+++ b/aiida/cmdline/commands/cmd_data/cmd_export.py
@@ -13,6 +13,7 @@ This module provides export functionality to all data types
 from __future__ import division
 from __future__ import print_function
 from __future__ import absolute_import
+
 import click
 from aiida.cmdline.utils import echo
 from aiida.cmdline.params import options

--- a/aiida/cmdline/commands/cmd_data/cmd_import.py
+++ b/aiida/cmdline/commands/cmd_data/cmd_import.py
@@ -13,6 +13,7 @@ This module provides import functionality to all data types
 from __future__ import division
 from __future__ import print_function
 from __future__ import absolute_import
+import io
 
 from aiida.cmdline.utils import echo
 
@@ -32,7 +33,7 @@ def data_import_xyz(filename, **kwargs):
 
     echo.echo('importing XYZ-structure from: \n  {}'.format(abspath(filename)))
     filepath = abspath(filename)
-    with open(filepath) as fobj:
+    with io.open(filepath, encoding='utf8') as fobj:
         xyz_txt = fobj.read()
     new_structure = StructureData()
     # pylint: disable=protected-access

--- a/aiida/cmdline/commands/cmd_data/cmd_remote.py
+++ b/aiida/cmdline/commands/cmd_data/cmd_remote.py
@@ -12,6 +12,7 @@ from __future__ import division
 from __future__ import print_function
 from __future__ import absolute_import
 
+import io
 import click
 
 from aiida.cmdline.commands.cmd_data import verdi_data
@@ -63,7 +64,7 @@ def remote_cat(datum, path):
         with tempfile.NamedTemporaryFile(delete=False) as tmpf:
             tmpf.close()
             datum.getfile(path, tmpf.name)
-            with open(tmpf.name) as fobj:
+            with io.open(tmpf.name, encoding='utf8') as fobj:
                 sys.stdout.write(fobj.read())
     except IOError as err:
         echo.echo_critical('{}: {}'.format(err.errno, str(err)))

--- a/aiida/cmdline/commands/cmd_data/cmd_remote.py
+++ b/aiida/cmdline/commands/cmd_data/cmd_remote.py
@@ -64,8 +64,8 @@ def remote_cat(datum, path):
         with tempfile.NamedTemporaryFile(delete=False) as tmpf:
             tmpf.close()
             datum.getfile(path, tmpf.name)
-            with io.open(tmpf.name, encoding='utf8') as fobj:
-                sys.stdout.write(fobj.read())
+            with io.open(tmpf.name, encoding='utf8') as fhandle:
+                sys.stdout.write(fhandle.read())
     except IOError as err:
         echo.echo_critical('{}: {}'.format(err.errno, str(err)))
 

--- a/aiida/cmdline/commands/cmd_data/cmd_upf.py
+++ b/aiida/cmdline/commands/cmd_data/cmd_upf.py
@@ -12,6 +12,7 @@ from __future__ import division
 from __future__ import print_function
 from __future__ import absolute_import
 
+import io
 import click
 
 from aiida.cmdline.commands.cmd_data import verdi_data
@@ -117,7 +118,7 @@ def upf_exportfamily(folder, group):
     for node in group.nodes:
         dest_path = os.path.join(folder, node.filename)
         if not os.path.isfile(dest_path):
-            with open(dest_path, 'w') as dest:
+            with io.open(dest_path, 'w', encoding='utf8') as dest:
                 with node._get_folder_pathsubfolder.open(node.filename) as source:
                     dest.write(source.read())
         else:

--- a/aiida/cmdline/commands/cmd_export.py
+++ b/aiida/cmdline/commands/cmd_export.py
@@ -192,10 +192,10 @@ def migrate(input_file, output_file, force, silent, archive_format):
         new_version = verify_metadata_version(metadata)
 
         with io.open(folder.get_abs_path('data.json'), 'wb', encoding=None) as fhandle:
-            json.dump(data, fhandle)
+            json.dump(data, fhandle, ensure_ascii=False)
 
         with io.open(folder.get_abs_path('metadata.json'), 'wb', encoding=None) as fhandle:
-            json.dump(metadata, fhandle)
+            json.dump(metadata, fhandle, ensure_ascii=False)
 
         if archive_format == 'zip' or archive_format == 'zip-uncompressed':
             compression = zipfile.ZIP_DEFLATED if archive_format == 'zip' else zipfile.ZIP_STORED

--- a/aiida/cmdline/commands/cmd_export.py
+++ b/aiida/cmdline/commands/cmd_export.py
@@ -167,12 +167,12 @@ def migrate(input_file, output_file, force, silent, archive_format):
             echo.echo_critical('invalid file format, expected either a zip archive or gzipped tarball')
 
         try:
-            with io.open(folder.get_abs_path('data.json'), encoding='utf8') as handle:
-                data = json.load(handle)
-            with io.open(folder.get_abs_path('metadata.json'), encoding='utf8') as handle:
-                metadata = json.load(handle)
+            with io.open(folder.get_abs_path('data.json'), 'r', encoding='utf8') as fhandle:
+                data = json.load(fhandle)
+            with io.open(folder.get_abs_path('metadata.json'), 'r', encoding='utf8') as fhandle:
+                metadata = json.load(fhandle)
         except IOError:
-            echo.echo_critical('export archive does not contain the required file {}'.format(handle.filename))
+            echo.echo_critical('export archive does not contain the required file {}'.format(fhandle.filename))
 
         old_version = verify_metadata_version(metadata)
 

--- a/aiida/cmdline/commands/cmd_export.py
+++ b/aiida/cmdline/commands/cmd_export.py
@@ -191,11 +191,11 @@ def migrate(input_file, output_file, force, silent, archive_format):
 
         new_version = verify_metadata_version(metadata)
 
-        with io.open(folder.get_abs_path('data.json'), 'w', encoding='utf8') as handle:
-            json.dump(data, handle)
+        with io.open(folder.get_abs_path('data.json'), 'wb', encoding=None) as fhandle:
+            json.dump(data, fhandle)
 
-        with io.open(folder.get_abs_path('metadata.json'), 'w', encoding='utf8') as handle:
-            json.dump(metadata, handle)
+        with io.open(folder.get_abs_path('metadata.json'), 'wb', encoding=None) as fhandle:
+            json.dump(metadata, fhandle)
 
         if archive_format == 'zip' or archive_format == 'zip-uncompressed':
             compression = zipfile.ZIP_DEFLATED if archive_format == 'zip' else zipfile.ZIP_STORED

--- a/aiida/cmdline/commands/cmd_export.py
+++ b/aiida/cmdline/commands/cmd_export.py
@@ -16,6 +16,7 @@ from __future__ import absolute_import
 import io
 
 import click
+import six
 import tabulate
 
 from aiida.cmdline.commands.cmd_verdi import verdi
@@ -192,11 +193,11 @@ def migrate(input_file, output_file, force, silent, archive_format):
 
         new_version = verify_metadata_version(metadata)
 
-        with io.open(folder.get_abs_path('data.json'), 'wb', encoding=None) as fhandle:
-            json.dump(data, fhandle, ensure_ascii=False)
+        with io.open(folder.get_abs_path('data.json'), 'w', encoding='utf8') as fhandle:
+            fhandle.write(six.text_type(json.dumps(data, ensure_ascii=False)))
 
-        with io.open(folder.get_abs_path('metadata.json'), 'wb', encoding=None) as fhandle:
-            json.dump(metadata, fhandle, ensure_ascii=False)
+        with io.open(folder.get_abs_path('metadata.json'), 'w', encoding='utf8') as fhandle:
+            fhandle.write(six.text_type(json.dumps(metadata, ensure_ascii=False)))
 
         if archive_format == 'zip' or archive_format == 'zip-uncompressed':
             compression = zipfile.ZIP_DEFLATED if archive_format == 'zip' else zipfile.ZIP_STORED

--- a/aiida/cmdline/commands/cmd_export.py
+++ b/aiida/cmdline/commands/cmd_export.py
@@ -13,6 +13,8 @@ from __future__ import division
 from __future__ import print_function
 from __future__ import absolute_import
 
+import io
+
 import click
 import tabulate
 
@@ -165,9 +167,9 @@ def migrate(input_file, output_file, force, silent, archive_format):
             echo.echo_critical('invalid file format, expected either a zip archive or gzipped tarball')
 
         try:
-            with open(folder.get_abs_path('data.json')) as handle:
+            with io.open(folder.get_abs_path('data.json'), encoding='utf8') as handle:
                 data = json.load(handle)
-            with open(folder.get_abs_path('metadata.json')) as handle:
+            with io.open(folder.get_abs_path('metadata.json'), encoding='utf8') as handle:
                 metadata = json.load(handle)
         except IOError:
             echo.echo_critical('export archive does not contain the required file {}'.format(handle.filename))
@@ -189,10 +191,10 @@ def migrate(input_file, output_file, force, silent, archive_format):
 
         new_version = verify_metadata_version(metadata)
 
-        with open(folder.get_abs_path('data.json'), 'w') as handle:
+        with io.open(folder.get_abs_path('data.json'), 'w', encoding='utf8') as handle:
             json.dump(data, handle)
 
-        with open(folder.get_abs_path('metadata.json'), 'w') as handle:
+        with io.open(folder.get_abs_path('metadata.json'), 'w', encoding='utf8') as handle:
             json.dump(metadata, handle)
 
         if archive_format == 'zip' or archive_format == 'zip-uncompressed':

--- a/aiida/cmdline/commands/cmd_export.py
+++ b/aiida/cmdline/commands/cmd_export.py
@@ -16,7 +16,6 @@ from __future__ import absolute_import
 import io
 
 import click
-import six
 import tabulate
 
 from aiida.cmdline.commands.cmd_verdi import verdi
@@ -150,11 +149,12 @@ def migrate(input_file, output_file, force, silent, archive_format):
     Migrate an existing export archive file to the most recent version of the export format
     """
     import os
-    import json
     import tarfile
     import zipfile
+
     from aiida.common.folders import SandboxFolder
     from aiida.common.archive import extract_zip, extract_tar
+    import aiida.utils.json as json
 
     if os.path.exists(output_file) and not force:
         echo.echo_critical('the output file already exists')
@@ -193,11 +193,11 @@ def migrate(input_file, output_file, force, silent, archive_format):
 
         new_version = verify_metadata_version(metadata)
 
-        with io.open(folder.get_abs_path('data.json'), 'w', encoding='utf8') as fhandle:
-            fhandle.write(six.text_type(json.dumps(data, ensure_ascii=False)))
+        with io.open(folder.get_abs_path('data.json'), 'wb') as fhandle:
+            json.dump(data, fhandle)
 
-        with io.open(folder.get_abs_path('metadata.json'), 'w', encoding='utf8') as fhandle:
-            fhandle.write(six.text_type(json.dumps(metadata, ensure_ascii=False)))
+        with io.open(folder.get_abs_path('metadata.json'), 'wb') as fhandle:
+            json.dump(metadata, fhandle)
 
         if archive_format == 'zip' or archive_format == 'zip-uncompressed':
             compression = zipfile.ZIP_DEFLATED if archive_format == 'zip' else zipfile.ZIP_STORED

--- a/aiida/cmdline/commands/cmd_export.py
+++ b/aiida/cmdline/commands/cmd_export.py
@@ -130,6 +130,7 @@ def create(output_file, codes, computers, groups, nodes, input_forward, create_r
 
     try:
         export_function(entities, outfile=output_file, **kwargs)
+
     except IOError as exception:
         echo.echo_critical('failed to write the export archive file: {}'.format(exception))
     else:

--- a/aiida/cmdline/commands/cmd_profile.py
+++ b/aiida/cmdline/commands/cmd_profile.py
@@ -109,7 +109,7 @@ def profile_delete(force, profiles):
         postgres.dbinfo["host"] = profile.get('AIIDADB_HOST')
         postgres.determine_setup()
 
-        import json
+        import aiida.utils.json as json
         echo.echo(json.dumps(postgres.dbinfo, indent=4))
 
         db_name = profile.get('AIIDADB_NAME', '')

--- a/aiida/cmdline/commands/cmd_run.py
+++ b/aiida/cmdline/commands/cmd_run.py
@@ -12,7 +12,6 @@ from __future__ import division
 from __future__ import print_function
 from __future__ import absolute_import
 import contextlib
-import io
 import os
 import sys
 
@@ -98,7 +97,8 @@ def run(scriptname, varargs, group, group_name, exclude, excludesubclasses, incl
     handle = None
 
     try:
-        handle = io.open(scriptname, encoding='utf8')
+        # Here we use a standard open and not io.open, as exec will later fail if passed a unicode type string.
+        handle = open(scriptname, 'r')
     except IOError:
         echo.echo_critical("Unable to load file '{}'".format(scriptname))
     else:

--- a/aiida/cmdline/commands/cmd_run.py
+++ b/aiida/cmdline/commands/cmd_run.py
@@ -12,6 +12,7 @@ from __future__ import division
 from __future__ import print_function
 from __future__ import absolute_import
 import contextlib
+import io
 import os
 import sys
 
@@ -97,7 +98,7 @@ def run(scriptname, varargs, group, group_name, exclude, excludesubclasses, incl
     handle = None
 
     try:
-        handle = open(scriptname)
+        handle = io.open(scriptname, encoding='utf8')
     except IOError:
         echo.echo_critical("Unable to load file '{}'".format(scriptname))
     else:

--- a/aiida/cmdline/commands/cmd_shell.py
+++ b/aiida/cmdline/commands/cmd_shell.py
@@ -12,6 +12,7 @@ from __future__ import division
 from __future__ import print_function
 from __future__ import absolute_import
 
+import io
 import os
 import click
 
@@ -74,7 +75,7 @@ def shell(plain, no_startup, interface):
                 if not os.path.isfile(pythonrc):
                     continue
                 try:
-                    with open(pythonrc) as handle:
+                    with io.open(pythonrc, encoding='utf8') as handle:
                         # Disable yapf to keep Python 3 style here
                         exec(compile(handle.read(), pythonrc, 'exec'),  # pylint: disable=exec-used
                              imported_objects)  # yapf:disable

--- a/aiida/cmdline/utils/echo.py
+++ b/aiida/cmdline/utils/echo.py
@@ -151,7 +151,7 @@ def echo_dictionary(dictionary, fmt='json+date'):
 
 def _format_dictionary_json_date(dictionary):
     """Return a dictionary formatted as a string using the json format and converting dates to strings."""
-    import json
+    import aiida.utils.json as json
 
     def default_jsondump(data):
         """Function needed to decode datetimes, that would otherwise not be JSON-decodable."""

--- a/aiida/cmdline/utils/repository.py
+++ b/aiida/cmdline/utils/repository.py
@@ -11,6 +11,8 @@
 from __future__ import division
 from __future__ import print_function
 from __future__ import absolute_import
+import io
+
 from aiida.cmdline.utils import echo
 
 
@@ -52,7 +54,7 @@ def cat_repo_files(node, path):
             raise ValueError("No file '{}' in the repo".format(path))
 
         absfname = fldr.get_abs_path(fname)
-        with open(absfname) as repofile:
+        with io.open(absfname, encoding='utf8') as repofile:
             for line in repofile:
                 sys.stdout.write(line)
 

--- a/aiida/common/additions/backup_script/backup_base.py
+++ b/aiida/common/additions/backup_script/backup_base.py
@@ -10,6 +10,7 @@
 from __future__ import print_function
 from __future__ import absolute_import
 from __future__ import division
+import io
 import json
 import datetime
 import shutil
@@ -93,7 +94,7 @@ class AbstractBackup(object):
         """
         backup_variables = None
 
-        with open(backup_info_file_name, 'r') as backup_info_file:
+        with io.open(backup_info_file_name, 'r', encoding='utf8') as backup_info_file:
             try:
                 backup_variables = json.load(backup_info_file)
             except ValueError:
@@ -257,7 +258,7 @@ class AbstractBackup(object):
         given filename.
         """
         backup_variables = self._dictionarize_backup_info()
-        with open(backup_info_file_name, 'w') as backup_info_file:
+        with io.open(backup_info_file_name, 'w', encoding='utf8') as backup_info_file:
             json.dump(backup_variables, backup_info_file)
 
     def _find_files_to_backup(self):

--- a/aiida/common/additions/backup_script/backup_base.py
+++ b/aiida/common/additions/backup_script/backup_base.py
@@ -11,18 +11,18 @@ from __future__ import print_function
 from __future__ import absolute_import
 from __future__ import division
 import io
-import json
 import datetime
 import shutil
 import os
 import logging
 
 from abc import abstractmethod, ABCMeta
-
 import six
 from dateutil.parser import parse
-from aiida.utils import timezone as dtimezone
 from pytz import timezone as ptimezone
+
+from aiida.utils import timezone as dtimezone
+import aiida.utils.json as json
 
 
 @six.add_metaclass(ABCMeta)
@@ -258,8 +258,8 @@ class AbstractBackup(object):
         given filename.
         """
         backup_variables = self._dictionarize_backup_info()
-        with io.open(backup_info_file_name, 'w', encoding='utf8') as backup_info_file:
-            backup_info_file.write(six.text_type(json.dumps(backup_variables, ensure_ascii=False)))
+        with io.open(backup_info_file_name, 'wb') as backup_info_file:
+            json.dump(backup_variables, backup_info_file)
 
     def _find_files_to_backup(self):
         """

--- a/aiida/common/additions/backup_script/backup_base.py
+++ b/aiida/common/additions/backup_script/backup_base.py
@@ -259,7 +259,7 @@ class AbstractBackup(object):
         """
         backup_variables = self._dictionarize_backup_info()
         with io.open(backup_info_file_name, 'wb', encoding=None) as backup_info_file:
-            json.dump(backup_variables, backup_info_file)
+            json.dump(backup_variables, backup_info_file, ensure_ascii=False)
 
     def _find_files_to_backup(self):
         """

--- a/aiida/common/additions/backup_script/backup_base.py
+++ b/aiida/common/additions/backup_script/backup_base.py
@@ -259,7 +259,7 @@ class AbstractBackup(object):
         """
         backup_variables = self._dictionarize_backup_info()
         with io.open(backup_info_file_name, 'w', encoding='utf8') as backup_info_file:
-            backup_info_file.write(six.text_type(json.dumps(backup_variables, backup_info_file, ensure_ascii=False)))
+            backup_info_file.write(six.text_type(json.dumps(backup_variables, ensure_ascii=False)))
 
     def _find_files_to_backup(self):
         """

--- a/aiida/common/additions/backup_script/backup_base.py
+++ b/aiida/common/additions/backup_script/backup_base.py
@@ -258,7 +258,7 @@ class AbstractBackup(object):
         given filename.
         """
         backup_variables = self._dictionarize_backup_info()
-        with io.open(backup_info_file_name, 'w', encoding='utf8') as backup_info_file:
+        with io.open(backup_info_file_name, 'wb', encoding=None) as backup_info_file:
             json.dump(backup_variables, backup_info_file)
 
     def _find_files_to_backup(self):

--- a/aiida/common/additions/backup_script/backup_base.py
+++ b/aiida/common/additions/backup_script/backup_base.py
@@ -258,8 +258,8 @@ class AbstractBackup(object):
         given filename.
         """
         backup_variables = self._dictionarize_backup_info()
-        with io.open(backup_info_file_name, 'wb', encoding=None) as backup_info_file:
-            json.dump(backup_variables, backup_info_file, ensure_ascii=False)
+        with io.open(backup_info_file_name, 'w', encoding='utf8') as backup_info_file:
+            backup_info_file.write(six.text_type(json.dumps(backup_variables, backup_info_file, ensure_ascii=False)))
 
     def _find_files_to_backup(self):
         """

--- a/aiida/common/additions/backup_script/backup_setup.py
+++ b/aiida/common/additions/backup_script/backup_setup.py
@@ -12,7 +12,6 @@ from __future__ import print_function
 from __future__ import absolute_import
 import datetime
 import io
-import json
 import logging
 import os
 import shutil
@@ -28,6 +27,7 @@ from aiida.backends.utils import load_dbenv, is_dbenv_loaded
 from aiida.common import utils
 from aiida.common.additions.backup_script.backup_base import AbstractBackup, BackupError
 from aiida.common.setup import AIIDA_CONFIG_FOLDER
+import aiida.utils.json as json
 
 if not is_dbenv_loaded():
     load_dbenv()
@@ -221,8 +221,8 @@ class BackupSetup(object):
             backup_variables = self.construct_backup_variables(
                 file_backup_folder_abs)
 
-            with io.open(final_conf_filepath, 'w', encoding='utf8') as backup_info_file:
-                backup_info_file.write(six.text_type(json.dumps(backup_variables, ensure_ascii=False)))
+            with io.open(final_conf_filepath, 'wb') as backup_info_file:
+                json.dump(backup_variables, backup_info_file)
         # If the backup parameters are configured manually
         else:
             sys.stdout.write(

--- a/aiida/common/additions/backup_script/backup_setup.py
+++ b/aiida/common/additions/backup_script/backup_setup.py
@@ -11,6 +11,7 @@ from __future__ import division
 from __future__ import print_function
 from __future__ import absolute_import
 import datetime
+import io
 import json
 import logging
 import os
@@ -218,7 +219,7 @@ class BackupSetup(object):
             backup_variables = self.construct_backup_variables(
                 file_backup_folder_abs)
 
-            with open(final_conf_filepath, 'w') as backup_info_file:
+            with io.open(final_conf_filepath, 'w', encoding='utf8') as backup_info_file:
                 json.dump(backup_variables, backup_info_file)
         # If the backup parameters are configured manually
         else:
@@ -269,7 +270,7 @@ backup_inst.run()
                                    self._script_filename)
 
         # Write the contents to the script
-        with open(script_path, 'w') as script_file:
+        with io.open(script_path, 'w', encoding='utf8') as script_file:
             script_file.write(script_content)
 
         # Set the right permissions

--- a/aiida/common/additions/backup_script/backup_setup.py
+++ b/aiida/common/additions/backup_script/backup_setup.py
@@ -219,7 +219,7 @@ class BackupSetup(object):
             backup_variables = self.construct_backup_variables(
                 file_backup_folder_abs)
 
-            with io.open(final_conf_filepath, 'w', encoding='utf8') as backup_info_file:
+            with io.open(final_conf_filepath, 'wb', encoding=None) as backup_info_file:
                 json.dump(backup_variables, backup_info_file)
         # If the backup parameters are configured manually
         else:
@@ -246,7 +246,7 @@ class BackupSetup(object):
             raise BackupError("Following backend is unknown: ".format(BACKEND))
 
         script_content = \
-"""#!/usr/bin/env python
+u"""#!/usr/bin/env python
 import logging
 from aiida.backends.utils import load_dbenv, is_dbenv_loaded
 

--- a/aiida/common/additions/backup_script/backup_setup.py
+++ b/aiida/common/additions/backup_script/backup_setup.py
@@ -220,7 +220,7 @@ class BackupSetup(object):
                 file_backup_folder_abs)
 
             with io.open(final_conf_filepath, 'wb', encoding=None) as backup_info_file:
-                json.dump(backup_variables, backup_info_file)
+                json.dump(backup_variables, backup_info_file, ensure_ascii=False)
         # If the backup parameters are configured manually
         else:
             sys.stdout.write(

--- a/aiida/common/additions/backup_script/backup_setup.py
+++ b/aiida/common/additions/backup_script/backup_setup.py
@@ -20,6 +20,8 @@ import stat
 import sys
 from os.path import expanduser
 
+import six
+
 from aiida.backends.profile import BACKEND_DJANGO
 from aiida.backends.profile import BACKEND_SQLA
 from aiida.backends.utils import load_dbenv, is_dbenv_loaded
@@ -219,8 +221,8 @@ class BackupSetup(object):
             backup_variables = self.construct_backup_variables(
                 file_backup_folder_abs)
 
-            with io.open(final_conf_filepath, 'wb', encoding=None) as backup_info_file:
-                json.dump(backup_variables, backup_info_file, ensure_ascii=False)
+            with io.open(final_conf_filepath, 'w', encoding='utf8') as backup_info_file:
+                backup_info_file.write(six.text_type(json.dumps(backup_variables, ensure_ascii=False)))
         # If the backup parameters are configured manually
         else:
             sys.stdout.write(

--- a/aiida/common/additions/config_migrations/test_migrations.py
+++ b/aiida/common/additions/config_migrations/test_migrations.py
@@ -13,7 +13,6 @@ from __future__ import absolute_import
 import io
 import os
 import uuid
-import json
 import unittest
 try:
     from unittest import mock
@@ -22,6 +21,8 @@ except ImportError:
 
 from ._utils import check_and_migrate_config
 from ._migrations import _MIGRATION_LOOKUP
+import aiida.utils.json as json
+
 
 
 def load_config_sample(filename):

--- a/aiida/common/additions/config_migrations/test_migrations.py
+++ b/aiida/common/additions/config_migrations/test_migrations.py
@@ -10,6 +10,7 @@
 from __future__ import division
 from __future__ import print_function
 from __future__ import absolute_import
+import io
 import os
 import uuid
 import json
@@ -26,7 +27,7 @@ from ._migrations import _MIGRATION_LOOKUP
 def load_config_sample(filename):
     currdir = os.path.dirname(os.path.abspath(__file__))
     filepath = os.path.join(currdir, 'test_samples', filename)
-    with open(filepath, 'r') as f:
+    with io.open(filepath, 'r', encoding='utf8') as f:
         return json.load(f)
 
 

--- a/aiida/common/archive.py
+++ b/aiida/common/archive.py
@@ -239,8 +239,7 @@ class Archive(object):
             return json.load(handle)
 
 
-def extract_zip(infile, folder, nodes_export_subfolder="nodes",
-                silent=False):
+def extract_zip(infile, folder, nodes_export_subfolder="nodes", silent=False):
     """
     Extract the nodes to be imported from a zip file.
 
@@ -261,10 +260,8 @@ def extract_zip(infile, folder, nodes_export_subfolder="nodes",
             if not zip.namelist():
                 raise ValueError("The zip file is empty.")
 
-            zip.extract(path=folder.abspath,
-                   member='metadata.json')
-            zip.extract(path=folder.abspath,
-                   member='data.json')
+            zip.extract(path=folder.abspath, member='metadata.json')
+            zip.extract(path=folder.abspath, member='data.json')
 
             if not silent:
                 print("EXTRACTING NODE DATA...")
@@ -274,16 +271,14 @@ def extract_zip(infile, folder, nodes_export_subfolder="nodes",
                 # the subfolder!
                 # TODO: better check such that there are no .. in the
                 # path; use probably the folder limit checks
-                if not membername.startswith(nodes_export_subfolder+os.sep):
+                if not membername.startswith(nodes_export_subfolder + os.sep):
                     continue
-                zip.extract(path=folder.abspath,
-                            member=membername)
+                zip.extract(path=folder.abspath, member=membername)
     except zipfile.BadZipfile:
-        raise ValueError("The input file format for import is not valid (not"
-                         " a zip file)")
+        raise ValueError("The input file format for import is not valid (not" " a zip file)")
 
-def extract_tar(infile, folder, nodes_export_subfolder="nodes",
-                silent=False):
+
+def extract_tar(infile, folder, nodes_export_subfolder="nodes", silent=False):
     """
     Extract the nodes to be imported from a (possibly zipped) tar file.
 
@@ -301,10 +296,8 @@ def extract_tar(infile, folder, nodes_export_subfolder="nodes",
     try:
         with tarfile.open(infile, "r:*", format=tarfile.PAX_FORMAT) as tar:
 
-            tar.extract(path=folder.abspath,
-                   member=tar.getmember('metadata.json'))
-            tar.extract(path=folder.abspath,
-                   member=tar.getmember('data.json'))
+            tar.extract(path=folder.abspath, member=tar.getmember('metadata.json'))
+            tar.extract(path=folder.abspath, member=tar.getmember('data.json'))
 
             if not silent:
                 print("EXTRACTING NODE DATA...")
@@ -312,25 +305,23 @@ def extract_tar(infile, folder, nodes_export_subfolder="nodes",
             for member in tar.getmembers():
                 if member.isdev():
                     # safety: skip if character device, block device or FIFO
-                    print("WARNING, device found inside the import file: {}"
-                          .format(member.name), file=sys.stderr)
+                    print("WARNING, device found inside the import file: {}".format(member.name), file=sys.stderr)
                     continue
                 if member.issym() or member.islnk():
                     # safety: in export, I set dereference=True therefore
                     # there should be no symbolic or hard links.
-                    print("WARNING, link found inside the import file: {}"
-                          .format(member.name), file=sys.stderr)
+                    print("WARNING, link found inside the import file: {}".format(member.name), file=sys.stderr)
                     continue
                 # Check that we are only exporting nodes within
                 # the subfolder!
                 # TODO: better check such that there are no .. in the
                 # path; use probably the folder limit checks
-                if not member.name.startswith(nodes_export_subfolder+os.sep):
+                if not member.name.startswith(nodes_export_subfolder + os.sep):
                     continue
-                tar.extract(path=folder.abspath,
-                            member=member)
+                tar.extract(path=folder.abspath, member=member)
     except tarfile.ReadError:
         raise ValueError("The input file format for import is not valid (1)")
+
 
 def extract_tree(infile, folder, silent=False):
     """
@@ -342,27 +333,25 @@ def extract_tree(infile, folder, silent=False):
     """
     import os
 
-    def add_files(args,path,files):
+    def add_files(args, path, files):
         folder = args['folder']
         root = args['root']
         for f in files:
-            fullpath = os.path.join(path,f)
-            relpath = os.path.relpath(fullpath,root)
+            fullpath = os.path.join(path, f)
+            relpath = os.path.relpath(fullpath, root)
             if os.path.isdir(fullpath):
                 if os.path.dirname(relpath) != '':
-                    folder.get_subfolder(os.path.dirname(relpath) +
-                                         os.sep, create=True)
+                    folder.get_subfolder(os.path.dirname(relpath) + os.sep, create=True)
             elif not os.path.isfile(fullpath):
                 continue
             if os.path.dirname(relpath) != '':
-                folder.get_subfolder(os.path.dirname(relpath)+os.sep,
-                                     create=True)
-            folder.insert_path(os.path.abspath(fullpath),relpath)
+                folder.get_subfolder(os.path.dirname(relpath) + os.sep, create=True)
+            folder.insert_path(os.path.abspath(fullpath), relpath)
 
-    os.path.walk(infile,add_files,{'folder': folder, 'root': infile})
+    os.path.walk(infile, add_files, {'folder': folder, 'root': infile})
 
-def extract_cif(infile, folder, nodes_export_subfolder="nodes",
-                aiida_export_subfolder="aiida", silent=False):
+
+def extract_cif(infile, folder, nodes_export_subfolder="nodes", aiida_export_subfolder="aiida", silent=False):
     """
     Extract the nodes to be imported from a TCOD CIF file. TCOD CIFs,
     exported by AiiDA, may contain an importable subset of AiiDA database,
@@ -384,16 +373,16 @@ def extract_cif(infile, folder, nodes_export_subfolder="nodes",
     from aiida.tools.dbexporters.tcod import decode_textfield
 
     values = CifFile.ReadCif(infile)
-    values = values[list(values.keys())[0]] # taking the first datablock in CIF
+    values = values[list(values.keys())[0]]  # taking the first datablock in CIF
 
-    for i in range(len(values['_tcod_file_id'])-1):
+    for i in range(len(values['_tcod_file_id']) - 1):
         name = values['_tcod_file_name'][i]
-        if not name.startswith(aiida_export_subfolder+os.sep):
+        if not name.startswith(aiida_export_subfolder + os.sep):
             continue
-        dest_path = os.path.relpath(name,aiida_export_subfolder)
+        dest_path = os.path.relpath(name, aiida_export_subfolder)
         if name.endswith(os.sep):
             if not os.path.exists(folder.get_abs_path(dest_path)):
-                folder.get_subfolder(folder.get_abs_path(dest_path),create=True)
+                folder.get_subfolder(folder.get_abs_path(dest_path), create=True)
             continue
         contents = values['_tcod_file_contents'][i]
         if contents == '?' or contents == '.':
@@ -403,13 +392,13 @@ def extract_cif(infile, folder, nodes_export_subfolder="nodes",
         encoding = values['_tcod_file_content_encoding'][i]
         if encoding == '.':
             encoding = None
-        contents = decode_textfield(contents,encoding)
+        contents = decode_textfield(contents, encoding)
         if os.path.dirname(dest_path) != '':
-            folder.get_subfolder(os.path.dirname(dest_path)+os.sep,create=True)
-        with io.open(folder.get_abs_path(dest_path),'w', encoding='utf8') as f:
-            f.write(contents)
-            f.flush()
-        md5  = values['_tcod_file_md5sum'][i]
+            folder.get_subfolder(os.path.dirname(dest_path) + os.sep, create=True)
+        with io.open(folder.get_abs_path(dest_path), 'w', encoding='utf8') as fhandle:
+            fhandle.write(contents)
+            fhandle.flush()
+        md5 = values['_tcod_file_md5sum'][i]
         if md5 is not None:
             if md5_file(folder.get_abs_path(dest_path)) != md5:
                 raise ValidationError("MD5 sum for extracted file '{}' is "

--- a/aiida/common/archive.py
+++ b/aiida/common/archive.py
@@ -13,7 +13,6 @@ from __future__ import print_function
 
 import contextlib
 import io
-import json
 import os
 import tarfile
 import sys
@@ -24,6 +23,7 @@ from six.moves import range
 
 from aiida.common.exceptions import ContentNotExistent, InvalidOperation
 from aiida.common.folders import SandboxFolder
+import aiida.utils.json as json
 
 
 class Archive(object):
@@ -235,8 +235,8 @@ class Archive(object):
         :param filename: the filename relative to the sandbox folder
         :return: a dictionary with the loaded JSON content
         """
-        with open(self.folder.get_abs_path(filename), 'r') as handle:
-            return json.load(handle)
+        with io.open(self.folder.get_abs_path(filename), 'r', encoding='utf8') as fhandle:
+            return json.load(fhandle)
 
 
 def extract_zip(infile, folder, nodes_export_subfolder="nodes", silent=False):

--- a/aiida/common/archive.py
+++ b/aiida/common/archive.py
@@ -12,12 +12,14 @@ from __future__ import absolute_import
 from __future__ import print_function
 
 import contextlib
+import io
 import json
 import os
 import tarfile
 import sys
 import zipfile
 from functools import wraps
+
 from six.moves import range
 
 from aiida.common.exceptions import ContentNotExistent, InvalidOperation
@@ -404,7 +406,7 @@ def extract_cif(infile, folder, nodes_export_subfolder="nodes",
         contents = decode_textfield(contents,encoding)
         if os.path.dirname(dest_path) != '':
             folder.get_subfolder(os.path.dirname(dest_path)+os.sep,create=True)
-        with open(folder.get_abs_path(dest_path),'w') as f:
+        with io.open(folder.get_abs_path(dest_path),'w', encoding='utf8') as f:
             f.write(contents)
             f.flush()
         md5  = values['_tcod_file_md5sum'][i]

--- a/aiida/common/caching.py
+++ b/aiida/common/caching.py
@@ -12,6 +12,7 @@
 from __future__ import division
 from __future__ import print_function
 from __future__ import absolute_import
+import io
 import os
 import copy
 from functools import wraps
@@ -47,7 +48,7 @@ DEFAULT_CONFIG = {
 
 def _get_config(config_file):
     try:
-        with open(config_file, 'r') as f:
+        with io.open(config_file, 'r', encoding='utf8') as f:
             config = yaml.load(f)[get_current_profile()]
     # no config file, or no config for this profile
     except (OSError, IOError, KeyError):

--- a/aiida/common/folders.py
+++ b/aiida/common/folders.py
@@ -14,6 +14,7 @@ import os
 import shutil
 import fnmatch
 import tempfile
+import io
 
 import six
 
@@ -239,7 +240,7 @@ class Folder(object):
         # go beyond the folder limits
         dest_abs_path = self.get_abs_path(filename)
 
-        with open(dest_abs_path, 'w') as f:
+        with io.open(dest_abs_path, 'w', encoding='utf8') as f:
             shutil.copyfileobj(src_filelike, f)
 
         # Set the mode
@@ -291,12 +292,15 @@ class Folder(object):
 
         return dest_abs_path
 
-    def open(self, name, mode='r'):
+    def open(self, name, mode='r', encoding='utf8'):
         """
         Open a file in the current folder and return the corresponding
         file object.
         """
-        return open(self.get_abs_path(name), mode)
+        if 'b' in mode:
+            encoding=None
+        
+        return io.open(self.get_abs_path(name), mode, encoding=encoding)
 
     @property
     def abspath(self):

--- a/aiida/common/folders.py
+++ b/aiida/common/folders.py
@@ -240,16 +240,19 @@ class Folder(object):
         # go beyond the folder limits
         dest_abs_path = self.get_abs_path(filename)
 
-        # Wrapper to decode ncoming src_filelike like it's UTF-8 encoded.
-        import codecs
-        utf8wrapper = codecs.getreader('utf8')
-
         # If Py2, the incoming filelike may contain a unicode or string type.
         # We want to write explicity with UTF8 encoding, so io.open requires
-        # a unicode type. First we try and use a UTF8 reader to decode the 
-        # incoming str type to unicode. If it is already unicode, this 
-        # will fail, so instead we try to write to file directly.
-        # In Py3 we can assume that the incoming text will be unicode.
+        # a unicode type. 
+        # First we try and use a UTF8 stream reader wrapper to decode the characters 
+        # from the incoming filelike object as if they are UFT8 encoded. 
+        # If a unicode type is encountered, Python will attempt to convert to a str 
+        # type using the ASCII codec which will fail if any non ASCII chars are 
+        # present, raising a UnicodeEncodeError exception. In this case, as we already 
+        # have unicode type text, we can catch this and call shutil.copyfileobj without 
+        # the wrapper.
+        # In Py3, all str types are unicode, so we can avoid using the wrapper.
+        import codecs
+        utf8wrapper = codecs.getreader('utf8')
 
         with io.open(dest_abs_path, 'w', encoding='utf8') as dest_fhandle:
             if six.PY2:  

--- a/aiida/common/folders.py
+++ b/aiida/common/folders.py
@@ -239,9 +239,9 @@ class Folder(object):
         # I get the full path of the filename, checking also that I don't
         # go beyond the folder limits
         dest_abs_path = self.get_abs_path(filename)
-
-        with io.open(dest_abs_path, 'w', encoding='utf8') as f:
-            shutil.copyfileobj(src_filelike, f)
+            
+        with io.open(dest_abs_path, 'w', encoding='utf8') as dest_fhandle:
+            shutil.copyfileobj(src_filelike, dest_fhandle)
 
         # Set the mode
         os.chmod(dest_abs_path, self.mode_file)

--- a/aiida/common/folders.py
+++ b/aiida/common/folders.py
@@ -240,8 +240,13 @@ class Folder(object):
         # go beyond the folder limits
         dest_abs_path = self.get_abs_path(filename)
 
+        # Treat the incoming src_filelike like it's UTF-8 encoded.
+        import codecs
+        utf8reader = codecs.getreader('utf8')
+        wrapped_src_filelike = utf8reader(src_filelike)
+
         with io.open(dest_abs_path, 'w', encoding='utf8') as dest_fhandle:
-            shutil.copyfileobj(src_filelike, dest_fhandle)
+            shutil.copyfileobj(wrapped_src_filelike, dest_fhandle)
 
         # Set the mode
         os.chmod(dest_abs_path, self.mode_file)

--- a/aiida/common/folders.py
+++ b/aiida/common/folders.py
@@ -239,7 +239,7 @@ class Folder(object):
         # I get the full path of the filename, checking also that I don't
         # go beyond the folder limits
         dest_abs_path = self.get_abs_path(filename)
-            
+
         with io.open(dest_abs_path, 'w', encoding='utf8') as dest_fhandle:
             shutil.copyfileobj(src_filelike, dest_fhandle)
 

--- a/aiida/common/graph.py
+++ b/aiida/common/graph.py
@@ -192,7 +192,7 @@ def draw_graph(origin_node,
             fhandle.write(u"    {}\n".format(n_values))
         for n_name, n_values in additional_nodes.items():
             fhandle.write(u"    {}\n".format(n_values))
-        fhandle.write("}\n")
+        fhandle.write(u"}\n")
 
     # Now I am producing the output file
     output_file_name = "{0}.{format}".format(origin_node.pk, format=format)

--- a/aiida/common/graph.py
+++ b/aiida/common/graph.py
@@ -7,15 +7,23 @@
 # For further information on the license, see the LICENSE.txt file        #
 # For further information please visit http://www.aiida.net               #
 ###########################################################################
+"""
+Draw the provenance graphs
+"""
 from __future__ import division
 from __future__ import print_function
 from __future__ import absolute_import
 import io
-import os 
+import os
 import tempfile
 
-def draw_graph(origin_node, ancestor_depth=None, descendant_depth=None, format='dot',
-        include_calculation_inputs=False, include_calculation_outputs=False):
+
+def draw_graph(origin_node,
+               ancestor_depth=None,
+               descendant_depth=None,
+               format='dot',
+               include_calculation_inputs=False,
+               include_calculation_outputs=False):
     """
     The algorithm starts from the original node and goes both input-ward and output-ward via a breadth-first algorithm.
 
@@ -30,7 +38,7 @@ def draw_graph(origin_node, ancestor_depth=None, descendant_depth=None, format='
     ..note::
         If an invalid format is provided graphviz prints a helpful message, so this doesn't need to be implemented here.
     """
-    # 
+    #
     # until the connected part of the graph that contains the root_pk is fully explored.
     # TODO this command deserves to be improved, with options and further subcommands
 
@@ -55,8 +63,7 @@ def draw_graph(origin_node, ancestor_depth=None, descendant_depth=None, format='
         else:
             shape = "shape=ellipse"
         if kwargs:
-            additional_params = ",{}".format(
-                ",".join('{}="{}"'.format(k, v) for k, v in kwargs.items()))
+            additional_params = ",{}".format(",".join('{}="{}"'.format(k, v) for k, v in kwargs.items()))
         else:
             additional_params = ""
         if node.label:
@@ -65,36 +72,36 @@ def draw_graph(origin_node, ancestor_depth=None, descendant_depth=None, format='
         else:
             additional_string = "\n {}".format(node.get_desc())
             label_string = ""
-        labelstring = 'label="{} ({}){}{}"'.format(
-            node.__class__.__name__, node.pk, label_string,
-            additional_string)
-        return "N{} [{},{}{}];".format(node.pk, shape, labelstring,
-                                       additional_params)
+        labelstring = 'label="{} ({}){}{}"'.format(node.__class__.__name__, node.pk, label_string, additional_string)
+        return "N{} [{},{}{}];".format(node.pk, shape, labelstring, additional_params)
 
     def draw_link_settings(inp_id, out_id, link_label, link_type):
         if link_type in (LinkType.CREATE.value, LinkType.INPUT.value):
-            style='solid'  # Solid lines and black colors
-            color = "0.0 0.0 0.0" # for CREATE and INPUT (The provenance graph)
+            style = 'solid'  # Solid lines and black colors
+            color = "0.0 0.0 0.0"  # for CREATE and INPUT (The provenance graph)
         elif link_type == LinkType.RETURN.value:
-            style='dotted'  # Dotted  lines of
-            color = "0.0 0.0 0.0" # black color for Returns
+            style = 'dotted'  # Dotted  lines of
+            color = "0.0 0.0 0.0"  # black color for Returns
         elif link_type == LinkType.CALL.value:
-            style='bold' # Bold lines and
-            color = "0.0 1.0 1.0" # Bright red for calls
+            style = 'bold'  # Bold lines and
+            color = "0.0 1.0 1.0"  # Bright red for calls
         else:
-            style='solid'   # Solid and
-            color="0.0 0.0 0.5" #grey lines for unspecified links!
-        return '    {} -> {} [label="{}", color="{}", style="{}"];'.format("N{}".format(inp_id),  "N{}".format(out_id), link_label, color, style)
+            style = 'solid'  # Solid and
+            color = "0.0 0.0 0.5"  #grey lines for unspecified links!
+        return '    {} -> {} [label="{}", color="{}", style="{}"];'.format("N{}".format(inp_id), "N{}".format(out_id),
+                                                                           link_label, color, style)
 
     # Breadth-first search of all ancestors and descendant nodes of a given node
     links = {}  # Accumulate links here
-    nodes = {origin_node.pk: draw_node_settings(origin_node, style='filled', color='lightblue')} #Accumulate nodes specs here
+    nodes = {
+        origin_node.pk: draw_node_settings(origin_node, style='filled', color='lightblue')
+    }  #Accumulate nodes specs here
     # Additional nodes (the ones added with either one of  include_calculation_inputs or include_calculation_outputs
     # is set to true. I have to put them in a different dictionary because nodes is the one used for the recursion,
     # whereas these should not be used for the recursion:
     additional_nodes = {}
 
-    last_nodes = [origin_node] # Put the nodes whose links have not been scanned yet
+    last_nodes = [origin_node]  # Put the nodes whose links have not been scanned yet
 
     # Go through the graph on-ward (i.e. look at inputs)
     depth = 0
@@ -109,7 +116,7 @@ def draw_graph(origin_node, ancestor_depth=None, descendant_depth=None, format='
         for node in last_nodes:
             # This query gives me all the inputs of this node, and link labels and types!
             input_query = QueryBuilder()
-            input_query.append(Node, filters={'id':node.pk}, tag='n')
+            input_query.append(Node, filters={'id': node.pk}, tag='n')
             input_query.append(Node, input_of='n', edge_project=('id', 'label', 'type'), project='*', tag='inp')
             for inp, link_id, link_label, link_type in input_query.iterall():
                 # I removed this check, to me there is no way that this link was already referred to!
@@ -124,7 +131,7 @@ def draw_graph(origin_node, ancestor_depth=None, descendant_depth=None, format='
             if include_calculation_outputs and isinstance(node, Calculation):
                 # Query for the outputs, giving me also link labels and types:
                 output_query = QueryBuilder()
-                output_query.append(Node, filters={'id':node.pk}, tag='n')
+                output_query.append(Node, filters={'id': node.pk}, tag='n')
                 output_query.append(Node, output_of='n', edge_project=('id', 'label', 'type'), project='*', tag='out')
                 # Iterate through results
                 for out, link_id, link_label, link_type in output_query.iterall():
@@ -140,7 +147,6 @@ def draw_graph(origin_node, ancestor_depth=None, descendant_depth=None, format='
 
         last_nodes = new_nodes
 
-
     # Go through the graph down-ward (i.e. look at outputs)
     last_nodes = [origin_node]
     depth = 0
@@ -154,7 +160,7 @@ def draw_graph(origin_node, ancestor_depth=None, descendant_depth=None, format='
         for node in last_nodes:
             # Query for the outputs:
             output_query = QueryBuilder()
-            output_query.append(Node, filters={'id':node.pk}, tag='n')
+            output_query.append(Node, filters={'id': node.pk}, tag='n')
             output_query.append(Node, output_of='n', edge_project=('id', 'label', 'type'), project='*', tag='out')
 
             for out, link_id, link_label, link_type in output_query.iterall():
@@ -166,7 +172,7 @@ def draw_graph(origin_node, ancestor_depth=None, descendant_depth=None, format='
 
             if include_calculation_inputs and isinstance(node, Calculation):
                 input_query = QueryBuilder()
-                input_query.append(Node, filters={'id':node.pk}, tag='n')
+                input_query.append(Node, filters={'id': node.pk}, tag='n')
                 input_query.append(Node, input_of='n', edge_project=('id', 'label', 'type'), project='*', tag='inp')
                 for inp, link_id, link_label, link_type in input_query.iterall():
                     # Also here, maybe it's just better not to check?
@@ -178,15 +184,15 @@ def draw_graph(origin_node, ancestor_depth=None, descendant_depth=None, format='
 
     # Writing the graph to a temporary file
     fd, fname = tempfile.mkstemp(suffix='.dot')
-    with io.open(fname, 'w', encoding='utf8') as fout:
-        fout.write("digraph G {\n")
+    with io.open(fname, 'w', encoding='utf8') as fhandle:
+        fhandle.write(u"digraph G {\n")
         for l_name, l_values in links.items():
-            fout.write('    {}\n'.format(l_values))
+            fhandle.write(u'    {}\n'.format(l_values))
         for n_name, n_values in nodes.items():
-            fout.write("    {}\n".format(n_values))
+            fhandle.write(u"    {}\n".format(n_values))
         for n_name, n_values in additional_nodes.items():
-            fout.write("    {}\n".format(n_values))
-        fout.write("}\n")
+            fhandle.write(u"    {}\n".format(n_values))
+        fhandle.write("}\n")
 
     # Now I am producing the output file
     output_file_name = "{0}.{format}".format(origin_node.pk, format=format)

--- a/aiida/common/graph.py
+++ b/aiida/common/graph.py
@@ -10,7 +10,9 @@
 from __future__ import division
 from __future__ import print_function
 from __future__ import absolute_import
-import os, tempfile
+import io
+import os 
+import tempfile
 
 def draw_graph(origin_node, ancestor_depth=None, descendant_depth=None, format='dot',
         include_calculation_inputs=False, include_calculation_outputs=False):
@@ -176,7 +178,7 @@ def draw_graph(origin_node, ancestor_depth=None, descendant_depth=None, format='
 
     # Writing the graph to a temporary file
     fd, fname = tempfile.mkstemp(suffix='.dot')
-    with open(fname, 'w') as fout:
+    with io.open(fname, 'w', encoding='utf8') as fout:
         fout.write("digraph G {\n")
         for l_name, l_values in links.items():
             fout.write('    {}\n'.format(l_values))

--- a/aiida/common/ipython/ipython_magics.py
+++ b/aiida/common/ipython/ipython_magics.py
@@ -36,11 +36,12 @@ Usage
 from __future__ import division
 from __future__ import print_function
 from __future__ import absolute_import
-import json
+
 import IPython
 import six
 from IPython.core.magic import magics_class, line_magic, Magics, needs_local_scope
 
+import aiida.utils.json as json
 
 def add_to_ns(local_ns, name, obj):
     """

--- a/aiida/common/setup.py
+++ b/aiida/common/setup.py
@@ -143,7 +143,7 @@ def store_config(confs):
     old_umask = os.umask(DEFAULT_UMASK)
     try:
         with io.open(conf_file, 'wb', encoding=None) as json_file:
-            json.dump(confs, json_file, indent=CONFIG_INDENT_SIZE, ensure_ascii=False)
+            json.dump(confs, json_file, indent=CONFIG_INDENT_SIZE)
     finally:
         os.umask(old_umask)
 

--- a/aiida/common/setup.py
+++ b/aiida/common/setup.py
@@ -142,7 +142,7 @@ def store_config(confs):
     conf_file = os.path.join(aiida_dir, CONFIG_FNAME)
     old_umask = os.umask(DEFAULT_UMASK)
     try:
-        with io.open(conf_file, 'w', encoding='utf8') as json_file:
+        with io.open(conf_file, 'wb', encoding=None) as json_file:
             json.dump(confs, json_file, indent=CONFIG_INDENT_SIZE)
     finally:
         os.umask(old_umask)

--- a/aiida/common/setup.py
+++ b/aiida/common/setup.py
@@ -142,8 +142,8 @@ def store_config(confs):
     conf_file = os.path.join(aiida_dir, CONFIG_FNAME)
     old_umask = os.umask(DEFAULT_UMASK)
     try:
-        with io.open(conf_file, 'wb', encoding=None) as json_file:
-            json.dump(confs, json_file, indent=CONFIG_INDENT_SIZE)
+        with io.open(conf_file, 'w', encoding='utf8') as json_file:
+            json_file.write(six.text_type(json.dumps(confs, indent=CONFIG_INDENT_SIZE, ensure_ascii=False)))
     finally:
         os.umask(old_umask)
 

--- a/aiida/common/setup.py
+++ b/aiida/common/setup.py
@@ -24,7 +24,6 @@ from aiida.common.exceptions import ConfigurationError
 from aiida.utils.find_folder import find_path
 from .additions.config_migrations import check_and_migrate_config, add_config_version
 
-
 USE_TZ = True
 DEFAULT_AIIDA_USER = 'aiida@localhost'
 
@@ -117,6 +116,7 @@ def _load_config():
         # No configuration file
         raise MissingConfigurationError("No configuration file found")
 
+
 def get_or_create_config():
     from aiida.common.exceptions import MissingConfigurationError
     try:
@@ -173,14 +173,14 @@ def try_create_secret_key():
 
     if os.path.exists(secret_key_full_name):
         # If for some reason the file is empty, regenerate it
-        with io.open(secret_key_full_name, encoding='utf8') as f:
-            if f.read().strip():
+        with io.open(secret_key_full_name, encoding='utf8') as fhandle:
+            if fhandle.read().strip():
                 return
 
     old_umask = os.umask(DEFAULT_UMASK)
     try:
-        with io.open(secret_key_full_name, 'w', encoding='utf8') as f:
-            f.write(generate_random_secret_key())
+        with io.open(secret_key_full_name, 'w', encoding='utf8') as fhandle:
+            fhandle.write(six.text_type(generate_random_secret_key()))
     finally:
         os.umask(old_umask)
 
@@ -204,9 +204,8 @@ def create_htaccess_file():
 
     old_umask = os.umask(DEFAULT_UMASK)
     try:
-        with io.open(htaccess_full_name, 'w', encoding='utf8') as f:
-            f.write(
-                """#### No one should read this folder!
+        with io.open(htaccess_full_name, 'w', encoding='utf8') as fhandle:
+            fhandle.write(u"""#### No one should read this folder!
                 ## Please double check, though, that your Apache configuration honors
                 ## the .htaccess files.
                 deny from all
@@ -231,8 +230,8 @@ def get_secret_key():
     secret_key_full_name = os.path.join(aiida_dir, SECRET_KEY_FNAME)
 
     try:
-        with io.open(secret_key_full_name, encoding='utf8') as f:
-            secret_key = f.read()
+        with io.open(secret_key_full_name, encoding='utf8') as fhandle:
+            secret_key = fhandle.read()
     except (OSError, IOError):
         raise ConfigurationError("Unable to find the secret key file "
                                  "(or to read from it): did you run "
@@ -366,9 +365,8 @@ def get_profile_config(profile, conf_dict=None):
     try:
         profile_info = confs['profiles'][profile]
     except KeyError:
-        raise ProfileConfigurationError(
-            "No profile configuration found for {}, allowed values are: {}.".format(
-                profile, ', '.join(get_profiles_list())))
+        raise ProfileConfigurationError("No profile configuration found for {}, allowed values are: {}.".format(
+            profile, ', '.join(get_profiles_list())))
 
     return profile_info
 
@@ -439,10 +437,8 @@ def create_config_noninteractive(profile='default', force_overwrite=False, dry_r
     :return: The populated profile that was also stored
     '''
     if profile_exists(profile) and not force_overwrite:
-        raise ValueError(
-            ('profile {profile} exists! '
-             'Cannot non-interactively edit a profile.').format(profile=profile)
-        )
+        raise ValueError(('profile {profile} exists! '
+                          'Cannot non-interactively edit a profile.').format(profile=profile))
 
     new_profile = {}
 
@@ -452,9 +448,7 @@ def create_config_noninteractive(profile='default', force_overwrite=False, dry_r
     if backend_v in backend_possibilities:
         new_profile['AIIDADB_BACKEND'] = backend_v
     else:
-        raise ValueError(
-            '{} is not a valid backend choice.'.format(
-                backend_v))
+        raise ValueError('{} is not a valid backend choice.'.format(backend_v))
 
     # Setting email
     from validate_email import validate_email
@@ -462,9 +456,7 @@ def create_config_noninteractive(profile='default', force_overwrite=False, dry_r
     if validate_email(email_v):
         new_profile[DEFAULT_USER_CONFIG_FIELD] = email_v
     else:
-        raise ValueError(
-            '{} is not a valid email address.'.format(
-                email_v))
+        raise ValueError('{} is not a valid email address.'.format(email_v))
 
     # setting up db
     new_profile['AIIDADB_ENGINE'] = 'postgresql_psycopg2'
@@ -552,8 +544,7 @@ def create_configuration(profile='default'):
     # to modify it.
     updating_existing_prof = False
     if this_existing_confs:
-        print("The following configuration found corresponding to "
-              "profile {}.".format(profile))
+        print("The following configuration found corresponding to " "profile {}.".format(profile))
         for k, v in this_existing_confs.items():
             if k in key_explanation:
                 print("{}: {}".format(key_explanation.get(k), v))
@@ -582,27 +573,22 @@ def create_configuration(profile='default'):
 
                 valid_aiida_backend = False
                 while not valid_aiida_backend:
-                    backend_ans = input(
-                        'AiiDA backend (available: {} - sqlalchemy is in beta mode): '
-                            .format(', '.join(backend_possibilities)))
+                    backend_ans = input('AiiDA backend (available: {} - sqlalchemy is in beta mode): '.format(
+                        ', '.join(backend_possibilities)))
                     if backend_ans in backend_possibilities:
                         valid_aiida_backend = True
                     else:
                         print("* ERROR! Invalid backend inserted.")
-                        print("*        The available middlewares are {}"
-                              .format(', '.join(backend_possibilities)))
+                        print("*        The available middlewares are {}".format(', '.join(backend_possibilities)))
                 this_new_confs['AIIDADB_BACKEND'] = backend_ans
                 aiida_backend = backend_ans
 
         # Setting the email
         valid_email = False
-        readline.set_startup_hook(lambda: readline.insert_text(
-            this_existing_confs.get(DEFAULT_AIIDA_USER)))
+        readline.set_startup_hook(lambda: readline.insert_text(this_existing_confs.get(DEFAULT_AIIDA_USER)))
         while not valid_email:
-            this_new_confs[DEFAULT_USER_CONFIG_FIELD] = input(
-                'Default user email: ')
-            valid_email = validate_email(
-                this_new_confs[DEFAULT_USER_CONFIG_FIELD])
+            this_new_confs[DEFAULT_USER_CONFIG_FIELD] = input('Default user email: ')
+            valid_email = validate_email(this_new_confs[DEFAULT_USER_CONFIG_FIELD])
             if not valid_email:
                 print("** Invalid email provided!")
 
@@ -614,20 +600,17 @@ def create_configuration(profile='default'):
             db_possibilities.extend(['postgresql_psycopg2'])
         if len(db_possibilities) > 0:
             db_engine = this_existing_confs.get('AIIDADB_ENGINE', db_possibilities[0])
-            readline.set_startup_hook(lambda: readline.insert_text(
-                db_engine))
+            readline.set_startup_hook(lambda: readline.insert_text(db_engine))
 
             valid_db_engine = False
             while not valid_db_engine:
-                db_engine_ans = input(
-                    'Database engine (available: {} - mysql is deprecated): '
-                        .format(', '.join(db_possibilities)))
+                db_engine_ans = input('Database engine (available: {} - mysql is deprecated): '.format(
+                    ', '.join(db_possibilities)))
                 if db_engine_ans in db_possibilities:
                     valid_db_engine = True
                 else:
                     print("* ERROR! Invalid database engine inserted.")
-                    print("*        The available engines are {}"
-                          .format(', '.join(db_possibilities)))
+                    print("*        The available engines are {}".format(', '.join(db_possibilities)))
             this_new_confs['AIIDADB_ENGINE'] = db_engine_ans
 
         if 'postgresql_psycopg2' in this_new_confs['AIIDADB_ENGINE']:
@@ -636,41 +619,34 @@ def create_configuration(profile='default'):
             old_host = this_existing_confs.get('AIIDADB_HOST', 'localhost')
             if not old_host:
                 old_host = 'localhost'
-            readline.set_startup_hook(lambda: readline.insert_text(
-                old_host))
+            readline.set_startup_hook(lambda: readline.insert_text(old_host))
             this_new_confs['AIIDADB_HOST'] = input('PostgreSQL host: ')
 
             old_port = this_existing_confs.get('AIIDADB_PORT', '5432')
             if not old_port:
                 old_port = '5432'
-            readline.set_startup_hook(lambda: readline.insert_text(
-                old_port))
+            readline.set_startup_hook(lambda: readline.insert_text(old_port))
             this_new_confs['AIIDADB_PORT'] = input('PostgreSQL port: ')
 
-            readline.set_startup_hook(lambda: readline.insert_text(
-                this_existing_confs.get('AIIDADB_NAME')))
+            readline.set_startup_hook(lambda: readline.insert_text(this_existing_confs.get('AIIDADB_NAME')))
             db_name = ''
             while True:
                 db_name = input('AiiDA Database name: ')
                 if is_test_profile and db_name.startswith(TEST_KEYWORD):
                     break
-                if (not is_test_profile and not
-                db_name.startswith(TEST_KEYWORD)):
+                if (not is_test_profile and not db_name.startswith(TEST_KEYWORD)):
                     break
                 print("The test databases should start with the prefix {} and "
-                      "the non-test databases should not have this prefix."
-                      .format(TEST_KEYWORD))
+                      "the non-test databases should not have this prefix.".format(TEST_KEYWORD))
             this_new_confs['AIIDADB_NAME'] = db_name
 
             old_user = this_existing_confs.get('AIIDADB_USER', 'aiida')
             if not old_user:
                 old_user = 'aiida'
-            readline.set_startup_hook(lambda: readline.insert_text(
-                old_user))
+            readline.set_startup_hook(lambda: readline.insert_text(old_user))
             this_new_confs['AIIDADB_USER'] = input('AiiDA Database user: ')
 
-            readline.set_startup_hook(lambda: readline.insert_text(
-                this_existing_confs.get('AIIDADB_PASS')))
+            readline.set_startup_hook(lambda: readline.insert_text(this_existing_confs.get('AIIDADB_PASS')))
             this_new_confs['AIIDADB_PASS'] = input('AiiDA Database password: ')
 
         elif 'mysql' in this_new_confs['AIIDADB_ENGINE']:
@@ -679,45 +655,37 @@ def create_configuration(profile='default'):
             old_host = this_existing_confs.get('AIIDADB_HOST', 'localhost')
             if not old_host:
                 old_host = 'localhost'
-            readline.set_startup_hook(lambda: readline.insert_text(
-                old_host))
+            readline.set_startup_hook(lambda: readline.insert_text(old_host))
             this_new_confs['AIIDADB_HOST'] = input('mySQL host: ')
 
             old_port = this_existing_confs.get('AIIDADB_PORT', '3306')
             if not old_port:
                 old_port = '3306'
-            readline.set_startup_hook(lambda: readline.insert_text(
-                old_port))
+            readline.set_startup_hook(lambda: readline.insert_text(old_port))
             this_new_confs['AIIDADB_PORT'] = input('mySQL port: ')
 
-            readline.set_startup_hook(lambda: readline.insert_text(
-                this_existing_confs.get('AIIDADB_NAME')))
+            readline.set_startup_hook(lambda: readline.insert_text(this_existing_confs.get('AIIDADB_NAME')))
             db_name = ''
             while True:
                 db_name = input('AiiDA Database name: ')
                 if is_test_profile and db_name.startswith(TEST_KEYWORD):
                     break
-                if (not is_test_profile and not
-                db_name.startswith(TEST_KEYWORD)):
+                if (not is_test_profile and not db_name.startswith(TEST_KEYWORD)):
                     break
                 print("The test databases should start with the prefix {} and "
-                      "the non-test databases should not have this prefix."
-                      .format(TEST_KEYWORD))
+                      "the non-test databases should not have this prefix.".format(TEST_KEYWORD))
             this_new_confs['AIIDADB_NAME'] = db_name
 
             old_user = this_existing_confs.get('AIIDADB_USER', 'aiida')
             if not old_user:
                 old_user = 'aiida'
-            readline.set_startup_hook(lambda: readline.insert_text(
-                old_user))
+            readline.set_startup_hook(lambda: readline.insert_text(old_user))
             this_new_confs['AIIDADB_USER'] = input('AiiDA Database user: ')
 
-            readline.set_startup_hook(lambda: readline.insert_text(
-                this_existing_confs.get('AIIDADB_PASS')))
+            readline.set_startup_hook(lambda: readline.insert_text(this_existing_confs.get('AIIDADB_PASS')))
             this_new_confs['AIIDADB_PASS'] = input('AiiDA Database password: ')
         else:
-            raise ValueError("You have to specify a valid database "
-                             "(valid choices are 'mysql', 'postgres')")
+            raise ValueError("You have to specify a valid database " "(valid choices are 'mysql', 'postgres')")
 
         # This part for the time being is a bit oddly written
         # it should change in the future to add the possibility of having a
@@ -738,18 +706,16 @@ def create_configuration(profile='default'):
         # Check if the new repository is a test repository and if it already exists.
         if is_test_profile:
             if TEST_KEYWORD not in os.path.basename(new_repo_path.rstrip('/')):
-                raise ValueError(
-                    "The repository directory for test profiles should "
-                    "contain the test keyword '{}'".format(TEST_KEYWORD))
+                raise ValueError("The repository directory for test profiles should "
+                                 "contain the test keyword '{}'".format(TEST_KEYWORD))
 
             if os.path.isdir(new_repo_path):
                 print("The repository {} already exists. It will be used for "
                       "tests. Any content may be deleted.".format(new_repo_path))
         else:
             if TEST_KEYWORD in os.path.basename(new_repo_path):
-                raise ValueError(
-                    "The repository directory for non-test profiles cannot "
-                    "contain the test keyword '{}'".format(TEST_KEYWORD))
+                raise ValueError("The repository directory for non-test profiles cannot "
+                                 "contain the test keyword '{}'".format(TEST_KEYWORD))
 
         if not os.path.isdir(new_repo_path):
             print("The repository {} will be created.".format(new_repo_path))
@@ -787,6 +753,7 @@ def create_configuration(profile='default'):
 # - the fourth entry is the default value. Use _NoDefaultValue() if you want
 #   an exception to be raised if no property is found.
 
+
 class _NoDefaultValue(object):
     pass
 
@@ -801,122 +768,54 @@ class _NoDefaultValue(object):
 # 4. The default value, if no setting is found
 # 5. A list of valid values, or None if no such list makes sense
 _property_table = {
-    "daemon.timeout": (
-        "daemon_timeout",
-        "int",
-        "The timeout in seconds for calls to the circus client",
-        DEFAULT_DAEMON_TIMEOUT,
-        None),
-    "verdishell.modules": (
-        "modules_for_verdi_shell",
-        "string",
-        "Additional modules/functions/classes to be automaticaly loaded in the "
-        "verdi shell (but not in the runaiida environment); it should be a "
-        "string with the full paths for each module,"
-        " function or class, separated by colons, e.g. "
-        "'aiida.backends.djsite.db.models:aiida.orm.querytool.Querytool'",
-        "",
-        None),
-    "verdishell.calculation_list": (
-        "projections_for_calculation_list",
-        "list_of_str",
-        "A list of the projections that should be shown by default "
-        "when typing 'verdi calculation list'. "
-        "Set by passing the projections space separated as a string, for example: "
-        "verdi devel setproperty verdishell.calculation_list 'pk time state'",
-        ('pk', 'ctime', 'state', 'type', 'computer', 'job_state'),
-        None),
-    "logging.aiida_loglevel": (
-        "logging_aiida_log_level",
-        "string",
-        "Minimum level to log to the file ~/.aiida/daemon/log/aiida_daemon.log "
-        "and to the DbLog table for the 'aiida' logger; for the DbLog, see "
-        "also the logging.db_loglevel variable to further filter messages going "
-        "to the database",
-        "REPORT",
-        ["CRITICAL", "ERROR", "WARNING", "REPORT", "INFO", "DEBUG"]),
-    "logging.tornado_loglevel": (
-        "logging_tornado_log_level",
-        "string",
-        "Minimum level to log to the file ~/.aiida/daemon/log/aiida_daemon.log "
-        "for the 'tornado' loggers",
-        "WARNING",
-        ["CRITICAL", "ERROR", "WARNING", "REPORT", "INFO", "DEBUG"]),
-    "logging.plumpy_loglevel": (
-        "logging_plumpy_log_level",
-        "string",
-        "Minimum level to log to the file ~/.aiida/daemon/log/aiida_daemon.log "
-        "for the 'plumpy' logger",
-        "WARNING",
-        ["CRITICAL", "ERROR", "WARNING", "REPORT", "INFO", "DEBUG"]),
-    "logging.paramiko_loglevel": (
-        "logging_paramiko_log_level",
-        "string",
-        "Minimum level to log to the file ~/.aiida/daemon/log/aiida_daemon.log "
-        "for the 'paramiko' logger",
-        "WARNING",
-        ["CRITICAL", "ERROR", "WARNING", "REPORT", "INFO", "DEBUG"]),
-    "logging.alembic_loglevel": (
-        "logging_alembic_log_level",
-        "string",
-        "Minimum level to log to the console",
-        "WARNING",
-        ["CRITICAL", "ERROR", "WARNING", "REPORT", "INFO", "DEBUG"]),
-    "logging.sqlalchemy_loglevel": (
-        "logging_sqlalchemy_loglevel",
-        "string",
-        "Minimum level to log to the console",
-        "WARNING",
-        ["CRITICAL", "ERROR", "WARNING", "REPORT", "INFO", "DEBUG"]),
-    "logging.circus_loglevel": (
-        "logging_circus_log_level",
-        "string",
-        "Minimum level to log to the circus daemon log file"
-        "for the 'circus' logger",
-        "INFO",
-        ["CRITICAL", "ERROR", "WARNING", "REPORT", "INFO", "DEBUG"]),
-    "logging.db_loglevel": (
-        "logging_db_log_level",
-        "string",
-        "Minimum level to log to the DbLog table",
-        "REPORT",
-        ["CRITICAL", "ERROR", "WARNING", "REPORT", "INFO", "DEBUG"]),
-    "tcod.depositor_username": (
-        "tcod_depositor_username",
-        "string",
-        "Username for TCOD deposition",
-        None,
-        None),
-    "tcod.depositor_password": (
-        "tcod_depositor_password",
-        "string",
-        "Password for TCOD deposition",
-        None,
-        None),
-    "tcod.depositor_email": (
-        "tcod_depositor_email",
-        "string",
-        "E-mail address for TCOD deposition",
-        None,
-        None),
-    "tcod.depositor_author_name": (
-        "tcod_depositor_author_name",
-        "string",
-        "Author name for TCOD depositions",
-        None,
-        None),
-    "tcod.depositor_author_email": (
-        "tcod_depositor_author_email",
-        "string",
-        "E-mail address for TCOD depositions",
-        None,
-        None),
-    "warnings.showdeprecations": (
-        "show_deprecations",
-        "bool",
-        "Boolean whether to print deprecation warnings",
-        False,
-        None)
+    "daemon.timeout": ("daemon_timeout", "int", "The timeout in seconds for calls to the circus client",
+                       DEFAULT_DAEMON_TIMEOUT, None),
+    "verdishell.modules": ("modules_for_verdi_shell", "string",
+                           "Additional modules/functions/classes to be automaticaly loaded in the "
+                           "verdi shell (but not in the runaiida environment); it should be a "
+                           "string with the full paths for each module,"
+                           " function or class, separated by colons, e.g. "
+                           "'aiida.backends.djsite.db.models:aiida.orm.querytool.Querytool'", "", None),
+    "verdishell.calculation_list": ("projections_for_calculation_list", "list_of_str",
+                                    "A list of the projections that should be shown by default "
+                                    "when typing 'verdi calculation list'. "
+                                    "Set by passing the projections space separated as a string, for example: "
+                                    "verdi devel setproperty verdishell.calculation_list 'pk time state'",
+                                    ('pk', 'ctime', 'state', 'type', 'computer', 'job_state'), None),
+    "logging.aiida_loglevel": ("logging_aiida_log_level", "string",
+                               "Minimum level to log to the file ~/.aiida/daemon/log/aiida_daemon.log "
+                               "and to the DbLog table for the 'aiida' logger; for the DbLog, see "
+                               "also the logging.db_loglevel variable to further filter messages going "
+                               "to the database", "REPORT", ["CRITICAL", "ERROR", "WARNING", "REPORT", "INFO",
+                                                             "DEBUG"]),
+    "logging.tornado_loglevel":
+    ("logging_tornado_log_level", "string", "Minimum level to log to the file ~/.aiida/daemon/log/aiida_daemon.log "
+     "for the 'tornado' loggers", "WARNING", ["CRITICAL", "ERROR", "WARNING", "REPORT", "INFO", "DEBUG"]),
+    "logging.plumpy_loglevel":
+    ("logging_plumpy_log_level", "string", "Minimum level to log to the file ~/.aiida/daemon/log/aiida_daemon.log "
+     "for the 'plumpy' logger", "WARNING", ["CRITICAL", "ERROR", "WARNING", "REPORT", "INFO", "DEBUG"]),
+    "logging.paramiko_loglevel":
+    ("logging_paramiko_log_level", "string", "Minimum level to log to the file ~/.aiida/daemon/log/aiida_daemon.log "
+     "for the 'paramiko' logger", "WARNING", ["CRITICAL", "ERROR", "WARNING", "REPORT", "INFO", "DEBUG"]),
+    "logging.alembic_loglevel": ("logging_alembic_log_level", "string", "Minimum level to log to the console",
+                                 "WARNING", ["CRITICAL", "ERROR", "WARNING", "REPORT", "INFO", "DEBUG"]),
+    "logging.sqlalchemy_loglevel": ("logging_sqlalchemy_loglevel", "string", "Minimum level to log to the console",
+                                    "WARNING", ["CRITICAL", "ERROR", "WARNING", "REPORT", "INFO", "DEBUG"]),
+    "logging.circus_loglevel": ("logging_circus_log_level", "string",
+                                "Minimum level to log to the circus daemon log file"
+                                "for the 'circus' logger", "INFO",
+                                ["CRITICAL", "ERROR", "WARNING", "REPORT", "INFO", "DEBUG"]),
+    "logging.db_loglevel": ("logging_db_log_level", "string", "Minimum level to log to the DbLog table", "REPORT",
+                            ["CRITICAL", "ERROR", "WARNING", "REPORT", "INFO", "DEBUG"]),
+    "tcod.depositor_username": ("tcod_depositor_username", "string", "Username for TCOD deposition", None, None),
+    "tcod.depositor_password": ("tcod_depositor_password", "string", "Password for TCOD deposition", None, None),
+    "tcod.depositor_email": ("tcod_depositor_email", "string", "E-mail address for TCOD deposition", None, None),
+    "tcod.depositor_author_name": ("tcod_depositor_author_name", "string", "Author name for TCOD depositions", None,
+                                   None),
+    "tcod.depositor_author_email": ("tcod_depositor_author_email", "string", "E-mail address for TCOD depositions",
+                                    None, None),
+    "warnings.showdeprecations": ("show_deprecations", "bool", "Boolean whether to print deprecation warnings", False,
+                                  None)
 }
 
 
@@ -1058,8 +957,7 @@ def set_property(name, value):
         actual_value = value.split()
     else:
         # Implement here other data types
-        raise NotImplementedError("Type string '{}' not implemented yet".format(
-            type_string))
+        raise NotImplementedError("Type string '{}' not implemented yet".format(type_string))
 
     if valid_values is not None:
         if actual_value not in valid_values:
@@ -1089,8 +987,7 @@ def parse_repository_uri(repository_uri):
     parts = uritools.urisplit(repository_uri)
 
     if parts.scheme != u'file':
-        raise ConfigurationError("The current AiiDA version supports only a "
-                                 "local repository")
+        raise ConfigurationError("The current AiiDA version supports only a " "local repository")
 
     if parts.scheme == u'file':
         if not os.path.isabs(parts.path):

--- a/aiida/common/setup.py
+++ b/aiida/common/setup.py
@@ -143,7 +143,7 @@ def store_config(confs):
     old_umask = os.umask(DEFAULT_UMASK)
     try:
         with io.open(conf_file, 'wb', encoding=None) as json_file:
-            json.dump(confs, json_file, indent=CONFIG_INDENT_SIZE)
+            json.dump(confs, json_file, indent=CONFIG_INDENT_SIZE, ensure_ascii=False)
     finally:
         os.umask(old_umask)
 

--- a/aiida/common/setup.py
+++ b/aiida/common/setup.py
@@ -14,7 +14,8 @@ import io
 import os
 import uuid
 import logging
-import json
+import aiida.utils.json as json
+
 
 import six
 from six.moves import input
@@ -100,9 +101,9 @@ def _load_config():
     """
     Return the current configurations, without checking their version.
     """
-    import json
     from aiida.common.exceptions import MissingConfigurationError
     from aiida.backends.settings import IN_RT_DOC_MODE, DUMMY_CONF_FILE
+    import aiida.utils.json as json
 
     if IN_RT_DOC_MODE:
         return DUMMY_CONF_FILE
@@ -136,14 +137,14 @@ def store_config(confs):
     from aiida.backends.settings import IN_RT_DOC_MODE
     if IN_RT_DOC_MODE:
         return
+    import aiida.utils.json as json
 
-    import json
     aiida_dir = os.path.expanduser(AIIDA_CONFIG_FOLDER)
     conf_file = os.path.join(aiida_dir, CONFIG_FNAME)
     old_umask = os.umask(DEFAULT_UMASK)
     try:
-        with io.open(conf_file, 'w', encoding='utf8') as json_file:
-            json_file.write(six.text_type(json.dumps(confs, indent=CONFIG_INDENT_SIZE, ensure_ascii=False)))
+        with io.open(conf_file, 'wb') as json_file:
+            json.dump(confs, json_file, indent=CONFIG_INDENT_SIZE)
     finally:
         os.umask(old_umask)
 

--- a/aiida/common/setup.py
+++ b/aiida/common/setup.py
@@ -10,15 +10,16 @@
 from __future__ import division
 from __future__ import absolute_import
 from __future__ import print_function
+import io
 import os
 import uuid
-import aiida
 import logging
 import json
 
 import six
 from six.moves import input
 
+import aiida
 from aiida.common.exceptions import ConfigurationError
 from aiida.utils.find_folder import find_path
 from .additions.config_migrations import check_and_migrate_config, add_config_version
@@ -110,7 +111,7 @@ def _load_config():
     aiida_dir = os.path.expanduser(AIIDA_CONFIG_FOLDER)
     conf_file = os.path.join(aiida_dir, CONFIG_FNAME)
     try:
-        with open(conf_file, 'r') as json_file:
+        with io.open(conf_file, 'r', encoding='utf8') as json_file:
             return json.load(json_file)
     except IOError:
         # No configuration file
@@ -141,7 +142,7 @@ def store_config(confs):
     conf_file = os.path.join(aiida_dir, CONFIG_FNAME)
     old_umask = os.umask(DEFAULT_UMASK)
     try:
-        with open(conf_file, 'w') as json_file:
+        with io.open(conf_file, 'w', encoding='utf8') as json_file:
             json.dump(confs, json_file, indent=CONFIG_INDENT_SIZE)
     finally:
         os.umask(old_umask)
@@ -172,13 +173,13 @@ def try_create_secret_key():
 
     if os.path.exists(secret_key_full_name):
         # If for some reason the file is empty, regenerate it
-        with open(secret_key_full_name) as f:
+        with io.open(secret_key_full_name, encoding='utf8') as f:
             if f.read().strip():
                 return
 
     old_umask = os.umask(DEFAULT_UMASK)
     try:
-        with open(secret_key_full_name, 'w') as f:
+        with io.open(secret_key_full_name, 'w', encoding='utf8') as f:
             f.write(generate_random_secret_key())
     finally:
         os.umask(old_umask)
@@ -203,7 +204,7 @@ def create_htaccess_file():
 
     old_umask = os.umask(DEFAULT_UMASK)
     try:
-        with open(htaccess_full_name, 'w') as f:
+        with io.open(htaccess_full_name, 'w', encoding='utf8') as f:
             f.write(
                 """#### No one should read this folder!
                 ## Please double check, though, that your Apache configuration honors
@@ -230,7 +231,7 @@ def get_secret_key():
     secret_key_full_name = os.path.join(aiida_dir, SECRET_KEY_FNAME)
 
     try:
-        with open(secret_key_full_name) as f:
+        with io.open(secret_key_full_name, encoding='utf8') as f:
             secret_key = f.read()
     except (OSError, IOError):
         raise ConfigurationError("Unable to find the secret key file "

--- a/aiida/common/test_extendeddicts.py
+++ b/aiida/common/test_extendeddicts.py
@@ -205,7 +205,7 @@ class TestAttributeDictSerialize(unittest.TestCase):
     """
 
     def test_json(self):
-        import json
+        import aiida.utils.json as json
 
         d1 = AttributeDict({'x': 1, 'y': 2})
         d2 = json.loads(json.dumps(d1))
@@ -214,7 +214,7 @@ class TestAttributeDictSerialize(unittest.TestCase):
         self.assertEquals(d1, d2)
 
     def test_json_recursive(self):
-        import json
+        import aiida.utils.json as json
 
         d1 = AttributeDict({'x': 1, 'y': 2, 'z': AttributeDict({'w': 4})})
         d2 = json.loads(json.dumps(d1))

--- a/aiida/common/test_folders.py
+++ b/aiida/common/test_folders.py
@@ -7,6 +7,9 @@
 # For further information on the license, see the LICENSE.txt file        #
 # For further information please visit http://www.aiida.net               #
 ###########################################################################
+"""
+Tests for the folder class
+"""
 from __future__ import division
 from __future__ import print_function
 from __future__ import absolute_import
@@ -14,39 +17,41 @@ import io
 import unittest
 
 
-
 class FoldersTest(unittest.TestCase):
     """
     Tests for the Folder class.
     """
 
-    def test_unicode(self):
+    @classmethod
+    def test_unicode(cls):
         """
-        Check that there are no exceptions raised when 
+        Check that there are no exceptions raised when
         using unicode folders.
         """
         from aiida.common.folders import Folder
-        import os, tempfile
+        import os
+        import tempfile
 
         tmpsource = tempfile.mkdtemp()
         tmpdest = tempfile.mkdtemp()
-        with io.open(os.path.join(tmpsource, "sąžininga"), 'w', encoding='utf8') as f:
-            f.write(u"test")
-        with io.open(os.path.join(tmpsource, "žąsis"), 'w', encoding='utf8') as f:
-            f.write(u"test")
-        fd = Folder(tmpdest)
-        fd.insert_path(tmpsource, "destination")
-        fd.insert_path(tmpsource, u"šaltinis")
+        with io.open(os.path.join(tmpsource, "sąžininga"), 'w', encoding='utf8') as fhandle:
+            fhandle.write(u"test")
+        with io.open(os.path.join(tmpsource, "žąsis"), 'w', encoding='utf8') as fhandle:
+            fhandle.write(u"test")
+        folder = Folder(tmpdest)
+        folder.insert_path(tmpsource, "destination")
+        folder.insert_path(tmpsource, u"šaltinis")
 
-        fd = Folder(os.path.join(tmpsource, u"šaltinis"))
-        fd.insert_path(tmpsource, "destination")
-        fd.insert_path(tmpdest, u"kitas-šaltinis")
-
+        folder = Folder(os.path.join(tmpsource, u"šaltinis"))
+        folder.insert_path(tmpsource, "destination")
+        folder.insert_path(tmpdest, u"kitas-šaltinis")
 
     def test_get_abs_path_without_limit(self):
+        """
+        Check that the absolute path function can get an absolute path
+        """
         from aiida.common.folders import Folder
 
-        fd = Folder('/tmp')
+        folder = Folder('/tmp')
         # Should not raise any exception
-        self.assertEquals(fd.get_abs_path('test_file.txt'),
-                          '/tmp/test_file.txt')
+        self.assertEquals(folder.get_abs_path('test_file.txt'), '/tmp/test_file.txt')

--- a/aiida/common/test_folders.py
+++ b/aiida/common/test_folders.py
@@ -54,4 +54,4 @@ class FoldersTest(unittest.TestCase):
 
         folder = Folder('/tmp')
         # Should not raise any exception
-        self.assertEquals(folder.get_abs_path('test_file.txt'), '/tmp/test_file.txt')
+        self.assertEqual(folder.get_abs_path('test_file.txt'), '/tmp/test_file.txt')

--- a/aiida/common/test_folders.py
+++ b/aiida/common/test_folders.py
@@ -10,6 +10,7 @@
 from __future__ import division
 from __future__ import print_function
 from __future__ import absolute_import
+import io
 import unittest
 
 
@@ -29,10 +30,10 @@ class FoldersTest(unittest.TestCase):
 
         tmpsource = tempfile.mkdtemp()
         tmpdest = tempfile.mkdtemp()
-        with open(os.path.join(tmpsource, "sąžininga"), 'w') as f:
-            f.write("test")
-        with open(os.path.join(tmpsource, "žąsis"), 'w') as f:
-            f.write("test")
+        with io.open(os.path.join(tmpsource, "sąžininga"), 'w', encoding='utf8') as f:
+            f.write(u"test")
+        with io.open(os.path.join(tmpsource, "žąsis"), 'w', encoding='utf8') as f:
+            f.write(u"test")
         fd = Folder(tmpdest)
         fd.insert_path(tmpsource, "destination")
         fd.insert_path(tmpsource, u"šaltinis")

--- a/aiida/common/test_hashing.py
+++ b/aiida/common/test_hashing.py
@@ -204,7 +204,7 @@ class MakeHashTest(unittest.TestCase):
         with SandboxFolder(sandbox_in_repo=False) as folder:
             folder.open('file1', 'a').close()
             fhandle = folder.open('file2', 'w')
-            fhandle.write("hello there!\n")
+            fhandle.write(u"hello there!\n")
             fhandle.close()
 
             folder_hash = make_hash(folder)

--- a/aiida/common/utils.py
+++ b/aiida/common/utils.py
@@ -597,7 +597,8 @@ def xyz_parser_iterator(xyz_string):
             """
             return self.__next__()
 
-    pos_regex = re.compile(r"""
+    pos_regex = re.compile(
+        r"""
 ^                                                                             # Linestart
 [ \t]*                                                                        # Optional white space
 (?P<sym>[A-Za-z]+[A-Za-z0-9]*)\s+                                             # get the symbol
@@ -605,7 +606,8 @@ def xyz_parser_iterator(xyz_string):
 (?P<y> [\+\-]?  ( \d*[\.]\d+  | \d+[\.]?\d* )  ([Ee][\+\-]?\d+)? ) [ \t]+     # Get y
 (?P<z> [\+\-]?  ( \d*[\.]\d+  | \d+[\.]?\d* )  ([Ee][\+\-]?\d+)? )            # Get z
 """, re.X | re.M)
-    pos_block_regex = re.compile(r"""
+    pos_block_regex = re.compile(
+        r"""
                                                             # First line contains an integer
                                                             # and only an integer: the number of atoms
 ^[ \t]* (?P<natoms> [0-9]+) [ \t]*[\n]                      # End first line

--- a/aiida/common/utils.py
+++ b/aiida/common/utils.py
@@ -20,6 +20,7 @@ import datetime
 import filecmp
 import functools
 import inspect
+import io
 import os.path
 import sys
 import numbers
@@ -335,7 +336,7 @@ def md5_file(filename, block_size_factor=128):
     import hashlib
 
     md5 = hashlib.md5()
-    with open(filename, 'rb') as fhandle:
+    with io.open(filename, 'rb', encoding=None) as fhandle:
         # I read 128 bytes at a time until it returns the empty string b''
         for chunk in iter(lambda: fhandle.read(block_size_factor * md5.block_size), b''):
             md5.update(chunk)
@@ -361,7 +362,7 @@ def sha1_file(filename, block_size_factor=128):
     import hashlib
 
     sha1 = hashlib.sha1()
-    with open(filename, 'rb') as fhandle:
+    with io.open(filename, 'rb', encoding=None) as fhandle:
         # I read 128 bytes at a time until it returns the empty string b''
         for chunk in iter(lambda: fhandle.read(block_size_factor * sha1.block_size), b''):
             sha1.update(chunk)
@@ -596,8 +597,7 @@ def xyz_parser_iterator(xyz_string):
             """
             return self.__next__()
 
-    pos_regex = re.compile(
-        r"""
+    pos_regex = re.compile(r"""
 ^                                                                             # Linestart
 [ \t]*                                                                        # Optional white space
 (?P<sym>[A-Za-z]+[A-Za-z0-9]*)\s+                                             # get the symbol
@@ -605,8 +605,7 @@ def xyz_parser_iterator(xyz_string):
 (?P<y> [\+\-]?  ( \d*[\.]\d+  | \d+[\.]?\d* )  ([Ee][\+\-]?\d+)? ) [ \t]+     # Get y
 (?P<z> [\+\-]?  ( \d*[\.]\d+  | \d+[\.]?\d* )  ([Ee][\+\-]?\d+)? )            # Get z
 """, re.X | re.M)
-    pos_block_regex = re.compile(
-        r"""
+    pos_block_regex = re.compile(r"""
                                                             # First line contains an integer
                                                             # and only an integer: the number of atoms
 ^[ \t]* (?P<natoms> [0-9]+) [ \t]*[\n]                      # End first line
@@ -1253,7 +1252,7 @@ class HiddenPrints(object):  # pylint: disable=too-few-public-methods
     def __enter__(self):
         from os import devnull
         self._original_stdout = sys.stdout
-        sys.stdout = open(devnull, 'w')
+        sys.stdout = io.open(devnull, 'w', encoding='utf8')
 
     def __exit__(self, exc_type, exc_val, exc_tb):
         sys.stdout = self._original_stdout

--- a/aiida/common/utils.py
+++ b/aiida/common/utils.py
@@ -1250,9 +1250,19 @@ class HiddenPrints(object):  # pylint: disable=too-few-public-methods
         self._original_stdout = None
 
     def __enter__(self):
+        """
+        Keep track of the original sdtout location and redirect stdout
+        to /dev/null
+        """
         from os import devnull
+
         self._original_stdout = sys.stdout
-        sys.stdout = io.open(devnull, 'w', encoding='utf8')
+
+        # N.B. Here we don't use io.open as we may need to swallow byte streams.
+        # In this instance, as we're just redirecting the output to dev null we
+        # don't need to worry about encoding and so we use regular system open.
+        # This will work in Python 2 or Python 3.
+        sys.stdout = open(devnull, 'w')
 
     def __exit__(self, exc_type, exc_val, exc_tb):
         sys.stdout = self._original_stdout

--- a/aiida/daemon/client.py
+++ b/aiida/daemon/client.py
@@ -7,6 +7,9 @@
 # For further information on the license, see the LICENSE.txt file        #
 # For further information please visit http://www.aiida.net               #
 ###########################################################################
+"""
+Controls the daemon
+"""
 from __future__ import division
 from __future__ import print_function
 from __future__ import absolute_import
@@ -146,8 +149,8 @@ class DaemonClient(object):
                 raise RuntimeError('daemon is running so port file should have been there but could not read it')
         else:
             port = self.get_available_port()
-            with io.open(self.circus_port_file, 'w', encoding='utf8') as handle:
-                handle.write(str(port))
+            with io.open(self.circus_port_file, 'w', encoding='utf8') as fhandle:
+                fhandle.write(six.text_type(port))
 
             return port
 
@@ -175,14 +178,14 @@ class DaemonClient(object):
         else:
 
             # The SOCKET_DIRECTORY is already set, a temporary directory was already created and the same should be used
-            if self._SOCKET_DIRECTORY is not None:
-                return self._SOCKET_DIRECTORY
+            if self._socket_directory is not None:
+                return self._socket_directory
 
             socket_dir_path = tempfile.mkdtemp()
-            with io.open(self.circus_socket_file, 'w', encoding='utf8') as handle:
-                handle.write(socket_dir_path)
+            with io.open(self.circus_socket_file, 'w', encoding='utf8') as fhandle:
+                fhandle.write(six.text_type(socket_dir_path))
 
-            self._SOCKET_DIRECTORY = socket_dir_path
+            self._socket_directory = socket_dir_path
             return socket_dir_path
 
     def get_daemon_pid(self):
@@ -223,7 +226,8 @@ class DaemonClient(object):
             else:
                 raise
 
-    def get_available_port(self):
+    @classmethod
+    def get_available_port(cls):
         """
         Get an available port from the operating system
 
@@ -321,7 +325,7 @@ class DaemonClient(object):
         :return: CircucClient instance
         """
         from circus.client import CircusClient
-        return CircusClient(endpoint=self.get_controller_endpoint(), timeout=self._DAEMON_TIMEOUT)
+        return CircusClient(endpoint=self.get_controller_endpoint(), timeout=self._daemon_timeout)
 
     def call_client(self, command):
         """
@@ -353,12 +357,7 @@ class DaemonClient(object):
 
         :return: the client call response
         """
-        command = {
-            'command': 'status',
-            'properties': {
-                'name': self.daemon_name
-            }
-        }
+        command = {'command': 'status', 'properties': {'name': self.daemon_name}}
 
         return self.call_client(command)
 
@@ -368,12 +367,7 @@ class DaemonClient(object):
 
         :return: the client call response
         """
-        command = {
-            'command': 'stats',
-            'properties': {
-                'name': self.daemon_name
-            }
-        }
+        command = {'command': 'stats', 'properties': {'name': self.daemon_name}}
 
         return self.call_client(command)
 
@@ -383,10 +377,7 @@ class DaemonClient(object):
 
         :return: the client call response
         """
-        command = {
-            'command': 'dstats',
-            'properties': {}
-        }
+        command = {'command': 'dstats', 'properties': {}}
 
         return self.call_client(command)
 
@@ -397,13 +388,7 @@ class DaemonClient(object):
         :param number: the number of workers to add
         :return: the client call response
         """
-        command = {
-            'command': 'incr',
-            'properties': {
-                'name': self.daemon_name,
-                'nb': number
-            }
-        }
+        command = {'command': 'incr', 'properties': {'name': self.daemon_name, 'nb': number}}
 
         return self.call_client(command)
 
@@ -414,13 +399,7 @@ class DaemonClient(object):
         :param number: the number of workers to remove
         :return: the client call response
         """
-        command = {
-            'command': 'decr',
-            'properties': {
-                'name': self.daemon_name,
-                'nb': number
-            }
-        }
+        command = {'command': 'decr', 'properties': {'name': self.daemon_name, 'nb': number}}
 
         return self.call_client(command)
 
@@ -431,12 +410,7 @@ class DaemonClient(object):
         :param wait: boolean to indicate whether to wait for the result of the command
         :return: the client call response
         """
-        command = {
-            'command': 'quit',
-            'properties': {
-                'waiting': wait
-            }
-        }
+        command = {'command': 'quit', 'properties': {'waiting': wait}}
 
         result = self.call_client(command)
 
@@ -452,12 +426,6 @@ class DaemonClient(object):
         :param wait: boolean to indicate whether to wait for the result of the command
         :return: the client call response
         """
-        command = {
-            'command': 'restart',
-            'properties': {
-                'name': self.daemon_name,
-                'waiting': wait
-            }
-        }
+        command = {'command': 'restart', 'properties': {'name': self.daemon_name, 'waiting': wait}}
 
         return self.call_client(command)

--- a/aiida/daemon/client.py
+++ b/aiida/daemon/client.py
@@ -11,6 +11,7 @@ from __future__ import division
 from __future__ import print_function
 from __future__ import absolute_import
 import enum
+import io
 import os
 import shutil
 import socket
@@ -139,13 +140,13 @@ class DaemonClient(object):
         """
         if self.is_daemon_running:
             try:
-                with open(self.circus_port_file, 'r') as fhandle:
+                with io.open(self.circus_port_file, 'r', encoding='utf8') as fhandle:
                     return int(fhandle.read().strip())
             except (ValueError, IOError):
                 raise RuntimeError('daemon is running so port file should have been there but could not read it')
         else:
             port = self.get_available_port()
-            with open(self.circus_port_file, 'w') as handle:
+            with io.open(self.circus_port_file, 'w', encoding='utf8') as handle:
                 handle.write(str(port))
 
             return port
@@ -168,7 +169,7 @@ class DaemonClient(object):
         """
         if self.is_daemon_running:
             try:
-                return open(self.circus_socket_file, 'r').read().strip()
+                return io.open(self.circus_socket_file, 'r', encoding='utf8').read().strip()
             except (ValueError, IOError):
                 raise RuntimeError('daemon is running so sockets file should have been there but could not read it')
         else:
@@ -178,7 +179,7 @@ class DaemonClient(object):
                 return self._SOCKET_DIRECTORY
 
             socket_dir_path = tempfile.mkdtemp()
-            with open(self.circus_socket_file, 'w') as handle:
+            with io.open(self.circus_socket_file, 'w', encoding='utf8') as handle:
                 handle.write(socket_dir_path)
 
             self._SOCKET_DIRECTORY = socket_dir_path
@@ -192,7 +193,7 @@ class DaemonClient(object):
         """
         if os.path.isfile(self.circus_pid_file):
             try:
-                return int(open(self.circus_pid_file, 'r').read().strip())
+                return int(io.open(self.circus_pid_file, 'r', encoding='utf8').read().strip())
             except (ValueError, IOError):
                 return None
         else:

--- a/aiida/daemon/client.py
+++ b/aiida/daemon/client.py
@@ -20,6 +20,8 @@ import shutil
 import socket
 import tempfile
 
+import six
+
 from aiida.common.profile import get_profile
 from aiida.common.setup import get_property
 from aiida.utils.which import which
@@ -29,7 +31,7 @@ VERDI_BIN = which('verdi')
 VIRTUALENV = os.environ.get('VIRTUAL_ENV', None)
 
 
-class ControllerProtocol(enum.Enum):
+class ControllerProtocol(enum.Enum):  #pylint: disable=too-few-public-methods
     """
     The protocol to use to for the controller of the Circus daemon
     """
@@ -51,7 +53,7 @@ def get_daemon_client(profile_name=None):
     return DaemonClient(get_profile(profile_name))
 
 
-class DaemonClient(object):
+class DaemonClient(object):  #pylint: disable=too-many-public-methods
     """
     Extension of the Profile which also provides handles to retrieve profile specific
     properties related to the daemon client
@@ -71,8 +73,8 @@ class DaemonClient(object):
         :param profile: the profile instance :class:`aiida.common.profile.Profile`
         """
         self._profile = profile
-        self._SOCKET_DIRECTORY = None
-        self._DAEMON_TIMEOUT = get_property('daemon.timeout')
+        self._SOCKET_DIRECTORY = None  #pylint: disable=invalid-name
+        self._DAEMON_TIMEOUT = get_property('daemon.timeout')  #pylint: disable=invalid-name
 
     @property
     def profile(self):
@@ -93,7 +95,7 @@ class DaemonClient(object):
         from aiida.common.exceptions import ConfigurationError
         if VERDI_BIN is None:
             raise ConfigurationError("Unable to find 'verdi' in the path. Make sure that you are working "
-                "in a virtual environment, or that at least the 'verdi' executable is on the PATH")
+                                     "in a virtual environment, or that at least the 'verdi' executable is on the PATH")
         return '{} -p {} devel run_daemon'.format(VERDI_BIN, self.profile.name)
 
     @property
@@ -178,14 +180,14 @@ class DaemonClient(object):
         else:
 
             # The SOCKET_DIRECTORY is already set, a temporary directory was already created and the same should be used
-            if self._socket_directory is not None:
-                return self._socket_directory
+            if self._SOCKET_DIRECTORY is not None:
+                return self._SOCKET_DIRECTORY
 
             socket_dir_path = tempfile.mkdtemp()
             with io.open(self.circus_socket_file, 'w', encoding='utf8') as fhandle:
                 fhandle.write(six.text_type(socket_dir_path))
 
-            self._socket_directory = socket_dir_path
+            self._SOCKET_DIRECTORY = socket_dir_path
             return socket_dir_path
 
     def get_daemon_pid(self):
@@ -325,7 +327,7 @@ class DaemonClient(object):
         :return: CircucClient instance
         """
         from circus.client import CircusClient
-        return CircusClient(endpoint=self.get_controller_endpoint(), timeout=self._daemon_timeout)
+        return CircusClient(endpoint=self.get_controller_endpoint(), timeout=self._DAEMON_TIMEOUT)
 
     def call_client(self, command):
         """

--- a/aiida/orm/calculation/job/simpleplugins/arithmetic/add.py
+++ b/aiida/orm/calculation/job/simpleplugins/arithmetic/add.py
@@ -72,7 +72,7 @@ class ArithmeticAddCalculation(JobCalculation):
         else:
             return valid_types
 
-    def _prepare_for_submission(self, tempfolder, input_nodes_raw):        
+    def _prepare_for_submission(self, tempfolder, input_nodes_raw):
         """
         This method is called prior to job submission with a set of calculation input nodes.
         The inputs will be validated and sanitized, after which the necessary input files will
@@ -177,7 +177,8 @@ class ArithmeticAddCalculation(JobCalculation):
 
         # Any remaining input nodes are not recognized raise an input validation exception
         if input_nodes_raw:
-            raise InputValidationError('the following input nodes were not recognized: {}'.format(input_nodes_raw.keys()))
+            raise InputValidationError('the following input nodes were not recognized: {}'.format(
+                input_nodes_raw.keys()))
 
         return input_nodes
 
@@ -193,4 +194,4 @@ class ArithmeticAddCalculation(JobCalculation):
         filename = tempfolder.get_abs_path(self._INPUT_FILE_NAME)
 
         with io.open(filename, 'w', encoding='utf8') as handle:
-            handle.write('{} {}\n'.format(input_x.value, input_y.value))
+            handle.write(u'{} {}\n'.format(input_x.value, input_y.value))

--- a/aiida/orm/calculation/job/simpleplugins/arithmetic/add.py
+++ b/aiida/orm/calculation/job/simpleplugins/arithmetic/add.py
@@ -10,6 +10,8 @@
 from __future__ import division
 from __future__ import print_function
 from __future__ import absolute_import
+import io
+
 from aiida.common.utils import classproperty
 from aiida.common.exceptions import InputValidationError, ValidationError
 from aiida.common.datastructures import CalcInfo, CodeInfo
@@ -190,5 +192,5 @@ class ArithmeticAddCalculation(JobCalculation):
         """
         filename = tempfolder.get_abs_path(self._INPUT_FILE_NAME)
 
-        with open(filename, 'w') as handle:
+        with io.open(filename, 'w', encoding='utf8') as handle:
             handle.write('{} {}\n'.format(input_x.value, input_y.value))

--- a/aiida/orm/calculation/job/simpleplugins/templatereplacer.py
+++ b/aiida/orm/calculation/job/simpleplugins/templatereplacer.py
@@ -92,7 +92,7 @@ class TemplatereplacerCalculation(JobCalculation):
         :param inputdict: a dictionary with the input nodes, as they would
                 be returned by get_inputs_dict (with the Code!)
         """
-        from six.moves import cStringIO as StringIO
+        from six.moves import StringIO as StringIO
 
         from aiida.orm.data.singlefile import SinglefileData
         from aiida.orm.data.remote import RemoteData

--- a/aiida/orm/data/__init__.py
+++ b/aiida/orm/data/__init__.py
@@ -50,8 +50,7 @@ class Data(Node):
     according to its method. This is done independently in order to allow
     cross-validation of plugins.
     """
-    _source_attributes = ['db_name', 'db_uri', 'uri', 'id', 'version',
-                          'extras', 'source_md5', 'description', 'license']
+    _source_attributes = ['db_name', 'db_uri', 'uri', 'id', 'version', 'extras', 'source_md5', 'description', 'license']
 
     # Replace this with a dictionary in each subclass that, given a file
     # extension, returns the corresponding fileformat string.
@@ -130,8 +129,7 @@ class Data(Node):
             raise ValueError("Source must be supplied as a dictionary")
         unknown_attrs = tuple(set(source.keys()) - set(self._source_attributes))
         if unknown_attrs:
-            raise KeyError("Unknown source parameters: "
-                           "{}".format(", ".join(unknown_attrs)))
+            raise KeyError("Unknown source parameters: " "{}".format(", ".join(unknown_attrs)))
 
         self._set_attr('source', source)
 
@@ -158,8 +156,7 @@ class Data(Node):
             raise ValueError("At most one CREATE node can enter a data node")
 
         if not isinstance(src, Calculation):
-            raise ValueError(
-                "Links entering a data object can only be of type calculation")
+            raise ValueError("Links entering a data object can only be of type calculation")
 
         return super(Data, self).add_link_from(src, label, link_type)
 
@@ -172,8 +169,7 @@ class Data(Node):
         """
         from aiida.orm.calculation import Calculation
         if not isinstance(dest, Calculation):
-            raise ValueError(
-                "The output of a data node can only be a calculation")
+            raise ValueError("The output of a data node can only be a calculation")
 
         return super(Data, self)._linking_as_output(dest, link_type)
 
@@ -205,13 +201,11 @@ class Data(Node):
         except KeyError:
             if len(exporters.keys()) > 0:
                 raise ValueError("The format {} is not implemented for {}. "
-                                 "Currently implemented are: {}.".format(
-                    fileformat, self.__class__.__name__,
-                    ",".join(exporters.keys())))
+                                 "Currently implemented are: {}.".format(fileformat, self.__class__.__name__, ",".join(
+                                     exporters.keys())))
             else:
                 raise ValueError("The format {} is not implemented for {}. "
-                                 "No formats are implemented yet.".format(
-                    fileformat, self.__class__.__name__))
+                                 "No formats are implemented yet.".format(fileformat, self.__class__.__name__))
 
         return func(main_file_name=main_file_name, **kwargs)
 
@@ -241,8 +235,7 @@ class Data(Node):
             if extension.startswith(os.path.extsep):
                 extension = extension[len(os.path.extsep):]
             if not extension:
-                raise ValueError("Cannot recognized the fileformat from the "
-                                 "extension")
+                raise ValueError("Cannot recognized the fileformat from the " "extension")
 
             # Replace the fileformat using the replacements specified in the
             # _custom_export_format_replacements dictionary. If not found there,
@@ -257,20 +250,18 @@ class Data(Node):
         if not overwrite:
             for fname in extra_files:
                 if os.path.exists(fname):
-                    raise OSError("The file {} already exists, stopping.".format(
-                        fname))
+                    raise OSError("The file {} already exists, stopping.".format(fname))
 
             if os.path.exists(path):
-                raise OSError("The file {} already exists, stopping.".format(
-                    path))
+                raise OSError("The file {} already exists, stopping.".format(path))
 
         for additional_fname, additional_fcontent in extra_files.items():
             retlist.append(additional_fname)
-            with io.open(additional_fname, 'wb', encoding=None) as f:
-                f.write(additional_fcontent) #.encode('utf-8')) # This is up to each specific plugin
+            with io.open(additional_fname, 'wb', encoding=None) as fhandle:
+                fhandle.write(additional_fcontent)  # This is up to each specific plugin
         retlist.append(path)
-        with io.open(path, 'wb', encoding=None) as f:
-            f.write(filetext)
+        with io.open(path, 'wb', encoding=None) as fhandle:
+            fhandle.write(filetext)
 
         return retlist
 
@@ -284,8 +275,7 @@ class Data(Node):
         # _prepare_"" with the name of the new format
         exporter_prefix = '_prepare_'
         valid_format_names = self.get_export_formats()
-        valid_formats = {k: getattr(self, exporter_prefix + k)
-                         for k in valid_format_names}
+        valid_formats = {k: getattr(self, exporter_prefix + k) for k in valid_format_names}
         return valid_formats
 
     @classmethod
@@ -297,8 +287,8 @@ class Data(Node):
         """
         exporter_prefix = '_prepare_'
         method_names = dir(cls)  # get list of class methods names
-        valid_format_names = [i[len(exporter_prefix):] for i in method_names
-                              if i.startswith(exporter_prefix)]  # filter them
+        valid_format_names = [i[len(exporter_prefix):] for i in method_names if i.startswith(exporter_prefix)
+                             ]  # filter them
         return sorted(valid_format_names)
 
     def importstring(self, inputstring, fileformat, **kwargs):
@@ -315,13 +305,11 @@ class Data(Node):
         except KeyError:
             if len(importers.keys()) > 0:
                 raise ValueError("The format {} is not implemented for {}. "
-                                 "Currently implemented are: {}.".format(
-                    fileformat, self.__class__.__name__,
-                    ",".join(importers.keys())))
+                                 "Currently implemented are: {}.".format(fileformat, self.__class__.__name__, ",".join(
+                                     importers.keys())))
             else:
                 raise ValueError("The format {} is not implemented for {}. "
-                                 "No formats are implemented yet.".format(
-                    fileformat, self.__class__.__name__))
+                                 "No formats are implemented yet.".format(fileformat, self.__class__.__name__))
 
         # func is bound to self by getattr in _get_importers()
         func(inputstring, **kwargs)
@@ -336,8 +324,8 @@ class Data(Node):
         """
         if fileformat is None:
             fileformat = fname.split('.')[-1]
-        with io.open(fname, 'r', encoding='utf8') as f:  # reads in cwd, if fname is not absolute
-            self.importstring(f.read(), fileformat)
+        with io.open(fname, 'r', encoding='utf8') as fhandle:  # reads in cwd, if fname is not absolute
+            self.importstring(fhandle.read(), fileformat)
 
     def _get_importers(self):
         """
@@ -349,10 +337,9 @@ class Data(Node):
         # _parse_"" with the name of the new format
         importer_prefix = '_parse_'
         method_names = dir(self)  # get list of class methods names
-        valid_format_names = [i[len(importer_prefix):] for i in method_names
-                              if i.startswith(importer_prefix)]  # filter them
-        valid_formats = {k: getattr(self, importer_prefix + k)
-                         for k in valid_format_names}
+        valid_format_names = [i[len(importer_prefix):] for i in method_names if i.startswith(importer_prefix)
+                             ]  # filter them
+        valid_formats = {k: getattr(self, importer_prefix + k) for k in valid_format_names}
         return valid_formats
 
     def convert(self, object_format=None, *args):
@@ -372,15 +359,12 @@ class Data(Node):
             func = converters[object_format]
         except KeyError:
             if len(converters.keys()) > 0:
-                raise ValueError(
-                    "The format {} is not implemented for {}. "
-                    "Currently implemented are: {}.".format(
-                        object_format, self.__class__.__name__,
-                        ",".join(converters.keys())))
+                raise ValueError("The format {} is not implemented for {}. "
+                                 "Currently implemented are: {}.".format(object_format, self.__class__.__name__,
+                                                                         ",".join(converters.keys())))
             else:
                 raise ValueError("The format {} is not implemented for {}. "
-                                 "No formats are implemented yet.".format(
-                    object_format, self.__class__.__name__))
+                                 "No formats are implemented yet.".format(object_format, self.__class__.__name__))
 
         return func(*args)
 
@@ -394,10 +378,9 @@ class Data(Node):
         # _prepare_"" with the name of the new format
         exporter_prefix = '_get_object_'
         method_names = dir(self)  # get list of class methods names
-        valid_format_names = [i[len(exporter_prefix):] for i in method_names
-                              if i.startswith(exporter_prefix)]  # filter them
-        valid_formats = {k: getattr(self, exporter_prefix + k)
-                         for k in valid_format_names}
+        valid_format_names = [i[len(exporter_prefix):] for i in method_names if i.startswith(exporter_prefix)
+                             ]  # filter them
+        valid_formats = {k: getattr(self, exporter_prefix + k) for k in valid_format_names}
         return valid_formats
 
     def _validate(self):
@@ -422,7 +405,6 @@ class Data(Node):
         ##     raise ValidationError("License of the object ({}) requires "
         ##                           "attribution, while none is given in the "
         ##                           "description".format(self.source['license']))
-
 
 
 @six.add_metaclass(ABCMeta)

--- a/aiida/orm/data/__init__.py
+++ b/aiida/orm/data/__init__.py
@@ -12,6 +12,7 @@ from __future__ import print_function
 from __future__ import absolute_import
 from abc import ABCMeta
 
+import io
 try:
     from functools import singledispatch  # Python 3.4+
 except ImportError:
@@ -265,10 +266,10 @@ class Data(Node):
 
         for additional_fname, additional_fcontent in extra_files.items():
             retlist.append(additional_fname)
-            with open(additional_fname, 'wb') as f:
+            with io.open(additional_fname, 'wb', encoding=None) as f:
                 f.write(additional_fcontent) #.encode('utf-8')) # This is up to each specific plugin
         retlist.append(path)
-        with open(path, 'wb') as f:
+        with io.open(path, 'wb', encoding=None) as f:
             f.write(filetext)
 
         return retlist
@@ -335,7 +336,7 @@ class Data(Node):
         """
         if fileformat is None:
             fileformat = fname.split('.')[-1]
-        with open(fname, 'r') as f:  # reads in cwd, if fname is not absolute
+        with io.open(fname, 'r', encoding='utf8') as f:  # reads in cwd, if fname is not absolute
             self.importstring(f.read(), fileformat)
 
     def _get_importers(self):

--- a/aiida/orm/data/array/bands.py
+++ b/aiida/orm/data/array/bands.py
@@ -860,7 +860,7 @@ class BandsData(KpointsData):
         For the possible parameters, see documentation of
         :py:meth:`~aiida.orm.data.array.bands.BandsData._matplotlib_get_dict`
         """
-        import json
+        import aiida.utils.json as json
 
         all_data = self._matplotlib_get_dict(*args, **kwargs)
 
@@ -882,8 +882,9 @@ class BandsData(KpointsData):
         For the possible parameters, see documentation of
         :py:meth:`~aiida.orm.data.array.bands.BandsData._matplotlib_get_dict`
         """
-        import json
         import os
+       
+        import aiida.utils.json as json
 
         all_data = self._matplotlib_get_dict(*args, main_file_name=main_file_name, **kwargs)
 
@@ -1017,11 +1018,12 @@ class BandsData(KpointsData):
         For the possible parameters, see documentation of
         :py:meth:`~aiida.orm.data.array.bands.BandsData._matplotlib_get_dict`
         """
-        import json
         import os
         import tempfile
         import subprocess
         import sys
+
+        import aiida.utils.json as json
 
         all_data = self._matplotlib_get_dict(*args, **kwargs)
 
@@ -1280,8 +1282,8 @@ class BandsData(KpointsData):
         :param comments: if True, print comments (if it makes sense for the given
             format)
         """
-        import json
         from aiida import get_file_header
+        import aiida.utils.json as json
 
         json_dict = self._get_band_segments(cartesian=True)
         json_dict['original_uuid'] = self.uuid

--- a/aiida/orm/data/array/bands.py
+++ b/aiida/orm/data/array/bands.py
@@ -15,6 +15,7 @@ in a Brillouin zone, and how to operate on them.
 from __future__ import print_function
 from __future__ import absolute_import
 from __future__ import division
+import io
 from string import Template
 
 import six
@@ -1057,7 +1058,7 @@ class BandsData(KpointsData):
         if not os.path.exists(filename):
             raise RuntimeError("Unable to generate the PDF...")
 
-        with open(filename, 'rb') as f:
+        with io.open(filename, 'rb', encoding=None) as f:
             imgdata = f.read()
         os.remove(filename)
 
@@ -1113,7 +1114,7 @@ class BandsData(KpointsData):
         if not os.path.exists(filename):
             raise RuntimeError("Unable to generate the PNG...")
 
-        with open(filename, 'rb') as f:
+        with io.open(filename, 'rb', encoding=None) as f:
             imgdata = f.read()
         os.remove(filename)
 
@@ -1715,7 +1716,7 @@ matplotlib_import_data_inline_template = Template(
 ''')
 
 matplotlib_import_data_fromfile_template = Template(
-    '''with open("$json_fname") as f:
+    '''with io.open("$json_fname", encoding='utf8') as f:
     all_data_str = f.read()
 ''')
 

--- a/aiida/orm/data/cif.py
+++ b/aiida/orm/data/cif.py
@@ -551,11 +551,11 @@ class CifData(SinglefileData):
         """
         import tempfile
         cif = cif_from_ase(aseatoms)
-        with tempfile.NamedTemporaryFile(mode='w+') as f:
+        with tempfile.NamedTemporaryFile(mode='w+') as tmpf:
             with HiddenPrints():
-                f.write(pycifrw_from_cif(cif, loops=ase_loops).WriteOut())
-            f.flush()
-            self.set_file(f.name)
+                tmpf.write(pycifrw_from_cif(cif, loops=ase_loops).WriteOut())
+            tmpf.flush()
+            self.set_file(tmpf.name)
 
     @ase.setter
     def ase(self, aseatoms):
@@ -589,11 +589,11 @@ class CifData(SinglefileData):
         .. note:: requires PyCifRW module.
         """
         import tempfile
-        with tempfile.NamedTemporaryFile(mode='w+') as f:
+        with tempfile.NamedTemporaryFile(mode='w+') as tmpf:
             with HiddenPrints():
-                f.write(values.WriteOut())
-            f.flush()
-            self.set_file(f.name)
+                tmpf.write(values.WriteOut())
+            tmpf.flush()
+            self.set_file(tmpf.name)
 
         self._values = values
 

--- a/aiida/orm/data/folder.py
+++ b/aiida/orm/data/folder.py
@@ -10,6 +10,7 @@
 from __future__ import division
 from __future__ import print_function
 from __future__ import absolute_import
+import io
 import os
 
 from aiida.orm import Data

--- a/aiida/orm/data/folder.py
+++ b/aiida/orm/data/folder.py
@@ -53,8 +53,8 @@ class FolderData(Data):
         from aiida.common.exceptions import NotExistent
 
         try:
-            with open(self._get_folder_pathsubfolder.get_abs_path(
-                    path, check_existence=True)) as f:
+            with io.open(self._get_folder_pathsubfolder.get_abs_path(
+                    path, check_existence=True), encoding='utf8') as f:
                 return f.read()
         except (OSError, IOError):
             raise NotExistent("Error reading the file '{}' inside node with "

--- a/aiida/orm/data/structure.py
+++ b/aiida/orm/data/structure.py
@@ -1042,7 +1042,8 @@ class StructureData(Data):
         """
         import numpy as np
         from itertools import product
-        import json
+        
+        import aiida.utils.json as json
 
         supercell_factors=[1, 1, 1]
 

--- a/aiida/orm/data/upf.py
+++ b/aiida/orm/data/upf.py
@@ -13,6 +13,7 @@ This module manages the UPF pseudopotentials in the local repository.
 from __future__ import division
 from __future__ import print_function
 from __future__ import absolute_import
+import io
 import re
 
 import six
@@ -265,7 +266,7 @@ def parse_upf(fname, check_filename=True):
 
     parsed_data = {}
 
-    with open(fname) as f:
+    with io.open(fname, encoding='utf8') as f:
         first_line = f.readline().strip()
         match = _upfversion_regexp.match(first_line)
         if match:

--- a/aiida/orm/implementation/django/authinfo.py
+++ b/aiida/orm/implementation/django/authinfo.py
@@ -10,12 +10,12 @@
 from __future__ import division
 from __future__ import print_function
 from __future__ import absolute_import
-import json
 
 from aiida.backends.djsite.db.models import DbAuthInfo
 from aiida.common import exceptions
 from aiida.common.utils import type_check
 from aiida.orm.authinfo import AuthInfo, AuthInfoCollection
+import aiida.utils.json as json
 
 from . import computer as computers
 from . import user as users
@@ -145,7 +145,7 @@ class DjangoAuthInfo(AuthInfo):
         """
         Replace the auth_params dictionary in the DB with the provided dictionary
         """
-        import json
+        import aiida.utils.json as json
 
         # Raises ValueError if data is not JSON-serializable
         self._dbauthinfo.auth_params = json.dumps(auth_params)
@@ -156,7 +156,7 @@ class DjangoAuthInfo(AuthInfo):
 
         :return: a dictionary
         """
-        import json
+        import aiida.utils.json as json
 
         try:
             return json.loads(self._dbauthinfo.metadata)

--- a/aiida/orm/implementation/django/computer.py
+++ b/aiida/orm/implementation/django/computer.py
@@ -11,7 +11,6 @@
 from __future__ import division
 from __future__ import print_function
 from __future__ import absolute_import
-import json
 import collections
 import six
 from django.db import IntegrityError, transaction
@@ -22,6 +21,8 @@ from aiida.common.exceptions import (NotExistent, ConfigurationError,
                                      InvalidOperation, DbContentError)
 from aiida.orm.computer import Computer, ComputerCollection
 from . import utils
+import aiida.utils.json as json
+
 
 
 class DjangoComputerCollection(ComputerCollection):

--- a/aiida/orm/implementation/django/log.py
+++ b/aiida/orm/implementation/django/log.py
@@ -10,11 +10,11 @@
 from __future__ import division
 from __future__ import print_function
 from __future__ import absolute_import
-import json
+
 from aiida.orm.log import LogCollection, Log
 from aiida.orm.log import ASCENDING
 from aiida.backends.djsite.db.models import DbLog
-
+import aiida.utils.json as json
 
 class DjangoLogCollection(LogCollection):
 

--- a/aiida/orm/implementation/general/calculation/job/__init__.py
+++ b/aiida/orm/implementation/general/calculation/job/__init__.py
@@ -1771,7 +1771,6 @@ class AbstractJobCalculation(AbstractCalculation):
             needed by the daemon to handle operations.
         """
         import os
-        import json
 
         from six.moves import StringIO as StringIO
 
@@ -1783,6 +1782,7 @@ class AbstractJobCalculation(AbstractCalculation):
         from aiida.common.datastructures import CodeInfo, code_run_modes
         from aiida.orm.code import Code
         from aiida.orm.utils import load_node
+        import aiida.utils.json as json
 
         computer = self.get_computer()
         inputdict = self.get_inputs_dict(only_in_db=not use_unstored_links, link_type=LinkType.INPUT)
@@ -1960,8 +1960,8 @@ class AbstractJobCalculation(AbstractCalculation):
         folder.create_file_from_filelike(StringIO(script_content), script_filename)
 
         subfolder = folder.get_subfolder('.aiida', create=True)
-        subfolder.create_file_from_filelike(StringIO(six.text_type(json.dumps(job_tmpl))), 'job_tmpl.json')
-        subfolder.create_file_from_filelike(StringIO(six.text_type(json.dumps(calcinfo))), 'calcinfo.json')
+        subfolder.create_file_from_filelike(StringIO(json.dumps(job_tmpl)), 'job_tmpl.json')
+        subfolder.create_file_from_filelike(StringIO(json.dumps(calcinfo)), 'calcinfo.json')
 
         if calcinfo.local_copy_list is None:
             calcinfo.local_copy_list = []

--- a/aiida/orm/implementation/general/calculation/job/__init__.py
+++ b/aiida/orm/implementation/general/calculation/job/__init__.py
@@ -14,6 +14,7 @@ import abc
 import copy
 import datetime
 import enum
+import io
 import warnings
 
 import six
@@ -2169,9 +2170,9 @@ class AbstractJobCalculation(AbstractCalculation):
                 t.put(src_abs_path, dest_rel_path)
 
             if remote_copy_list:
-                with open(os.path.join(subfolder.abspath,
+                with io.open(os.path.join(subfolder.abspath,
                                        '_aiida_remote_copy_list.txt'),
-                          'w') as f:
+                          'w', encoding='utf8') as f:
                     for (remote_computer_uuid, remote_abs_path,
                          dest_rel_path) in remote_copy_list:
                         try:
@@ -2186,9 +2187,9 @@ class AbstractJobCalculation(AbstractCalculation):
                                                          dest_rel_path))
 
             if remote_symlink_list:
-                with open(os.path.join(subfolder.abspath,
+                with io.open(os.path.join(subfolder.abspath,
                                        '_aiida_remote_symlink_list.txt'),
-                          'w') as f:
+                          'w', encoding='utf8') as f:
                     for (remote_computer_uuid, remote_abs_path,
                          dest_rel_path) in remote_symlink_list:
                         try:

--- a/aiida/orm/implementation/general/calculation/job/__init__.py
+++ b/aiida/orm/implementation/general/calculation/job/__init__.py
@@ -1960,8 +1960,8 @@ class AbstractJobCalculation(AbstractCalculation):
         folder.create_file_from_filelike(StringIO(script_content), script_filename)
 
         subfolder = folder.get_subfolder('.aiida', create=True)
-        subfolder.create_file_from_filelike(StringIO(json.dumps(job_tmpl)), 'job_tmpl.json')
-        subfolder.create_file_from_filelike(StringIO(json.dumps(calcinfo)), 'calcinfo.json')
+        subfolder.create_file_from_filelike(StringIO(six.text_type(json.dumps(job_tmpl)), 'job_tmpl.json'))
+        subfolder.create_file_from_filelike(StringIO(six.text_type(json.dumps(calcinfo)), 'calcinfo.json'))
 
         if calcinfo.local_copy_list is None:
             calcinfo.local_copy_list = []

--- a/aiida/orm/implementation/general/calculation/job/__init__.py
+++ b/aiida/orm/implementation/general/calculation/job/__init__.py
@@ -1773,7 +1773,7 @@ class AbstractJobCalculation(AbstractCalculation):
         import os
         import json
 
-        from six.moves import cStringIO as StringIO
+        from six.moves import StringIO as StringIO
 
         from aiida.common.exceptions import (NotExistent, PluginInternalError, ValidationError)
         from aiida.scheduler.datastructures import JobTemplate

--- a/aiida/orm/implementation/general/calculation/job/__init__.py
+++ b/aiida/orm/implementation/general/calculation/job/__init__.py
@@ -91,9 +91,8 @@ class AbstractJobCalculation(AbstractCalculation):
     @classproperty
     def _updatable_attributes(cls):
         return super(AbstractJobCalculation, cls)._updatable_attributes + (
-            'job_id', 'scheduler_state', 'scheduler_lastchecktime', 'last_jobinfo', 'remote_workdir',
-            'retrieve_list', 'retrieve_temporary_list', 'retrieve_singlefile_list', 'state'
-        )
+            'job_id', 'scheduler_state', 'scheduler_lastchecktime', 'last_jobinfo', 'remote_workdir', 'retrieve_list',
+            'retrieve_temporary_list', 'retrieve_singlefile_list', 'state')
 
     @classproperty
     def _hash_ignored_attributes(cls):
@@ -108,10 +107,7 @@ class AbstractJobCalculation(AbstractCalculation):
 
     def get_hash(self, ignore_errors=True, ignored_folder_content=('raw_input',), **kwargs):
         return super(AbstractJobCalculation, self).get_hash(
-            ignore_errors=ignore_errors,
-            ignored_folder_content=ignored_folder_content,
-            **kwargs
-        )
+            ignore_errors=ignore_errors, ignored_folder_content=ignored_folder_content, **kwargs)
 
     @classmethod
     def process(cls):
@@ -209,9 +205,7 @@ class AbstractJobCalculation(AbstractCalculation):
         """
         parent_dict = super(AbstractJobCalculation, self)._set_defaults
 
-        parent_dict.update({
-            "parser_name": self._default_parser,
-            "_linkname_retrieved": self._linkname_retrieved})
+        parent_dict.update({"parser_name": self._default_parser, "_linkname_retrieved": self._linkname_retrieved})
 
         return parent_dict
 
@@ -229,9 +223,7 @@ class AbstractJobCalculation(AbstractCalculation):
 
     def _add_outputs_from_cache(self, cache_node):
         self._set_state(calc_states.PARSING)
-        super(AbstractJobCalculation, self)._add_outputs_from_cache(
-            cache_node=cache_node
-        )
+        super(AbstractJobCalculation, self)._add_outputs_from_cache(cache_node=cache_node)
         self._set_state(cache_node.get_state())
 
     def _validate(self):
@@ -248,17 +240,14 @@ class AbstractJobCalculation(AbstractCalculation):
             raise ValidationError("You did not specify a computer")
 
         if self.get_state() not in calc_states:
-            raise ValidationError("Calculation state '{}' is not valid".format(
-                self.get_state()))
+            raise ValidationError("Calculation state '{}' is not valid".format(self.get_state()))
 
         try:
             _ = self.get_parserclass()
         except MissingPluginError:
-            raise ValidationError(
-                "No valid class/implementation found for the parser '{}'. "
-                "Set the parser to None if you do not need an automatic "
-                "parser.".format(self.get_option('parser_name'))
-            )
+            raise ValidationError("No valid class/implementation found for the parser '{}'. "
+                                  "Set the parser to None if you do not need an automatic "
+                                  "parser.".format(self.get_option('parser_name')))
 
         computer = self.get_computer()
         s = computer.get_scheduler()
@@ -269,14 +258,11 @@ class AbstractJobCalculation(AbstractCalculation):
         try:
             _ = s.create_job_resource(**resources)
         except (TypeError, ValueError) as exc:
-            raise ValidationError("Invalid resources for the scheduler of the "
-                                  "specified computer: {}".format(exc))
+            raise ValidationError("Invalid resources for the scheduler of the " "specified computer: {}".format(exc))
 
         if not isinstance(self.get_option('withmpi', only_actually_set=False), bool):
-            raise ValidationError(
-                "withmpi property must be boolean! It in instead {}"
-                "".format(str(type(self.get_option('withmpi'))))
-            )
+            raise ValidationError("withmpi property must be boolean! It in instead {}"
+                                  "".format(str(type(self.get_option('withmpi')))))
 
     def _linking_as_output(self, dest, link_type):
         """
@@ -299,13 +285,11 @@ class AbstractJobCalculation(AbstractCalculation):
         ]
 
         if self.get_state() not in valid_states:
-            raise ModificationNotAllowed(
-                "Can add an output node to a calculation only if it is in one "
-                "of the following states: {}, it is instead {}".format(
-                    valid_states, self.get_state()))
+            raise ModificationNotAllowed("Can add an output node to a calculation only if it is in one "
+                                         "of the following states: {}, it is instead {}".format(
+                                             valid_states, self.get_state()))
 
-        return super(AbstractJobCalculation, self)._linking_as_output(dest,
-                                                                      link_type)
+        return super(AbstractJobCalculation, self)._linking_as_output(dest, link_type)
 
     def _store_raw_input_folder(self, folder_path):
         """
@@ -317,16 +301,12 @@ class AbstractJobCalculation(AbstractCalculation):
         """
         # This function can be called only if the state is TOSUBMIT
         if self.get_state() != calc_states.TOSUBMIT:
-            raise ModificationNotAllowed(
-                "The raw input folder can be stored only if the "
-                "state is TOSUBMIT, it is instead {}".format(
-                    self.get_state()))
+            raise ModificationNotAllowed("The raw input folder can be stored only if the "
+                                         "state is TOSUBMIT, it is instead {}".format(self.get_state()))
 
         # get subfolder and replace with copy
-        _raw_input_folder = self.folder.get_subfolder(
-            _input_subfolder, create=True)
-        _raw_input_folder.replace_with_folder(
-            folder_path, move=False, overwrite=True)
+        _raw_input_folder = self.folder.get_subfolder(_input_subfolder, create=True)
+        _raw_input_folder.replace_with_folder(folder_path, move=False, overwrite=True)
 
     @property
     def _raw_input_folder(self):
@@ -346,12 +326,15 @@ class AbstractJobCalculation(AbstractCalculation):
 
     options = {
         'resources': {
-            'attribute_key': 'jobresource_params',
-            'valid_type': dict,
+            'attribute_key':
+            'jobresource_params',
+            'valid_type':
+            dict,
             'default': {},
-            'help': 'Set the dictionary of resources to be used by the scheduler plugin, like the number of nodes, '
-                    'cpus etc. This dictionary is scheduler-plugin dependent. Look at the documentation of the '
-                    'scheduler for more details.'
+            'help':
+            'Set the dictionary of resources to be used by the scheduler plugin, like the number of nodes, '
+            'cpus etc. This dictionary is scheduler-plugin dependent. Look at the documentation of the '
+            'scheduler for more details.'
         },
         'max_wallclock_seconds': {
             'attribute_key': 'max_wallclock_seconds',
@@ -361,15 +344,21 @@ class AbstractJobCalculation(AbstractCalculation):
             'help': 'Set the wallclock in seconds asked to the scheduler',
         },
         'custom_scheduler_commands': {
-            'attribute_key': 'custom_scheduler_commands',
-            'valid_type': six.string_types,
-            'non_db': True,
-            'required': False,
-            'default': '',
-            'help': 'Set a (possibly multiline) string with the commands that the user wants to manually set for the '
-                    'scheduler. The difference of this option with respect to the `prepend_text` is the position in '
-                    'the scheduler submission file where such text is inserted: with this option, the string is '
-                    'inserted before any non-scheduler command',
+            'attribute_key':
+            'custom_scheduler_commands',
+            'valid_type':
+            six.string_types,
+            'non_db':
+            True,
+            'required':
+            False,
+            'default':
+            '',
+            'help':
+            'Set a (possibly multiline) string with the commands that the user wants to manually set for the '
+            'scheduler. The difference of this option with respect to the `prepend_text` is the position in '
+            'the scheduler submission file where such text is inserted: with this option, the string is '
+            'inserted before any non-scheduler command',
         },
         'queue_name': {
             'attribute_key': 'queue_name',
@@ -408,13 +397,17 @@ class AbstractJobCalculation(AbstractCalculation):
             'help': 'Set the calculation to use mpi',
         },
         'mpirun_extra_params': {
-            'attribute_key': 'mpirun_extra_params',
+            'attribute_key':
+            'mpirun_extra_params',
             'valid_type': (list, tuple),
-            'non_db': True,
-            'required': False,
+            'non_db':
+            True,
+            'required':
+            False,
             'default': [],
-            'help': 'Set the extra params to pass to the mpirun (or equivalent) command after the one provided in '
-                    'computer.mpirun_command. Example: mpirun -np 8 extra_params[0] extra_params[1] ... exec.x',
+            'help':
+            'Set the extra params to pass to the mpirun (or equivalent) command after the one provided in '
+            'computer.mpirun_command. Example: mpirun -np 8 extra_params[0] extra_params[1] ... exec.x',
         },
         'import_sys_environment': {
             'attribute_key': 'import_sys_environment',
@@ -447,22 +440,34 @@ class AbstractJobCalculation(AbstractCalculation):
             'help': 'Set the maximum memory (in KiloBytes) to be asked to the scheduler',
         },
         'prepend_text': {
-            'attribute_key': 'prepend_text',
-            'valid_type': six.string_types[0],
-            'non_db': True,
-            'required': False,
-            'default': '',
-            'help': 'Set the calculation-specific prepend text, which is going to be prepended in the scheduler-job '
-                    'script, just before the code execution',
+            'attribute_key':
+            'prepend_text',
+            'valid_type':
+            six.string_types[0],
+            'non_db':
+            True,
+            'required':
+            False,
+            'default':
+            '',
+            'help':
+            'Set the calculation-specific prepend text, which is going to be prepended in the scheduler-job '
+            'script, just before the code execution',
         },
         'append_text': {
-            'attribute_key': 'append_text',
-            'valid_type': six.string_types[0],
-            'non_db': True,
-            'required': False,
-            'default': '',
-            'help': 'Set the calculation-specific append text, which is going to be appended in the scheduler-job '
-                    'script, just after the code execution',
+            'attribute_key':
+            'append_text',
+            'valid_type':
+            six.string_types[0],
+            'non_db':
+            True,
+            'required':
+            False,
+            'default':
+            '',
+            'help':
+            'Set the calculation-specific append text, which is going to be appended in the scheduler-job '
+            'script, just after the code execution',
         },
         'parser_name': {
             'attribute_key': 'parser',
@@ -547,8 +552,8 @@ class AbstractJobCalculation(AbstractCalculation):
 
         :param str val: the queue name
         """
-        warnings.warn(
-            'explicit option getter/setter methods are deprecated, use get_option and set_option', DeprecationWarning)
+        warnings.warn('explicit option getter/setter methods are deprecated, use get_option and set_option',
+                      DeprecationWarning)
         if val is not None:
             self._set_attr('queue_name', six.text_type(val))
 
@@ -558,8 +563,8 @@ class AbstractJobCalculation(AbstractCalculation):
 
         :param str val: the account name
         """
-        warnings.warn(
-            'explicit option getter/setter methods are deprecated, use get_option and set_option', DeprecationWarning)
+        warnings.warn('explicit option getter/setter methods are deprecated, use get_option and set_option',
+                      DeprecationWarning)
         if val is not None:
             self._set_attr('account', six.text_type(val))
 
@@ -569,8 +574,8 @@ class AbstractJobCalculation(AbstractCalculation):
 
         :param str val: the quality of service
         """
-        warnings.warn(
-            'explicit option getter/setter methods are deprecated, use get_option and set_option', DeprecationWarning)
+        warnings.warn('explicit option getter/setter methods are deprecated, use get_option and set_option',
+                      DeprecationWarning)
         if val is not None:
             self._set_attr('qos', six.text_type(val))
 
@@ -581,8 +586,8 @@ class AbstractJobCalculation(AbstractCalculation):
 
         :param bool val: load the environment if True
         """
-        warnings.warn(
-            'explicit option getter/setter methods are deprecated, use get_option and set_option', DeprecationWarning)
+        warnings.warn('explicit option getter/setter methods are deprecated, use get_option and set_option',
+                      DeprecationWarning)
         self._set_attr('import_sys_environment', bool(val))
 
     def get_import_sys_environment(self):
@@ -592,8 +597,8 @@ class AbstractJobCalculation(AbstractCalculation):
 
         :return: a boolean. If True the system environment will be load.
         """
-        warnings.warn(
-            'explicit option getter/setter methods are deprecated, use get_option and set_option', DeprecationWarning)
+        warnings.warn('explicit option getter/setter methods are deprecated, use get_option and set_option',
+                      DeprecationWarning)
         return self.get_attr('import_sys_environment', True)
 
     def set_environment_variables(self, env_vars_dict):
@@ -605,19 +610,16 @@ class AbstractJobCalculation(AbstractCalculation):
         In the remote-computer submission script, it's going to export
         variables as ``export 'keys'='values'``
         """
-        warnings.warn(
-            'explicit option getter/setter methods are deprecated, use get_option and set_option', DeprecationWarning)
+        warnings.warn('explicit option getter/setter methods are deprecated, use get_option and set_option',
+                      DeprecationWarning)
         if not isinstance(env_vars_dict, dict):
-            raise ValueError("You have to pass a "
-                             "dictionary to set_environment_variables")
+            raise ValueError("You have to pass a " "dictionary to set_environment_variables")
 
         for k, v in env_vars_dict.items():
             if not isinstance(k, six.string_types) or not isinstance(v, six.string_types):
-                raise ValueError(
-                    "Both the keys and the values of the "
-                    "dictionary passed to set_environment_variables must be "
-                    "strings."
-                )
+                raise ValueError("Both the keys and the values of the "
+                                 "dictionary passed to set_environment_variables must be "
+                                 "strings.")
 
         return self._set_attr('custom_environment_variables', env_vars_dict)
 
@@ -629,8 +631,8 @@ class AbstractJobCalculation(AbstractCalculation):
         Return an empty dictionary if no special environment variables have
         to be set for this calculation.
         """
-        warnings.warn(
-            'explicit option getter/setter methods are deprecated, use get_option and set_option', DeprecationWarning)
+        warnings.warn('explicit option getter/setter methods are deprecated, use get_option and set_option',
+                      DeprecationWarning)
         return self.get_attr('custom_environment_variables', {})
 
     def set_priority(self, val):
@@ -639,8 +641,8 @@ class AbstractJobCalculation(AbstractCalculation):
 
         :param val: the values of priority as accepted by the cluster scheduler.
         """
-        warnings.warn(
-            'explicit option getter/setter methods are deprecated, use get_option and set_option', DeprecationWarning)
+        warnings.warn('explicit option getter/setter methods are deprecated, use get_option and set_option',
+                      DeprecationWarning)
         self._set_attr('priority', six.text_type(val))
 
     def set_max_memory_kb(self, val):
@@ -649,8 +651,8 @@ class AbstractJobCalculation(AbstractCalculation):
 
         :param val: an integer. Default=None
         """
-        warnings.warn(
-            'explicit option getter/setter methods are deprecated, use get_option and set_option', DeprecationWarning)
+        warnings.warn('explicit option getter/setter methods are deprecated, use get_option and set_option',
+                      DeprecationWarning)
         self._set_attr('max_memory_kb', int(val))
 
     def get_max_memory_kb(self):
@@ -659,8 +661,8 @@ class AbstractJobCalculation(AbstractCalculation):
 
         :return: an integer
         """
-        warnings.warn(
-            'explicit option getter/setter methods are deprecated, use get_option and set_option', DeprecationWarning)
+        warnings.warn('explicit option getter/setter methods are deprecated, use get_option and set_option',
+                      DeprecationWarning)
         return self.get_attr('max_memory_kb', None)
 
     def set_max_wallclock_seconds(self, val):
@@ -669,8 +671,8 @@ class AbstractJobCalculation(AbstractCalculation):
 
         :param val: An integer. Default=None
         """
-        warnings.warn(
-            'explicit option getter/setter methods are deprecated, use get_option and set_option', DeprecationWarning)
+        warnings.warn('explicit option getter/setter methods are deprecated, use get_option and set_option',
+                      DeprecationWarning)
         self._set_attr('max_wallclock_seconds', int(val))
 
     def get_max_wallclock_seconds(self):
@@ -680,8 +682,8 @@ class AbstractJobCalculation(AbstractCalculation):
         :return: an integer
         :rtype: int
         """
-        warnings.warn(
-            'explicit option getter/setter methods are deprecated, use get_option and set_option', DeprecationWarning)
+        warnings.warn('explicit option getter/setter methods are deprecated, use get_option and set_option',
+                      DeprecationWarning)
         return self.get_attr('max_wallclock_seconds', None)
 
     def set_resources(self, resources_dict):
@@ -693,8 +695,8 @@ class AbstractJobCalculation(AbstractCalculation):
         (scheduler type can be found with
         calc.get_computer().get_scheduler_type() )
         """
-        warnings.warn(
-            'explicit option getter/setter methods are deprecated, use get_option and set_option', DeprecationWarning)
+        warnings.warn('explicit option getter/setter methods are deprecated, use get_option and set_option',
+                      DeprecationWarning)
         # Note: for the time being, resources are only validated during the
         # 'store' because here we are not sure that a Computer has been set
         # yet (in particular, if both computer and resources are set together
@@ -707,8 +709,8 @@ class AbstractJobCalculation(AbstractCalculation):
 
         :param val: A boolean. Default=True
         """
-        warnings.warn(
-            'explicit option getter/setter methods are deprecated, use get_option and set_option', DeprecationWarning)
+        warnings.warn('explicit option getter/setter methods are deprecated, use get_option and set_option',
+                      DeprecationWarning)
         self._set_attr('withmpi', val)
 
     def get_withmpi(self):
@@ -717,8 +719,8 @@ class AbstractJobCalculation(AbstractCalculation):
 
         :return: a boolean. Default=True.
         """
-        warnings.warn(
-            'explicit option getter/setter methods are deprecated, use get_option and set_option', DeprecationWarning)
+        warnings.warn('explicit option getter/setter methods are deprecated, use get_option and set_option',
+                      DeprecationWarning)
         return self.get_attr('withmpi', True)
 
     def get_resources(self, full=False):
@@ -730,16 +732,15 @@ class AbstractJobCalculation(AbstractCalculation):
 
         :return: a dictionary
         """
-        warnings.warn(
-            'explicit option getter/setter methods are deprecated, use get_option and set_option', DeprecationWarning)
+        warnings.warn('explicit option getter/setter methods are deprecated, use get_option and set_option',
+                      DeprecationWarning)
         resources_dict = self.get_attr('jobresource_params', {})
 
         if full:
             computer = self.get_computer()
             def_cpus_machine = computer.get_default_mpiprocs_per_machine()
             if def_cpus_machine is not None:
-                resources_dict[
-                    'default_mpiprocs_per_machine'] = def_cpus_machine
+                resources_dict['default_mpiprocs_per_machine'] = def_cpus_machine
 
         return resources_dict
 
@@ -749,8 +750,8 @@ class AbstractJobCalculation(AbstractCalculation):
 
         :return: a string or None.
         """
-        warnings.warn(
-            'explicit option getter/setter methods are deprecated, use get_option and set_option', DeprecationWarning)
+        warnings.warn('explicit option getter/setter methods are deprecated, use get_option and set_option',
+                      DeprecationWarning)
         return self.get_attr('queue_name', None)
 
     def get_account(self):
@@ -759,8 +760,8 @@ class AbstractJobCalculation(AbstractCalculation):
 
         :return: a string or None.
         """
-        warnings.warn(
-            'explicit option getter/setter methods are deprecated, use get_option and set_option', DeprecationWarning)
+        warnings.warn('explicit option getter/setter methods are deprecated, use get_option and set_option',
+                      DeprecationWarning)
         return self.get_attr('account', None)
 
     def get_qos(self):
@@ -769,8 +770,8 @@ class AbstractJobCalculation(AbstractCalculation):
 
         :return: a string or None.
         """
-        warnings.warn(
-            'explicit option getter/setter methods are deprecated, use get_option and set_option', DeprecationWarning)
+        warnings.warn('explicit option getter/setter methods are deprecated, use get_option and set_option',
+                      DeprecationWarning)
         return self.get_attr('qos', None)
 
     def get_priority(self):
@@ -779,8 +780,8 @@ class AbstractJobCalculation(AbstractCalculation):
 
         :return: a string or None
         """
-        warnings.warn(
-            'explicit option getter/setter methods are deprecated, use get_option and set_option', DeprecationWarning)
+        warnings.warn('explicit option getter/setter methods are deprecated, use get_option and set_option',
+                      DeprecationWarning)
         return self.get_attr('priority', None)
 
     def get_prepend_text(self):
@@ -789,8 +790,8 @@ class AbstractJobCalculation(AbstractCalculation):
         which is going to be prepended in the scheduler-job script, just before
         the code execution.
         """
-        warnings.warn(
-            'explicit option getter/setter methods are deprecated, use get_option and set_option', DeprecationWarning)
+        warnings.warn('explicit option getter/setter methods are deprecated, use get_option and set_option',
+                      DeprecationWarning)
         return self.get_attr("prepend_text", "")
 
     def set_prepend_text(self, val):
@@ -803,8 +804,8 @@ class AbstractJobCalculation(AbstractCalculation):
 
         :param val: a (possibly multiline) string
         """
-        warnings.warn(
-            'explicit option getter/setter methods are deprecated, use get_option and set_option', DeprecationWarning)
+        warnings.warn('explicit option getter/setter methods are deprecated, use get_option and set_option',
+                      DeprecationWarning)
         self._set_attr("prepend_text", six.text_type(val))
 
     def get_append_text(self):
@@ -813,8 +814,8 @@ class AbstractJobCalculation(AbstractCalculation):
         which is going to be appended in the scheduler-job script, just after
         the code execution.
         """
-        warnings.warn(
-            'explicit option getter/setter methods are deprecated, use get_option and set_option', DeprecationWarning)
+        warnings.warn('explicit option getter/setter methods are deprecated, use get_option and set_option',
+                      DeprecationWarning)
         return self.get_attr("append_text", "")
 
     def set_append_text(self, val):
@@ -825,8 +826,8 @@ class AbstractJobCalculation(AbstractCalculation):
 
         :param val: a (possibly multiline) string
         """
-        warnings.warn(
-            'explicit option getter/setter methods are deprecated, use get_option and set_option', DeprecationWarning)
+        warnings.warn('explicit option getter/setter methods are deprecated, use get_option and set_option',
+                      DeprecationWarning)
         self._set_attr("append_text", six.text_type(val))
 
     def set_custom_scheduler_commands(self, val):
@@ -839,8 +840,8 @@ class AbstractJobCalculation(AbstractCalculation):
         inserted: with this method, the string is inserted before any
         non-scheduler command.
         """
-        warnings.warn(
-            'explicit option getter/setter methods are deprecated, use get_option and set_option', DeprecationWarning)
+        warnings.warn('explicit option getter/setter methods are deprecated, use get_option and set_option',
+                      DeprecationWarning)
         self._set_attr("custom_scheduler_commands", six.text_type(val))
 
     def get_custom_scheduler_commands(self):
@@ -853,8 +854,8 @@ class AbstractJobCalculation(AbstractCalculation):
         :return: the custom scheduler command, or an empty string if no
           custom command was defined.
         """
-        warnings.warn(
-            'explicit option getter/setter methods are deprecated, use get_option and set_option', DeprecationWarning)
+        warnings.warn('explicit option getter/setter methods are deprecated, use get_option and set_option',
+                      DeprecationWarning)
         return self.get_attr("custom_scheduler_commands", "")
 
     def get_mpirun_extra_params(self):
@@ -866,8 +867,8 @@ class AbstractJobCalculation(AbstractCalculation):
 
         Return an empty list if no parameters have been defined.
         """
-        warnings.warn(
-            'explicit option getter/setter methods are deprecated, use get_option and set_option', DeprecationWarning)
+        warnings.warn('explicit option getter/setter methods are deprecated, use get_option and set_option',
+                      DeprecationWarning)
         return self.get_attr("mpirun_extra_params", [])
 
     def set_mpirun_extra_params(self, extra_params):
@@ -880,8 +881,8 @@ class AbstractJobCalculation(AbstractCalculation):
         :param extra_params: must be a list of strings, one for each
             extra parameter
         """
-        warnings.warn(
-            'explicit option getter/setter methods are deprecated, use get_option and set_option', DeprecationWarning)
+        warnings.warn('explicit option getter/setter methods are deprecated, use get_option and set_option',
+                      DeprecationWarning)
         if extra_params is None:
             try:
                 self._del_attr("mpirun_extra_params")
@@ -891,12 +892,10 @@ class AbstractJobCalculation(AbstractCalculation):
             return
 
         if not isinstance(extra_params, (list, tuple)):
-            raise ValueError("You must pass a list of strings to "
-                             "set_mpirun_extra_params")
+            raise ValueError("You must pass a list of strings to " "set_mpirun_extra_params")
         for param in extra_params:
             if not isinstance(param, six.string_types):
-                raise ValueError("You must pass a list of strings to "
-                                 "set_mpirun_extra_params")
+                raise ValueError("You must pass a list of strings to " "set_mpirun_extra_params")
 
         self._set_attr("mpirun_extra_params", list(extra_params))
 
@@ -908,8 +907,8 @@ class AbstractJobCalculation(AbstractCalculation):
         :param parser: a string identifying the module of the parser.
               Such module must be located within the folder 'aiida/parsers/plugins'
         """
-        warnings.warn(
-            'explicit option getter/setter methods are deprecated, use get_option and set_option', DeprecationWarning)
+        warnings.warn('explicit option getter/setter methods are deprecated, use get_option and set_option',
+                      DeprecationWarning)
         self._set_attr('parser', parser)
 
     def get_parser_name(self):
@@ -920,8 +919,8 @@ class AbstractJobCalculation(AbstractCalculation):
 
         :return: a string.
         """
-        warnings.warn(
-            'explicit option getter/setter methods are deprecated, use get_option and set_option', DeprecationWarning)
+        warnings.warn('explicit option getter/setter methods are deprecated, use get_option and set_option',
+                      DeprecationWarning)
 
         return self.get_attr('parser', None)
 
@@ -942,13 +941,11 @@ class AbstractJobCalculation(AbstractCalculation):
         valid_states = [calc_states.NEW]
 
         if self.get_state() not in valid_states:
-            raise ModificationNotAllowed(
-                "Can add an input link to a JobCalculation only if it is in "
-                "one of the following states: {}, it is instead {}".format(
-                    valid_states, self.get_state()))
+            raise ModificationNotAllowed("Can add an input link to a JobCalculation only if it is in "
+                                         "one of the following states: {}, it is instead {}".format(
+                                             valid_states, self.get_state()))
 
-        return super(AbstractJobCalculation, self).add_link_from(src, label,
-                                                                 link_type)
+        return super(AbstractJobCalculation, self).add_link_from(src, label, link_type)
 
     def _replace_link_from(self, src, label, link_type=LinkType.INPUT):
         """
@@ -962,14 +959,11 @@ class AbstractJobCalculation(AbstractCalculation):
         valid_states = [calc_states.NEW]
 
         if self.get_state() not in valid_states:
-            raise ModificationNotAllowed(
-                "Can replace an input link to a Jobalculation only if it is in "
-                "one of the following states: {}, it is instead {}".format(
-                    valid_states, self.get_state()))
+            raise ModificationNotAllowed("Can replace an input link to a Jobalculation only if it is in "
+                                         "one of the following states: {}, it is instead {}".format(
+                                             valid_states, self.get_state()))
 
-        return super(AbstractJobCalculation, self)._replace_link_from(src,
-                                                                      label,
-                                                                      link_type)
+        return super(AbstractJobCalculation, self)._replace_link_from(src, label, link_type)
 
     def _remove_link_from(self, label):
         """
@@ -980,10 +974,9 @@ class AbstractJobCalculation(AbstractCalculation):
         valid_states = [calc_states.NEW]
 
         if self.get_state() not in valid_states:
-            raise ModificationNotAllowed(
-                "Can remove an input link to a calculation only if it is in one "
-                "of the following states:\n   {}\n it is instead {}".format(
-                    valid_states, self.get_state()))
+            raise ModificationNotAllowed("Can remove an input link to a calculation only if it is in one "
+                                         "of the following states:\n   {}\n it is instead {}".format(
+                                             valid_states, self.get_state()))
 
         return super(AbstractJobCalculation, self)._remove_link_from(label)
 
@@ -1059,12 +1052,8 @@ class AbstractJobCalculation(AbstractCalculation):
         :return: a boolean
         """
         return self.get_state() in [
-            calc_states.TOSUBMIT,
-            calc_states.SUBMITTING,
-            calc_states.WITHSCHEDULER,
-            calc_states.COMPUTED,
-            calc_states.RETRIEVING,
-            calc_states.PARSING
+            calc_states.TOSUBMIT, calc_states.SUBMITTING, calc_states.WITHSCHEDULER, calc_states.COMPUTED,
+            calc_states.RETRIEVING, calc_states.PARSING
         ]
 
     @property
@@ -1087,17 +1076,15 @@ class AbstractJobCalculation(AbstractCalculation):
         :return: True if the calculation has failed, False otherwise
         :rtype: bool
         """
-        return self.get_state() in [calc_states.SUBMISSIONFAILED,
-                                    calc_states.RETRIEVALFAILED,
-                                    calc_states.PARSINGFAILED,
-                                    calc_states.FAILED]
+        return self.get_state() in [
+            calc_states.SUBMISSIONFAILED, calc_states.RETRIEVALFAILED, calc_states.PARSINGFAILED, calc_states.FAILED
+        ]
 
     def _set_remote_workdir(self, remote_workdir):
         if self.get_state() != calc_states.SUBMITTING:
-            raise ModificationNotAllowed(
-                "Cannot set the remote workdir if you are not "
-                "submitting the calculation (current state is "
-                "{})".format(self.get_state()))
+            raise ModificationNotAllowed("Cannot set the remote workdir if you are not "
+                                         "submitting the calculation (current state is "
+                                         "{})".format(self.get_state()))
         self._set_attr('remote_workdir', remote_workdir)
 
     def _get_remote_workdir(self):
@@ -1111,9 +1098,8 @@ class AbstractJobCalculation(AbstractCalculation):
 
     def _set_retrieve_list(self, retrieve_list):
         if self.get_state() not in (calc_states.TOSUBMIT, calc_states.NEW):
-            raise ModificationNotAllowed(
-                "Cannot set the retrieve_list for a calculation that is neither "
-                "NEW nor TOSUBMIT (current state is {})".format(self.get_state()))
+            raise ModificationNotAllowed("Cannot set the retrieve_list for a calculation that is neither "
+                                         "NEW nor TOSUBMIT (current state is {})".format(self.get_state()))
 
         # accept format of: [ 'remotename',
         #                     ['remotepath','localpath',0] ]
@@ -1124,20 +1110,13 @@ class AbstractJobCalculation(AbstractCalculation):
             raise ValueError("You should pass a list/tuple")
         for item in retrieve_list:
             if not isinstance(item, six.string_types):
-                if (not (isinstance(item, (tuple, list))) or
-                        len(item) != 3):
-                    raise ValueError(
-                        "You should pass a list containing either "
-                        "strings or lists/tuples"
-                    )
-                if (not (isinstance(item[0], six.string_types)) or
-                        not (isinstance(item[1], six.string_types)) or
+                if (not (isinstance(item, (tuple, list))) or len(item) != 3):
+                    raise ValueError("You should pass a list containing either " "strings or lists/tuples")
+                if (not (isinstance(item[0], six.string_types)) or not (isinstance(item[1], six.string_types)) or
                         not (isinstance(item[2], int))):
-                    raise ValueError(
-                        "You have to pass a list (or tuple) of "
-                        "lists, with remotepath(string), "
-                        "localpath(string) and depth (integer)"
-                    )
+                    raise ValueError("You have to pass a list (or tuple) of "
+                                     "lists, with remotepath(string), "
+                                     "localpath(string) and depth (integer)")
 
         self._set_attr('retrieve_list', retrieve_list)
 
@@ -1156,9 +1135,8 @@ class AbstractJobCalculation(AbstractCalculation):
         as the parsing has been completed.
         """
         if self.get_state() not in (calc_states.TOSUBMIT, calc_states.NEW):
-            raise ModificationNotAllowed(
-                'Cannot set the retrieve_temporary_list for a calculation that is neither '
-                'NEW nor TOSUBMIT (current state is {})'.format(self.get_state()))
+            raise ModificationNotAllowed('Cannot set the retrieve_temporary_list for a calculation that is neither '
+                                         'NEW nor TOSUBMIT (current state is {})'.format(self.get_state()))
 
         if not (isinstance(retrieve_temporary_list, (tuple, list))):
             raise ValueError('You should pass a list/tuple')
@@ -1166,18 +1144,12 @@ class AbstractJobCalculation(AbstractCalculation):
         for item in retrieve_temporary_list:
             if not isinstance(item, six.string_types):
                 if (not (isinstance(item, (tuple, list))) or len(item) != 3):
-                    raise ValueError(
-                        'You should pass a list containing either '
-                        'strings or lists/tuples'
-                    )
+                    raise ValueError('You should pass a list containing either ' 'strings or lists/tuples')
 
-                if (not (isinstance(item[0], six.string_types)) or
-                        not (isinstance(item[1], six.string_types)) or
+                if (not (isinstance(item[0], six.string_types)) or not (isinstance(item[1], six.string_types)) or
                         not (isinstance(item[2], int))):
-                    raise ValueError(
-                        'You have to pass a list (or tuple) of lists, with remotepath(string), '
-                        'localpath(string) and depth (integer)'
-                    )
+                    raise ValueError('You have to pass a list (or tuple) of lists, with remotepath(string), '
+                                     'localpath(string) and depth (integer)')
 
         self._set_attr('retrieve_temporary_list', retrieve_temporary_list)
 
@@ -1195,16 +1167,13 @@ class AbstractJobCalculation(AbstractCalculation):
         Set the list of information for the retrieval of singlefiles
         """
         if self.get_state() not in (calc_states.TOSUBMIT, calc_states.NEW):
-            raise ModificationNotAllowed(
-                "Cannot set the retrieve_singlefile_list for a calculation that is neither "
-                "NEW nor TOSUBMIT (current state is {})".format(self.get_state()))
+            raise ModificationNotAllowed("Cannot set the retrieve_singlefile_list for a calculation that is neither "
+                                         "NEW nor TOSUBMIT (current state is {})".format(self.get_state()))
 
         if not isinstance(retrieve_singlefile_list, (tuple, list)):
-            raise ValueError("You have to pass a list (or tuple) of lists of "
-                             "strings as retrieve_singlefile_list")
+            raise ValueError("You have to pass a list (or tuple) of lists of " "strings as retrieve_singlefile_list")
         for j in retrieve_singlefile_list:
-            if (not (isinstance(j, (tuple, list))) or
-                    not (all(isinstance(i, six.string_types) for i in j))):
+            if (not (isinstance(j, (tuple, list))) or not (all(isinstance(i, six.string_types) for i in j))):
                 raise ValueError("You have to pass a list (or tuple) of lists "
                                  "of strings as retrieve_singlefile_list")
         self._set_attr('retrieve_singlefile_list', retrieve_singlefile_list)
@@ -1225,11 +1194,9 @@ class AbstractJobCalculation(AbstractCalculation):
         Always set as a string
         """
         if self.get_state() != calc_states.SUBMITTING:
-            raise ModificationNotAllowed(
-                "Cannot set the job id if you are not "
-                "submitting the calculation (current state is "
-                "{})".format(self.get_state())
-            )
+            raise ModificationNotAllowed("Cannot set the job id if you are not "
+                                         "submitting the calculation (current state is "
+                                         "{})".format(self.get_state()))
 
         return self._set_attr('job_id', six.text_type(job_id))
 
@@ -1310,11 +1277,19 @@ class AbstractJobCalculation(AbstractCalculation):
     }
 
     @classmethod
-    def _list_calculations(
-            cls, states=None, past_days=None, groups=None, all_users=False, pks=tuple(),
-            relative_ctime=True, with_scheduler_state=False, order_by=None, limit=None, filters=None,
-            projections=('pk', 'state', 'ctime', 'sched', 'computer', 'type'), raw=False
-    ):
+    def _list_calculations(cls,
+                           states=None,
+                           past_days=None,
+                           groups=None,
+                           all_users=False,
+                           pks=tuple(),
+                           relative_ctime=True,
+                           with_scheduler_state=False,
+                           order_by=None,
+                           limit=None,
+                           filters=None,
+                           projections=('pk', 'state', 'ctime', 'sched', 'computer', 'type'),
+                           raw=False):
         """
         Print a description of the AiiDA calculations.
 
@@ -1421,11 +1396,7 @@ class AbstractJobCalculation(AbstractCalculation):
         calc_list_header = [projection_label_dict[p] for p in projections]
 
         qb = QueryBuilder()
-        qb.append(
-            cls,
-            filters=calculation_filters,
-            tag='calculation'
-        )
+        qb.append(cls, filters=calculation_filters, tag='calculation')
         if group_filters is not None:
             qb.append(type='group', filters=group_filters, group_of='calculation')
 
@@ -1466,8 +1437,7 @@ class AbstractJobCalculation(AbstractCalculation):
                 for i in range(100):
                     res = next(results_generator)
 
-                    row = cls._get_calculation_info_row(
-                        res, projections, now if relative_ctime else None)
+                    row = cls._get_calculation_info_row(res, projections, now if relative_ctime else None)
 
                     # Build the row of information
                     calc_list_data.append(row)
@@ -1525,13 +1495,12 @@ class AbstractJobCalculation(AbstractCalculation):
                 time = d['calculation'][proj]
                 if times_since:
                     dt = timezone.delta(time, times_since)
-                    d['calculation'][proj] = str_timedelta(
-                        dt, negative_to_zero=True, max_num_fields=1)
+                    d['calculation'][proj] = str_timedelta(dt, negative_to_zero=True, max_num_fields=1)
                 else:
                     d['calculation'][proj] = " ".join([
                         timezone.localtime(time).isoformat().split('T')[0],
-                        timezone.localtime(time).isoformat().split('T')[
-                            1].split('.')[0].rsplit(":", 1)[0]])
+                        timezone.localtime(time).isoformat().split('T')[1].split('.')[0].rsplit(":", 1)[0]
+                    ])
             except (KeyError, ValueError):
                 pass
 
@@ -1570,11 +1539,13 @@ class AbstractJobCalculation(AbstractCalculation):
         return result
 
     @classmethod
-    def _get_all_with_state(
-            cls, state, computer=None, user=None,
-            only_computer_user_pairs=False,
-            only_enabled=True, limit=None
-    ):
+    def _get_all_with_state(cls,
+                            state,
+                            computer=None,
+                            user=None,
+                            only_computer_user_pairs=False,
+                            only_enabled=True,
+                            limit=None):
         """
         Filter all calculations with a given state.
 
@@ -1623,9 +1594,7 @@ class AbstractJobCalculation(AbstractCalculation):
             try:
                 computerfilter.update({'id': {'==': computer.id}})
             except AttributeError as e:
-                raise Exception(
-                    "{} is not a valid computer\n{}".format(computer, e)
-                )
+                raise Exception("{} is not a valid computer\n{}".format(computer, e))
 
         if user is None:
             pass
@@ -1641,8 +1610,7 @@ class AbstractJobCalculation(AbstractCalculation):
         qb = QueryBuilder()
         qb.append(type="computer", tag='computer', filters=computerfilter)
         qb.append(cls, filters=calcfilter, tag='calc', has_computer='computer')
-        qb.append(type="user", tag='user', filters=userfilter,
-                  creator_of="calc")
+        qb.append(type="user", tag='user', filters=userfilter, creator_of="calc")
 
         if only_computer_user_pairs:
             qb.add_projection("computer", "*")
@@ -1702,10 +1670,8 @@ class AbstractJobCalculation(AbstractCalculation):
         import warnings
         from aiida.work.job_processes import ContinueJobCalculation
         from aiida.work.launch import submit
-        warnings.warn(
-            'directly creating and submitting calculations is deprecated, use the {}\nSee:{}'.format(
-                'ProcessBuilder', DEPRECATION_DOCS_URL), DeprecationWarning
-        )
+        warnings.warn('directly creating and submitting calculations is deprecated, use the {}\nSee:{}'.format(
+            'ProcessBuilder', DEPRECATION_DOCS_URL), DeprecationWarning)
 
         submit(ContinueJobCalculation, _calc=self)
 
@@ -1766,14 +1732,13 @@ class AbstractJobCalculation(AbstractCalculation):
                 else:
                     raise MultipleObjectsError("More than one output node "
                                                "with label '{}' for calc with pk= {}".format(
-                        retrieved_linkname, self.pk))
+                                                   retrieved_linkname, self.pk))
 
         if retrieved_node is None:
             return None
 
         if not isinstance(retrieved_node, FolderData):
-            raise TypeError("The retrieved node of calc with pk= {} is not of "
-                            "type FolderData".format(self.pk))
+            raise TypeError("The retrieved node of calc with pk= {} is not of " "type FolderData".format(self.pk))
 
         return retrieved_node
 
@@ -1810,9 +1775,7 @@ class AbstractJobCalculation(AbstractCalculation):
 
         from six.moves import cStringIO as StringIO
 
-        from aiida.common.exceptions import (NotExistent,
-                                             PluginInternalError,
-                                             ValidationError)
+        from aiida.common.exceptions import (NotExistent, PluginInternalError, ValidationError)
         from aiida.scheduler.datastructures import JobTemplate
         from aiida.common.utils import validate_list_of_string_tuples
         from aiida.orm.computer import Computer
@@ -1822,8 +1785,7 @@ class AbstractJobCalculation(AbstractCalculation):
         from aiida.orm.utils import load_node
 
         computer = self.get_computer()
-        inputdict = self.get_inputs_dict(
-            only_in_db=not use_unstored_links, link_type=LinkType.INPUT)
+        inputdict = self.get_inputs_dict(only_in_db=not use_unstored_links, link_type=LinkType.INPUT)
 
         codes = [_ for _ in inputdict.values() if isinstance(_, Code)]
 
@@ -1833,10 +1795,8 @@ class AbstractJobCalculation(AbstractCalculation):
         for code in codes:
             if code.is_local():
                 if code.get_local_executable() in folder.get_content_list():
-                    raise PluginInternalError(
-                        "The plugin created a file {} that is also "
-                        "the executable name!".format(
-                            code.get_local_executable()))
+                    raise PluginInternalError("The plugin created a file {} that is also "
+                                              "the executable name!".format(code.get_local_executable()))
 
         # I create the job template to pass to the scheduler
         job_tmpl = JobTemplate()
@@ -1855,21 +1815,16 @@ class AbstractJobCalculation(AbstractCalculation):
             job_tmpl.sched_join_files = False
 
         # Set retrieve path, add also scheduler STDOUT and STDERR
-        retrieve_list = (calcinfo.retrieve_list
-                         if calcinfo.retrieve_list is not None
-                         else [])
-        if (job_tmpl.sched_output_path is not None and
-                job_tmpl.sched_output_path not in retrieve_list):
+        retrieve_list = (calcinfo.retrieve_list if calcinfo.retrieve_list is not None else [])
+        if (job_tmpl.sched_output_path is not None and job_tmpl.sched_output_path not in retrieve_list):
             retrieve_list.append(job_tmpl.sched_output_path)
         if not job_tmpl.sched_join_files:
-            if (job_tmpl.sched_error_path is not None and
-                    job_tmpl.sched_error_path not in retrieve_list):
+            if (job_tmpl.sched_error_path is not None and job_tmpl.sched_error_path not in retrieve_list):
                 retrieve_list.append(job_tmpl.sched_error_path)
         self._set_retrieve_list(retrieve_list)
 
         retrieve_singlefile_list = (calcinfo.retrieve_singlefile_list
-                                    if calcinfo.retrieve_singlefile_list is not None
-                                    else [])
+                                    if calcinfo.retrieve_singlefile_list is not None else [])
         # a validation on the subclasses of retrieve_singlefile_list
         SinglefileData = DataFactory('singlefile')
         for _, subclassname, _ in retrieve_singlefile_list:
@@ -1877,13 +1832,12 @@ class AbstractJobCalculation(AbstractCalculation):
             if not issubclass(FileSubclass, SinglefileData):
                 raise PluginInternalError("[presubmission of calc {}] "
                                           "retrieve_singlefile_list subclass problem: "
-                                          "{} is not subclass of SinglefileData".format(
-                    self.pk, FileSubclass.__name__))
+                                          "{} is not subclass of SinglefileData".format(self.pk, FileSubclass.__name__))
         self._set_retrieve_singlefile_list(retrieve_singlefile_list)
 
         # Handle the retrieve_temporary_list
-        retrieve_temporary_list = (
-            calcinfo.retrieve_temporary_list if calcinfo.retrieve_temporary_list is not None else [])
+        retrieve_temporary_list = (calcinfo.retrieve_temporary_list
+                                   if calcinfo.retrieve_temporary_list is not None else [])
         self._set_retrieve_temporary_list(retrieve_temporary_list)
 
         # the if is done so that if the method returns None, this is
@@ -1892,17 +1846,15 @@ class AbstractJobCalculation(AbstractCalculation):
         # - most importantly, skips the cases in which one of the methods
         #   would return None, in which case the join method would raise
         #   an exception
-        job_tmpl.prepend_text = "\n\n".join(_ for _ in
-                                            [computer.get_prepend_text()] +
-                                            [code.get_prepend_text() for code in codes] +
-                                            [calcinfo.prepend_text,
-                                             self.get_option('prepend_text')] if _)
+        job_tmpl.prepend_text = "\n\n".join(
+            _ for _ in [computer.get_prepend_text()] + [code.get_prepend_text() for code in codes] +
+            [calcinfo.prepend_text, self.get_option('prepend_text')] if _)
 
-        job_tmpl.append_text = "\n\n".join(_ for _ in
-                                           [self.get_option('append_text'),
-                                            calcinfo.append_text,
-                                            code.get_append_text(),
-                                            computer.get_append_text()] if _)
+        job_tmpl.append_text = "\n\n".join(
+            _ for _ in
+            [self.get_option('append_text'), calcinfo.append_text,
+             code.get_append_text(),
+             computer.get_append_text()] if _)
 
         # Set resources, also with get_default_mpiprocs_per_machine
         resources = self.get_option('resources')
@@ -1911,26 +1863,22 @@ class AbstractJobCalculation(AbstractCalculation):
             resources['default_mpiprocs_per_machine'] = def_cpus_machine
         job_tmpl.job_resource = s.create_job_resource(**resources)
 
-        subst_dict = {'tot_num_mpiprocs':
-                          job_tmpl.job_resource.get_tot_num_mpiprocs()}
+        subst_dict = {'tot_num_mpiprocs': job_tmpl.job_resource.get_tot_num_mpiprocs()}
 
         for k, v in job_tmpl.job_resource.items():
             subst_dict[k] = v
         mpi_args = [arg.format(**subst_dict) for arg in computer.get_mpirun_command()]
         extra_mpirun_params = self.get_option('mpirun_extra_params')  # this is the same for all codes in the same calc
 
-
         # set the codes_info
         if not isinstance(calcinfo.codes_info, (list, tuple)):
-            raise PluginInternalError("codes_info passed to CalcInfo must be a "
-                                      "list of CalcInfo objects")
+            raise PluginInternalError("codes_info passed to CalcInfo must be a " "list of CalcInfo objects")
 
         codes_info = []
         for code_info in calcinfo.codes_info:
 
             if not isinstance(code_info, CodeInfo):
-                raise PluginInternalError("Invalid codes_info, must be a list "
-                                          "of CodeInfo objects")
+                raise PluginInternalError("Invalid codes_info, must be a list " "of CodeInfo objects")
 
             if code_info.code_uuid is None:
                 raise PluginInternalError("CalcInfo should have "
@@ -1948,14 +1896,11 @@ class AbstractJobCalculation(AbstractCalculation):
                     this_withmpi = self.get_option('withmpi')
 
             if this_withmpi:
-                this_argv = (mpi_args + extra_mpirun_params +
-                             [this_code.get_execname()] +
-                             (code_info.cmdline_params if
-                              code_info.cmdline_params is not None else []))
+                this_argv = (mpi_args + extra_mpirun_params + [this_code.get_execname()] +
+                             (code_info.cmdline_params if code_info.cmdline_params is not None else []))
             else:
-                this_argv = [this_code.get_execname()] + (
-                    code_info.cmdline_params if
-                    code_info.cmdline_params is not None else [])
+                this_argv = [this_code.get_execname()] + (code_info.cmdline_params
+                                                          if code_info.cmdline_params is not None else [])
 
             this_stdin_name = code_info.stdin_name
             this_stdout_name = code_info.stdout_name
@@ -1974,8 +1919,7 @@ class AbstractJobCalculation(AbstractCalculation):
             try:
                 job_tmpl.codes_run_mode = calcinfo.codes_run_mode
             except KeyError:
-                raise PluginInternalError("Need to set the order of the code "
-                                          "execution (parallel or serial?)")
+                raise PluginInternalError("Need to set the order of the code " "execution (parallel or serial?)")
         else:
             job_tmpl.codes_run_mode = code_run_modes.SERIAL
         ########################################################################
@@ -2029,38 +1973,30 @@ class AbstractJobCalculation(AbstractCalculation):
         this_pk = self.pk if self.pk is not None else "[UNSTORED]"
         local_copy_list = calcinfo.local_copy_list
         try:
-            validate_list_of_string_tuples(local_copy_list,
-                                           tuple_length=2)
+            validate_list_of_string_tuples(local_copy_list, tuple_length=2)
         except ValidationError as exc:
-            raise PluginInternalError(
-                "[presubmission of calc {}] "
-                "local_copy_list format problem: {}".format(this_pk, exc))
+            raise PluginInternalError("[presubmission of calc {}] "
+                                      "local_copy_list format problem: {}".format(this_pk, exc))
 
         remote_copy_list = calcinfo.remote_copy_list
         try:
-            validate_list_of_string_tuples(remote_copy_list,
-                                           tuple_length=3)
+            validate_list_of_string_tuples(remote_copy_list, tuple_length=3)
         except ValidationError as exc:
-            raise PluginInternalError(
-                "[presubmission of calc {}] "
-                "remote_copy_list format problem: {}".
-                    format(this_pk, exc))
+            raise PluginInternalError("[presubmission of calc {}] "
+                                      "remote_copy_list format problem: {}".format(this_pk, exc))
 
-        for (remote_computer_uuid, remote_abs_path,
-             dest_rel_path) in remote_copy_list:
+        for (remote_computer_uuid, remote_abs_path, dest_rel_path) in remote_copy_list:
             try:
                 remote_computer = self.backend.computers.get(uuid=remote_computer_uuid)
             except NotExistent:
-                raise PluginInternalError(
-                    "[presubmission of calc {}] "
-                    "The remote copy requires a computer with UUID={}"
-                    "but no such computer was found in the "
-                    "database".format(this_pk, remote_computer_uuid))
+                raise PluginInternalError("[presubmission of calc {}] "
+                                          "The remote copy requires a computer with UUID={}"
+                                          "but no such computer was found in the "
+                                          "database".format(this_pk, remote_computer_uuid))
             if os.path.isabs(dest_rel_path):
-                raise PluginInternalError(
-                    "[presubmission of calc {}] "
-                    "The destination path of the remote copy "
-                    "is absolute! ({})".format(this_pk, dest_rel_path))
+                raise PluginInternalError("[presubmission of calc {}] "
+                                          "The destination path of the remote copy "
+                                          "is absolute! ({})".format(this_pk, dest_rel_path))
 
         return calcinfo, script_filename
 
@@ -2105,8 +2041,7 @@ class AbstractJobCalculation(AbstractCalculation):
         folder.create()
 
         if subfolder_name is None:
-            subfolder_basename = timezone.localtime(timezone.now()).strftime(
-                '%Y%m%d')
+            subfolder_basename = timezone.localtime(timezone.now()).strftime('%Y%m%d')
         else:
             subfolder_basename = subfolder_name
 
@@ -2117,9 +2052,7 @@ class AbstractJobCalculation(AbstractCalculation):
         counter = 0
         while True:
             counter += 1
-            subfolder_path = os.path.join(folder.abspath,
-                                          "{}-{:05d}".format(subfolder_basename,
-                                                             counter))
+            subfolder_path = os.path.join(folder.abspath, "{}-{:05d}".format(subfolder_basename, counter))
             # This check just tried to avoid to try to create the folder
             # (hoping that a test of existence is faster than a
             # test and failure in directory creation)
@@ -2141,9 +2074,7 @@ class AbstractJobCalculation(AbstractCalculation):
                 # permissions
                 raise
 
-        subfolder = folder.get_subfolder(
-            os.path.relpath(subfolder_path, folder.abspath),
-            reset_limit=True)
+        subfolder = folder.get_subfolder(os.path.relpath(subfolder_path, folder.abspath), reset_limit=True)
 
         # I use the local transport where possible, to be as similar
         # as possible to a real submission
@@ -2151,8 +2082,7 @@ class AbstractJobCalculation(AbstractCalculation):
         with t:
             t.chdir(subfolder.abspath)
 
-            calcinfo, script_filename = self._presubmit(
-                subfolder, use_unstored_links=True)
+            calcinfo, script_filename = self._presubmit(subfolder, use_unstored_links=True)
 
             code = self.get_code()
 
@@ -2170,37 +2100,28 @@ class AbstractJobCalculation(AbstractCalculation):
                 t.put(src_abs_path, dest_rel_path)
 
             if remote_copy_list:
-                with io.open(os.path.join(subfolder.abspath,
-                                       '_aiida_remote_copy_list.txt'),
-                          'w', encoding='utf8') as f:
-                    for (remote_computer_uuid, remote_abs_path,
-                         dest_rel_path) in remote_copy_list:
+                with io.open(os.path.join(subfolder.abspath, '_aiida_remote_copy_list.txt'), 'w', encoding='utf8') as f:
+                    for (remote_computer_uuid, remote_abs_path, dest_rel_path) in remote_copy_list:
                         try:
                             remote_computer = self.backend.computers.get(uuid=remote_computer_uuid)
                         except NotExistent:
                             remote_computer = "[unknown]"
-                        f.write("* I WOULD REMOTELY COPY "
+                        f.write(u"* I WOULD REMOTELY COPY "
                                 "FILES/DIRS FROM COMPUTER {} (UUID {}) "
-                                "FROM {} TO {}\n".format(remote_computer.name,
-                                                         remote_computer_uuid,
-                                                         remote_abs_path,
+                                "FROM {} TO {}\n".format(remote_computer.name, remote_computer_uuid, remote_abs_path,
                                                          dest_rel_path))
 
             if remote_symlink_list:
-                with io.open(os.path.join(subfolder.abspath,
-                                       '_aiida_remote_symlink_list.txt'),
-                          'w', encoding='utf8') as f:
-                    for (remote_computer_uuid, remote_abs_path,
-                         dest_rel_path) in remote_symlink_list:
+                with io.open(
+                        os.path.join(subfolder.abspath, '_aiida_remote_symlink_list.txt'), 'w', encoding='utf8') as f:
+                    for (remote_computer_uuid, remote_abs_path, dest_rel_path) in remote_symlink_list:
                         try:
                             remote_computer = self.backend.computers.get(uuid=remote_computer_uuid)
                         except NotExistent:
                             remote_computer = "[unknown]"
-                        f.write("* I WOULD PUT SYMBOLIC LINKS FOR "
+                        f.write(u"* I WOULD PUT SYMBOLIC LINKS FOR "
                                 "FILES/DIRS FROM COMPUTER {} (UUID {}) "
-                                "FROM {} TO {}\n".format(remote_computer.name,
-                                                         remote_computer_uuid,
-                                                         remote_abs_path,
+                                "FROM {} TO {}\n".format(remote_computer.name, remote_computer_uuid, remote_abs_path,
                                                          dest_rel_path))
 
         return subfolder, script_filename
@@ -2224,8 +2145,7 @@ class AbstractJobCalculation(AbstractCalculation):
             return None
 
         try:
-            outfile_content = retrieved_node.get_file_content(
-                self._SCHED_OUTPUT_FILE)
+            outfile_content = retrieved_node.get_file_content(self._SCHED_OUTPUT_FILE)
         except (NotExistent):
             # Return None if no file is found
             return None
@@ -2251,8 +2171,7 @@ class AbstractJobCalculation(AbstractCalculation):
             return None
 
         try:
-            errfile_content = retrieved_node.get_file_content(
-                self._SCHED_ERROR_FILE)
+            errfile_content = retrieved_node.get_file_content(self._SCHED_ERROR_FILE)
         except (NotExistent):
             # Return None if no file is found
             return None
@@ -2332,8 +2251,8 @@ class CalculationResultManager(object):
         try:
             return self._parser.get_result(name)
         except AttributeError:
-            raise AttributeError("Parser '{}' did not provide a result '{}'"
-                                 .format(self._parser.__class__.__name__, name))
+            raise AttributeError("Parser '{}' did not provide a result '{}'".format(self._parser.__class__.__name__,
+                                                                                    name))
 
     def __getitem__(self, name):
         """
@@ -2344,5 +2263,4 @@ class CalculationResultManager(object):
         try:
             return self._parser.get_result(name)
         except AttributeError:
-            raise KeyError("Parser '{}' did not provide a result '{}'"
-                           .format(self._parser.__class__.__name__, name))
+            raise KeyError("Parser '{}' did not provide a result '{}'".format(self._parser.__class__.__name__, name))

--- a/aiida/orm/implementation/general/calculation/job/__init__.py
+++ b/aiida/orm/implementation/general/calculation/job/__init__.py
@@ -1960,8 +1960,8 @@ class AbstractJobCalculation(AbstractCalculation):
         folder.create_file_from_filelike(StringIO(script_content), script_filename)
 
         subfolder = folder.get_subfolder('.aiida', create=True)
-        subfolder.create_file_from_filelike(StringIO(six.text_type(json.dumps(job_tmpl)), 'job_tmpl.json'))
-        subfolder.create_file_from_filelike(StringIO(six.text_type(json.dumps(calcinfo)), 'calcinfo.json'))
+        subfolder.create_file_from_filelike(StringIO(six.text_type(json.dumps(job_tmpl))), 'job_tmpl.json')
+        subfolder.create_file_from_filelike(StringIO(six.text_type(json.dumps(calcinfo))), 'calcinfo.json')
 
         if calcinfo.local_copy_list is None:
             calcinfo.local_copy_list = []

--- a/aiida/orm/implementation/sqlalchemy/computer.py
+++ b/aiida/orm/implementation/sqlalchemy/computer.py
@@ -11,7 +11,6 @@
 from __future__ import division
 from __future__ import print_function
 from __future__ import absolute_import
-import json
 from copy import copy
 import six
 from sqlalchemy.exc import SQLAlchemyError
@@ -24,6 +23,7 @@ from aiida.backends.sqlalchemy.models.computer import DbComputer
 from aiida.common.exceptions import (ConfigurationError, InvalidOperation)
 from aiida.common.lang import override
 from . import utils
+import aiida.utils.json as json
 
 
 class SqlaComputerCollection(ComputerCollection):

--- a/aiida/orm/importexport.py
+++ b/aiida/orm/importexport.py
@@ -10,6 +10,7 @@
 from __future__ import division
 from __future__ import absolute_import
 from __future__ import print_function
+import io
 import sys
 
 import six
@@ -396,10 +397,10 @@ def import_data_dj(in_path, ignore_unknown_nodes=False,
             raise ContentNotExistent("The provided file/folder ({}) is empty"
                                      .format(in_path))
         try:
-            with open(folder.get_abs_path('metadata.json')) as f:
+            with io.open(folder.get_abs_path('metadata.json'), encoding='utf8') as f:
                 metadata = json.load(f)
 
-            with open(folder.get_abs_path('data.json')) as f:
+            with io.open(folder.get_abs_path('data.json'), encoding='utf8') as f:
                 data = json.load(f)
         except IOError as e:
             raise ValueError("Unable to find the file {} in the import "
@@ -918,10 +919,10 @@ def import_data_sqla(in_path, ignore_unknown_nodes=False, silent=False):
             raise ContentNotExistent("The provided file/folder ({}) is empty"
                                      .format(in_path))
         try:
-            with open(folder.get_abs_path('metadata.json')) as f:
+            with io.open(folder.get_abs_path('metadata.json'), encoding='utf8') as f:
                 metadata = json.load(f)
 
-            with open(folder.get_abs_path('data.json')) as f:
+            with io.open(folder.get_abs_path('data.json'), encoding='utf8') as f:
                 data = json.load(f)
         except IOError as e:
             raise ValueError("Unable to find the file {} in the import "

--- a/aiida/orm/importexport.py
+++ b/aiida/orm/importexport.py
@@ -397,11 +397,11 @@ def import_data_dj(in_path, ignore_unknown_nodes=False,
             raise ContentNotExistent("The provided file/folder ({}) is empty"
                                      .format(in_path))
         try:
-            with io.open(folder.get_abs_path('metadata.json'), encoding='utf8') as f:
-                metadata = json.load(f)
+            with io.open(folder.get_abs_path('metadata.json'), 'r', encoding='utf8') as fhandle:
+                metadata = json.load(fhandle)
 
-            with io.open(folder.get_abs_path('data.json'), encoding='utf8') as f:
-                data = json.load(f)
+            with io.open(folder.get_abs_path('data.json'), 'r', encoding='utf8') as fhandle:
+                data = json.load(fhandle)
         except IOError as e:
             raise ValueError("Unable to find the file {} in the import "
                              "file or folder".format(e.filename))
@@ -2352,14 +2352,14 @@ def export_tree(what, folder,allowed_licenses=None, forbidden_licenses=None,
     if not silent:
         print("STORING DATA...")
 
-    with folder.open('data.json', 'w') as fhandle:
+    with folder.open('data.json', 'wb') as fhandle:
         json.dump({
             'node_attributes': node_attributes,
             'node_attributes_conversion': node_attributes_conversion,
             'export_data': export_data,
             'links_uuid': links_uuid,
             'groups_uuid': groups_uuid,
-        }, fhandle)
+        }, fhandle, ensure_ascii=False)
 
     # Add proper signature to unique identifiers & all_fields_info
     # Ignore if a key doesn't exist in any of the two dictionaries
@@ -2371,8 +2371,8 @@ def export_tree(what, folder,allowed_licenses=None, forbidden_licenses=None,
         'unique_identifiers': unique_identifiers,
     }
 
-    with folder.open('metadata.json', 'w') as fhandle:
-        json.dump(metadata, fhandle)
+    with folder.open('metadata.json', 'wb') as fhandle:
+        json.dump(metadata, fhandle, ensure_ascii=False)
 
     if silent is not True:
         print("STORING FILES...")

--- a/aiida/orm/importexport.py
+++ b/aiida/orm/importexport.py
@@ -24,7 +24,6 @@ from aiida.orm.group import Group
 from aiida.orm.node import Node
 from aiida.orm.user import User
 
-
 IMPORTGROUP_TYPE = 'aiida.import'
 COMP_DUPL_SUFFIX = ' (Imported #{})'
 
@@ -2351,8 +2350,9 @@ def export_tree(what, folder,allowed_licenses=None, forbidden_licenses=None,
 
     if not silent:
         print("STORING DATA...")
-
-    with folder.open('data.json', "w", encoding='utf-8') as fhandle:
+    
+    # N.B. We're really calling zipfolder.open
+    with folder.open('data.json', mode='w') as fhandle:
         fhandle.write(six.text_type(json.dumps({
             'node_attributes': node_attributes,
             'node_attributes_conversion': node_attributes_conversion,
@@ -2371,7 +2371,7 @@ def export_tree(what, folder,allowed_licenses=None, forbidden_licenses=None,
         'unique_identifiers': unique_identifiers,
     }
 
-    with folder.open('metadata.json', "w", encoding='utf-8') as fhandle:
+    with folder.open('metadata.json', "w") as fhandle:
         fhandle.write(six.text_type(json.dumps(
             metadata, ensure_ascii=False)))
 
@@ -2471,7 +2471,7 @@ class MyWritingZipFile(object):
         self._buffer = None
 
     def open(self):
-        from six.moves import cStringIO as StringIO
+        from six.moves import StringIO as StringIO
 
         if self._buffer is not None:
             raise IOError("Cannot open again!")

--- a/aiida/orm/importexport.py
+++ b/aiida/orm/importexport.py
@@ -2352,14 +2352,14 @@ def export_tree(what, folder,allowed_licenses=None, forbidden_licenses=None,
     if not silent:
         print("STORING DATA...")
 
-    with folder.open('data.json', 'wb') as fhandle:
-        json.dump({
+    with folder.open('data.json', "w", encoding='utf-8') as fhandle:
+        fhandle.write(six.text_type(json.dumps({
             'node_attributes': node_attributes,
             'node_attributes_conversion': node_attributes_conversion,
             'export_data': export_data,
             'links_uuid': links_uuid,
             'groups_uuid': groups_uuid,
-        }, fhandle, ensure_ascii=False)
+        }, ensure_ascii=False)))
 
     # Add proper signature to unique identifiers & all_fields_info
     # Ignore if a key doesn't exist in any of the two dictionaries
@@ -2371,8 +2371,9 @@ def export_tree(what, folder,allowed_licenses=None, forbidden_licenses=None,
         'unique_identifiers': unique_identifiers,
     }
 
-    with folder.open('metadata.json', 'wb') as fhandle:
-        json.dump(metadata, fhandle, ensure_ascii=False)
+    with folder.open('metadata.json', "w", encoding='utf-8') as fhandle:
+        fhandle.write(six.text_type(json.dumps(
+            metadata, ensure_ascii=False)))
 
     if silent is not True:
         print("STORING FILES...")

--- a/aiida/orm/importexport.py
+++ b/aiida/orm/importexport.py
@@ -2352,14 +2352,14 @@ def export_tree(what, folder,allowed_licenses=None, forbidden_licenses=None,
     if not silent:
         print("STORING DATA...")
 
-    with folder.open('data.json', 'w') as f:
+    with folder.open('data.json', 'w') as fhandle:
         json.dump({
             'node_attributes': node_attributes,
             'node_attributes_conversion': node_attributes_conversion,
             'export_data': export_data,
             'links_uuid': links_uuid,
             'groups_uuid': groups_uuid,
-        }, f)
+        }, fhandle)
 
     # Add proper signature to unique identifiers & all_fields_info
     # Ignore if a key doesn't exist in any of the two dictionaries
@@ -2371,8 +2371,8 @@ def export_tree(what, folder,allowed_licenses=None, forbidden_licenses=None,
         'unique_identifiers': unique_identifiers,
     }
 
-    with folder.open('metadata.json', 'w') as f:
-        json.dump(metadata, f)
+    with folder.open('metadata.json', 'w') as fhandle:
+        json.dump(metadata, fhandle)
 
     if silent is not True:
         print("STORING FILES...")

--- a/aiida/orm/mixins.py
+++ b/aiida/orm/mixins.py
@@ -12,6 +12,7 @@ from __future__ import division
 from __future__ import print_function
 from __future__ import absolute_import
 import inspect
+import io
 from aiida.common.exceptions import ModificationNotAllowed
 from aiida.common.lang import override
 from aiida.common.links import LinkType
@@ -57,7 +58,7 @@ class FunctionCalculationMixin(object):
 
         try:
             source_file_path = inspect.getsourcefile(func)
-            with open(source_file_path) as handle:
+            with io.open(source_file_path, encoding='utf8') as handle:
                 self._set_source_file(handle)
         except (IOError, OSError):
             pass

--- a/aiida/parsers/simpleplugins/arithmetic/add.py
+++ b/aiida/parsers/simpleplugins/arithmetic/add.py
@@ -10,6 +10,8 @@
 from __future__ import division
 from __future__ import print_function
 from __future__ import absolute_import
+import io
+
 from aiida.orm import CalculationFactory
 from aiida.parsers.parser import Parser
 from aiida.orm.data.int import Int
@@ -86,7 +88,7 @@ class ArithmeticAddParser(Parser):
         is_successful = True
 
         try:
-            with open(filepath, 'r') as handle:
+            with io.open(filepath, 'r', encoding='utf8') as handle:
                 output = handle.read()
         except IOError:
             return False, None

--- a/aiida/parsers/simpleplugins/templatereplacer/doubler.py
+++ b/aiida/parsers/simpleplugins/templatereplacer/doubler.py
@@ -10,6 +10,8 @@
 from __future__ import division
 from __future__ import print_function
 from __future__ import absolute_import
+import io
+
 from aiida.orm import CalculationFactory
 from aiida.parsers.parser import Parser
 from aiida.orm.data.parameter import ParameterData
@@ -84,7 +86,7 @@ class TemplatereplacerDoublerParser(Parser):
                         .format(retrieved_file, retrieved_temporary_folder))
                     return False, ()
 
-                with open(file_path, 'r') as handle:
+                with io.open(file_path, 'r', encoding='utf8') as handle:
                     parsed_value = handle.read().strip()
 
                 # We always strip the content of the file from whitespace to simplify testing for expected output

--- a/aiida/plugins/utils.py
+++ b/aiida/plugins/utils.py
@@ -15,12 +15,11 @@ utilities for:
 * pickling to the registry cache folder
 """
 from __future__ import absolute_import
-import io
-
-
 from __future__ import division
 from __future__ import print_function
 from __future__ import absolute_import
+import io
+
 def registry_cache_folder_name():
     """
     return the name of the subfolder of aiida_dir where registry caches are stored.

--- a/aiida/plugins/utils.py
+++ b/aiida/plugins/utils.py
@@ -14,6 +14,8 @@ utilities for:
 * downloading json files
 * pickling to the registry cache folder
 """
+from __future__ import absolute_import
+import io
 
 
 from __future__ import division
@@ -65,7 +67,7 @@ def pickle_to_registry_cache_folder(obj, fname):
     safe_create_registry_cache_folder()
     cache_dir = registry_cache_folder_path()
     fpath = osp.join(cache_dir, fname)
-    with open(fpath, 'w') as cache_file:
+    with io.open(fpath, 'w', encoding='utf8') as cache_file:
         pdump(obj, cache_file)
 
 
@@ -77,7 +79,7 @@ def unpickle_from_registry_cache_folder(fname):
     from os import path as osp
     cache_dir = registry_cache_folder_path()
     fpath = osp.join(cache_dir, fname)
-    with open(fpath, 'r') as cache:
+    with io.open(fpath, 'r', encoding='utf8') as cache:
         return pload(cache)
 
 

--- a/aiida/scheduler/datastructures.py
+++ b/aiida/scheduler/datastructures.py
@@ -587,7 +587,7 @@ class JobInfo(DefaultFieldsAttributeDict):
         Serialise the current data
         :return: A serialised representation of the current data
         """
-        import json
+        import aiida.utils.json as json
 
         ser_data = {k: self.serialize_field(v, self._special_serializers.get(k, None)) for k, v in self.items()}
 
@@ -599,7 +599,7 @@ class JobInfo(DefaultFieldsAttributeDict):
         :param data: The data to load from
         :return: The value after loading
         """
-        import json
+        import aiida.utils.json as json
 
         deser_data = json.loads(data)
 

--- a/aiida/tools/dbexporters/tcod.py
+++ b/aiida/tools/dbexporters/tcod.py
@@ -580,7 +580,7 @@ def _collect_files(base, path=''):
         files = []
         files.append(get_dict(name=path, full_path=os.path.join(base, path)))
 
-        import json
+        import aiida.utils.json as json
         with open(os.path.join(base,path)) as f:
             calcinfo = json.load(f)
         if 'local_copy_list' in calcinfo:
@@ -678,8 +678,10 @@ def _collect_tags(node, calc,parameters=None,
     and prepare it to be saved in TCOD CIF.
     """
     from aiida.common.links import LinkType
-    import os, json
+    import os 
     import aiida
+    import aiida.utils.json as json
+
     tags = { '_audit_creation_method': "AiiDA version {}".format(aiida.__version__) }
 
     # Recording the dictionaries (if any)
@@ -738,10 +740,10 @@ def _collect_tags(node, calc,parameters=None,
     # Creating importable AiiDA database dump in CIF tags
 
     if dump_aiida_database and node.is_stored:
-        import json
         from aiida.common.exceptions import LicensingException
         from aiida.common.folders import SandboxFolder
         from aiida.orm.importexport import export_tree
+        import aiida.utils.json as json
 
         with SandboxFolder() as folder:
             try:

--- a/aiida/tools/dbimporters/plugins/mpds.py
+++ b/aiida/tools/dbimporters/plugins/mpds.py
@@ -13,14 +13,13 @@ from __future__ import print_function
 from __future__ import absolute_import
 import copy
 import enum
-import json
 import os
 
 from six.moves import range
 import requests
 
 from aiida.tools.dbimporters.baseclasses import CifEntry, DbEntry, DbImporter, DbSearchResults
-
+import aiida.utils.json as json
 
 
 class ApiFormat(enum.Enum):

--- a/aiida/transport/plugins/ssh.py
+++ b/aiida/transport/plugins/ssh.py
@@ -11,6 +11,7 @@ from __future__ import division
 from __future__ import print_function
 from __future__ import absolute_import
 from stat import S_ISDIR, S_ISREG
+import io
 import os
 import click
 import glob
@@ -38,7 +39,7 @@ def parse_sshconfig(computername):
     import paramiko
     config = paramiko.SSHConfig()
     try:
-        config.parse(open(os.path.expanduser('~/.ssh/config')))
+        config.parse(io.open(os.path.expanduser('~/.ssh/config'), encoding='utf8'))
     except IOError:
         # No file found, so empty configuration
         pass

--- a/aiida/transport/plugins/test_all_plugins.py
+++ b/aiida/transport/plugins/test_all_plugins.py
@@ -22,6 +22,7 @@ Plugin specific tests will be written in the plugin itself.
 from __future__ import division
 from __future__ import absolute_import
 from __future__ import print_function
+import io
 import unittest
 
 from six.moves import range
@@ -219,7 +220,7 @@ class TestDirectoryManipulation(unittest.TestCase):
             # create file
             local_file_name = 'file.txt'
             text = 'Viva Verdi\n'
-            with open(os.path.join(t.getcwd(), local_file_name), 'w') as f:
+            with io.open(os.path.join(t.getcwd(), local_file_name), 'w', encoding='utf8') as f:
                 f.write(text)
             # remove it
             t.rmtree(local_file_name)
@@ -582,7 +583,7 @@ class TestPutGetFile(unittest.TestCase):
             retrieved_file_name = os.path.join(local_dir, directory, 'file_retrieved.txt')
 
             text = 'Viva Verdi\n'
-            with open(local_file_name, 'w') as f:
+            with io.open(local_file_name, 'w', encoding='utf8') as f:
                 f.write(text)
 
             # here use full path in src and dst
@@ -632,7 +633,7 @@ class TestPutGetFile(unittest.TestCase):
             remote_file_name = 'file_remote.txt'
             retrieved_file_name = os.path.join(local_dir, directory, 'file_retrieved.txt')
 
-            f = open(local_file_name, 'w')
+            f = io.open(local_file_name, 'w', encoding='utf8')
             f.close()
 
             # partial_file_name is not an abs path
@@ -696,7 +697,7 @@ class TestPutGetFile(unittest.TestCase):
             retrieved_file_name = os.path.join(local_dir, directory, 'file_retrieved.txt')
 
             text = 'Viva Verdi\n'
-            with open(local_file_name, 'w') as f:
+            with io.open(local_file_name, 'w', encoding='utf8') as f:
                 f.write(text)
 
             # localpath is an empty string
@@ -783,8 +784,8 @@ class TestPutGetTree(unittest.TestCase):
 
             local_file_name = os.path.join(local_subfolder, 'file.txt')
 
-            text = 'Viva Verdi\n'
-            with open(local_file_name, 'w') as f:
+            text = u'Viva Verdi\n'
+            with io.open(local_file_name, 'w', encoding='utf8') as f:
                 f.write(text)
 
             # here use full path in src and dst
@@ -849,7 +850,7 @@ class TestPutGetTree(unittest.TestCase):
             local_file_name = os.path.join(local_subfolder, 'file.txt')
 
             text = 'Viva Verdi\n'
-            with open(local_file_name, 'w') as f:
+            with io.open(local_file_name, 'w', encoding='utf8') as f:
                 f.write(text)
 
             t.put(local_subfolder, remote_subfolder)
@@ -905,7 +906,7 @@ class TestPutGetTree(unittest.TestCase):
             file_3 = os.path.join(local_base_dir, 'c.txt')
             text = 'Viva Verdi\n'
             for filename in [file_1, file_2, file_3]:
-                with open(filename, 'w') as f:
+                with io.open(filename, 'w', encoding='utf8') as f:
                     f.write(text)
 
             # first test the copy. Copy of two files matching patterns, into a folder
@@ -978,7 +979,7 @@ class TestPutGetTree(unittest.TestCase):
             file_3 = os.path.join(local_base_dir, 'c.txt')
             text = 'Viva Verdi\n'
             for filename in [file_1, file_2, file_3]:
-                with open(filename, 'w') as f:
+                with io.open(filename, 'w', encoding='utf8') as f:
                     f.write(text)
 
             # first test put. Copy of two files matching patterns, into a folder
@@ -1007,7 +1008,7 @@ class TestPutGetTree(unittest.TestCase):
             with self.assertRaises(OSError):
                 t.put(os.path.join(local_base_dir, '*.txt'), 'prova')
             # copy of folder into file
-            with open(os.path.join(local_dir, directory, 'existing.txt'), 'w') as f:
+            with io.open(os.path.join(local_dir, directory, 'existing.txt'), 'w', encoding='utf8') as f:
                 f.write(text)
             with self.assertRaises(OSError):
                 t.put(os.path.join(local_base_dir), 'existing.txt')
@@ -1058,7 +1059,7 @@ class TestPutGetTree(unittest.TestCase):
             file_3 = os.path.join(local_base_dir, 'c.txt')
             text = 'Viva Verdi\n'
             for filename in [file_1, file_2, file_3]:
-                with open(filename, 'w') as f:
+                with io.open(filename, 'w', encoding='utf8') as f:
                     f.write(text)
 
             # first test put. Copy of two files matching patterns, into a folder
@@ -1089,7 +1090,7 @@ class TestPutGetTree(unittest.TestCase):
             with self.assertRaises(OSError):
                 t.get(os.path.join('local', '*.txt'), os.path.join(local_destination, 'prova'))
             # copy of folder into file
-            with open(os.path.join(local_destination, 'existing.txt'), 'w') as f:
+            with io.open(os.path.join(local_destination, 'existing.txt'), 'w', encoding='utf8') as f:
                 f.write(text)
             with self.assertRaises(OSError):
                 t.get('local', os.path.join(local_destination, 'existing.txt'))
@@ -1138,7 +1139,7 @@ class TestPutGetTree(unittest.TestCase):
             t.chdir(directory)
             local_file_name = os.path.join(local_subfolder, 'file.txt')
 
-            f = open(local_file_name, 'w')
+            f = io.open(local_file_name, 'w', encoding='utf8')
             f.close()
 
             # 'tmp1' is not an abs path
@@ -1213,8 +1214,8 @@ class TestPutGetTree(unittest.TestCase):
             t.chdir(directory)
             local_file_name = os.path.join(local_subfolder, 'file.txt')
 
-            text = 'Viva Verdi\n'
-            with open(local_file_name, 'w') as f:
+            text = u'Viva Verdi\n'
+            with io.open(local_file_name, 'w', encoding='utf8') as f:
                 f.write(text)
 
             # localpath is an empty string

--- a/aiida/transport/plugins/test_all_plugins.py
+++ b/aiida/transport/plugins/test_all_plugins.py
@@ -47,7 +47,7 @@ def get_all_custom_transports():
     thisdir, thisfname = os.path.split(this_full_fname)
 
     test_modules = [
-        os.path.split(f)[1][:-3] for f in os.listdir(thisdir) if f.endswith('.py') and f.startswith('test_')
+        os.path.split(fname)[1][:-3] for fname in os.listdir(thisdir) if fname.endswith('.py') and fname.startswith('test_')
     ]
 
     # Remove this module: note that I should be careful because __file__, from
@@ -219,9 +219,9 @@ class TestDirectoryManipulation(unittest.TestCase):
             # also tests that it works with a single file
             # create file
             local_file_name = 'file.txt'
-            text = 'Viva Verdi\n'
-            with io.open(os.path.join(t.getcwd(), local_file_name), 'w', encoding='utf8') as f:
-                f.write(text)
+            text = u'Viva Verdi\n'
+            with io.open(os.path.join(t.getcwd(), local_file_name), 'w', encoding='utf8') as fhandle:
+                fhandle.write(text)
             # remove it
             t.rmtree(local_file_name)
             # verify the removal
@@ -241,43 +241,43 @@ class TestDirectoryManipulation(unittest.TestCase):
         import string
         import os
 
-        with custom_transport as t:
+        with custom_transport as trans:
             # We cannot use tempfile.mkdtemp because we're on a remote folder
-            location = t.normalize(os.path.join('/', 'tmp'))
+            location = trans.normalize(os.path.join('/', 'tmp'))
             directory = 'temp_dir_test'
-            t.chdir(location)
+            trans.chdir(location)
 
-            self.assertEquals(location, t.getcwd())
-            while t.isdir(directory):
+            self.assertEquals(location, trans.getcwd())
+            while trans.isdir(directory):
                 # I append a random letter/number until it is unique
                 directory += random.choice(string.ascii_uppercase + string.digits)
-            t.mkdir(directory)
-            t.chdir(directory)
+            trans.mkdir(directory)
+            trans.chdir(directory)
             list_of_dir = ['1', '-f a&', 'as', 'a2', 'a4f']
             list_of_files = ['a', 'b']
             for this_dir in list_of_dir:
-                t.mkdir(this_dir)
+                trans.mkdir(this_dir)
             for fname in list_of_files:
-                with tempfile.NamedTemporaryFile() as f:
+                with tempfile.NamedTemporaryFile() as tmpf:
                     # Just put an empty file there at the right file name
-                    t.putfile(f.name, fname)
+                    trans.putfile(tmpf.name, fname)
 
-            list_found = t.listdir('.')
+            list_found = trans.listdir('.')
 
             self.assertTrue(sorted(list_found) == sorted(list_of_dir + list_of_files))
 
-            self.assertTrue(sorted(t.listdir('.', 'a*')), sorted(['as', 'a2', 'a4f']))
-            self.assertTrue(sorted(t.listdir('.', 'a?')), sorted(['as', 'a2']))
-            self.assertTrue(sorted(t.listdir('.', 'a[2-4]*')), sorted(['a2', 'a4f']))
+            self.assertTrue(sorted(trans.listdir('.', 'a*')), sorted(['as', 'a2', 'a4f']))
+            self.assertTrue(sorted(trans.listdir('.', 'a?')), sorted(['as', 'a2']))
+            self.assertTrue(sorted(trans.listdir('.', 'a[2-4]*')), sorted(['a2', 'a4f']))
 
             for this_dir in list_of_dir:
-                t.rmdir(this_dir)
+                trans.rmdir(this_dir)
 
             for this_file in list_of_files:
-                t.remove(this_file)
+                trans.remove(this_file)
 
-            t.chdir('..')
-            t.rmdir(directory)
+            trans.chdir('..')
+            trans.rmdir(directory)
 
     @run_for_all_plugins
     def test_listdir_withattributes(self, custom_transport):
@@ -300,50 +300,50 @@ class TestDirectoryManipulation(unittest.TestCase):
             """
             return {_['name']: _['isdir'] for _ in data}
 
-        with custom_transport as t:
+        with custom_transport as trans:
             # We cannot use tempfile.mkdtemp because we're on a remote folder
-            location = t.normalize(os.path.join('/', 'tmp'))
+            location = trans.normalize(os.path.join('/', 'tmp'))
             directory = 'temp_dir_test'
-            t.chdir(location)
+            trans.chdir(location)
 
-            self.assertEquals(location, t.getcwd())
-            while t.isdir(directory):
+            self.assertEquals(location, trans.getcwd())
+            while trans.isdir(directory):
                 # I append a random letter/number until it is unique
                 directory += random.choice(string.ascii_uppercase + string.digits)
-            t.mkdir(directory)
-            t.chdir(directory)
+            trans.mkdir(directory)
+            trans.chdir(directory)
             list_of_dir = ['1', '-f a&', 'as', 'a2', 'a4f']
             list_of_files = ['a', 'b']
             for this_dir in list_of_dir:
-                t.mkdir(this_dir)
+                trans.mkdir(this_dir)
             for fname in list_of_files:
-                with tempfile.NamedTemporaryFile() as f:
+                with tempfile.NamedTemporaryFile() as tmpf:
                     # Just put an empty file there at the right file name
-                    t.putfile(f.name, fname)
+                    trans.putfile(tmpf.name, fname)
 
             comparison_list = {k: True for k in list_of_dir}
             for k in list_of_files:
                 comparison_list[k] = False
-            self.assertTrue(simplify_attributes(t.listdir_withattributes('.')), comparison_list)
+            self.assertTrue(simplify_attributes(trans.listdir_withattributes('.')), comparison_list)
 
             self.assertTrue(
-                simplify_attributes(t.listdir_withattributes('.', 'a*')), {
+                simplify_attributes(trans.listdir_withattributes('.', 'a*')), {
                     'as': True,
                     'a2': True,
                     'a4f': True,
                     'a': False
                 })
-            self.assertTrue(simplify_attributes(t.listdir_withattributes('.', 'a?')), {'as': True, 'a2': True})
-            self.assertTrue(simplify_attributes(t.listdir_withattributes('.', 'a[2-4]*')), {'a2': True, 'a4f': True})
+            self.assertTrue(simplify_attributes(trans.listdir_withattributes('.', 'a?')), {'as': True, 'a2': True})
+            self.assertTrue(simplify_attributes(trans.listdir_withattributes('.', 'a[2-4]*')), {'a2': True, 'a4f': True})
 
             for this_dir in list_of_dir:
-                t.rmdir(this_dir)
+                trans.rmdir(this_dir)
 
             for this_file in list_of_files:
-                t.remove(this_file)
+                trans.remove(this_file)
 
-            t.chdir('..')
-            t.rmdir(directory)
+            trans.chdir('..')
+            trans.rmdir(directory)
 
     @run_for_all_plugins
     def test_dir_creation_deletion(self, custom_transport):
@@ -582,9 +582,9 @@ class TestPutGetFile(unittest.TestCase):
             remote_file_name = 'file_remote.txt'
             retrieved_file_name = os.path.join(local_dir, directory, 'file_retrieved.txt')
 
-            text = 'Viva Verdi\n'
-            with io.open(local_file_name, 'w', encoding='utf8') as f:
-                f.write(text)
+            text = u'Viva Verdi\n'
+            with io.open(local_file_name, 'w', encoding='utf8') as fhandle:
+                fhandle.write(text)
 
             # here use full path in src and dst
             t.put(local_file_name, remote_file_name)
@@ -633,8 +633,8 @@ class TestPutGetFile(unittest.TestCase):
             remote_file_name = 'file_remote.txt'
             retrieved_file_name = os.path.join(local_dir, directory, 'file_retrieved.txt')
 
-            f = io.open(local_file_name, 'w', encoding='utf8')
-            f.close()
+            fhandle = io.open(local_file_name, 'w', encoding='utf8')
+            fhandle.close()
 
             # partial_file_name is not an abs path
             with self.assertRaises(ValueError):
@@ -696,9 +696,9 @@ class TestPutGetFile(unittest.TestCase):
             remote_file_name = 'file_remote.txt'
             retrieved_file_name = os.path.join(local_dir, directory, 'file_retrieved.txt')
 
-            text = 'Viva Verdi\n'
-            with io.open(local_file_name, 'w', encoding='utf8') as f:
-                f.write(text)
+            text = u'Viva Verdi\n'
+            with io.open(local_file_name, 'w', encoding='utf8') as fhandle:
+                fhandle.write(text)
 
             # localpath is an empty string
             # ValueError because it is not an abs path
@@ -785,8 +785,8 @@ class TestPutGetTree(unittest.TestCase):
             local_file_name = os.path.join(local_subfolder, 'file.txt')
 
             text = u'Viva Verdi\n'
-            with io.open(local_file_name, 'w', encoding='utf8') as f:
-                f.write(text)
+            with io.open(local_file_name, 'w', encoding='utf8') as fhandle:
+                fhandle.write(text)
 
             # here use full path in src and dst
             for i in range(2):
@@ -849,9 +849,9 @@ class TestPutGetTree(unittest.TestCase):
 
             local_file_name = os.path.join(local_subfolder, 'file.txt')
 
-            text = 'Viva Verdi\n'
-            with io.open(local_file_name, 'w', encoding='utf8') as f:
-                f.write(text)
+            text = u'Viva Verdi\n'
+            with io.open(local_file_name, 'w', encoding='utf8') as fhandle:
+                fhandle.write(text)
 
             t.put(local_subfolder, remote_subfolder)
             t.get(remote_subfolder, retrieved_subfolder)
@@ -904,10 +904,10 @@ class TestPutGetTree(unittest.TestCase):
             file_1 = os.path.join(local_base_dir, 'a.txt')
             file_2 = os.path.join(local_base_dir, 'b.tmp')
             file_3 = os.path.join(local_base_dir, 'c.txt')
-            text = 'Viva Verdi\n'
+            text = u'Viva Verdi\n'
             for filename in [file_1, file_2, file_3]:
-                with io.open(filename, 'w', encoding='utf8') as f:
-                    f.write(text)
+                with io.open(filename, 'w', encoding='utf8') as fhandle:
+                    fhandle.write(text)
 
             # first test the copy. Copy of two files matching patterns, into a folder
             t.copy(os.path.join('local', '*.txt'), '.')
@@ -977,10 +977,10 @@ class TestPutGetTree(unittest.TestCase):
             file_1 = os.path.join(local_base_dir, 'a.txt')
             file_2 = os.path.join(local_base_dir, 'b.tmp')
             file_3 = os.path.join(local_base_dir, 'c.txt')
-            text = 'Viva Verdi\n'
+            text = u'Viva Verdi\n'
             for filename in [file_1, file_2, file_3]:
-                with io.open(filename, 'w', encoding='utf8') as f:
-                    f.write(text)
+                with io.open(filename, 'w', encoding='utf8') as fhandle:
+                    fhandle.write(text)
 
             # first test put. Copy of two files matching patterns, into a folder
             t.put(os.path.join(local_base_dir, '*.txt'), '.')
@@ -1008,8 +1008,8 @@ class TestPutGetTree(unittest.TestCase):
             with self.assertRaises(OSError):
                 t.put(os.path.join(local_base_dir, '*.txt'), 'prova')
             # copy of folder into file
-            with io.open(os.path.join(local_dir, directory, 'existing.txt'), 'w', encoding='utf8') as f:
-                f.write(text)
+            with io.open(os.path.join(local_dir, directory, 'existing.txt'), 'w', encoding='utf8') as fhandle:
+                fhandle.write(text)
             with self.assertRaises(OSError):
                 t.put(os.path.join(local_base_dir), 'existing.txt')
             t.remove('existing.txt')
@@ -1057,10 +1057,10 @@ class TestPutGetTree(unittest.TestCase):
             file_1 = os.path.join(local_base_dir, 'a.txt')
             file_2 = os.path.join(local_base_dir, 'b.tmp')
             file_3 = os.path.join(local_base_dir, 'c.txt')
-            text = 'Viva Verdi\n'
+            text = u'Viva Verdi\n'
             for filename in [file_1, file_2, file_3]:
-                with io.open(filename, 'w', encoding='utf8') as f:
-                    f.write(text)
+                with io.open(filename, 'w', encoding='utf8') as fhandle:
+                    fhandle.write(text)
 
             # first test put. Copy of two files matching patterns, into a folder
             t.get(os.path.join('local', '*.txt'), local_destination)
@@ -1090,8 +1090,8 @@ class TestPutGetTree(unittest.TestCase):
             with self.assertRaises(OSError):
                 t.get(os.path.join('local', '*.txt'), os.path.join(local_destination, 'prova'))
             # copy of folder into file
-            with io.open(os.path.join(local_destination, 'existing.txt'), 'w', encoding='utf8') as f:
-                f.write(text)
+            with io.open(os.path.join(local_destination, 'existing.txt'), 'w', encoding='utf8') as fhandle:
+                fhandle.write(text)
             with self.assertRaises(OSError):
                 t.get('local', os.path.join(local_destination, 'existing.txt'))
             os.remove(os.path.join(local_destination, 'existing.txt'))
@@ -1139,8 +1139,8 @@ class TestPutGetTree(unittest.TestCase):
             t.chdir(directory)
             local_file_name = os.path.join(local_subfolder, 'file.txt')
 
-            f = io.open(local_file_name, 'w', encoding='utf8')
-            f.close()
+            fhandle = io.open(local_file_name, 'w', encoding='utf8')
+            fhandle.close()
 
             # 'tmp1' is not an abs path
             with self.assertRaises(ValueError):
@@ -1215,8 +1215,8 @@ class TestPutGetTree(unittest.TestCase):
             local_file_name = os.path.join(local_subfolder, 'file.txt')
 
             text = u'Viva Verdi\n'
-            with io.open(local_file_name, 'w', encoding='utf8') as f:
-                f.write(text)
+            with io.open(local_file_name, 'w', encoding='utf8') as fhandle:
+                fhandle.write(text)
 
             # localpath is an empty string
             # ValueError because it is not an abs path

--- a/aiida/utils/json.py
+++ b/aiida/utils/json.py
@@ -38,7 +38,7 @@ def dumps(data, **kwargs):
     as this improves the readability of the json and reduces the file size.
     When writing to file, use io.open(filename, 'w', encoding='utf8')
     """
-    simplejson.dumps(data, ensure_ascii=False, encoding='utf8', **kwargs)
+    return simplejson.dumps(data, ensure_ascii=False, encoding='utf8', **kwargs)
 
 
 def load(fhandle, **kwargs):

--- a/aiida/utils/json.py
+++ b/aiida/utils/json.py
@@ -9,6 +9,9 @@
 ###########################################################################
 """
 Abstracts JSON usage to ensure compatibility with Python2 and Python3.
+
+Use this module prefentially over standard json to ensure compatibility.
+Also note the conventions for using io.open for dump and dumps.
 """
 from __future__ import absolute_import
 import simplejson
@@ -33,7 +36,7 @@ def dumps(data, **kwargs):
     """
     Write JSON encoded 'data' to a string.
     simplejson is useful here as it always returns unicode if ensure_ascii=False is used,
-    unlike the standard library json.
+    unlike the standard library json, rather than being dependant on the input.
     We use also ensure_ascii=False to write unicode characters specifically
     as this improves the readability of the json and reduces the file size.
     When writing to file, use io.open(filename, 'w', encoding='utf8')

--- a/aiida/utils/json.py
+++ b/aiida/utils/json.py
@@ -1,0 +1,57 @@
+# -*- coding: utf-8 -*-
+###########################################################################
+# Copyright (c), The AiiDA team. All rights reserved.                     #
+# This file is part of the AiiDA code.                                    #
+#                                                                         #
+# The code is hosted on GitHub at https://github.com/aiidateam/aiida_core #
+# For further information on the license, see the LICENSE.txt file        #
+# For further information please visit http://www.aiida.net               #
+###########################################################################
+"""
+Abstracts JSON usage to ensure compatibility with Python2 and Python3.
+"""
+from __future__ import absolute_import
+import simplejson
+
+
+def dump(data, fhandle, **kwargs):
+    """
+    Write JSON encoded 'data' to a file-like object, fhandle
+    In Py2/3, use io.open(filename, 'wb') to write.
+    The utf8write object is used to ensure that the resulting serialised data is
+    encoding as UTF8.
+    Any strings with non-ASCII characters need to be unicode strings.
+    We use ensure_ascii=False to write unicode characters specifically
+    as this improves the readability of the json and reduces the file size.
+    """
+    import codecs
+    utf8writer = codecs.getwriter('utf8')
+    simplejson.dump(data, utf8writer(fhandle), ensure_ascii=False, encoding='utf8', **kwargs)
+
+
+def dumps(data, **kwargs):
+    """
+    Write JSON encoded 'data' to a string.
+    simplejson is useful here as it always returns unicode if ensure_ascii=False is used,
+    unlike the standard library json.
+    We use also ensure_ascii=False to write unicode characters specifically
+    as this improves the readability of the json and reduces the file size.
+    When writing to file, use io.open(filename, 'w', encoding='utf8')
+    """
+    simplejson.dumps(data, ensure_ascii=False, encoding='utf8', **kwargs)
+
+
+def load(fhandle, **kwargs):
+    """
+    Deserialise a JSON file.
+    For Py2/Py3 compatibility, io.open(filename, 'r' encoding='utf8')
+    should be used.
+    """
+    return simplejson.load(fhandle, encoding='utf8', **kwargs)
+
+
+def loads(json_string, **kwargs):
+    """
+    Deserialise a JSON string.
+    """
+    return simplejson.loads(json_string, encoding='utf8', **kwargs)

--- a/docs/requirements_for_rtd.txt
+++ b/docs/requirements_for_rtd.txt
@@ -60,6 +60,7 @@ pytz==2018.4
 qe-tools==1.1.0
 reentry==1.2.1
 seekpath==1.8.1
+simplejson==3.16.0
 singledispatch>=3.4.0.3; python_version<"3.5"
 six==1.11.0
 spglib==1.10.3.65

--- a/setup_requirements.py
+++ b/setup_requirements.py
@@ -54,6 +54,7 @@ install_requires = [
     'pathlib2; python_version<"3.5"',
     'singledispatch>=3.4.0.3; python_version<"3.5"',
     'enum34==1.1.6; python_version<"3.5"',
+    'simplejson==3.16.0'
 ]
 
 extras_require = {


### PR DESCRIPTION
Fixes #2047 and fixes #2142  

- Changes the folders.Folder.open function to use io.open and checks to see if the file should be opened in binary mode or formatted mode. Enforces UTF-8 by default.
- Replaces system "open" with "io.open" everywhere in the codebasem, except where sys open is preferable (e.g. HiddenFiles()). Explicitly sets the encoding as UTF-8, or as None for binary files.   
- Sets a number of testing strings as unicode strings explicitly.
- Changes how writing JSON  to zip files is done in Import/Export to handle uniicode.
- In some cases, change cStringIO to StringIO to ensure that unicode can bed used.  

