### PR TITLE
Make `update`, `submit` and `retrieve` transport tasks idem potent

### DIFF
--- a/aiida/daemon/execmanager.py
+++ b/aiida/daemon/execmanager.py
@@ -340,12 +340,11 @@ def parse_results(job, retrieved_temporary_folder=None):
     from aiida.orm.calculation.job import JobCalculationExitStatus
     from aiida.work import ExitCode
 
-    logger_extra = get_dblogger_extra(job)
-
-    job._set_state(calc_states.PARSING)
+    assert job.get_state() == calc_states.PARSING, 'the job should be in the PARSING state when calling this function'
 
     Parser = job.get_parserclass()
     exit_code = ExitCode()
+    logger_extra = get_dblogger_extra(job)
 
     if retrieved_temporary_folder:
         files = []


### PR DESCRIPTION
Fixes #2109 

The transport tasks for job processes can be interrupted violently after having
completed the bulk of their task but before being able to create the state
transition and therewith creating a checkpoint. This means that when the daemon
is restarted the same task is executed. This could lead to various side effects.
Here we make sure that for the update, submit and retrieve transport tasks can
safely be executed twice. When the task finishes, if applicable, the calculation
state will be set. In the beginning of the task we check if the state is already
set, which indicates that the task was already ran, and we skip it.

This still leaves a small window for the task being executed twice, since there
is sometime between the task returning successfully and the state being set, but
this should minimize the time window.

Note that the submit task is not truly idem potent, as when it will be executed
a second time (after the first time successfully submitted a job, but didn't get
the chance to set the state), the job will be submitted once more to the scheduler.
However, there is really no way to guarantee that his happens as there will always
be a time window between the job being submitted to the scheduler and for us to
get the chance to reflect that in the node, in which the daemon process can be
abruptly killed.