### PR TITLE
Refactor the `Profile`, `ProfileConfig` and `DaemonClient` classes

### DIFF
--- a/.ci/test_daemon.py
+++ b/.ci/test_daemon.py
@@ -19,7 +19,7 @@ from six.moves import range
 
 from aiida.common.exceptions import NotExistent
 from aiida.common.caching import enable_caching
-from aiida.daemon.client import DaemonClient
+from aiida.daemon.client import get_daemon_client
 from aiida.orm import Code, CalculationFactory, DataFactory
 from aiida.orm.data.int import Int
 from aiida.orm.data.str import Str
@@ -43,7 +43,7 @@ number_workchains = 8 # Number of workchains to submit
 
 
 def print_daemon_log():
-    daemon_client = DaemonClient()
+    daemon_client = get_daemon_client()
     daemon_log = daemon_client.daemon_log_file
 
     print("Output of 'cat {}':".format(daemon_log))

--- a/aiida/backends/tests/daemon/test_client.py
+++ b/aiida/backends/tests/daemon/test_client.py
@@ -12,7 +12,7 @@ from __future__ import print_function
 from __future__ import absolute_import
 import zmq
 from aiida.backends.testbase import AiidaTestCase
-from aiida.daemon.client import DaemonClient
+from aiida.daemon.client import get_daemon_client
 
 
 class TestBackendLog(AiidaTestCase):
@@ -27,7 +27,7 @@ class TestBackendLog(AiidaTestCase):
 
         See issue #1317 and pull request #1403 for the discussion
         """
-        daemon_client = DaemonClient()
+        daemon_client = get_daemon_client()
 
         controller_endpoint = daemon_client.get_controller_endpoint()
         pubsub_endpoint = daemon_client.get_pubsub_endpoint()

--- a/aiida/cmdline/commands/cmd_daemon.py
+++ b/aiida/cmdline/commands/cmd_daemon.py
@@ -24,7 +24,7 @@ from aiida.cmdline.utils.common import get_env_with_venv_bin
 from aiida.cmdline.utils.daemon import get_daemon_status, print_client_response_status
 from aiida.common.profile import get_current_profile_name
 from aiida.common.setup import get_profiles_list
-from aiida.daemon.client import DaemonClient
+from aiida.daemon.client import get_daemon_client
 
 
 @verdi.group('daemon')
@@ -41,14 +41,14 @@ def start(foreground):
     """
     Start the daemon
     """
-    client = DaemonClient()
+    client = get_daemon_client()
 
     echo.echo('Starting the daemon... ', nl=False)
 
     if foreground:
-        command = ['verdi', '-p', client.profile_name, 'daemon', '_start_circus', '--foreground']
+        command = ['verdi', '-p', client.profile.name, 'daemon', '_start_circus', '--foreground']
     else:
-        command = ['verdi', '-p', client.profile_name, 'daemon', '_start_circus']
+        command = ['verdi', '-p', client.profile.name, 'daemon', '_start_circus']
 
     try:
         currenv = get_env_with_venv_bin()
@@ -76,7 +76,7 @@ def status(all_profiles):
         profiles = [get_current_profile_name()]
 
     for profile_name in profiles:
-        client = DaemonClient(profile_name)
+        client = get_daemon_client(profile_name)
         click.secho('Profile: ', fg='red', bold=True, nl=False)
         click.secho('{}'.format(profile_name), bold=True)
         result = get_daemon_status(client)
@@ -90,7 +90,7 @@ def incr(number):
     """
     Add NUMBER [default=1] workers to the running daemon
     """
-    client = DaemonClient()
+    client = get_daemon_client()
     response = client.increase_workers(number)
     print_client_response_status(response)
 
@@ -102,7 +102,7 @@ def decr(number):
     """
     Remove NUMBER [default=1] workers from the running daemon
     """
-    client = DaemonClient()
+    client = get_daemon_client()
     response = client.decrease_workers(number)
     print_client_response_status(response)
 
@@ -112,7 +112,7 @@ def logshow():
     """
     Show the log of the daemon, press CTRL+C to quit
     """
-    client = DaemonClient()
+    client = get_daemon_client()
 
     try:
         currenv = get_env_with_venv_bin()
@@ -136,7 +136,7 @@ def stop(no_wait, all_profiles):
 
     for profile_name in profiles:
 
-        client = DaemonClient(profile_name)
+        client = get_daemon_client(profile_name)
 
         click.secho('Profile: ', fg='red', bold=True, nl=False)
         click.secho('{}'.format(profile_name), bold=True)
@@ -171,7 +171,7 @@ def restart(ctx, reset, no_wait):
     is passed, however, the full circus daemon will be stopped and restarted with just
     a single worker
     """
-    client = DaemonClient()
+    client = get_daemon_client()
 
     wait = not no_wait
 
@@ -208,7 +208,7 @@ def _start_circus(foreground):
     from circus.pidfile import Pidfile
     from circus.util import check_future_exception_and_log, configure_logger
 
-    client = DaemonClient()
+    client = get_daemon_client()
 
     loglevel = client.loglevel
     logoutput = '-'

--- a/aiida/cmdline/commands/cmd_profile.py
+++ b/aiida/cmdline/commands/cmd_profile.py
@@ -64,7 +64,7 @@ def profile_show(profile):
     import tabulate
 
     headers = ('Attribute', 'Value')
-    data = sorted([(k.lower(), v) for k, v in profile.items()])
+    data = sorted([(k.lower(), v) for k, v in profile.config.items()])
     echo.echo(tabulate.tabulate(data, headers=headers))
 
 

--- a/aiida/cmdline/params/types/profile.py
+++ b/aiida/cmdline/params/types/profile.py
@@ -21,21 +21,15 @@ class ProfileParamType(click.ParamType):
 
     def convert(self, value, param, ctx):
         """Attempt to match the given value to a valid profile."""
-        from aiida.common.exceptions import MissingConfigurationError
-        from aiida.common.profile import Profile
-        from aiida.common.setup import get_config
+        from aiida.common.exceptions import MissingConfigurationError, ProfileConfigurationError
+        from aiida.common.profile import get_profile
 
         try:
-            profiles = get_config()
-        except MissingConfigurationError:
-            self.fail('could not load the configuration file')
+            profile = get_profile(name=value)
+        except (MissingConfigurationError, ProfileConfigurationError) as exception:
+            self.fail(str(exception))
 
-        try:
-            profile = profiles['profiles'][value]
-        except KeyError:
-            self.fail('invalid profile name {}'.format(value))
-
-        return Profile(name=value, **profile)
+        return profile
 
     def complete(self, ctx, incomplete):  # pylint: disable=unused-argument,no-self-use
         """

--- a/aiida/cmdline/utils/common.py
+++ b/aiida/cmdline/utils/common.py
@@ -55,12 +55,12 @@ def print_last_process_state_change(process_type=None):
         Valid process types are either 'calculation' or 'work'.
     """
     from aiida.cmdline.utils.echo import echo_info, echo_warning
-    from aiida.daemon.client import DaemonClient
+    from aiida.daemon.client import get_daemon_client
     from aiida.utils import timezone
     from aiida.common.utils import str_timedelta
     from aiida.work.utils import get_process_state_change_timestamp
 
-    client = DaemonClient()
+    client = get_daemon_client()
 
     timestamp = get_process_state_change_timestamp(process_type)
 

--- a/aiida/cmdline/utils/decorators.py
+++ b/aiida/cmdline/utils/decorators.py
@@ -143,9 +143,9 @@ def only_if_daemon_running(echo_function=echo.echo_critical, message=None):
         @wraps(function)
         def decorated_function(*args, **kwargs):
             """If daemon pid file is not found / empty, echo message and call decorated function."""
-            from aiida.daemon.client import DaemonClient
+            from aiida.daemon.client import get_daemon_client
 
-            daemon_client = DaemonClient()
+            daemon_client = get_daemon_client()
 
             if not daemon_client.get_daemon_pid():
                 echo_function(message)

--- a/aiida/common/setup.py
+++ b/aiida/common/setup.py
@@ -355,9 +355,6 @@ def get_profile_config(profile, conf_dict=None):
     :param conf_dict: if passed, use the provided dictionary rather than reading
         it from file.
     """
-    import sys
-    import tempfile
-
     from aiida.common.exceptions import ConfigurationError, ProfileConfigurationError
 
     if conf_dict is None:

--- a/aiida/daemon/runner.py
+++ b/aiida/daemon/runner.py
@@ -15,7 +15,7 @@ import signal
 from functools import partial
 
 from aiida.common.log import configure_logging
-from aiida.daemon.client import DaemonClient
+from aiida.daemon.client import get_daemon_client
 from aiida.work.rmq import get_rmq_config
 from aiida.work import DaemonRunner, set_runner
 
@@ -29,7 +29,7 @@ def start_daemon():
     """
     Start a daemon runner for the currently configured profile
     """
-    daemon_client = DaemonClient()
+    daemon_client = get_daemon_client()
     configure_logging(daemon=True, daemon_log_file=daemon_client.daemon_log_file)
 
     try:

--- a/aiida/work/rmq.py
+++ b/aiida/work/rmq.py
@@ -76,10 +76,10 @@ def get_rmq_prefix():
 
     :returns: string prefix for the RMQ communicators
     """
-    from aiida.common.profile import ProfileConfig
+    from aiida.common.profile import get_profile
 
-    profile_config = ProfileConfig()
-    prefix = profile_config.rmq_prefix
+    profile = get_profile()
+    prefix = profile.rmq_prefix
 
     return prefix
 


### PR DESCRIPTION
Fixes #2143 

I need these changes to be able to write the necessary code of creating runners on the `new_engine` branch. Runners take different settings for test profiles in order to make sure that the RabbitMQ resources are cleaned up properly. This change makes it easier to get the profile and check whether it is a test profile. In the future, other code dealing with profiles and test settings will have to be plugged onto this code.

The `ProfileConfig` class is merged into the `Profile` class as the single
class to represent a profile. The config dictionary from the configuration
file is stored as the `config` property. The `Profile` class now also implements
the `is_test_profile` property, which should be the single point of truth when
determining whether a profile is a test profile. This is currently still based
on whether its name starts with `test_`, but by centralizing this question in
this class, it will be easy to change in the future when we device a more robust
definition of a test profile.

The `DaemonClient` now takes a `Profile` instance on construction instead of
sub classing it. To instantiate a `Profile` or `DaemonClient` instance, the
helper functions `get_profile` and `get_daemon_client` should be used, which
take an optional profile name and if left unspecified will use the current
default profile.