### PR TITLE
Implement the `verdi export inspect` command

### DIFF
--- a/aiida/backends/tests/__init__.py
+++ b/aiida/backends/tests/__init__.py
@@ -82,6 +82,7 @@ db_test_list = {
         'cmdline.params.types.node': ['aiida.backends.tests.cmdline.params.types.test_node'],
         'cmdline.params.types.plugin': ['aiida.backends.tests.cmdline.params.types.test_plugin'],
         'cmdline.params.types.workflow': ['aiida.backends.tests.cmdline.params.types.test_workflow'],
+        'common.archive': ['aiida.backends.tests.common.test_archive'],
         'common.datastructures': ['aiida.backends.tests.common.test_datastructures'],
         'daemon.client': ['aiida.backends.tests.daemon.test_client'],
         'orm.computer': ['aiida.backends.tests.computer'],

--- a/aiida/backends/tests/cmdline/commands/test_export.py
+++ b/aiida/backends/tests/cmdline/commands/test_export.py
@@ -257,3 +257,27 @@ class TestVerdiExport(AiidaTestCase):
                     self.assertTrue(tarfile.is_tarfile(filename_output))
                 finally:
                     delete_temporary_file(filename_output)
+
+    def test_inspect(self):
+        """Test the functionality of `verdi export inspect`."""
+        archives = [
+            ('export_v0.1.aiida', '0.1'),
+            ('export_v0.2.aiida', '0.2'),
+            ('export_v0.3.aiida', '0.3'),
+        ]
+
+        for archive, version_number in archives:
+
+            filename_input = get_archive_file(archive)
+
+            # Testing the options that will print the meta data and data respectively
+            for option in ['-m', '-d']:
+                options = [option, filename_input]
+                result = self.cli_runner.invoke(cmd_export.inspect, options)
+                self.assertIsNone(result.exception)
+
+            # Test the --version option which should print the archive format version
+            options = ['--version', filename_input]
+            result = self.cli_runner.invoke(cmd_export.inspect, options)
+            self.assertIsNone(result.exception)
+            self.assertEquals(result.output.strip(), version_number)

--- a/aiida/backends/tests/common/test_archive.py
+++ b/aiida/backends/tests/common/test_archive.py
@@ -1,0 +1,43 @@
+# -*- coding: utf-8 -*-
+"""Tests for the Archive class."""
+from __future__ import division
+from __future__ import print_function
+from __future__ import absolute_import
+
+import os
+
+from aiida.backends.testbase import AiidaTestCase
+from aiida.common.archive import Archive
+from aiida.common.exceptions import InvalidOperation
+
+
+def get_archive_file(archive):
+    """
+    Return the absolute path of the archive file used for testing purposes. The expected path for these files:
+
+        aiida.backends.tests.export_import_test_files.migrate
+
+    :param archive: the relative filename of the archive
+    :returns: absolute filepath of the archive test file
+    """
+    dirpath_current = os.path.dirname(os.path.abspath(__file__))
+    dirpath_archive = os.path.join(dirpath_current, os.pardir, 'fixtures', 'export', 'migrate')
+
+    return os.path.join(dirpath_archive, archive)
+
+
+class TestCommonArchive(AiidaTestCase):
+    """Tests for the :class:`aiida.common.archive.Archive` class."""
+
+    def test_context_required(self):
+        """Verify that accessing a property of an Archive outside of a context manager raises."""
+        with self.assertRaises(InvalidOperation):
+            filepath = get_archive_file('export_v0.1.aiida')
+            archive = Archive(filepath)
+            _ = archive.version_format
+
+    def test_version_format(self):
+        """Verify that `version_format` return the correct archive format version."""
+        filepath = get_archive_file('export_v0.1.aiida')
+        with Archive(filepath) as archive:
+            self.assertEqual(archive.version_format, '0.1')

--- a/aiida/cmdline/utils/echo.py
+++ b/aiida/cmdline/utils/echo.py
@@ -131,7 +131,7 @@ def echo_deprecated(message, bold=False, nl=True, err=True, exit=False):
         sys.exit(ExitCode.DEPRECATED.value)
 
 
-def echo_dictionary(dictionary, fmt):
+def echo_dictionary(dictionary, fmt='json+date'):
     """
     Print the given dictionary to stdout in the given format
 
@@ -162,7 +162,7 @@ def _format_dictionary_json_date(dictionary):
 
         raise TypeError(repr(data) + ' is not JSON serializable')
 
-    return json.dumps(dictionary, indent=2, sort_keys=True, default=default_jsondump)
+    return json.dumps(dictionary, indent=4, sort_keys=True, default=default_jsondump)
 
 
 def is_stdout_redirected():

--- a/aiida/common/archive.py
+++ b/aiida/common/archive.py
@@ -7,12 +7,234 @@
 # For further information on the license, see the LICENSE.txt file        #
 # For further information please visit http://www.aiida.net               #
 ###########################################################################
-
 from __future__ import division
 from __future__ import absolute_import
 from __future__ import print_function
+
+import contextlib
+import json
+import os
+import tarfile
 import sys
+import zipfile
+from functools import wraps
 from six.moves import range
+
+from aiida.common.exceptions import ContentNotExistent, InvalidOperation
+from aiida.common.folders import SandboxFolder
+
+
+class Archive(object):
+    """
+    Utility class to operate on exported archive files or directories.
+
+    The main usage should be to construct the class with the filepath of the export archive as an argument.
+    The contents will be lazily unpacked into a sand box folder which is constructed upon entering the instance
+    within a context and which will be automatically cleaned upon leaving that context. Example::
+
+        with Archive('/some/path/archive.aiida') as archive:
+            archive.version
+
+    """
+
+    FILENAME_DATA = 'data.json'
+    FILENAME_METADATA = 'metadata.json'
+
+    def __init__(self, filepath):
+        self._filepath = filepath
+        self._folder = None
+        self._unpacked = False
+        self._data = None
+        self._meta_data = None
+
+    def __enter__(self):
+        """Instantiate a SandboxFolder into which the archive can be lazily unpacked."""
+        self._folder = SandboxFolder()
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        """Clean the sandbox folder if it was instatiated."""
+        if self.folder:
+            self.folder.erase()
+
+    def ensure_within_context(function):
+        """Decorator to ensure that the instance is called within a context manager."""
+
+        @wraps(function)
+        def decorated(self, *args, **kwargs):
+            if not self._folder:
+                raise InvalidOperation('the Archive class should be used within a context')
+
+            return function(self, *args, **kwargs)
+
+        return decorated
+
+    def ensure_unpacked(function):
+        """Decorator to ensure that the archive is unpacked before entering the decorated function."""
+
+        @wraps(function)
+        def decorated_function(self, *args, **kwargs):
+            if not self.unpacked:
+                self.unpack()
+
+            return function(self, *args, **kwargs)
+
+        return decorated_function
+
+    @ensure_within_context
+    def unpack(self):
+        """Unpack the archive and store the contents in a sandbox."""
+        if os.path.isdir(self.filepath):
+            extract_tree(self.filepath, self.folder, silent=True)
+        else:
+            if tarfile.is_tarfile(self.filepath):
+                extract_tar(self.filepath, self.folder, silent=True, nodes_export_subfolder='nodes')
+            elif zipfile.is_zipfile(self.filepath):
+                extract_zip(self.filepath, self.folder, silent=True, nodes_export_subfolder='nodes')
+            else:
+                raise ValueError('unrecognized archive format')
+
+        if not self.folder.get_content_list():
+            raise ContentNotExistent('the provided archive {} is empty'.format(self.filepath))
+
+        self._unpacked = True
+
+    @property
+    def filepath(self):
+        """
+        Return the filepath of the archive
+
+        :return: the archive filepath
+        """
+        return self._filepath
+
+    @property
+    def folder(self):
+        """
+        Return the sandbox folder
+
+        :return: sandbox folder :class:`aiida.common.folders.SandboxFolder`
+        """
+        return self._folder
+
+    @property
+    @ensure_within_context
+    def data(self):
+        """
+        Return the loaded content of the data file
+
+        :return: dictionary with contents of data file
+        """
+        if self._data is None:
+            self._data = self._read_json_file(self.FILENAME_DATA)
+
+        return self._data
+
+    @property
+    @ensure_within_context
+    def meta_data(self):
+        """
+        Return the loaded content of the meta data file
+
+        :return: dictionary with contents of meta data file
+        """
+        if self._meta_data is None:
+            self._meta_data = self._read_json_file(self.FILENAME_METADATA)
+
+        return self._meta_data
+
+    @property
+    @ensure_within_context
+    def unpacked(self):
+        """Return whether the archive has been unpacked into the sandbox folder."""
+        return self._unpacked
+
+    @ensure_within_context
+    def get_info(self):
+        """
+        Return a dictionary with basic information about the archive.
+
+        :return: a dictionary with basic details
+        """
+        info = {
+            'version aiida': self.version_aiida,
+            'version format': self.version_format,
+        }
+
+        if self.conversion_info:
+            info['conversion info'] = '\n'.join(self.conversion_info)
+
+        return info
+
+    @ensure_within_context
+    def get_data_statistics(self):
+        """
+        Return a dictionary with statistics about data content, i.e. how many entries of each entity type it contains.
+
+        :return: a dictionary with basic details
+        """
+        export_data = self.data.get('export_data', {})
+        links_data = self.data.get('links_uuid', {})
+
+        computers = export_data.get('Computer', {})
+        groups = export_data.get('Group', {})
+        nodes = export_data.get('Node', {})
+        users = export_data.get('User', {})
+
+        statistics = {
+            'computers': len(computers),
+            'groups': len(groups),
+            'links': len(links_data),
+            'nodes': len(nodes),
+            'users': len(users),
+        }
+
+        return statistics
+
+    @property
+    @ensure_within_context
+    def version_aiida(self):
+        """
+        Return the version of AiiDA the archive was created with.
+
+        :return: version number
+        """
+        return self.meta_data['aiida_version']
+
+    @property
+    @ensure_within_context
+    def version_format(self):
+        """
+        Return the version of the archive format.
+
+        :return: version number
+        """
+        return self.meta_data['export_version']
+
+    @property
+    @ensure_within_context
+    def conversion_info(self):
+        """
+        Return information about migration events that were applied to this archive.
+
+        :return: list of conversion notifications
+        """
+        try:
+            return self.meta_data['conversion_info']
+        except KeyError:
+            return None
+
+    @ensure_within_context
+    @ensure_unpacked
+    def _read_json_file(self, filename):
+        """
+        Read the contents of a JSON file from the unpacked archive contents.
+
+        :param filename: the filename relative to the sandbox folder
+        :return: a dictionary with the loaded JSON content
+        """
+        with open(self.folder.get_abs_path(filename), 'r') as handle:
+            return json.load(handle)
 
 
 def extract_zip(infile, folder, nodes_export_subfolder="nodes",


### PR DESCRIPTION
Fixes #584 at least the basic functionality. It does not address all the requirements specified in that issue, but for example how to inspect the actual content should be discussed, because just printing to terminal becomes useless for big archives. I would propose new issues can be opened if there are specific suggestions.

This command enables a user to easily inspect the contents of an export
archive. The implementation uses a new class `Archive` which is a utility
class to deal with export archives. It should be used in a context manager:

    with Archive('/some/archive.aiida') as archive:
        version = archive.version_format

The context manager will ensure that the archive is lazily unpacked into a
sandbox folder which will be automatically cleaned when the context is left.

The command by default prints a summary of the contents and the version numbers
of the format itself and AiiDA with which it was exported. With flags one can
toggle to print just the format version, or the contents of the data or metadata
files contained within the archive.