### PR TITLE
Fix cyclic dependency in REST API translators

### DIFF
--- a/aiida/restapi/translator/node.py
+++ b/aiida/restapi/translator/node.py
@@ -483,10 +483,7 @@ class NodeTranslator(BaseTranslator):
         :param node: node object
         :returns: list of calc inputls command
         """
-
-        if node.type.startswith("calculation"):
-            from aiida.restapi.translator.calculation import CalculationTranslator
-            return CalculationTranslator.get_retrieved_inputs(node, filename=filename, rtype=rtype)
+        # pylint: disable=unused-argument
         return []
 
     @staticmethod
@@ -500,10 +497,7 @@ class NodeTranslator(BaseTranslator):
         :param node: node object
         :returns: list of calc outputls command
         """
-
-        if node.type.startswith("calculation"):
-            from aiida.restapi.translator.calculation import CalculationTranslator
-            return CalculationTranslator.get_retrieved_outputs(node, filename=filename, rtype=rtype)
+        # pylint: disable=unused-argument
         return []
 
     @staticmethod


### PR DESCRIPTION
Fixes #2137  (this might not be the optimal solution, but I think the class hierarchy might need some reorganizing for that which would be too much work for now.)

The `CalculationTranslator` is a sub class of the `NodeTranslator`, but the
latter was importing the former in the `get_retrieved_inputs` and the
`get_retrieved_ouputs` methods. These methods are called in the `_get_content`
method of the `NodeTranslator` but are only meaningful and only really
implemented for the `CalculationTranslator`. Since the latter is a sub class
simply overriding it will yield the correct result when the `_get_content`
method is called as it will be overridden.