### PR TITLE
Fix several issues with the hashing method

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -186,7 +186,6 @@
         aiida/common/extendeddicts.py|
         aiida/common/folders.py|
         aiida/common/graph.py|
-        aiida/common/hashing.py|
         aiida/common/__init__.py|
         aiida/common/ipython/__init__.py|
         aiida/common/ipython/ipython_magics.py|

--- a/aiida/common/hashing.py
+++ b/aiida/common/hashing.py
@@ -49,9 +49,9 @@ UNUSABLE_PASSWORD_SUFFIX_LENGTH = 40
 
 HASHING_KEY = "HashingKey"
 
-pwd_context = CryptContext(
+pwd_context = CryptContext(  # pylint: disable=invalid-name
     # The list of hashes that we support
-    schemes=["pbkdf2_sha256", "des_crypt"],
+    schemes=["argon2", "pbkdf2_sha256", "des_crypt"],
     # The default hashing mechanism
     default="pbkdf2_sha256",
 

--- a/aiida/common/hashing.py
+++ b/aiida/common/hashing.py
@@ -16,27 +16,26 @@ import numbers
 import random
 import time
 import uuid
+import codecs
 from datetime import datetime
 
 import six
 from six.moves import range
 from passlib.context import CryptContext
 
-try: # Python3
+try:  # Python3
     from functools import singledispatch
     from collections import abc
-except ImportError: # Python2
+except ImportError:  # Python2
     from singledispatch import singledispatch
     import collections as abc
 
 import numpy as np
 
 from .folders import Folder
-
 """
 Here we define a single password hashing instance for the full AiiDA.
 """
-
 
 # The prefix of the hashed using pbkdf2_sha256 algorithm in Django
 HASHING_PREFIX_DJANGO = "pbkdf2_sha256"
@@ -48,7 +47,7 @@ UNUSABLE_PASSWORD_PREFIX = '!'
 # Number of random chars to add after UNUSABLE_PASSWORD_PREFIX
 UNUSABLE_PASSWORD_SUFFIX_LENGTH = 40
 
-HASHING_KEY="HashingKey"
+HASHING_KEY = "HashingKey"
 
 pwd_context = CryptContext(
     # The list of hashes that we support
@@ -58,12 +57,11 @@ pwd_context = CryptContext(
 
     # We set the number of rounds that should be used...
     pbkdf2_sha256__default_rounds=8000,
-    )
+)
 
 
 def create_unusable_pass():
-    return UNUSABLE_PASSWORD_PREFIX + get_random_string(
-        UNUSABLE_PASSWORD_SUFFIX_LENGTH)
+    return UNUSABLE_PASSWORD_PREFIX + get_random_string(UNUSABLE_PASSWORD_SUFFIX_LENGTH)
 
 
 def is_password_usable(enc_pass):
@@ -75,12 +73,12 @@ def is_password_usable(enc_pass):
 
     # Backward compatibility for old Django hashing
     if enc_pass.startswith(HASHING_PREFIX_DJANGO):
-        enc_pass = enc_pass.replace(HASHING_PREFIX_DJANGO,
-                                    HASHING_PREFIX_PBKDF2_SHA256, 1)
+        enc_pass = enc_pass.replace(HASHING_PREFIX_DJANGO, HASHING_PREFIX_PBKDF2_SHA256, 1)
         if pwd_context.identify(enc_pass) is not None:
             return True
 
     return False
+
 
 ###################################################################
 # THE FOLLOWING WAS TAKEN FROM DJANGO BUT IT CAN BE EASILY REPLACED
@@ -97,9 +95,7 @@ except NotImplementedError:
     using_sysrandom = False
 
 
-def get_random_string(length=12,
-                      allowed_chars='abcdefghijklmnopqrstuvwxyz'
-                                    'ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789'):
+def get_random_string(length=12, allowed_chars='abcdefghijklmnopqrstuvwxyz' 'ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789'):
     """
     Returns a securely generated random string.
 
@@ -113,31 +109,10 @@ def get_random_string(length=12,
         # time a random string is required. This may change the
         # properties of the chosen random sequence slightly, but this
         # is better than absolute predictability.
-        random.seed(
-            hashlib.sha256(
-                ("%s%s%s" % (
-                    random.getstate(),
-                    time.time(),
-                    HASHING_KEY)).encode('utf-8')
-            ).digest())
+        random.seed(hashlib.sha256(("%s%s%s" % (random.getstate(), time.time(), HASHING_KEY)).encode('utf-8')).digest())
     return ''.join(random.choice(allowed_chars) for i in range(length))
 
 
-def make_hash_with_type(type_chr, string_to_hash):
-    """
-    get a hash digest for a given enumerated type and its content
-
-    :param type_chr: a single char, lower case for simple datatypes, upper case for composite datatypes
-    :param string_to_hash: an encoded string (a `str` in Python 2, latin1-encoded `bytes` in Python 3)
-
-    We don't check anything for speed efficiency.
-
-    The `latin1` here is not an error. Since this was introduced in Python 2 and no proper care was
-    taken to properly encode/decode strings, the default was used, which was `latin1` at that time.
-    """
-    return hashlib.sha224(type_chr.encode('latin1') + string_to_hash).hexdigest()
-
-@singledispatch
 def make_hash(object_to_hash, **kwargs):
     """
     Makes a hash from a dictionary, list, tuple or set to any level, that contains
@@ -206,91 +181,127 @@ def make_hash(object_to_hash, **kwargs):
     the string of dictionary do not suffice if we want to check for equality
     of dictionaries using hashes.
     """
-    raise ValueError("Value of type {} cannot be hashed".format(
-        type(object_to_hash))
-    )
+    int_hash = _make_int_hash(object_to_hash, **kwargs)
+    return u'{:052x}'.format(int_hash)
 
-@make_hash.register(abc.Sequence)
+
+# int hashes with size 28 bytes
+INT_HASH_MASK = 2**(8 * 28) - 1
+
+
+@singledispatch
+def _make_int_hash(object_to_hash, **kwargs):
+    raise ValueError("Value of type {} cannot be hashed".format(type(object_to_hash)))
+
+
+def _combine_hash_list(hashes):
+    if not hashes:
+        return 0
+    res = hashes[0]
+    for val in hashes[1:]:
+        res = _hash_combine(res, val)
+    return res
+
+
+# def _make_int_hash_with_type(type_bytes, bytes_to_hash):
+#     """
+#     get a hash digest for a given enumerated type and its content
+#
+#     :param type_chr: a single char, lower case for simple datatypes, upper case for composite datatypes
+#     :param string_to_hash: an encoded string (a `str` in Python 2, latin1-encoded `bytes` in Python 3)
+#
+#     We don't check anything for speed efficiency.
+#
+#     The `latin1` here is not an error. Since this was introduced in Python 2 and no proper care was
+#     taken to properly encode/decode strings, the default was used, which was `latin1` at that time.
+#     """
+#     return _hash_combine(hashlib.sha)
+#     return hashlib.sha224(type_chr.encode('latin1') + string_to_hash).hexdigest()
+
+
+def _add_type_salt(type_bytes):
+    assert isinstance(type_bytes, six.binary_type)
+    salt_hash = int(codecs.encode(hashlib.sha224(type_bytes).digest(), 'hex'), 16)
+
+    def decorator(func):
+
+        def inner(object_to_hash, **kwargs):
+            return _hash_combine(salt_hash, func(object_to_hash, **kwargs))
+
+        return inner
+
+    return decorator
+
+
+def _hash_combine(hash1, hash2):
+    """
+    Combine two hashes, using the approach of boost::hash_combine.
+    """
+    return (hash1 ^ (hash2 + 0x9e3779b9 + (hash1 << 6) + (hash1 >> 2))) & INT_HASH_MASK
+
+
+@_make_int_hash.register(abc.Sequence)
+@_add_type_salt(b'L')
 def _(sequence, **kwargs):
-    hashes = tuple([
-        make_hash(x, **kwargs) for x in sequence
-    ])
-    return make_hash_with_type('L', ",".join(hashes).encode('latin1'))
+    return _combine_hash_list([_make_int_hash(x, **kwargs) for x in sequence])
 
-@make_hash.register(abc.Set)
+
+@_make_int_hash.register(abc.Set)
+@_add_type_salt(b'S')
 def _(object_to_hash, **kwargs):
-    hashes = tuple([
-            make_hash(x, **kwargs)
-            for x
-            in sorted(object_to_hash)
-        ])
-    return make_hash_with_type('S', ",".join(hashes).encode('latin1'))
+    hashes = sorted(_make_int_hash(x, **kwargs) for x in object_to_hash)
+    return _combine_hash_list(hashes)
 
-@make_hash.register(abc.Mapping)
+
+@_make_int_hash.register(abc.Mapping)
+@_add_type_salt(b'D')
 def _(mapping, **kwargs):
-    hashed_dictionary = {
-        k: make_hash(v, **kwargs)
-        for k,v
-        in mapping.items()
-    }
-    return make_hash_with_type(
-        'D',
-        make_hash(sorted(hashed_dictionary.items()), **kwargs).encode('latin1')
-    )
+    hashed_items = sorted(_make_int_hash(item, **kwargs) for item in mapping.items())
+    return _combine_hash_list(hashed_items)
 
-@make_hash.register(numbers.Real)
-def _(object_to_hash, **kwargs):
-    return make_hash_with_type(
-            'f',
-            truncate_float64(object_to_hash).tobytes()
-        )
 
-@make_hash.register(numbers.Complex)
+@_make_int_hash.register(numbers.Real)
+@_add_type_salt(b'f')
 def _(object_to_hash, **kwargs):
-    return make_hash_with_type(
-        'c',
-        ','.join([
-            make_hash(object_to_hash.real, **kwargs),
-            make_hash(object_to_hash.imag, **kwargs)
-        ]).encode('latin1')
-    )
+    return _make_int_hash(truncate_float64(object_to_hash).tobytes(), **kwargs)
 
-@make_hash.register(numbers.Integral)
-def _(object_to_hash, **kwargs):
-    return make_hash_with_type('i', str(object_to_hash).encode('latin1'))
 
-# if the type is unicode in Python 2 or a str in Python 3, convert it
-# to a str in Python 2 and bytes in Python 3 using the default Python 2 encoding.
-# This should emulate what the hashlib has been doing internally: converting
-# unicode strings to latin1 bytes representation before hashing.
-@make_hash.register(six.text_type)
+@_make_int_hash.register(numbers.Complex)
+@_add_type_salt(b'c')
 def _(object_to_hash, **kwargs):
-    return make_hash_with_type('s', object_to_hash.encode('latin1'))
+    return _combine_hash_list(
+        [_make_int_hash(object_to_hash.real, **kwargs),
+         _make_int_hash(object_to_hash.imag, **kwargs)])
+
+
+# If the type is unicode in Python 2 or a str in Python 3, convert it
+# to a str in Python 2 and bytes in Python 3 using the utf-8 encoding.
+@_make_int_hash.register(six.text_type)
+@_add_type_salt(b's')
+def _(object_to_hash, **kwargs):
+    return _make_int_hash(object_to_hash.encode('utf-8'), **kwargs)
+
 
 # for str in Python 2 and bytes in Python 3, simply forward them to
 # the hashing function, without trying to encode them
-@make_hash.register(six.binary_type)
+@_make_int_hash.register(six.binary_type)
 def _(object_to_hash, **kwargs):
-    return make_hash_with_type('s', object_to_hash)
-
-@make_hash.register(bool)
-def _(object_to_hash, **kwargs):
-    return make_hash_with_type('b', str(object_to_hash).encode('latin1'))
-
-@make_hash.register(type(None))
-def _(object_to_hash, **kwargs):
-    return make_hash_with_type('n', str(object_to_hash).encode('latin1'))
-
-@make_hash.register(datetime)
-def _(object_to_hash, **kwargs):
-    return make_hash_with_type('d', str(object_to_hash).encode('latin1'))
-
-@make_hash.register(uuid.UUID)
-def _(object_to_hash, **kwargs):
-    return make_hash_with_type('u', str(object_to_hash).encode('latin1'))
+    return int(codecs.encode(hashlib.sha224(object_to_hash).digest(), 'hex'), 16)
 
 
-@make_hash.register(Folder)
+def _make_int_hash_from_str_repr(object_to_hash):
+    return _make_int_hash(str(object_to_hash).encode('utf-8'))
+
+
+_make_int_hash.register(int)(_add_type_salt(b'i')(_make_int_hash_from_str_repr))
+_make_int_hash.register(bool)(_add_type_salt(b'b')(_make_int_hash_from_str_repr))
+_make_int_hash.register(type(None))(_add_type_salt(b'n')(_make_int_hash_from_str_repr))
+_make_int_hash.register(datetime)(_add_type_salt(b'd')(_make_int_hash_from_str_repr))
+_make_int_hash.register(uuid.UUID)(_add_type_salt(b'u')(_make_int_hash_from_str_repr))
+
+
+@_make_int_hash.register(Folder)
+@_add_type_salt(b'pd')
 def _(folder, **kwargs):
     # make sure file is closed after being read
     def _read_file(folder, name):
@@ -299,39 +310,27 @@ def _(folder, **kwargs):
 
     ignored_folder_content = kwargs.get('ignored_folder_content', [])
 
-    return make_hash_with_type(
-        'pd',
-        make_hash([
-            (
-                name,
-                folder.get_subfolder(name) if folder.isdir(name) else
-                make_hash_with_type('pf', _read_file(folder, name))
-            )
-            for name in sorted(folder.get_content_list())
-            if name not in ignored_folder_content
-        ], **kwargs).encode('latin1')
-    )
+    return _make_int_hash([(name, folder.get_subfolder(name)) if folder.isdir(name) else _hash_combine(
+        _make_int_hash(b'pf', **kwargs), _make_int_hash(_read_file(folder, name), **kwargs))
+                           for name in sorted(folder.get_content_list())
+                           if name not in ignored_folder_content], **kwargs)
 
-@make_hash.register(np.ndarray)
+
+@_make_int_hash.register(np.ndarray)
 def _(object_to_hash, **kwargs):
     if object_to_hash.dtype == np.float64:
-        return make_hash_with_type(
-            'af',
-            make_hash(truncate_array64(object_to_hash).tobytes(), **kwargs).encode('latin1')
-        )
+        return _hash_combine(
+            _make_int_hash(b'af', **kwargs),
+            _make_int_hash(truncate_array64(object_to_hash).tobytes(), **kwargs))
     elif object_to_hash.dtype == np.complex128:
-        return make_hash_with_type(
-            'ac',
-            make_hash([
-                object_to_hash.real,
-                object_to_hash.imag
-            ], **kwargs).encode('latin1')
-        )
+        return _hash_combine(
+            _make_int_hash(b'ac', **kwargs),
+            _make_int_hash([object_to_hash.real, object_to_hash.imag], **kwargs))
     else:
-        return make_hash_with_type(
-            'ao',
-            make_hash(object_to_hash.tobytes(), **kwargs).encode('latin1')
-        )
+        return _hash_combine(
+            _make_int_hash(b'ao', **kwargs),
+            _make_int_hash(object_to_hash.tobytes(), **kwargs))
+
 
 def truncate_float64(x, num_bits=4):
     mask = ~(2**num_bits - 1)
@@ -339,6 +338,7 @@ def truncate_float64(x, num_bits=4):
     masked_int = int_repr & mask
     truncated_x = masked_int.view(np.float64)
     return truncated_x
+
 
 def truncate_array64(x, num_bits=4):
     mask = ~(2**num_bits - 1)

--- a/aiida/common/hashing.py
+++ b/aiida/common/hashing.py
@@ -7,6 +7,9 @@
 # For further information on the license, see the LICENSE.txt file        #
 # For further information please visit http://www.aiida.net               #
 ###########################################################################
+"""
+Common password and hash generation functions.
+"""
 
 from __future__ import division
 from __future__ import print_function
@@ -16,8 +19,11 @@ import numbers
 import random
 import time
 import uuid
-import codecs
+import struct
+import sys
 from datetime import datetime
+from operator import itemgetter
+from itertools import chain
 
 import six
 from six.moves import range
@@ -33,9 +39,6 @@ except ImportError:  # Python2
 import numpy as np
 
 from .folders import Folder
-"""
-Here we define a single password hashing instance for the full AiiDA.
-"""
 
 # The prefix of the hashed using pbkdf2_sha256 algorithm in Django
 HASHING_PREFIX_DJANGO = "pbkdf2_sha256"
@@ -65,6 +68,8 @@ def create_unusable_pass():
 
 
 def is_password_usable(enc_pass):
+    """check whether the passed password string is a valid hashed password"""
+
     if enc_pass is None or enc_pass.startswith(UNUSABLE_PASSWORD_PREFIX):
         return False
 
@@ -86,13 +91,14 @@ def is_password_usable(enc_pass):
 
 # Use the system PRNG if possible
 try:
+    # pylint: disable=invalid-name
     random = random.SystemRandom()
     using_sysrandom = True
 except NotImplementedError:
     import warnings
     warnings.warn('A secure pseudo-random number generator is not available '
                   'on your system. Falling back to Mersenne Twister.')
-    using_sysrandom = False
+    using_sysrandom = False  # pylint: disable=invalid-name
 
 
 def get_random_string(length=12, allowed_chars='abcdefghijklmnopqrstuvwxyz' 'ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789'):
@@ -110,7 +116,15 @@ def get_random_string(length=12, allowed_chars='abcdefghijklmnopqrstuvwxyz' 'ABC
         # properties of the chosen random sequence slightly, but this
         # is better than absolute predictability.
         random.seed(hashlib.sha256(("%s%s%s" % (random.getstate(), time.time(), HASHING_KEY)).encode('utf-8')).digest())
-    return ''.join(random.choice(allowed_chars) for i in range(length))
+    return u''.join(random.choice(allowed_chars) for i in range(length))
+
+
+BLAKE2B_OPTIONS = {
+    'fanout': 0,  # unlimited fanout/depth mode
+    'depth': 2,  # has fixed depth of 2
+    'digest_size': 32,  # we do not need a cryptographically relevant digest
+    'inner_size': 64,  # ... but still use 64 as the inner size
+}
 
 
 def make_hash(object_to_hash, **kwargs):
@@ -131,210 +145,175 @@ def make_hash(object_to_hash, **kwargs):
     dictionary.
 
     This function avoids this by recursing through nonhashable items and
-    hashing iteratively.
-    Uses python's sorted function to sort unsorted sets and dictionaries
-    and hashlib.sha224 to hash the value.
-    We make an example with two dictionaries that should produce the
-    same hash because only the order of the keys is different::
-
-        aa = {
-            '3':4,
-            3:4,
-            'a':{
-                '1':'hello', 2:'goodbye', 1:'here'
-            },
-            'b':4,
-            'c': set([2, '5','a', 'b', 5])
-        }
-        bb = {
-            'c': set([2, 'b', 5, 'a', '5']),
-            'b':4, 'a':{2:'goodbye', 1:'here', '1':'hello'},
-            '3':4, 3:4
-        }
-
-        print(str(aa) == str(bb))
-        print(aa == bb)
-        print()
-        print(hashlib.sha224(str(aa)).hexdigest())
-        print(hashlib.sha224(str(bb)).hexdigest())
-        print(hashlib.sha224(str(aa)).hexdigest(
-            ) == hashlib.sha224(str(bb)).hexdigest())
-        print()
-        print(make_hash(aa))
-        print(make_hash(bb))
-        print(make_hash(aa) == make_hash(bb))
-
-    produces the output::
-
-        False
-        True
-
-        0f6f0cc1e3256f6486e998e934d07cb192ea78d3ce75595267b4c665
-        86877298dfb629201055e8bc410b5a2157ce65cf246677c54316723a
-        False
-
-        696cdf26b46d7abc5d6fdfb2244829dad9dd2b0100afd1e2f20a8002
-        696cdf26b46d7abc5d6fdfb2244829dad9dd2b0100afd1e2f20a8002
-        True
-
-    We can conclude that using simple hashfunctions operating on
-    the string of dictionary do not suffice if we want to check for equality
-    of dictionaries using hashes.
+    hashing iteratively. Uses python's sorted function to sort unsorted
+    sets and dictionaries by sorting the hashed keys.
     """
-    int_hash = _make_int_hash(object_to_hash, **kwargs)
-    return u'{:052x}'.format(int_hash)
+
+    hashes = _make_hash(object_to_hash, **kwargs)  # pylint: disable=assignment-from-no-return
+
+    # use the Unlimited fanout hashing protocol outlined in
+    #   https://blake2.net/blake2_20130129.pdf
+    final_hash = hashlib.blake2b(node_depth=1, last_node=True, **BLAKE2B_OPTIONS)  # pylint: disable=no-member
+
+    for sub in hashes:
+        final_hash.update(sub)
+
+    # add an empty last leaf node
+    final_hash.update(hashlib.blake2b(node_depth=0, last_node=True, **BLAKE2B_OPTIONS).digest())  # pylint: disable=no-member
+
+    return final_hash.hexdigest()
 
 
 @singledispatch
-def _make_int_hash(object_to_hash, **kwargs):
+def _make_hash(object_to_hash, **_):
     """
     Implementation of the ``make_hash`` function. The hash is created as a
     28 byte integer, and only later converted to a string.
     """
     raise ValueError("Value of type {} cannot be hashed".format(type(object_to_hash)))
 
-# int hashes with size 28 bytes
-INT_HASH_MASK = 2**(8 * 28) - 1
 
-def _hash_combine(hash1, hash2):
-    """
-    Combine two hashes, using the approach of boost::hash_combine.
-    """
-    return (hash1 ^ (hash2 + 0x9e3779b9 + (hash1 << 6) + (hash1 >> 2))) & INT_HASH_MASK
+def _single_digest(obj_type, obj_bytes=b''):
+    return hashlib.blake2b(obj_bytes, person=obj_type.encode('ascii'), node_depth=0, **BLAKE2B_OPTIONS).digest()  # pylint: disable=no-member
 
 
-def _combine_hash_list(hashes):
-    """
-    Combines multiple hashes.
-    """
-    if not hashes:
-        return 0
-    res = hashes[0]
-    for val in hashes[1:]:
-        res = _hash_combine(res, val)
-    return res
+@_make_hash.register(six.binary_type)
+def _(bytes_obj, **kwargs):
+    return [_single_digest('', bytes_obj)]
 
 
-def _add_type_salt(type_bytes):
-    """
-    Decorator which combines the output of the decorated function with a given
-    'type salt', which is a type-specific hash. The purpose of this is that
-    two objects which have the same binary structure but different types do not
-    hash to the same value.
-    """
-    assert isinstance(type_bytes, six.binary_type)
-    salt_hash = int(codecs.encode(hashlib.sha224(type_bytes).digest(), 'hex'), 16)
-
-    def decorator(func):
-
-        def inner(object_to_hash, **kwargs):
-            return _hash_combine(salt_hash, func(object_to_hash, **kwargs))
-
-        return inner
-
-    return decorator
+@_make_hash.register(abc.Sequence)
+def _(sequence_obj, **kwargs):
+    # unpack the list and use the elements
+    return [_single_digest('list')] + list(chain.from_iterable(_make_hash(i, **kwargs) for i in sequence_obj))
 
 
-@_make_int_hash.register(abc.Sequence)
-@_add_type_salt(b'L')
-def _(sequence, **kwargs):
-    return _combine_hash_list([_make_int_hash(x, **kwargs) for x in sequence])
+@_make_hash.register(abc.Set)
+def _(set_obj, **kwargs):
+    # turn the set objects into a list of hashes which are always sortable,
+    # then return a flattened list of the hashes
+    return [_single_digest('set')] + list(chain.from_iterable(sorted(_make_hash(i, **kwargs) for i in set_obj)))
 
 
-@_make_int_hash.register(abc.Set)
-@_add_type_salt(b'S')
-def _(object_to_hash, **kwargs):
-    hashes = sorted(_make_int_hash(x, **kwargs) for x in object_to_hash)
-    return _combine_hash_list(hashes)
-
-
-@_make_int_hash.register(abc.Mapping)
-@_add_type_salt(b'D')
+@_make_hash.register(abc.Mapping)
 def _(mapping, **kwargs):
-    hashed_items = sorted(_make_int_hash(item, **kwargs) for item in mapping.items())
-    return _combine_hash_list(hashed_items)
+    """Hashing arbitrary mapping containers (dict, OrderedDict) by first sorting by hashed keys"""
+
+    def hashed_key_mapping():
+        for key, value in mapping.items():
+            yield (_make_hash(key, **kwargs), value)
+
+    return ([_single_digest('dict')] + list(
+        chain.from_iterable((k_digest + _make_hash(val, **kwargs))
+                            for k_digest, val in sorted(hashed_key_mapping(), key=itemgetter(0)))))
 
 
-@_make_int_hash.register(numbers.Real)
-@_add_type_salt(b'f')
+@_make_hash.register(numbers.Real)
 def _(object_to_hash, **kwargs):
-    return _make_int_hash(truncate_float64(object_to_hash).tobytes(), **kwargs)
+    return [_single_digest('float', struct.pack("<d", truncate_float64(object_to_hash)))]
 
 
-@_make_int_hash.register(numbers.Complex)
-@_add_type_salt(b'c')
-def _(object_to_hash, **kwargs):
-    return _combine_hash_list(
-        [_make_int_hash(object_to_hash.real, **kwargs),
-         _make_int_hash(object_to_hash.imag, **kwargs)])
+@_make_hash.register(numbers.Complex)
+def _(val, **kwargs):
+    return [_single_digest('complex', struct.pack("<dd", truncate_float64(val.real), truncate_float64(val.imag)))]
 
 
 # If the type is unicode in Python 2 or a str in Python 3, convert it
 # to a str in Python 2 and bytes in Python 3 using the utf-8 encoding.
-@_make_int_hash.register(six.text_type)
-@_add_type_salt(b's')
-def _(object_to_hash, **kwargs):
-    return _make_int_hash(object_to_hash.encode('utf-8'), **kwargs)
+@_make_hash.register(six.text_type)
+def _(val, **kwargs):
+    return [_single_digest('str', val.encode('utf-8'))]
 
 
-@_make_int_hash.register(six.binary_type)
-def _(object_to_hash, **kwargs):
-    return int(codecs.encode(hashlib.sha224(object_to_hash).digest(), 'hex'), 16)
+@_make_hash.register(int)
+def _(val, **kwargs):
+    """get the hash of the little-endian signed long long representation of the integer"""
+    return [_single_digest('int', struct.pack("<q", val))]
 
 
-def _make_int_hash_from_str_repr(object_to_hash):
-    return _make_int_hash(str(object_to_hash).encode('utf-8'))
+@_make_hash.register(bool)
+def _(val, **kwargs):
+    return [_single_digest('bool', b'\x01' if val else b'\x00')]
 
 
-_make_int_hash.register(int)(_add_type_salt(b'i')(_make_int_hash_from_str_repr))
-_make_int_hash.register(bool)(_add_type_salt(b'b')(_make_int_hash_from_str_repr))
-_make_int_hash.register(type(None))(_add_type_salt(b'n')(_make_int_hash_from_str_repr))
-_make_int_hash.register(datetime)(_add_type_salt(b'd')(_make_int_hash_from_str_repr))
-_make_int_hash.register(uuid.UUID)(_add_type_salt(b'u')(_make_int_hash_from_str_repr))
+@_make_hash.register(type(None))
+def _(val, **kwargs):
+    return [_single_digest('none')]
 
 
-@_make_int_hash.register(Folder)
-@_add_type_salt(b'pd')
+@_make_hash.register(datetime)
+def _(val, **kwargs):
+    """hashes the little-endian rep of the float <epoch-seconds>.<subseconds>"""
+    return [_single_digest('datetime', struct.pack("<d", (val - datetime(1970, 1, 1)).total_seconds()))]
+
+
+@_make_hash.register(uuid.UUID)
+def _(val, **kwargs):
+    return [_single_digest('uuid', val.bytes)]
+
+
+@_make_hash.register(Folder)
 def _(folder, **kwargs):
-    # make sure file is closed after being read
-    def _read_file(folder, name):
-        with folder.open(name, mode='rb') as f:
-            return f.read()
+    """
+    Hash the content of a Folder object. The name of the folder itself is actually ignored
+    :param ignored_folder_content: list of filenames to be ignored for the hashing
+    """
 
     ignored_folder_content = kwargs.get('ignored_folder_content', [])
 
-    return _make_int_hash([(name, folder.get_subfolder(name)) if folder.isdir(name) else _hash_combine(
-        _make_int_hash(b'pf', **kwargs), _make_int_hash(_read_file(folder, name), **kwargs))
-                           for name in sorted(folder.get_content_list())
-                           if name not in ignored_folder_content], **kwargs)
+    def folder_digests(subfolder):
+        """traverses the given folder and yields digests for the contained objects"""
+        for name in sorted(subfolder.get_content_list()):
+            if name in ignored_folder_content:
+                continue
+
+            if subfolder.isdir(name):
+                yield _single_digest('folder', name.encode('utf-8'))
+                for digest in folder_digests(subfolder.get_subfolder(name)):
+                    yield digest
+            else:
+                with subfolder.open(name, mode='rb') as fhandle:
+                    yield _single_digest('file', fhandle.read())
+
+    return [_single_digest('folder')] + [d for d in folder_digests(folder)]
 
 
-@_make_int_hash.register(np.ndarray)
-def _(object_to_hash, **kwargs):
-    if object_to_hash.dtype == np.float64:
-        return _hash_combine(
-            _make_int_hash(b'af', **kwargs),
-            _make_int_hash(truncate_array64(object_to_hash).tobytes(), **kwargs))
-    elif object_to_hash.dtype == np.complex128:
-        return _hash_combine(
-            _make_int_hash(b'ac', **kwargs),
-            _make_int_hash([object_to_hash.real, object_to_hash.imag], **kwargs))
-    else:
-        return _hash_combine(
-            _make_int_hash(b'ao', **kwargs),
-            _make_int_hash(object_to_hash.tobytes(), **kwargs))
+@_make_hash.register(np.ndarray)
+def _(arr, **kwargs):
+    """Hashing for Numpy arrays"""
+
+    def little_endian_array(array):
+        if sys.byteorder == 'little':
+            return array
+        return array.byteswap()
+
+    if arr.dtype == np.float64:
+        return [_single_digest('arr.float', little_endian_array(truncate_array64(arr)).tobytes())]
+
+    if arr.dtype == np.complex128:
+        return [
+            _single_digest('arr.complex'),
+            little_endian_array(truncate_array64(arr.real)).tobytes() + little_endian_array(truncate_array64(
+                arr.imag)).tobytes()
+        ]
+
+    return [_single_digest('arr.*', little_endian_array(arr).tobytes())]
 
 
-def truncate_float64(x, num_bits=4):
+def truncate_float64(value, num_bits=4):
+    """
+    reduce the number of bits making it into the hash to avoid rehashing due to
+    possible truncation in float->str->float roundtrips
+    """
     mask = ~(2**num_bits - 1)
-    int_repr = np.float64(x).view(np.int64)
+    int_repr = np.float64(value).view(np.int64)  # pylint: disable=no-member
     masked_int = int_repr & mask
-    truncated_x = masked_int.view(np.float64)
-    return truncated_x
+    truncated_value = masked_int.view(np.float64)
+    return truncated_value
 
 
-def truncate_array64(x, num_bits=4):
+def truncate_array64(value, num_bits=4):
     mask = ~(2**num_bits - 1)
-    int_array = np.array(x, dtype=np.float64).view(np.int64)
+    int_array = np.array(value, dtype=np.float64).view(np.int64)
     masked_array = int_array & mask
     return masked_array.view(np.float64)

--- a/aiida/common/test_hashing.py
+++ b/aiida/common/test_hashing.py
@@ -20,6 +20,7 @@ import uuid
 from datetime import datetime
 
 import numpy as np
+import pytz
 
 try:
     import unittest2 as unittest
@@ -130,10 +131,19 @@ class MakeHashTest(unittest.TestCase):
         self.assertNotEqual(make_hash(some_uuid), make_hash(str(some_uuid)))
 
     def test_datetime(self):
+        # test for timezone-naive datetime:
         self.assertEqual(
             make_hash(datetime(2018, 8, 18, 8, 18)), 'c5ba00262f54deb718601b44dea01765ce009fd08f31967f2e65b7050b036426')
         self.assertEqual(
             make_hash(datetime.utcfromtimestamp(0)), 'a4de78590a7a290f0446f15c68639f5be3a4dde9140606cf6edcdcfc6bb8b5b0')
+
+        # test with timezone-aware datetime:
+        self.assertEqual(
+            make_hash(datetime(2018, 8, 18, 8, 18).replace(tzinfo=pytz.timezone('US/Eastern'))),
+            '2e7cb55d2a3982bd7a509aac0cb74c7dd485a9350d55eeb944bec3e1971d8dc0')
+        self.assertEqual(
+            make_hash(datetime(2018, 8, 18, 8, 18).replace(tzinfo=pytz.timezone('Europe/Amsterdam'))),
+            'd28a58c7af872bab9f07d2610e313bbd14de8530e62245ebc52821708883188f')
 
     def test_numpy_types(self):
         self.assertEqual(

--- a/aiida/common/test_hashing.py
+++ b/aiida/common/test_hashing.py
@@ -15,9 +15,10 @@ from __future__ import division
 from __future__ import print_function
 from __future__ import absolute_import
 import itertools
+import collections
+import uuid
 from datetime import datetime
 
-import six
 import numpy as np
 
 try:
@@ -52,76 +53,102 @@ class MakeHashTest(unittest.TestCase):
     # pylint: disable=missing-docstring,too-few-public-methods
 
     def test_builtin_types(self):
-        self.assertEqual(make_hash('something in ASCII'), u'7ada3e803dc6b66a8151c12985b0098d4f434da422bfd0740fcef562')
-        self.assertEqual(make_hash(42), u'2ab4140f3a4686f65ed84a4524bc56156e23a9e37736e273d83e99f5')
-        self.assertEqual(make_hash(3.141), u'e2f8e979916f99f6002239400f41949b94eecbaefdc064ecc51f8907')
-        self.assertEqual(make_hash(complex(1, 2)), u'1d819b8d8f2ae0a2033471f556b6f4dee7fa7fd4ca7bd1c0d0d2c70a')
-        self.assertEqual(make_hash(True), u'40f09510111ae311ce3f2406b547adcc222f8276dfe93e9f4dfc5098')
-        self.assertEqual(make_hash(None), u'2d4ca80c884a9f6dfedc579cd8072fce7918ed390bf71c1fa9fea081')
+        test_data = {
+            'something in ASCII': '06e87857590c91280d25e02f05637cd2381002bd1425dff3e36ca860bbb26a29',
+            42: '9498ab55b7c66c66b2d19f9dd8b668acf8e2facf44da0fb466f6986999bb8a56',
+            3.141: 'd00f2e88a088626f5db3eadb6d9d40c74b4b4d3f9f07c1ca2f76b247fe39530b',
+            complex(1, 2): '31800fbabb47c8fbf60c848571ee25e7dcbdfc5dfb60c1e8421c1c363a80ea6a',
+            True: '31ad5fa163a0c478d966c7f7568f3248f0c58d294372b2e8f7cb0560d8c8b12f',
+            None: '1729486cc7e56a6383542b1ec73125ccb26093651a5da05e04657ac416a74b8f',
+        }
+
+        for val, digest in test_data.items():
+            with self.subTest(val=val):
+                self.assertEqual(make_hash(val), digest)
 
     def test_unicode_string(self):
         self.assertEqual(
-            make_hash(u'something still in ASCII'), u'7cbae2b37638c56d5fe98429d5582edc3aad061e83fa1e45d754b2d6')
+            make_hash(u'something still in ASCII'), 'd55e492596cf214d877e165cdc3394f27e82e011838474f5ba5b9824074b9e91')
 
         self.assertEqual(
             make_hash(u"öpis mit Umluut wie ä, ö, ü und emene ß"),
-            "524b0fb4e50f855046796751f9045d581f5758b0b91d59a6803c2535")
+            'c404bf9a62cba3518de5c2bae8c67010aff6e4051cce565fa247a7f1d71f1fc7')
 
-    def test_collection_with_builtin_types(self):
-        self.assertEqual(make_hash((1, 2, 3)), '44d5ef36d5ae47a6e9aee5d910d148f1b63b6cdf073d11750159518f')
-        self.assertEqual(make_hash([1, 2, 3]), '44d5ef36d5ae47a6e9aee5d910d148f1b63b6cdf073d11750159518f')
-        self.assertEqual(make_hash([3, 1, 2]), '26e80d9e69085eca985309695732d132696c3dad6953b785e8faa963')
-        self.assertEqual(make_hash({1, 2, 3}), 'd1b190427d67bc95366a44c987e34fd68aa80716c4f45500db2bc635')
+    def test_collection_with_ordered_sets(self):
+        self.assertEqual(make_hash((1, 2, 3)), '27e6598a3bd1c878ca09db22f4d93ebcb1a0e08db27e09c737e7f2e698dcce5b')
+        self.assertEqual(make_hash([1, 2, 3]), '27e6598a3bd1c878ca09db22f4d93ebcb1a0e08db27e09c737e7f2e698dcce5b')
+
         for perm in itertools.permutations([1, 2, 3]):
-            self.assertNotEqual(make_hash(perm), make_hash({1, 2, 3}))
-        self.assertEqual(make_hash({'a': 'b', 'c': 'd'}), 'f5a57db4d625848dba7dade0a1b64c612779bc536e3008453eb442d2')
-        self.assertEqual(make_hash({'c': 'd', 'a': 'b'}), 'f5a57db4d625848dba7dade0a1b64c612779bc536e3008453eb442d2')
+            with self.subTest(orig=[1, 2, 3], perm=perm):
+                self.assertNotEqual(make_hash(perm), make_hash({1, 2, 3}))
 
-    @unittest.skipIf(six.PY3, "Broken on Python 3")
+    def test_collection_with_unordered_sets(self):
+        self.assertEqual(make_hash({1, 2, 3}), '2e096a4b81ab724c2250835fc2fef7d932a7a86deafe1fb584ff329adcc34e0f')
+        self.assertEqual(make_hash({1, 2, 3}), make_hash({2, 1, 3}))
+
+    def test_collection_with_dicts(self):
+        self.assertEqual(
+            make_hash({
+                'a': 'b',
+                'c': 'd'
+            }), '1890162a70dbbcbef2d0cc40b9bd90463459f2e7e72573628e7f1c003ca25c95')
+
+        # order changes in dictionaries should give the same hashes
+        self.assertEqual(
+            make_hash(collections.OrderedDict([('c', 'd'), ('a', 'b')])),
+            make_hash(collections.OrderedDict([('a', 'b'), ('c', 'd')])))
+
     def test_nested_collections(self):
-        obj_a = {
-            '3': 4,
-            3: 4,
-            'a': {
+        obj_a = collections.OrderedDict([
+            ('3', 4),
+            (3, 4),
+            ('a', {
                 '1': 'hello',
                 2: 'goodbye',
                 1: 'here',
-            },
-            'b': 4,
-            'c': set([2, '5', 'a', 'b', 5]),
-        }
+            }),
+            ('b', 4),
+            ('c', set([2, '5', 'a', 'b', 5])),
+        ])
 
-        obj_b = {
-            'c': set([2, 'b', 5, 'a', '5']),
-            'b': 4,
-            'a': {
-                2: 'goodbye',
-                1: 'here',
-                '1': 'hello',
-            },
-            '3': 4,
-            3: 4
-        }
+        obj_b = collections.OrderedDict([('c', set([2, 'b', 5, 'a', '5'])), ('b', 4), ('a', {
+            2: 'goodbye',
+            1: 'here',
+            '1': 'hello',
+        }), ('3', 4), (3, 4)])
 
-        self.assertEqual(make_hash(obj_a), '28dd36897f1fcd153c71330f843e0fb28566f6b752fcdcb7fc7e0cfe')
-        self.assertEqual(make_hash(obj_b), '28dd36897f1fcd153c71330f843e0fb28566f6b752fcdcb7fc7e0cfe')
+        self.assertEqual(make_hash(obj_a), 'e6cd3e2e7f540793a91330776a16e8908d6fe4db0d7d01fd592195f92bffe2b9')
+        self.assertEqual(make_hash(obj_a), make_hash(obj_b))
+
+    def test_bytes(self):
+        self.assertEqual(make_hash(b'foo'), '814a149f7569f1009b24670adfdc8a1edddb4759e2d7da85cd00386facfaebb2')
+
+    def test_uuid(self):
+        some_uuid = uuid.UUID('62c42d58-56e8-4ade-9d5e-18de3a7baacd')
+
+        self.assertEqual(make_hash(some_uuid), '3df6ae6dd5930e4cf8b22de123e5ac4f004f63ab396dff6225e656acc42dcf6f')
+        self.assertNotEqual(make_hash(some_uuid), make_hash(str(some_uuid)))
 
     def test_datetime(self):
         self.assertEqual(
-            make_hash(datetime(2018, 8, 18, 8, 18)), 'b71d8e8cd775cc6bb61ba545e4674005515f9db212d8dcb9c779e915')
+            make_hash(datetime(2018, 8, 18, 8, 18)), 'c5ba00262f54deb718601b44dea01765ce009fd08f31967f2e65b7050b036426')
         self.assertEqual(
-            make_hash(datetime.utcfromtimestamp(0)), 'b932cff36ce23f7d3a43757d34fe935d03a083134e987c022973a35e')
+            make_hash(datetime.utcfromtimestamp(0)), 'a4de78590a7a290f0446f15c68639f5be3a4dde9140606cf6edcdcfc6bb8b5b0')
 
     def test_numpy_types(self):
-        self.assertEqual(make_hash(np.float64(3.141)), 'e2f8e979916f99f6002239400f41949b94eecbaefdc064ecc51f8907')  # pylint: disable=no-member
-        self.assertEqual(make_hash(np.int64(42)), '2ab4140f3a4686f65ed84a4524bc56156e23a9e37736e273d83e99f5')  # pylint: disable=no-member
+        self.assertEqual(
+            make_hash(np.float64(3.141)), 'd00f2e88a088626f5db3eadb6d9d40c74b4b4d3f9f07c1ca2f76b247fe39530b')  # pylint: disable=no-member
+        self.assertEqual(make_hash(np.int64(42)), '3369413755ea6c01984a21d01fe231fab8dfde02787ba5d9c1527b08778acc12')  # pylint: disable=no-member
 
     def test_numpy_arrays(self):
-        self.assertEqual(make_hash(np.array([1, 2, 3])), '9b2bec0622bc5bedcb3d02c0b5b9d19bdbde36eec41be423715285df')
         self.assertEqual(
-            make_hash(np.array([np.float64(3.141)])), 'e437b69603b2189abaf2fd8f2cc3d3f9fbebc537052ba3dad75e22a8')  # pylint: disable=no-member
+            make_hash(np.array([1, 2, 3])), '8735e6439da0bd6949e97c7da08774fef2407dccef5e87bf569303e683c838ae')
         self.assertEqual(
-            make_hash(np.array([np.complex128(1 + 2j)])), '37451dd77b55202142b5367f26830dfa751c208b4bb15da66d46200d')  # pylint: disable=no-member
+            make_hash(np.array([np.float64(3.141)])),
+            'e03f2b6485f7a6ba0a2767c69724a1f5a9f73b8c36f5413d660f85631b4b562d')  # pylint: disable=no-member
+        self.assertEqual(
+            make_hash(np.array([np.complex128(1 + 2j)])),
+            'c8dab6e4d3f3904c90f2bb7a7f5ea84e36b6f0b8ad311e681dcd1863a7fdbb77')  # pylint: disable=no-member
 
     def test_unhashable_type(self):
 
@@ -139,12 +166,24 @@ class MakeHashTest(unittest.TestCase):
             fhandle.write("hello there!\n")
             fhandle.close()
 
-            self.assertEqual(make_hash(folder), '6e5ddd16e397aa0a0154abde43d1f262c8b0f7ae388508221bbdd155')
+            folder_hash = make_hash(folder)
+            self.assertEqual(folder_hash, '5a4f4a762f6e6be02baca1922a4bb82fe8d9665c3ee356acbd141326adff0e0d')
 
             nested_obj = ['1.0.0a2', {u'array|a': [1001]}, folder, None]
-            self.assertEqual(make_hash(nested_obj), '80d1905172f136615cbe1dded3131527d54dff7fd2d643adf63f3b49')
+            self.assertEqual(make_hash(nested_obj), '70a831e02a5d26985cab4a83e45bef439b2fbc771900f23362a91631d545d621')
 
-            fhandle = folder.open('file3.npy', 'wb')
-            np.save(fhandle, np.arange(10))
-            fhandle.close()
-            self.assertEqual(make_hash(folder), '4ed5bec24a050386812e6666bfab96ffee04795ca29561e115d16bcc')
+            with folder.open('file3.npy', 'wb') as fhandle:
+                np.save(fhandle, np.arange(10))
+
+            # after adding a file, the folder hash should have changed
+            self.assertNotEqual(make_hash(folder), folder_hash)
+            # ... unless we explicitly tell it to ignore the new file
+            self.assertEqual(make_hash(folder, ignored_folder_content='file3.npy'), folder_hash)
+
+            subfolder = folder.get_subfolder("some_subdir", create=True)
+
+            with subfolder.open('file4.npy', 'wb') as fhandle:
+                np.save(fhandle, np.arange(5))
+
+            self.assertNotEqual(make_hash(folder), folder_hash)
+            self.assertEqual(make_hash(folder, ignored_folder_content=['file3.npy', 'some_subdir']), folder_hash)

--- a/aiida/common/test_hashing.py
+++ b/aiida/common/test_hashing.py
@@ -14,12 +14,16 @@ Unittests for aiida.common.hashing:make_hash with hardcoded hash values
 from __future__ import division
 from __future__ import print_function
 from __future__ import absolute_import
-import unittest
 import itertools
 from datetime import datetime
 
 import six
 import numpy as np
+
+try:
+    import unittest2 as unittest
+except ImportError:
+    import unittest
 
 from aiida.common.hashing import make_hash, create_unusable_pass, is_password_usable
 from aiida.common.folders import SandboxFolder

--- a/aiida/common/test_hashing.py
+++ b/aiida/common/test_hashing.py
@@ -121,7 +121,7 @@ class MakeHashTest(unittest.TestCase):
         self.assertEqual(make_hash(obj_a), make_hash(obj_b))
 
     def test_bytes(self):
-        self.assertEqual(make_hash(b'foo'), '814a149f7569f1009b24670adfdc8a1edddb4759e2d7da85cd00386facfaebb2')
+        self.assertEqual(make_hash(b'foo'), '459062c44082269b2d07f78c1b6e8c98b93448606bfb1cc1f48284cdfcea74e3')
 
     def test_uuid(self):
         some_uuid = uuid.UUID('62c42d58-56e8-4ade-9d5e-18de3a7baacd')
@@ -138,7 +138,7 @@ class MakeHashTest(unittest.TestCase):
     def test_numpy_types(self):
         self.assertEqual(
             make_hash(np.float64(3.141)), 'd00f2e88a088626f5db3eadb6d9d40c74b4b4d3f9f07c1ca2f76b247fe39530b')  # pylint: disable=no-member
-        self.assertEqual(make_hash(np.int64(42)), '3369413755ea6c01984a21d01fe231fab8dfde02787ba5d9c1527b08778acc12')  # pylint: disable=no-member
+        self.assertEqual(make_hash(np.int64(42)), '9498ab55b7c66c66b2d19f9dd8b668acf8e2facf44da0fb466f6986999bb8a56')  # pylint: disable=no-member
 
     def test_numpy_arrays(self):
         self.assertEqual(

--- a/aiida/common/test_hashing.py
+++ b/aiida/common/test_hashing.py
@@ -21,8 +21,23 @@ from datetime import datetime
 import six
 import numpy as np
 
-from aiida.common.hashing import make_hash
+from aiida.common.hashing import make_hash, create_unusable_pass, is_password_usable
 from aiida.common.folders import SandboxFolder
+
+
+class PasswordFunctions(unittest.TestCase):
+    """
+    Tests for the password hashing functions.
+    """
+
+    def test_unusable_password(self):
+        self.assertTrue(create_unusable_pass().startswith('!'))
+        self.assertTrue(len(create_unusable_pass()) > 20)
+
+    def test_is_usable(self):
+        self.assertFalse(is_password_usable(None))
+        self.assertFalse(is_password_usable('!foo'))
+        self.assertFalse(is_password_usable('random string without hash identification'))
 
 
 class MakeHashTest(unittest.TestCase):

--- a/aiida/common/test_hashing.py
+++ b/aiida/common/test_hashing.py
@@ -15,6 +15,7 @@ from __future__ import division
 from __future__ import print_function
 from __future__ import absolute_import
 import unittest
+import itertools
 from datetime import datetime
 
 import six
@@ -32,26 +33,30 @@ class MakeHashTest(unittest.TestCase):
     # pylint: disable=missing-docstring,too-few-public-methods
 
     def test_builtin_types(self):
-        self.assertEqual(make_hash('something in ASCII'), '82c78710eebc41c0f0684e817944d6f08e54be54a279f9fc263f8403')
-        self.assertEqual(make_hash(42), 'f7d4da96058de015a3a6f6b98cff45a80a2852fe721b0d06a2627944')
-        self.assertEqual(make_hash(3.141), '2086094b3fbadc66b71c38281fc079d7c3978e74eb28ca7f3b966371')
-        self.assertEqual(make_hash(complex(1, 2)), '59975775040ab3a41ca969fc360f0ff1b1663d64046005a6ee68bf7b')
-        self.assertEqual(make_hash(True), '15ca7d7468e8aa86ea3db945ae856d783e2f92056550a50cb96fe7fd')
-        self.assertEqual(make_hash(None), '9a5b682a9a6a99a1d2ce4353d52062d511d418af058679d1b9b97570')
+        self.assertEqual(make_hash('something in ASCII'), u'7ada3e803dc6b66a8151c12985b0098d4f434da422bfd0740fcef562')
+        self.assertEqual(make_hash(42), u'2ab4140f3a4686f65ed84a4524bc56156e23a9e37736e273d83e99f5')
+        self.assertEqual(make_hash(3.141), u'e2f8e979916f99f6002239400f41949b94eecbaefdc064ecc51f8907')
+        self.assertEqual(make_hash(complex(1, 2)), u'1d819b8d8f2ae0a2033471f556b6f4dee7fa7fd4ca7bd1c0d0d2c70a')
+        self.assertEqual(make_hash(True), u'40f09510111ae311ce3f2406b547adcc222f8276dfe93e9f4dfc5098')
+        self.assertEqual(make_hash(None), u'2d4ca80c884a9f6dfedc579cd8072fce7918ed390bf71c1fa9fea081')
 
     def test_unicode_string(self):
         self.assertEqual(
-            make_hash(u'something still in ASCII'), '753df9fb179504652f66dd15877d393a743cbfe31d6bf6a9faed7e37')
-        # current implementation fails with real unicode:
-        # self.assertEqual(make_hash(u'öpis mit Umluut wie ä, ö, ü und emene ß 😊'), '')
+            make_hash(u'something still in ASCII'), u'7cbae2b37638c56d5fe98429d5582edc3aad061e83fa1e45d754b2d6')
+
+        self.assertEqual(
+            make_hash(u"öpis mit Umluut wie ä, ö, ü und emene ß"),
+            "524b0fb4e50f855046796751f9045d581f5758b0b91d59a6803c2535")
 
     def test_collection_with_builtin_types(self):
-        self.assertEqual(make_hash((1, 2, 3)), 'ccbd4c0c83df304a4d8fa1cb4d556f370d8d09c03b49cd069fd72598')
-        self.assertEqual(make_hash([1, 2, 3]), 'ccbd4c0c83df304a4d8fa1cb4d556f370d8d09c03b49cd069fd72598')
-        self.assertEqual(make_hash([3, 1, 2]), '401c29a918e635ab4b384e7a0ac1d189eb857bfc3e8085fe3aaa17c2')
-        self.assertEqual(make_hash({1, 2, 3}), '95467151c8099d6bef0e52588f0e651d6276fa4cad0866c710447a58')
-        self.assertEqual(make_hash({'a': 'b', 'c': 'd'}), 'ee137be5e9397e30612b6628df24be4e4913c6cc4a6be5bf85509ef3')
-        self.assertEqual(make_hash({'c': 'd', 'a': 'b'}), 'ee137be5e9397e30612b6628df24be4e4913c6cc4a6be5bf85509ef3')
+        self.assertEqual(make_hash((1, 2, 3)), '44d5ef36d5ae47a6e9aee5d910d148f1b63b6cdf073d11750159518f')
+        self.assertEqual(make_hash([1, 2, 3]), '44d5ef36d5ae47a6e9aee5d910d148f1b63b6cdf073d11750159518f')
+        self.assertEqual(make_hash([3, 1, 2]), '26e80d9e69085eca985309695732d132696c3dad6953b785e8faa963')
+        self.assertEqual(make_hash({1, 2, 3}), 'd1b190427d67bc95366a44c987e34fd68aa80716c4f45500db2bc635')
+        for perm in itertools.permutations([1, 2, 3]):
+            self.assertNotEqual(make_hash(perm), make_hash({1, 2, 3}))
+        self.assertEqual(make_hash({'a': 'b', 'c': 'd'}), 'f5a57db4d625848dba7dade0a1b64c612779bc536e3008453eb442d2')
+        self.assertEqual(make_hash({'c': 'd', 'a': 'b'}), 'f5a57db4d625848dba7dade0a1b64c612779bc536e3008453eb442d2')
 
     @unittest.skipIf(six.PY3, "Broken on Python 3")
     def test_nested_collections(self):
@@ -79,25 +84,25 @@ class MakeHashTest(unittest.TestCase):
             3: 4
         }
 
-        self.assertEqual(make_hash(obj_a), '41f1b6de377112ea0068416c00c6bb6cd2abf0133fe852fa4bb9dfbb')
-        self.assertEqual(make_hash(obj_b), '41f1b6de377112ea0068416c00c6bb6cd2abf0133fe852fa4bb9dfbb')
+        self.assertEqual(make_hash(obj_a), '28dd36897f1fcd153c71330f843e0fb28566f6b752fcdcb7fc7e0cfe')
+        self.assertEqual(make_hash(obj_b), '28dd36897f1fcd153c71330f843e0fb28566f6b752fcdcb7fc7e0cfe')
 
     def test_datetime(self):
         self.assertEqual(
-            make_hash(datetime(2018, 8, 18, 8, 18)), 'bc10b5f4152733191369a40dd96cb8992ac40ece6f0e59e77518f46f')
+            make_hash(datetime(2018, 8, 18, 8, 18)), 'b71d8e8cd775cc6bb61ba545e4674005515f9db212d8dcb9c779e915')
         self.assertEqual(
-            make_hash(datetime.utcfromtimestamp(0)), 'aaff3b5717365f5fbf4d415ae893cda13fef1b1a28cb66f381fddea2')
+            make_hash(datetime.utcfromtimestamp(0)), 'b932cff36ce23f7d3a43757d34fe935d03a083134e987c022973a35e')
 
     def test_numpy_types(self):
-        self.assertEqual(make_hash(np.float64(3.141)), '2086094b3fbadc66b71c38281fc079d7c3978e74eb28ca7f3b966371')  # pylint: disable=no-member
-        self.assertEqual(make_hash(np.int64(42)), 'f7d4da96058de015a3a6f6b98cff45a80a2852fe721b0d06a2627944')  # pylint: disable=no-member
+        self.assertEqual(make_hash(np.float64(3.141)), 'e2f8e979916f99f6002239400f41949b94eecbaefdc064ecc51f8907')  # pylint: disable=no-member
+        self.assertEqual(make_hash(np.int64(42)), '2ab4140f3a4686f65ed84a4524bc56156e23a9e37736e273d83e99f5')  # pylint: disable=no-member
 
     def test_numpy_arrays(self):
-        self.assertEqual(make_hash(np.array([1, 2, 3])), '88348823a5582f72b20b9bc51221dbbf2e52adedfa949b537f41d0f3')
+        self.assertEqual(make_hash(np.array([1, 2, 3])), '9b2bec0622bc5bedcb3d02c0b5b9d19bdbde36eec41be423715285df')
         self.assertEqual(
-            make_hash(np.array([np.float64(3.141)])), '57a640be101799c6b70ced7aa688af6dd76f0ed75007c05a97d0af6c')  # pylint: disable=no-member
+            make_hash(np.array([np.float64(3.141)])), 'e437b69603b2189abaf2fd8f2cc3d3f9fbebc537052ba3dad75e22a8')  # pylint: disable=no-member
         self.assertEqual(
-            make_hash(np.array([np.complex128(1 + 2j)])), 'eddf5fbcd94f8caf2b821ddd03c6bca1593d7029914c928c29ba25f4')  # pylint: disable=no-member
+            make_hash(np.array([np.complex128(1 + 2j)])), '37451dd77b55202142b5367f26830dfa751c208b4bb15da66d46200d')  # pylint: disable=no-member
 
     def test_unhashable_type(self):
 
@@ -115,12 +120,12 @@ class MakeHashTest(unittest.TestCase):
             fhandle.write("hello there!\n")
             fhandle.close()
 
-            self.assertEqual(make_hash(folder), '7e09b5bc4fec5b85ef85ff1679efea2c11fa1fd9212f8cb70550627b')
+            self.assertEqual(make_hash(folder), '6e5ddd16e397aa0a0154abde43d1f262c8b0f7ae388508221bbdd155')
 
             nested_obj = ['1.0.0a2', {u'array|a': [1001]}, folder, None]
-            self.assertEqual(make_hash(nested_obj), 'd7e6914da5cf7bf3c1c98cab90192362d440e2c13bd4fe04cdd71bde')
+            self.assertEqual(make_hash(nested_obj), '80d1905172f136615cbe1dded3131527d54dff7fd2d643adf63f3b49')
 
             fhandle = folder.open('file3.npy', 'wb')
             np.save(fhandle, np.arange(10))
             fhandle.close()
-            self.assertEqual(make_hash(folder), '18e28635210ec949097222567d0c8ecfbcd918af8721766e4aaecf73')
+            self.assertEqual(make_hash(folder), '4ed5bec24a050386812e6666bfab96ffee04795ca29561e115d16bcc')

--- a/docs/requirements_for_rtd.txt
+++ b/docs/requirements_for_rtd.txt
@@ -47,6 +47,7 @@ pgtest==1.1.0
 pika==0.12.0
 plumpy==0.10.6
 psutil==5.4.5
+pyblake2==1.1.2; python_version<"3.6"
 pymatgen==2018.4.20
 pyparsing==2.2.0
 pytest-cov==2.5.1

--- a/docs/requirements_for_rtd.txt
+++ b/docs/requirements_for_rtd.txt
@@ -68,5 +68,6 @@ tabulate==0.8.2
 tornado==4.5.3
 tzlocal==1.5.1
 ujson==1.35
+unittest2==1.1.0; python_version<"3.5"
 uritools==2.1.0
 validate-email==1.3

--- a/docs/source/nitpick-exceptions
+++ b/docs/source/nitpick-exceptions
@@ -56,6 +56,7 @@ py:class  list
 py:class  object
 py:class  unittest.case.TestCase
 py:class  unittest.runner.TextTestRunner
+py:class  unittest2.case.TestCase
 py:meth   unittest.TestLoader.discover
 py:class  ABCMeta
 py:class  exceptions.Exception

--- a/setup_requirements.py
+++ b/setup_requirements.py
@@ -104,6 +104,7 @@ extras_require = {
     ],
     # Requirements for testing
     'testing': [
+        'unittest2==1.1.0; python_version<"3.5"',
         'pgtest==1.1.0',
         'sqlalchemy-diff==0.1.3',
         'coverage==4.5.1',

--- a/setup_requirements.py
+++ b/setup_requirements.py
@@ -49,6 +49,7 @@ install_requires = [
     'kiwipy==0.2.1',
     'circus==0.14.0',
     'tornado==4.5.3',  # As of 2018/03/06 Tornado released v5.0 which breaks circus 0.14.0
+    'pyblake2==1.1.2; python_version<"3.6"',
     'chainmap; python_version<"3.5"',
     'pathlib2; python_version<"3.5"',
     'singledispatch>=3.4.0.3; python_version<"3.5"',


### PR DESCRIPTION
This is an an alternative to #2049 using Blake2b as the hash algorithm (in tree configuration).

Besides fixing the same issues, I discovered some other problems which slipped through the cracks:

* the dispatch on `int` type works differently between Python 2 and 3: while a `np.int64` was matched by it in Python 2, Python 3 was using the string type instead, which is why we are using `numbers.Integral` now
*  we can't distinguish in hash types between str, bytes and unicode. Otherwise a simple `"..."` will be a differerent hash type in Python 2 and 3
* furthermore I also made everything byte-ordner agnostic by converting numerical types to little-endian if necessary
* for some of the representations I used `struct.pack` with the little-endian standard for getting the byte representation instead of the string representation. Arbitrary length of integers are therefore currently not supported I guess.

I guess it may make sense to squash @greschd 's commits with my main commit. So, instead of reviewing the diff, it is probably better to review the final code.