### PR TITLE
Allow the `CodeParamType` to require a specific entry point

### DIFF
--- a/aiida/backends/tests/cmdline/params/types/test_code.py
+++ b/aiida/backends/tests/cmdline/params/types/test_code.py
@@ -10,6 +10,9 @@
 from __future__ import division
 from __future__ import print_function
 from __future__ import absolute_import
+
+import click
+
 from aiida.backends.testbase import AiidaTestCase
 from aiida.cmdline.params.types import CodeParamType
 from aiida.orm import Code
@@ -28,10 +31,13 @@ class TestCodeParamType(AiidaTestCase):
         """
         super(TestCodeParamType, cls).setUpClass()
 
-        cls.param = CodeParamType()
+        cls.param_base = CodeParamType()
+        cls.param_entry_point = CodeParamType(entry_point='simpleplugins.arithmetic.add')
         cls.entity_01 = Code(remote_computer_exec=(cls.computer, '/bin/true')).store()
-        cls.entity_02 = Code(remote_computer_exec=(cls.computer, '/bin/true')).store()
-        cls.entity_03 = Code(remote_computer_exec=(cls.computer, '/bin/true')).store()
+        cls.entity_02 = Code(remote_computer_exec=(cls.computer, '/bin/true'),
+            input_plugin_name='simpleplugins.arithmetic.add').store()
+        cls.entity_03 = Code(remote_computer_exec=(cls.computer, '/bin/true'),
+            input_plugin_name='simpleplugins.templatereplacer').store()
 
         cls.entity_01.label = 'computer_01'
         cls.entity_02.label = str(cls.entity_01.pk)
@@ -42,7 +48,7 @@ class TestCodeParamType(AiidaTestCase):
         Verify that using the ID will retrieve the correct entity
         """
         identifier = '{}'.format(self.entity_01.pk)
-        result = self.param.convert(identifier, None, None)
+        result = self.param_base.convert(identifier, None, None)
         self.assertEquals(result.uuid, self.entity_01.uuid)
 
     def test_get_by_uuid(self):
@@ -50,7 +56,7 @@ class TestCodeParamType(AiidaTestCase):
         Verify that using the UUID will retrieve the correct entity
         """
         identifier = '{}'.format(self.entity_01.uuid)
-        result = self.param.convert(identifier, None, None)
+        result = self.param_base.convert(identifier, None, None)
         self.assertEquals(result.uuid, self.entity_01.uuid)
 
     def test_get_by_label(self):
@@ -58,7 +64,7 @@ class TestCodeParamType(AiidaTestCase):
         Verify that using the LABEL will retrieve the correct entity
         """
         identifier = '{}'.format(self.entity_01.label)
-        result = self.param.convert(identifier, None, None)
+        result = self.param_base.convert(identifier, None, None)
         self.assertEquals(result.uuid, self.entity_01.uuid)
 
     def test_get_by_fullname(self):
@@ -66,7 +72,7 @@ class TestCodeParamType(AiidaTestCase):
         Verify that using the LABEL@machinename will retrieve the correct entity
         """
         identifier = '{}@{}'.format(self.entity_01.label, self.computer.name)
-        result = self.param.convert(identifier, None, None)
+        result = self.param_base.convert(identifier, None, None)
         self.assertEquals(result.uuid, self.entity_01.uuid)
 
     def test_ambiguous_label_pk(self):
@@ -77,11 +83,11 @@ class TestCodeParamType(AiidaTestCase):
         Appending the special ambiguity breaker character will force the identifier to be treated as a LABEL
         """
         identifier = '{}'.format(self.entity_02.label)
-        result = self.param.convert(identifier, None, None)
+        result = self.param_base.convert(identifier, None, None)
         self.assertEquals(result.uuid, self.entity_01.uuid)
 
         identifier = '{}{}'.format(self.entity_02.label, OrmEntityLoader.LABEL_AMBIGUITY_BREAKER_CHARACTER)
-        result = self.param.convert(identifier, None, None)
+        result = self.param_base.convert(identifier, None, None)
         self.assertEquals(result.uuid, self.entity_02.uuid)
 
     def test_ambiguous_label_uuid(self):
@@ -92,9 +98,19 @@ class TestCodeParamType(AiidaTestCase):
         Appending the special ambiguity breaker character will force the identifier to be treated as a LABEL
         """
         identifier = '{}'.format(self.entity_03.label)
-        result = self.param.convert(identifier, None, None)
+        result = self.param_base.convert(identifier, None, None)
         self.assertEquals(result.uuid, self.entity_01.uuid)
 
         identifier = '{}{}'.format(self.entity_03.label, OrmEntityLoader.LABEL_AMBIGUITY_BREAKER_CHARACTER)
-        result = self.param.convert(identifier, None, None)
+        result = self.param_base.convert(identifier, None, None)
         self.assertEquals(result.uuid, self.entity_03.uuid)
+
+    def test_entry_point_validation(self):
+        """Verify that when an `entry_point` is defined in the constructor, it is respected in the validation."""
+        identifier = '{}'.format(self.entity_02.pk)
+        result = self.param_entry_point.convert(identifier, None, None)
+        self.assertEquals(result.uuid, self.entity_02.uuid)
+
+        with self.assertRaises(click.BadParameter):
+            identifier = '{}'.format(self.entity_03.pk)
+            result = self.param_entry_point.convert(identifier, None, None)

--- a/aiida/cmdline/params/types/code.py
+++ b/aiida/cmdline/params/types/code.py
@@ -7,13 +7,12 @@
 # For further information on the license, see the LICENSE.txt file        #
 # For further information please visit http://www.aiida.net               #
 ###########################################################################
-"""
-Module to define the custom click type for code
-"""
-
+"""Module to define the custom click type for code."""
 from __future__ import division
 from __future__ import print_function
 from __future__ import absolute_import
+
+import click
 from .identifier import IdentifierParamType
 
 
@@ -23,6 +22,15 @@ class CodeParamType(IdentifierParamType):
     """
 
     name = 'Code'
+
+    def __init__(self, sub_classes=None, entry_point=None):
+        """Construct the param type
+
+        :param sub_classes: specify a tuple of Code sub classes to narrow the query set
+        :param entry_point: specify an optional calculation entry point that the Code's input plugin should match
+        """
+        super(CodeParamType, self).__init__(sub_classes)
+        self._entry_point = entry_point
 
     @property
     def orm_class_loader(self):
@@ -34,3 +42,14 @@ class CodeParamType(IdentifierParamType):
         """
         from aiida.orm.utils.loaders import CodeEntityLoader
         return CodeEntityLoader
+
+    def convert(self, value, param, ctx):
+        code = super(CodeParamType, self).convert(value, param, ctx)
+
+        if code and self._entry_point is not None:
+            entry_point = code.get_input_plugin_name()
+            if entry_point != self._entry_point:
+                raise click.BadParameter('the retrieved Code<{}> has plugin type "{}" while "{}" is required'.format(
+                    code.pk, entry_point, self._entry_point))
+
+        return code


### PR DESCRIPTION
Fixes #2148 

The `CodeParamType` enables automatic value parsing and validation for
options for command line utilities that expect a `Code` instance. In many
cases, one wants to narrow that down to not just any code, but a code
that is configured for a specific input plugin (i.e. calculation entry
point).