### PR TITLE
Check for spurious output at bash login shell

### DIFF
--- a/docs/source/install/details/troubleshooting.rst
+++ b/docs/source/install/details/troubleshooting.rst
@@ -3,7 +3,10 @@
 Troubleshooting
 ===============
 
-* On a clean Ubuntu 16.04 install the pip install command ``pip install -e aiida_core``
+Installation phase
+------------------
+
+* [**numpy dependency**] On a clean Ubuntu 16.04 install the pip install command ``pip install -e aiida_core``
   may fail due to a problem with dependencies on the ``numpy`` package. In this case
   you may be presented with a message like the following::
 
@@ -20,57 +23,7 @@ Troubleshooting
 
   This should fix the dependency error.
 
-* If the ``pip install`` command gives you an error that resembles the one
-  shown below, you might need to downgrade to an older version of pip::
-
-    Cannot fetch index base URL https://pypi.python.org/simple/
-
-  To downgrade pip, use the following command::
-
-    sudo easy_install pip==1.2.1
-
-* In order to use the AiiDA objects and functions in Jupyter, this latter has to be instructed to use the iPython kernel installed in the AiiDA virtual environment. This happens by default if you install AiiDA with ``pip`` including the ``notebook`` option and run Jupyter from the AiiDA virtual environment.
-
-  If, for any reason, you do not want to install Jupyter in the virtual environment, you might consider to install it out of the virtual environment, if not already done::
-
-      $ pip install jupyter
-
-  Then, activate the AiiDA virtual environment::
-
-      $ source ~/<aiida.virtualenv>/bin/activate
-
-  and setup the AiiDA iPython kernel::
-
-      $ pip install ipykernel
-      $ python -m ipykernel install --user --name=<aiida.kernel.name>
-
-  where you have chosen a meaningful name for the new kernel.
-
-  Finally, start a Jupyter server::
-
-      $ jupyter notebook
-
-  and from the newly opened browser tab select ``New -> <aiida.kernel.name>``
-
-
-* When installing the ``ssh_kerberos`` optional requirement through Anaconda you may encounter the following error on Ubuntu machines::
-
-    version 'GFORTRAN_1.4' not found (required by /usr/lib/libblas.so.3)
-
-  This is related to an open issue in anaconda `ContinuumIO/anaconda-issues#686`_.
-  A potential solution is to run the following command::
-
-    export LD_PRELOAD=/usr/lib/x86_64-linux-gnu/libgfortran.so.3
-
-.. _ContinuumIO/anaconda-issues#686: https://github.com/ContinuumIO/anaconda-issues/issues/686
-
-* Several users reported the need to install also ``libpq-dev`` (header files for libpq5 - PostgreSQL library)::
-
-    apt-get install libpq-dev
-
-  But under Ubuntu 12.04 this is not needed.
-
-* If the installation fails while installing the packages related
+* [**Database installation and location**] If the installation fails while installing the packages related
   to the database, you may have not installed or set up the database
   libraries.
 
@@ -103,8 +56,8 @@ Troubleshooting
 
 .. _Stackoverflow link: http://stackoverflow.com/questions/21079820/how-to-find-pg-config-pathlink
 
-
-* For some reasons, on some machines (notably often on Mac OS X) there is no
+* [**ensuring a UTF-8 locale**]For some reasons, on some machines 
+  (notably often on Mac OS X) there is no
   default locale defined, and when you run ``verdi setup`` for the first
   time it fails (see also `this issue`_ of django).
   Run in your terminal (or maybe even better, add to your ``.bashrc``, but
@@ -117,9 +70,77 @@ Troubleshooting
 
 .. _this issue: https://code.djangoproject.com/ticket/16017
 
+* [**possible Ubuntu dependencies**] Several users reported the need to install 
+  also ``libpq-dev`` (header files for libpq5 - PostgreSQL library)::
 
-* Within a virtual environment, attempt to visualize a structure with ``ase`` (either from the shell, or using the 
-  command ``verdi data structure show --format=ase <PK>``), might end up with the following error message::
+    apt-get install libpq-dev
+
+  But under Ubuntu 12.04 this is not needed.
+
+Configuring remote SSH computers
+--------------------------------
+
+* [**ssh_kerberos installation**] When installing the ``ssh_kerberos`` *optional*
+  requirement through Anaconda you may encounter the following error on Ubuntu machines::
+
+    version 'GFORTRAN_1.4' not found (required by /usr/lib/libblas.so.3)
+
+  This is related to an open issue in anaconda `ContinuumIO/anaconda-issues#686`_.
+  A potential solution is to run the following command::
+
+    export LD_PRELOAD=/usr/lib/x86_64-linux-gnu/libgfortran.so.3
+
+.. _ContinuumIO/anaconda-issues#686: https://github.com/ContinuumIO/anaconda-issues/issues/686
+
+* [**.bashrc and .bash_profile behavior on remote computers**] When connecting
+  to remote computers, AiiDA (like other codes as ``sftp``) might get very confused
+  if you have code in your ``.bashrc`` or ``.bash_profile`` producing output
+  or e.g. running commands like ``clean`` that require a terminal.
+
+  For instance, if you add a ``echo "a"`` in your .bashrc and then try to SFTP
+  a file from it, you will get an error like ``Received message too long 1091174400``.
+
+  If you still want to have code that needs an interactive shell (``echo``, 
+  ``clean``, ...), but you want to disable it for non-interactive shells, put your
+  code in a guard like this::
+
+    case $- in
+    *i*)
+       ## Put here code that can only work on interactive shells
+       clear
+       echo "Hi! This is a new shell"
+       ;;
+    esac
+
+  Also, if you need to have some environment variables set (e.g. the path
+  to an executable), make sure that this is set in the ``.bashrc`` file 
+  (and not only in the ``.bash_profile`` or equivalent files that are only
+  loaded for login shells; see e.g. this `StackExchange thread`_ for the difference 
+  - as suggested in one of the answers, you might want to put the PATH definitions
+  in ``.bashrc``, and source it from ``.bash_profile``).
+
+  To test if a command works in a non-interactive shell, you can run::
+
+     ssh <MACHINENAME> <COMMAND>
+
+  (this is equivalent to what AiiDA does) and check, e.g., that the executable
+  is found, that there is no spurious output, etc.
+
+  **Notes**: The fact that there is no spurious output is checked by
+  ``verdi computer test``, which suggests how to solve the problem.
+  You can track the discussion on this issue in `aiidateam/aiida_core#1890`_.
+
+.. _aiidateam/aiida_core#1890: https://github.com/aiidateam/aiida_core/issues/1890
+.. _StackExchange thread: https://apple.stackexchange.com/questions/51036/what-is-the-difference-between-bash-profile-and-bashrc
+
+
+Improvements for dependencies
+-----------------------------
+* [**Activating the ASE visualizer**] Within a virtual environment, 
+  attempt to visualize a structure 
+  with ``ase`` (either from the shell, or using the 
+  command ``verdi data structure show --format=ase <PK>``), 
+  might end up with the following error message::
   
      ImportError: No module named pygtk
 
@@ -153,7 +174,38 @@ Troubleshooting
 
   After that, ``verdi data structure show --format=ase <PK>`` should work.
 
-* [*Only for developers*] The developer tests of the *SSH* transport plugin are
+Use in ipython/jupyter
+----------------------
+
+* In order to use the AiiDA objects and functions in Jupyter, this latter has to be instructed to use the iPython kernel installed in the AiiDA virtual environment. This happens by default if you install AiiDA with ``pip`` including the ``notebook`` option and run Jupyter from the AiiDA virtual environment.
+
+  If, for any reason, you do not want to install Jupyter in the virtual environment, you might consider to install it out of the virtual environment, if not already done::
+
+      $ pip install jupyter
+
+  Then, activate the AiiDA virtual environment::
+
+      $ source ~/<aiida.virtualenv>/bin/activate
+
+  and setup the AiiDA iPython kernel::
+
+      $ pip install ipykernel
+      $ python -m ipykernel install --user --name=<aiida.kernel.name>
+
+  where you have chosen a meaningful name for the new kernel.
+
+  Finally, start a Jupyter server::
+
+      $ jupyter notebook
+
+  and from the newly opened browser tab select ``New -> <aiida.kernel.name>``
+
+.. _updating_aiida:
+
+For developers (testing)
+------------------------
+
+* [**Making the SSH tests pass**] The developer tests of the *SSH* transport plugin are
   performed connecting to ``localhost``. The tests will fail if
   a passwordless ssh connection is not set up. Therefore, if you want to run
   the tests:
@@ -171,7 +223,4 @@ Troubleshooting
 
     (it will ask your password, because it is connecting via ssh to ``localhost``
     to install your public key inside ~/.ssh/authorized_keys).
-
-.. _updating_aiida:
-
 

--- a/docs/source/install/details/troubleshooting.rst
+++ b/docs/source/install/details/troubleshooting.rst
@@ -92,42 +92,36 @@ Configuring remote SSH computers
 
 .. _ContinuumIO/anaconda-issues#686: https://github.com/ContinuumIO/anaconda-issues/issues/686
 
-* [**.bashrc and .bash_profile behavior on remote computers**] When connecting
+* [**.bashrc and .bash_profile behavior on remote computers**] 
+  (**NOTE** This applies also to a computer configured via a ``local`` transport!)
+  
+  When connecting
   to remote computers, AiiDA (like other codes as ``sftp``) might get very confused
   if you have code in your ``.bashrc`` or ``.bash_profile`` producing output
   or e.g. running commands like ``clean`` that require a terminal.
 
-  For instance, if you add a ``echo "a"`` in your .bashrc and then try to SFTP
+  For instance, if you add a ``echo "a"`` in your ``.bashrc`` and then try to SFTP
   a file from it, you will get an error like ``Received message too long 1091174400``.
 
   If you still want to have code that needs an interactive shell (``echo``, 
-  ``clean``, ...), but you want to disable it for non-interactive shells, put your
-  code in a guard like this::
+  ``clean``, ...), but you want to disable it for non-interactive shells, put 
+  at the top of your file a guard like this::
 
-    case $- in
-    *i*)
-       ## Put here code that can only work on interactive shells
-       clear
-       echo "Hi! This is a new shell"
-       ;;
-    esac
+    if [[ $- != *i* ]] ; then
+      # Shell is non-interactive.  Be done now!
+      return
+    fi
 
-  Also, if you need to have some environment variables set (e.g. the path
-  to an executable), make sure that this is set in the ``.bashrc`` file 
-  (and not only in the ``.bash_profile`` or equivalent files that are only
-  loaded for login shells; see e.g. this `StackExchange thread`_ for the difference 
-  - as suggested in one of the answers, you might want to put the PATH definitions
-  in ``.bashrc``, and source it from ``.bash_profile``).
+  Everything below this will not be executed in a non-interactive shell.
+  **Note**: Still, you might want to have some code on top, like e.g. setting the PATH or 
+  similar, if this needs to be run also in the case of non-interactive shells.
 
-  To test if a command works in a non-interactive shell, you can run::
+  To test if a the computer does not produce spurious output, run (after 
+  configuring)::
 
-     ssh <MACHINENAME> <COMMAND>
+     verdi computer test <COMPUTERNAME>
 
-  (this is equivalent to what AiiDA does) and check, e.g., that the executable
-  is found, that there is no spurious output, etc.
-
-  **Notes**: The fact that there is no spurious output is checked by
-  ``verdi computer test``, which suggests how to solve the problem.
+  which checks and, in case of problems, suggests how to solve the problem.
   You can track the discussion on this issue in `aiidateam/aiida_core#1890`_.
 
 .. _aiidateam/aiida_core#1890: https://github.com/aiidateam/aiida_core/issues/1890


### PR DESCRIPTION
This fixes #1890 and fixes #1887.
This is a different solution than PR #1888 and superses it.
We both document what the user shell should NOT do (produce
output if in interactive mode), and explain how to keep this
but guard it so that no output is produced at least in
non-interactive mode.
Moreover, we add a test in `verdi computer test` that has pointers
to the documentation and the issue, making it (hopefully) clear
early on to the user on how to solve the issue.