### PR TITLE
Engine stability and communications improvements

### DIFF
--- a/.ci/test_script.sh
+++ b/.ci/test_script.sh
@@ -34,7 +34,7 @@ case "$TEST_TYPE" in
 
         # Run verdi devel tests
         VERDI=`which verdi`
-        coverage run -a $VERDI -p test_${TEST_AIIDA_BACKEND} devel tests
+        coverage run -a $VERDI -p test_${TEST_AIIDA_BACKEND} devel tests -v
 
         # Run the daemon tests using docker
         # Note: This is not a typo, the profile is called ${TEST_AIIDA_BACKEND}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -364,7 +364,6 @@
         aiida/utils/find_folder.py|
         aiida/utils/__init__.py|
         aiida/utils/queries.py|
-        aiida/utils/serialize.py|
         aiida/utils/test_timezone.py|
         aiida/utils/timezone.py|
         aiida/utils/which.py|

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -37,7 +37,6 @@
         aiida/backends/djsite/db/subtests/__init__.py|
         aiida/backends/djsite/db/subtests/nodes.py|
         aiida/backends/djsite/db/subtests/query.py|
-        aiida/backends/djsite/db/testbase.py|
         aiida/backends/djsite/db/views.py|
         aiida/backends/djsite/globalsettings.py|
         aiida/backends/djsite/__init__.py|
@@ -149,7 +148,6 @@
         aiida/backends/tests/test_caching_config.py|
         aiida/backends/tests/test_plugin_loader.py|
         aiida/backends/tests/utils/fixtures.py|
-        aiida/backends/tests/utils/test_serialize.py|
         aiida/backends/tests/work/class_loader.py|
         aiida/backends/tests/work/daemon.py|
         aiida/backends/tests/workflows.py|
@@ -288,7 +286,6 @@
         aiida/orm/implementation/sqlalchemy/workflow.py|
         aiida/orm/importexport.py|
         aiida/orm/__init__.py|
-        aiida/orm/log.py|
         aiida/orm/mixins.py|
         aiida/orm/node.py|
         aiida/orm/querybuilder.py|
@@ -374,7 +371,6 @@
         aiida/workflows/wf_XTiO3.py|
         aiida/work/__init__.py|
         aiida/work/job_processes.py|
-        aiida/work/processes.py|
         aiida/work/run.py|
         fastentrypoints.py|
         setup.py|

--- a/aiida/backends/djsite/db/testbase.py
+++ b/aiida/backends/djsite/db/testbase.py
@@ -19,7 +19,6 @@ import os
 from aiida.orm.implementation.django.backend import DjangoBackend
 from aiida.backends.testimplbase import AiidaTestImplementation
 
-
 # Add a new entry here if you add a file with tests under aiida.backends.djsite.db.subtests
 # The key is the name to use in the 'verdi test' command (e.g., a key 'generic'
 # can be run using 'verdi test db.generic')
@@ -34,6 +33,8 @@ class DjangoTests(AiidaTestImplementation):
     """
     Automatically takes care of the setUpClass and TearDownClass, when needed.
     """
+
+    # pylint: disable=attribute-defined-outside-init
 
     # Note this is has to be a normal method, not a class method
     def setUpClass_method(self):
@@ -62,16 +63,14 @@ class DjangoTests(AiidaTestImplementation):
         try:
             self.user = DbUser.objects.get(email=get_configured_user_email())
         except ObjectDoesNotExist:
-            self.user = DbUser.objects.create_user(get_configured_user_email(),
-                                                   'fakepwd')
+            self.user = DbUser.objects.create_user(get_configured_user_email(), 'fakepwd')
         # Reqired by the calling class
         self.user_email = self.user.email
 
         super(DjangoTests, self).insert_data()
 
     def clean_db(self):
-        from aiida.backends.djsite.db.models import (
-            DbComputer, DbUser, DbWorkflow, DbWorkflowStep, DbWorkflowData)
+        from aiida.backends.djsite.db.models import (DbComputer, DbUser, DbWorkflow, DbWorkflowStep, DbWorkflowData)
         from aiida.common.utils import get_configured_user_email
 
         # Complicated way to make sure we 'unwind' all the relationships
@@ -80,7 +79,7 @@ class DjangoTests(AiidaTestImplementation):
         DbWorkflowStep.sub_workflows.through.objects.all().delete()
         DbWorkflowData.objects.all().delete()
         DbWorkflowStep.objects.all().delete()
-        DbWorkflow.objects.all().delete()
+        DbWorkflow.objects.all().delete()  # pylint: disable=no-member
 
         # Delete groups
         from aiida.backends.djsite.db.models import DbGroup
@@ -98,7 +97,7 @@ class DjangoTests(AiidaTestImplementation):
         # delete computers and users
         from aiida.backends.djsite.db.models import DbNode
 
-        DbNode.objects.all().delete()
+        DbNode.objects.all().delete()  # pylint: disable=no-member
 
         # I delete all the users except the default user.
         # See discussion in setUpClass
@@ -116,8 +115,7 @@ class DjangoTests(AiidaTestImplementation):
         from aiida.common.setup import TEST_KEYWORD
         from aiida.common.exceptions import InvalidOperation
 
-        base_repo_path = os.path.basename(
-            os.path.normpath(REPOSITORY_PATH))
+        base_repo_path = os.path.basename(os.path.normpath(REPOSITORY_PATH))
         if TEST_KEYWORD not in base_repo_path:
             raise InvalidOperation("Be careful. The repository for the tests "
                                    "is not a test repository. I will not "

--- a/aiida/backends/testimplbase.py
+++ b/aiida/backends/testimplbase.py
@@ -38,8 +38,8 @@ class AiidaTestImplementation(object):
     """
 
     # This should be set by the implementing class in setUpClass_method()
-    backend = None  # type: :class:`aiida.orm.backend.Backend`
-    computer = None  # type: :class:`aiida.orm.Computer`
+    backend = None  # type: aiida.orm.Backend
+    computer = None  # type: aiida.orm.Computer
 
     @abstractmethod
     def setUpClass_method(self):

--- a/aiida/backends/tests/cmdline/commands/test_calculation.py
+++ b/aiida/backends/tests/cmdline/commands/test_calculation.py
@@ -41,13 +41,6 @@ class TestVerdiCalculation(AiidaTestCase):
         from aiida.orm.backend import construct_backend
         backend = construct_backend()
 
-        rmq_config = rmq.get_rmq_config()
-
-        # These two need to share a common event loop otherwise the first will never send
-        # the message while the daemon is running listening to intercept
-        cls.runner = runners.Runner(rmq_config=rmq_config, rmq_submit=True, poll_interval=0., testing_mode=True)
-        cls.daemon_runner = runners.DaemonRunner(rmq_config=rmq_config, rmq_submit=True, poll_interval=0., testing_mode=True)
-
         cls.computer = backend.computers.create(name='comp', hostname='localhost', transport_type='local',
                                                 scheduler_type='direct', workdir='/tmp/aiida').store()
 

--- a/aiida/backends/tests/cmdline/commands/test_calculation.py
+++ b/aiida/backends/tests/cmdline/commands/test_calculation.py
@@ -45,8 +45,8 @@ class TestVerdiCalculation(AiidaTestCase):
 
         # These two need to share a common event loop otherwise the first will never send
         # the message while the daemon is running listening to intercept
-        cls.runner = runners.Runner(rmq_config=rmq_config, rmq_submit=True, poll_interval=0.)
-        cls.daemon_runner = runners.DaemonRunner(rmq_config=rmq_config, rmq_submit=True, poll_interval=0.)
+        cls.runner = runners.Runner(rmq_config=rmq_config, rmq_submit=True, poll_interval=0., testing_mode=True)
+        cls.daemon_runner = runners.DaemonRunner(rmq_config=rmq_config, rmq_submit=True, poll_interval=0., testing_mode=True)
 
         cls.computer = backend.computers.create(name='comp', hostname='localhost', transport_type='local',
                                                 scheduler_type='direct', workdir='/tmp/aiida').store()

--- a/aiida/backends/tests/cmdline/commands/test_process.py
+++ b/aiida/backends/tests/cmdline/commands/test_process.py
@@ -11,17 +11,18 @@
 from __future__ import division
 from __future__ import print_function
 from __future__ import absolute_import
-from __future__ import print_function
 
 import datetime
 import sys
 import subprocess
+import unittest
+import time
 from concurrent.futures import Future
 
 from click.testing import CliRunner
 from tornado import gen
-import plumpy
 import kiwipy
+import plumpy
 
 from aiida.backends.testbase import AiidaTestCase
 from aiida.cmdline.commands import cmd_process
@@ -31,11 +32,15 @@ from aiida.work import runners, rmq, test_utils
 class TestVerdiProcess(AiidaTestCase):
     """Tests for `verdi process`."""
 
+    TEST_TIMEOUT = 10.
+
     def setUp(self):
         super(TestVerdiProcess, self).setUp()
+        from aiida.common.profile import get_profile
         from aiida.daemon.client import DaemonClient
 
-        self.daemon_client = DaemonClient()
+        profile = get_profile()
+        self.daemon_client = DaemonClient(profile)
         self.daemon_pid = subprocess.Popen(
             self.daemon_client.cmd_string.split(), stderr=sys.stderr, stdout=sys.stdout).pid
         self.runner = runners.Runner(
@@ -50,6 +55,7 @@ class TestVerdiProcess(AiidaTestCase):
         self.runner.close()
         super(TestVerdiProcess, self).tearDown()
 
+    @unittest.skip('until issue #2154 has been addressed')
     def test_pause_play_kill(self):
         """
         Test the pause/play/kill commands
@@ -57,6 +63,11 @@ class TestVerdiProcess(AiidaTestCase):
         from aiida.orm import load_node
 
         calc = self.runner.submit(test_utils.WaitProcess)
+        start_time = time.time()
+        while calc.process_state is not plumpy.ProcessState.WAITING:
+            if time.time() - start_time >= self.TEST_TIMEOUT:
+                self.fail("Timed out waiting for process to enter waiting state")
+
         self.assertFalse(calc.paused)
         result = self.cli_runner.invoke(cmd_process.process_pause, [str(calc.pk)])
         self.assertIsNone(result.exception, result.exception)
@@ -79,15 +90,15 @@ class TestVerdiProcess(AiidaTestCase):
 
         # Here we now that the process is with the daemon runner and in the waiting state so we can starting running
         # the `verdi process` commands that we want to test
-        result = self.cli_runner.invoke(cmd_process.process_pause, [str(calc.pk)])
+        result = self.cli_runner.invoke(cmd_process.process_pause, ['--wait', str(calc.pk)])
         self.assertIsNone(result.exception, result.exception)
         self.assertTrue(calc.paused)
 
-        result = self.cli_runner.invoke(cmd_process.process_play, [str(calc.pk)])
+        result = self.cli_runner.invoke(cmd_process.process_play, ['--wait', str(calc.pk)])
         self.assertIsNone(result.exception, result.exception)
         self.assertFalse(calc.paused)
 
-        result = self.cli_runner.invoke(cmd_process.process_kill, [str(calc.pk)])
+        result = self.cli_runner.invoke(cmd_process.process_kill, ['--wait', str(calc.pk)])
         self.assertIsNone(result.exception, result.exception)
         self.assertTrue(calc.is_terminated)
         self.assertTrue(calc.is_killed)

--- a/aiida/backends/tests/cmdline/commands/test_work.py
+++ b/aiida/backends/tests/cmdline/commands/test_work.py
@@ -20,7 +20,6 @@ from aiida.common.links import LinkType
 from aiida.common.log import LOG_LEVEL_REPORT
 from aiida.orm.calculation.function import FunctionCalculation
 from aiida.orm.calculation.work import WorkCalculation
-from aiida.work import runners, rmq, test_utils
 
 
 def get_result_lines(result):
@@ -30,24 +29,13 @@ def get_result_lines(result):
 class TestVerdiWork(AiidaTestCase):
     """Tests for `verdi work`."""
 
-    @classmethod
-    def setUpClass(cls, *args, **kwargs):
-        super(TestVerdiWork, cls).setUpClass(*args, **kwargs)
-        rmq_config = rmq.get_rmq_config()
-
-        # These two need to share a common event loop otherwise the first will never send
-        # the message while the daemon is running listening to intercept
-        cls.runner = runners.Runner(rmq_config=rmq_config, rmq_submit=True, poll_interval=0., testing_mode=True)
-
-        cls.daemon_runner = runners.DaemonRunner(rmq_config=rmq_config, rmq_submit=True, poll_interval=0., testing_mode=True)
-
     def setUp(self):
         super(TestVerdiWork, self).setUp()
         self.cli_runner = CliRunner()
 
     def test_status(self):
         """Test the status command."""
-        calc = self.runner.submit(test_utils.WaitProcess)
+        calc = WorkCalculation().store()
         result = self.cli_runner.invoke(cmd_work.work_status, [str(calc.pk)])
         self.assertIsNone(result.exception)
 

--- a/aiida/backends/tests/cmdline/commands/test_work.py
+++ b/aiida/backends/tests/cmdline/commands/test_work.py
@@ -37,9 +37,9 @@ class TestVerdiWork(AiidaTestCase):
 
         # These two need to share a common event loop otherwise the first will never send
         # the message while the daemon is running listening to intercept
-        cls.runner = runners.Runner(rmq_config=rmq_config, rmq_submit=True, poll_interval=0.)
+        cls.runner = runners.Runner(rmq_config=rmq_config, rmq_submit=True, poll_interval=0., testing_mode=True)
 
-        cls.daemon_runner = runners.DaemonRunner(rmq_config=rmq_config, rmq_submit=True, poll_interval=0.)
+        cls.daemon_runner = runners.DaemonRunner(rmq_config=rmq_config, rmq_submit=True, poll_interval=0., testing_mode=True)
 
     def setUp(self):
         super(TestVerdiWork, self).setUp()

--- a/aiida/backends/tests/utils/test_serialize.py
+++ b/aiida/backends/tests/utils/test_serialize.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+"""Serialization tests"""
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #
@@ -12,10 +13,10 @@ from __future__ import print_function
 from __future__ import absolute_import
 
 from aiida.orm import Group, Node
-from aiida.utils.serialize import serialize_data, deserialize_data
+from aiida.utils import serialize
 from aiida.backends.testbase import AiidaTestCase
-import aiida.utils.json as json
 
+# pylint: disable=missing-docstring
 
 
 class TestSerialize(AiidaTestCase):
@@ -28,19 +29,10 @@ class TestSerialize(AiidaTestCase):
         node_a = Node().store()
         node_b = Node().store()
 
-        data = {
-            'test': 1,
-            'list': [1, 2, 3, node_a],
-            'dict': {
-                ('Si',): node_b,
-                'foo': 'bar'
-            },
-            'baz': 'aar'
-        }
+        data = {'test': 1, 'list': [1, 2, 3, node_a], 'dict': {('Si',): node_b, 'foo': 'bar'}, 'baz': 'aar'}
 
-        serialized_data = serialize_data(data)
-        json_dumped = json.dumps(serialized_data)
-        deserialized_data = deserialize_data(serialized_data)
+        serialized_data = serialize.serialize(data)
+        deserialized_data = serialize.deserialize(serialized_data)
 
         # For now manual element-for-element comparison until we come up with general
         # purpose function that can equate two node instances properly
@@ -58,13 +50,54 @@ class TestSerialize(AiidaTestCase):
         group_name = 'groupie'
         group_a = Group(name=group_name).store()
 
-        data = {
-            'group': group_a
-        }
+        data = {'group': group_a}
 
-        serialized_data = serialize_data(data)
-        json_dumped = json.dumps(serialized_data)
-        deserialized_data = deserialize_data(serialized_data)
+        serialized_data = serialize.serialize(data)
+        deserialized_data = serialize.deserialize(serialized_data)
 
         self.assertEqual(data['group'].uuid, deserialized_data['group'].uuid)
         self.assertEqual(data['group'].name, deserialized_data['group'].name)
+
+    def test_serialize_node_round_trip(self):
+        """Test you can serialize and deserialize a node"""
+        node = Node().store()
+        deserialized = serialize.deserialize(serialize.serialize(node))
+        self.assertEqual(node.uuid, deserialized.uuid)
+
+    def test_serialize_group_round_trip(self):
+        """Test you can serialize and deserialize a group"""
+        group = Group(name='test_serialize_group_round_trip').store()
+        deserialized = serialize.deserialize(serialize.serialize(group))
+
+        self.assertEqual(group.uuid, deserialized.uuid)
+        self.assertEqual(group.name, deserialized.name)
+
+    def test_serialize_computer_round_trip(self):
+        """Test you can serialize and deserialize a computer"""
+        computer = self.computer
+        deserialized = serialize.deserialize(serialize.serialize(computer))
+
+        # pylint: disable=no-member
+        self.assertEqual(computer.uuid, deserialized.uuid)
+        self.assertEqual(computer.name, deserialized.name)
+
+    def test_serialize_unstored_node(self):
+        """Test that you can't serialize an unstored node"""
+        node = Node()
+
+        with self.assertRaises(ValueError):
+            serialize.serialize(node)
+
+    def test_serialize_unstored_group(self):
+        """Test that you can't serialize an unstored group"""
+        group = Group(name='test_serialize_unstored_group')
+
+        with self.assertRaises(ValueError):
+            serialize.serialize(group)
+
+    def test_serialize_unstored_computer(self):
+        """Test that you can't serialize an unstored node"""
+        computer = self.backend.computers.create('test_computer', 'test_host')
+
+        with self.assertRaises(ValueError):
+            serialize.serialize(computer)

--- a/aiida/backends/tests/work/persistence.py
+++ b/aiida/backends/tests/work/persistence.py
@@ -11,7 +11,6 @@
 from __future__ import division
 from __future__ import print_function
 from __future__ import absolute_import
-import tempfile
 
 import six
 
@@ -40,12 +39,13 @@ class TestProcess(AiidaTestCase):
         del process
 
         loaded_process = saved_state.unbundle()
-        result_from_loaded = work.launch.run(loaded_process)
+        work.launch.run(loaded_process)
 
         self.assertEqual(loaded_process.state, work.ProcessState.FINISHED)
 
 
 class TestAiiDAPersister(AiidaTestCase):
+    maxDiff = 1024
 
     def setUp(self):
         super(TestAiiDAPersister, self).setUp()
@@ -57,7 +57,7 @@ class TestAiiDAPersister(AiidaTestCase):
         bundle_saved = self.persister.save_checkpoint(process)
         bundle_loaded = self.persister.load_checkpoint(process.calc.pk)
 
-        self.assertEquals(bundle_saved, bundle_loaded)
+        self.assertDictEqual(bundle_saved, bundle_loaded)
 
     def test_delete_checkpoint(self):
         process = DummyProcess()

--- a/aiida/backends/tests/work/process.py
+++ b/aiida/backends/tests/work/process.py
@@ -66,7 +66,7 @@ class TestProcessNamespace(AiidaTestCase):
 
 class ProcessStackTest(work.Process):
     @override
-    def _run(self):
+    def run(self):
         pass
 
     @override

--- a/aiida/backends/tests/work/test_futures.py
+++ b/aiida/backends/tests/work/test_futures.py
@@ -10,14 +10,21 @@
 from __future__ import division
 from __future__ import print_function
 from __future__ import absolute_import
+
+import datetime
+
 from aiida.backends.testbase import AiidaTestCase
 from aiida import work
 import aiida.work.test_utils
+
+from tornado import gen
 
 from . import utils
 
 
 class TestWf(AiidaTestCase):
+    TIMEOUT = datetime.timedelta(seconds=5.0)
+
     def test_calculation_future_broadcasts(self):
         runner = utils.create_test_runner(with_communicator=True)
         proc = work.test_utils.DummyProcess()
@@ -27,7 +34,7 @@ class TestWf(AiidaTestCase):
             poll_interval=None,
             communicator=runner.communicator)
         work.run(proc)
-        calc_node = runner.run_until_complete(future)
+        calc_node = runner.run_until_complete(gen.with_timeout(self.TIMEOUT, future))
         self.assertEqual(proc.calc.pk, calc_node.pk)
 
     def test_calculation_future_polling(self):
@@ -39,5 +46,5 @@ class TestWf(AiidaTestCase):
             loop=runner.loop,
             poll_interval=0)
         work.run(proc)
-        calc_node = runner.run_until_complete(future)
+        calc_node = runner.run_until_complete(gen.with_timeout(self.TIMEOUT, future))
         self.assertEqual(proc.calc.pk, calc_node.pk)

--- a/aiida/backends/tests/work/test_rmq.py
+++ b/aiida/backends/tests/work/test_rmq.py
@@ -24,26 +24,31 @@ class TestProcessControl(AiidaTestCase):
     Test AiiDA's RabbitMQ functionalities.
     """
 
+    TIMEOUT = 2.
+
     def setUp(self):
         super(TestProcessControl, self).setUp()
+        from concurrent.futures import ThreadPoolExecutor
+
         prefix = '{}.{}'.format(self.__class__.__name__, uuid.uuid4())
         rmq_config = rmq.get_rmq_config(prefix)
 
         # These two need to share a common event loop otherwise the first will never send
         # the message while the daemon is running listening to intercept
-        self.runner = runners.Runner(
-            rmq_config=rmq_config,
-            rmq_submit=True,
-            poll_interval=0.)
+        self.runner = runners.Runner(rmq_config=rmq_config, poll_interval=0.)
         self.daemon_runner = runners.DaemonRunner(
             rmq_config=rmq_config,
             rmq_submit=True,
-            loop=self.runner.loop,
-            poll_interval=0.)
+            poll_interval=0.,
+            loop=self.runner.loop)
+
+        self.executor = ThreadPoolExecutor(max_workers=1)
+        self.executor.submit(self.daemon_runner.start)
 
     def tearDown(self):
         self.daemon_runner.close()
         self.runner.close()
+        self.executor.shutdown()
         super(TestProcessControl, self).tearDown()
 
     def test_submit_simple(self):
@@ -75,31 +80,49 @@ class TestProcessControl(AiidaTestCase):
         self.assertEqual(calc_node.process_state.value, plumpy.ProcessState.EXCEPTED.value)
 
     def test_pause(self):
-        """ Testing sending a pause message to the process """
+        """Testing sending a pause message to the process."""
         calc_node = self.runner.submit(test_utils.WaitProcess)
-        future = self.runner.rmq.pause_process(calc_node.pk)
-        result = self.runner.run_until_complete(future)
+        self.assertFalse(calc_node.paused)
+
+        future = self.runner.controller.pause_process(calc_node.pk)
+        result = future.result(timeout=self.TIMEOUT)
         self.assertTrue(result)
+        self.assertTrue(calc_node.paused)
 
     def test_pause_play(self):
-        """ Test sending a pause and then a play message """
+        """Test sending a pause and then a play message."""
         calc_node = self.runner.submit(test_utils.WaitProcess)
-        future = self.runner.rmq.pause_process(calc_node.pk)
-        result = self.runner.run_until_complete(future)
-        self.assertTrue(result)
+        self.assertFalse(calc_node.paused)
 
-        future = self.runner.rmq.play_process(calc_node.pk)
-        result = self.runner.run_until_complete(future)
+        pause_message = 'Take a seat'
+        future = self.runner.controller.pause_process(calc_node.pk, msg=pause_message)
+        result = future.result(timeout=self.TIMEOUT)
+        self.assertTrue(calc_node.paused)
+        self.assertEqual(calc_node.process_status, pause_message)
+
+        future = self.runner.controller.play_process(calc_node.pk)
+        result = future.result(timeout=self.TIMEOUT)
         self.assertTrue(result)
+        self.assertFalse(calc_node.paused)
+        self.assertEqual(calc_node.process_status, None)
 
     def test_kill(self):
-        """ Test sending a kill message """
+        """Test sending a kill message."""
         calc_node = self.runner.submit(test_utils.WaitProcess)
-        future = self.runner.rmq.kill_process(calc_node.pk, "Sorry, you have to go mate")
-        result = self.runner.run_until_complete(future)
-        # TODO: Check kill message
+        self.assertFalse(calc_node.is_killed)
+
+        kill_message = 'Sorry, you have to go mate'
+        future = self.runner.controller.kill_process(calc_node.pk, msg=kill_message)
+        result = future.result(timeout=self.TIMEOUT)
         self.assertTrue(result)
 
+        self._wait_for_calc(calc_node)
+        self.assertTrue(calc_node.is_killed)
+        self.assertEqual(calc_node.process_status, kill_message)
+
     def _wait_for_calc(self, calc_node, timeout=2.):
+        import threading
+        event = threading.Event()
         future = self.runner.get_calculation_future(calc_node.pk)
-        self.runner.run_until_complete(future)
+        future.add_done_callback(lambda x: event.set())
+        event.wait(timeout=timeout)

--- a/aiida/backends/tests/work/test_rmq.py
+++ b/aiida/backends/tests/work/test_rmq.py
@@ -35,12 +35,13 @@ class TestProcessControl(AiidaTestCase):
 
         # These two need to share a common event loop otherwise the first will never send
         # the message while the daemon is running listening to intercept
-        self.runner = runners.Runner(rmq_config=rmq_config, poll_interval=0.)
+        self.runner = runners.Runner(rmq_config=rmq_config, poll_interval=0., testing_mode=True)
         self.daemon_runner = runners.DaemonRunner(
             rmq_config=rmq_config,
             rmq_submit=True,
             poll_interval=0.,
-            loop=self.runner.loop)
+            loop=self.runner.loop,
+            testing_mode=True)
 
         self.executor = ThreadPoolExecutor(max_workers=1)
         self.executor.submit(self.daemon_runner.start)

--- a/aiida/backends/tests/work/test_rmq.py
+++ b/aiida/backends/tests/work/test_rmq.py
@@ -97,7 +97,8 @@ class TestProcessControl(AiidaTestCase):
             calc_node = self.runner.submit(test_utils.WaitProcess)
             self.assertFalse(calc_node.paused)
 
-            result = yield with_timeout(self.runner.controller.pause_process(calc_node.pk))
+            future = yield with_timeout(self.runner.controller.pause_process(calc_node.pk))
+            result = yield self.wait_future(future)
             self.assertTrue(result)
             self.assertTrue(calc_node.paused)
 
@@ -112,11 +113,13 @@ class TestProcessControl(AiidaTestCase):
             self.assertFalse(calc_node.paused)
 
             pause_message = 'Take a seat'
-            yield with_timeout(self.runner.controller.pause_process(calc_node.pk, msg=pause_message))
+            future = yield with_timeout(self.runner.controller.pause_process(calc_node.pk, msg=pause_message))
+            result = yield self.wait_future(future)
             self.assertTrue(calc_node.paused)
             self.assertEqual(calc_node.process_status, pause_message)
 
-            result = yield with_timeout(self.runner.controller.play_process(calc_node.pk))
+            future = yield with_timeout(self.runner.controller.play_process(calc_node.pk))
+            result = yield self.wait_future(future)
             self.assertTrue(result)
             self.assertFalse(calc_node.paused)
             self.assertEqual(calc_node.process_status, None)
@@ -132,7 +135,8 @@ class TestProcessControl(AiidaTestCase):
             self.assertFalse(calc_node.is_killed)
 
             kill_message = 'Sorry, you have to go mate'
-            result = yield with_timeout(self.runner.controller.kill_process(calc_node.pk, msg=kill_message))
+            future = yield with_timeout(self.runner.controller.kill_process(calc_node.pk, msg=kill_message))
+            result = yield self.wait_future(future)
             self.assertTrue(result)
 
             self.wait_for_calc(calc_node)
@@ -144,6 +148,10 @@ class TestProcessControl(AiidaTestCase):
     @gen.coroutine
     def wait_for_calc(self, calc_node, timeout=2.):
         future = self.runner.get_calculation_future(calc_node.pk)
+        raise gen.Return((yield with_timeout(future, timeout)))
+
+    @gen.coroutine
+    def wait_future(self, future, timeout=2.):
         raise gen.Return((yield with_timeout(future, timeout)))
 
 

--- a/aiida/backends/tests/work/test_runners.py
+++ b/aiida/backends/tests/work/test_runners.py
@@ -21,7 +21,7 @@ from . import utils
 
 
 class Proc(work.Process):
-    def _run(self):
+    def run(self):
         pass
 
 

--- a/aiida/backends/tests/work/work_chain.py
+++ b/aiida/backends/tests/work/work_chain.py
@@ -380,12 +380,12 @@ class TestWorkchain(AiidaTestCase):
         test_case = self
 
         class ReturnA(work.Process):
-            def _run(self):
+            def run(self):
                 self.out('res', A)
                 return
 
         class ReturnB(work.Process):
-            def _run(self):
+            def run(self):
                 self.out('res', B)
                 return
 
@@ -597,7 +597,7 @@ class TestWorkchain(AiidaTestCase):
         test_case = self
 
         class SimpleWc(work.Process):
-            def _run(self):
+            def run(self):
                 self.out('_return', val)
                 return
 
@@ -1296,7 +1296,7 @@ class TestDefaultUniqueness(AiidaTestCase):
             super(TestDefaultUniqueness.Child, cls).define(spec)
             spec.input('a', valid_type=Bool, default=Bool(True))
 
-        def _run(self):
+        def run(self):
             pass
 
     def test_unique_default_inputs(self):

--- a/aiida/backends/tests/work/work_chain.py
+++ b/aiida/backends/tests/work/work_chain.py
@@ -411,6 +411,27 @@ class TestWorkchain(AiidaTestCase):
 
         run_and_check_success(Wf)
 
+    def test_unstored_nodes_in_context(self):
+
+        class TestWorkChain(WorkChain):
+
+            @classmethod
+            def define(cls, spec):
+                super(TestWorkChain, cls).define(spec)
+                spec.outline(
+                    cls.setup_context,
+                    cls.read_context
+                )
+
+            def setup_context(self):
+                self.ctx['some_string'] = 'Verify that strings in the context do not cause infinite recursions'
+                self.ctx['node'] = Int(1)
+
+            def read_context(self):
+                assert self.ctx['node'].is_stored, 'the node in the context was not stored during step transition'
+
+        run_and_check_success(TestWorkChain)
+
     def test_str(self):
         self.assertIsInstance(str(Wf.spec()), six.string_types)
 

--- a/aiida/cmdline/commands/cmd_calculation.py
+++ b/aiida/cmdline/commands/cmd_calculation.py
@@ -363,17 +363,20 @@ def calculation_kill(calculations, force):
         warning = 'Are you sure you want to kill {} calculations?'.format(len(calculations))
         click.confirm(warning, abort=True)
 
-    with work.new_control_panel() as control_panel:
+    with work.create_communicator() as communicator:
+
+        controller = work.create_controller(communicator=communicator)
+
         futures = []
         for calculation in calculations:
             try:
-                future = control_panel.kill_process(calculation)
+                future = controller.kill_process(calculation)
                 futures.append((calculation, future))
             except (work.RemoteException, work.DeliveryFailed) as exc:
                 echo.echo_error('Calculation<{}> killing failed {}'.format(calculation, exc))
 
         for future in futures:
-            result = control_panel._communicator.await(future[1])
+            result = future.result()
             if result:
                 echo.echo_success('Calculation<{}> successfully killed'.format(future[0]))
             else:

--- a/aiida/cmdline/commands/cmd_process.py
+++ b/aiida/cmdline/commands/cmd_process.py
@@ -65,9 +65,12 @@ def process_list(all_entries, process_state, exit_status, failed, past_days, lim
 @decorators.only_if_daemon_running(echo.echo_warning, 'daemon is not running, so process may not be reachable')
 def process_kill(processes, timeout):
     """Kill running processes."""
-    from aiida.work import RemoteException, DeliveryFailed, CommunicationTimeout, new_blocking_control_panel
+    from aiida.work import RemoteException, DeliveryFailed, CommunicationTimeout, create_communicator, create_controller
 
-    with new_blocking_control_panel(timeout=timeout) as control_panel:
+    with create_communicator() as communicator:
+
+        controller = create_controller(communicator=communicator)
+
         for process in processes:
 
             if process.is_terminated:
@@ -75,7 +78,10 @@ def process_kill(processes, timeout):
                 continue
 
             try:
-                if control_panel.kill_process(process.pk, msg='Killed through `verdi process kill`'):
+                future = controller.kill_process(process.pk, msg='Killed through `verdi process kill`')
+                result = future.result(timeout=timeout)
+
+                if result:
                     echo.echo_success('killed Process<{}>'.format(process.pk))
                 else:
                     echo.echo_error('problem killing Process<{}>'.format(process.pk))
@@ -92,9 +98,12 @@ def process_kill(processes, timeout):
 @decorators.only_if_daemon_running(echo.echo_warning, 'daemon is not running, so process may not be reachable')
 def process_pause(processes, timeout):
     """Pause running processes."""
-    from aiida.work import RemoteException, DeliveryFailed, CommunicationTimeout, new_blocking_control_panel
+    from aiida.work import RemoteException, DeliveryFailed, CommunicationTimeout, create_communicator, create_controller
 
-    with new_blocking_control_panel(timeout=timeout) as control_panel:
+    with create_communicator() as communicator:
+
+        controller = create_controller(communicator=communicator)
+
         for process in processes:
 
             if process.is_terminated:
@@ -102,7 +111,10 @@ def process_pause(processes, timeout):
                 continue
 
             try:
-                if control_panel.pause_process(process.pk, msg='Paused through `verdi process pause`'):
+                future = controller.pause_process(process.pk, msg='Paused through `verdi process pause`')
+                result = future.result(timeout=timeout)
+
+                if result:
                     echo.echo_success('paused Process<{}>'.format(process.pk))
                 else:
                     echo.echo_error('problem pausing Process<{}>'.format(process.pk))
@@ -119,9 +131,12 @@ def process_pause(processes, timeout):
 @decorators.only_if_daemon_running(echo.echo_warning, 'daemon is not running, so process may not be reachable')
 def process_play(processes, timeout):
     """Play paused processes."""
-    from aiida.work import RemoteException, DeliveryFailed, CommunicationTimeout, new_blocking_control_panel
+    from aiida.work import RemoteException, DeliveryFailed, CommunicationTimeout, create_communicator, create_controller
 
-    with new_blocking_control_panel(timeout=timeout) as control_panel:
+    with create_communicator() as communicator:
+
+        controller = create_controller(communicator=communicator)
+
         for process in processes:
 
             if process.is_terminated:
@@ -129,7 +144,10 @@ def process_play(processes, timeout):
                 continue
 
             try:
-                if control_panel.play_process(process.pk):
+                future = controller.play_process(process.pk)
+                result = future.result(timeout=timeout)
+
+                if result:
                     echo.echo_success('played Process<{}>'.format(process.pk))
                 else:
                     echo.echo_critical('problem playing Process<{}>'.format(process.pk))
@@ -147,6 +165,7 @@ def process_watch(processes):
     """Watch the state transitions for a process."""
     from kiwipy import BroadcastFilter
     from aiida.work.rmq import create_communicator
+    import concurrent.futures
 
     def _print(body, sender, subject, correlation_id):
         echo.echo('pk={}, subject={}, body={}, correlation_id={}'.format(sender, subject, body, correlation_id))
@@ -162,11 +181,11 @@ def process_watch(processes):
         communicator.add_broadcast_subscriber(BroadcastFilter(_print, sender=process.pk))
 
     try:
-        communicator.await()
+        # Block this thread indefinitely
+        concurrent.futures.Future().result()
     except (SystemExit, KeyboardInterrupt):
-
         try:
-            communicator.disconnect()
+            communicator.stop()
         except RuntimeError:
             pass
 

--- a/aiida/cmdline/commands/cmd_process.py
+++ b/aiida/cmdline/commands/cmd_process.py
@@ -61,15 +61,21 @@ def process_list(all_entries, process_state, exit_status, failed, past_days, lim
 @verdi_process.command('kill')
 @arguments.PROCESSES()
 @options.TIMEOUT()
+@click.option(
+    '--wait/--no-wait',
+    default=False,
+    help="wait for the action to be completed otherwise return as soon as it's scheduled")
 @decorators.with_dbenv()
 @decorators.only_if_daemon_running(echo.echo_warning, 'daemon is not running, so process may not be reachable')
-def process_kill(processes, timeout):
+def process_kill(processes, timeout, wait):
     """Kill running processes."""
-    from aiida.work import RemoteException, DeliveryFailed, CommunicationTimeout, create_communicator, create_controller
+    from aiida.work import create_communicator, create_controller
 
     with create_communicator() as communicator:
 
         controller = create_controller(communicator=communicator)
+
+        futures = {}
 
         for process in processes:
 
@@ -77,32 +83,31 @@ def process_kill(processes, timeout):
                 echo.echo_error('Process<{}> is already terminated'.format(process.pk))
                 continue
 
-            try:
-                future = controller.kill_process(process.pk, msg='Killed through `verdi process kill`')
-                result = future.result(timeout=timeout)
+            future = controller.kill_process(process.pk, msg='Killed through `verdi process kill`')
+            futures[future] = process
 
-                if result:
-                    echo.echo_success('killed Process<{}>'.format(process.pk))
-                else:
-                    echo.echo_error('problem killing Process<{}>'.format(process.pk))
-            except CommunicationTimeout:
-                echo.echo_error('call to kill Process<{}> timed out'.format(process.pk))
-            except (RemoteException, DeliveryFailed) as exception:
-                echo.echo_error('failed to kill Process<{}>: {}'.format(process.pk, exception))
+        process_actions(futures, 'kill', 'killing', 'killed', wait, timeout)
 
 
 @verdi_process.command('pause')
 @arguments.PROCESSES()
 @options.TIMEOUT()
+@click.option(
+    '--wait/--no-wait',
+    default=False,
+    help="wait for the action to be completed otherwise return as soon as it's scheduled")
 @decorators.with_dbenv()
 @decorators.only_if_daemon_running(echo.echo_warning, 'daemon is not running, so process may not be reachable')
-def process_pause(processes, timeout):
+def process_pause(processes, timeout, wait):
     """Pause running processes."""
-    from aiida.work import RemoteException, DeliveryFailed, CommunicationTimeout, create_communicator, create_controller
+    from aiida.work import create_communicator, create_controller
 
     with create_communicator() as communicator:
 
         controller = create_controller(communicator=communicator)
+
+        # Keep track of the relation between the future and process
+        futures = {}
 
         for process in processes:
 
@@ -110,32 +115,29 @@ def process_pause(processes, timeout):
                 echo.echo_error('Process<{}> is already terminated'.format(process.pk))
                 continue
 
-            try:
-                future = controller.pause_process(process.pk, msg='Paused through `verdi process pause`')
-                result = future.result(timeout=timeout)
+            future = controller.pause_process(process.pk, msg='Paused through `verdi process pause`')
+            futures[future] = process
 
-                if result:
-                    echo.echo_success('paused Process<{}>'.format(process.pk))
-                else:
-                    echo.echo_error('problem pausing Process<{}>'.format(process.pk))
-            except CommunicationTimeout:
-                echo.echo_error('call to pause Process<{}> timed out'.format(process.pk))
-            except (RemoteException, DeliveryFailed) as exception:
-                echo.echo_error('failed to pause Process<{}>: {}'.format(process.pk, exception))
+        process_actions(futures, 'pause', 'pausing', 'paused', wait, timeout)
 
 
 @verdi_process.command('play')
 @arguments.PROCESSES()
 @options.TIMEOUT()
+@click.option(
+    '--wait/--no-wait',
+    default=False,
+    help="wait for the action to be completed otherwise return as soon as it's scheduled")
 @decorators.with_dbenv()
 @decorators.only_if_daemon_running(echo.echo_warning, 'daemon is not running, so process may not be reachable')
-def process_play(processes, timeout):
+def process_play(processes, timeout, wait):
     """Play paused processes."""
-    from aiida.work import RemoteException, DeliveryFailed, CommunicationTimeout, create_communicator, create_controller
+    from aiida.work import create_communicator, create_controller
 
     with create_communicator() as communicator:
 
         controller = create_controller(communicator=communicator)
+        futures = {}
 
         for process in processes:
 
@@ -143,18 +145,10 @@ def process_play(processes, timeout):
                 echo.echo_error('Process<{}> is already terminated'.format(process.pk))
                 continue
 
-            try:
-                future = controller.play_process(process.pk)
-                result = future.result(timeout=timeout)
+            future = controller.play_process(process.pk)
+            futures[future] = process
 
-                if result:
-                    echo.echo_success('played Process<{}>'.format(process.pk))
-                else:
-                    echo.echo_critical('problem playing Process<{}>'.format(process.pk))
-            except CommunicationTimeout:
-                echo.echo_error('call to play Process<{}> timed out'.format(process.pk))
-            except (RemoteException, DeliveryFailed) as exception:
-                echo.echo_critical('failed to play Process<{}>: {}'.format(process.pk, exception))
+        process_actions(futures, 'play', 'playing', 'played', wait, timeout)
 
 
 @verdi_process.command('watch')
@@ -191,3 +185,76 @@ def process_watch(processes):
 
         # Reraise to trigger clicks builtin abort sequence
         raise
+
+
+def process_actions(futures_map, infinitive, present, past, wait=False, timeout=None):
+    """
+    Process the requested actions sent to a set of Processes given a map of the futures and the
+    corresponding processes.  This function will echo the correct information strings based on
+    the outcomes of the futures and the given verb conjugations.  You can optionally wait for
+    any pending actions to be completed before the functions returns and use a timeout to put
+    a maximum wait time on the actions.
+
+    :param futures_map: the map of action futures and the corresponding processes
+    :type futures_map: dict
+    :param infinitive: the infinitive form of the action verb
+    :type infinitive: str
+    :param present: the present tense form
+    :type present: str
+    :param past: the past tense form
+    :type past: str
+    :param wait: if True, waits for pending actions to be competed, otherwise just returns
+    :type wait: bool
+    :param timeout: the timeout (in seconds) to wait for actions to be completed
+    :type timeout: float
+    """
+    # pylint: disable=too-many-branches
+    import kiwipy
+    from aiida.work import CommunicationTimeout
+    from concurrent import futures
+
+    scheduled = {}
+    try:
+        for future in futures.as_completed(futures_map.keys(), timeout=timeout):
+            # Get the corresponding process
+            process = futures_map[future]
+
+            try:
+                result = future.result()
+            except CommunicationTimeout:
+                echo.echo_error('call to {} Process<{}> timed out'.format(infinitive, process.pk))
+            except Exception as exception:  # pylint: disable=broad-except
+                echo.echo_error('failed to {} Process<{}>: {}'.format(infinitive, process.pk, exception))
+            else:
+                if result is True:
+                    echo.echo_success('{} Process<{}>'.format(past, process.pk))
+                elif result is False:
+                    echo.echo_error('problem {} Process<{}>'.format(present, process.pk))
+                elif isinstance(result, kiwipy.Future):
+                    echo.echo_success('scheduled {} Process<{}>'.format(infinitive, process.pk))
+                    scheduled[result] = process
+                else:
+                    echo.echo_error('got unexpected response when {} Process<{}>: {}'.format(
+                        present, process.pk, result))
+
+        if wait and scheduled:
+            echo.echo_info('waiting for process(es) {}'.format(','.join([str(proc.pk) for proc in scheduled.values()])))
+
+            for future in futures.as_completed(scheduled.keys(), timeout=timeout):
+                process = scheduled[future]
+
+                try:
+                    result = future.result()
+                except Exception as exception:  # pylint: disable=broad-except
+                    echo.echo_error('failed to {} Process<{}>: {}'.format(infinitive, process.pk, exception))
+                else:
+                    if result is True:
+                        echo.echo_success('{} Process<{}>'.format(past, process.pk))
+                    elif result is False:
+                        echo.echo_error('problem {} Process<{}>'.format(present, process.pk))
+                    else:
+                        echo.echo_error('got unexpected response when {} Process<{}>: {}'.format(
+                            present, process.pk, result))
+
+    except futures.TimeoutError:
+        echo.echo_error('timed out trying to {} processes {}'.format(infinitive, futures_map.values()))

--- a/aiida/common/log.py
+++ b/aiida/common/log.py
@@ -21,7 +21,6 @@ from aiida.common import setup
 LOG_LEVEL_REPORT = 23
 logging.addLevelName(LOG_LEVEL_REPORT, 'REPORT')
 
-
 # Convenience dictionary of available log level names and their log level integer
 LOG_LEVELS = {
     logging.getLevelName(logging.NOTSET): logging.NOTSET,
@@ -32,7 +31,6 @@ LOG_LEVELS = {
     logging.getLevelName(logging.ERROR): logging.ERROR,
     logging.getLevelName(logging.CRITICAL): logging.CRITICAL,
 }
-
 
 # The AiiDA logger
 aiidalogger = logging.getLogger('aiida')
@@ -54,6 +52,11 @@ class DBLogHandler(logging.Handler):
         from aiida.backends.utils import is_dbenv_loaded
         if not is_dbenv_loaded():
             return
+
+        if record.exc_info:
+            # We do this because if there is exc_info this will put an appropriate string in exc_text.
+            # See: https://github.com/python/cpython/blob/1c2cb516e49ceb56f76e90645e67e8df4e5df01a/Lib/logging/handlers.py#L590
+            self.format(record)
 
         from aiida.orm.backend import construct_backend
         from django.core.exceptions import ImproperlyConfigured

--- a/aiida/common/log.py
+++ b/aiida/common/log.py
@@ -131,6 +131,11 @@ LOGGING = {
             'level': setup.get_property('logging.plumpy_loglevel'),
             'propagate': False,
         },
+        'kiwipy': {
+            'handlers': ['console'],
+            'level': setup.get_property('logging.kiwipy_loglevel'),
+            'propagate': False,
+        },
         'paramiko': {
             'handlers': ['console'],
             'level': setup.get_property('logging.paramiko_loglevel'),

--- a/aiida/common/setup.py
+++ b/aiida/common/setup.py
@@ -795,6 +795,9 @@ _property_table = {
     "logging.plumpy_loglevel":
     ("logging_plumpy_log_level", "string", "Minimum level to log to the file ~/.aiida/daemon/log/aiida_daemon.log "
      "for the 'plumpy' logger", "WARNING", ["CRITICAL", "ERROR", "WARNING", "REPORT", "INFO", "DEBUG"]),
+    "logging.kiwipy_loglevel":
+    ("logging_kiwipy_log_level", "string", "Minimum level to log to the file ~/.aiida/daemon/log/aiida_daemon.log "
+     "for the 'kiwipy' logger", "WARNING", ["CRITICAL", "ERROR", "WARNING", "REPORT", "INFO", "DEBUG"]),
     "logging.paramiko_loglevel":
     ("logging_paramiko_log_level", "string", "Minimum level to log to the file ~/.aiida/daemon/log/aiida_daemon.log "
      "for the 'paramiko' logger", "WARNING", ["CRITICAL", "ERROR", "WARNING", "REPORT", "INFO", "DEBUG"]),

--- a/aiida/daemon/runner.py
+++ b/aiida/daemon/runner.py
@@ -10,6 +10,7 @@
 from __future__ import division
 from __future__ import print_function
 from __future__ import absolute_import
+from __future__ import print_function
 import logging
 import signal
 from functools import partial

--- a/aiida/orm/implementation/django/log.py
+++ b/aiida/orm/implementation/django/log.py
@@ -71,11 +71,11 @@ class DjangoLogCollection(LogCollection):
 
         return [DjangoLog(entry) for entry in entries]
 
-    def delete_many(self, filter):
+    def delete_many(self, filters):
         """
         Delete all log entries in the table
         """
-        if not filter:
+        if not filters:
             DbLog.objects.all().delete()
         else:
             raise NotImplementedError(

--- a/aiida/orm/implementation/sqlalchemy/log.py
+++ b/aiida/orm/implementation/sqlalchemy/log.py
@@ -78,11 +78,11 @@ class SqlaLogCollection(LogCollection):
 
         return [SqlaLog(entry) for entry in entries]
 
-    def delete_many(self, filter):
+    def delete_many(self, filters):
         """
         Delete all log entries in the table
         """
-        if not filter:
+        if not filters:
             for entry in DbLog.query.all():
                 entry.delete()
             session.commit()

--- a/aiida/utils/serialize.py
+++ b/aiida/utils/serialize.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+"""Serialisation functions for AiiDA types"""
 ###########################################################################
 # Copyright (c), The AiiDA team. All rights reserved.                     #
 # This file is part of the AiiDA code.                                    #
@@ -20,7 +21,6 @@ from plumpy.utils import AttributesFrozendict
 from aiida.common.extendeddicts import AttributeDict
 from aiida.orm import Group, Node, load_group, load_node
 
-
 _PREFIX_KEY_TUPLE = 'tuple():'
 _PREFIX_VALUE_NODE = 'aiida_node:'
 _PREFIX_VALUE_GROUP = 'aiida_group:'
@@ -38,8 +38,8 @@ def encode_key(key):
     """
     if isinstance(key, tuple):
         return '{}{}'.format(_PREFIX_KEY_TUPLE, key)
-    else:
-        return key
+
+    return key
 
 
 def decode_key(key):
@@ -53,8 +53,8 @@ def decode_key(key):
 
     if isinstance(key, six.string_types) and key.startswith(_PREFIX_KEY_TUPLE):
         return literal_eval(key[len(_PREFIX_KEY_TUPLE):])
-    else:
-        return key
+
+    return key
 
 
 def serialize_data(data):
@@ -68,22 +68,24 @@ def serialize_data(data):
     :param data: a single value or collection
     :return: the serialized data with the same internal structure
     """
+    # pylint: disable=too-many-return-statements
+
     if isinstance(data, Node):
         return '{}{}'.format(_PREFIX_VALUE_NODE, data.uuid)
-    elif isinstance(data, Group):
+    if isinstance(data, Group):
         return '{}{}'.format(_PREFIX_VALUE_GROUP, data.uuid)
-    elif isinstance(data, uuid.UUID):
+    if isinstance(data, uuid.UUID):
         return '{}{}'.format(_PREFIX_VALUE_UUID, data)
-    elif isinstance(data, AttributeDict):
+    if isinstance(data, AttributeDict):
         return AttributeDict({encode_key(key): serialize_data(value) for key, value in data.items()})
-    elif isinstance(data, AttributesFrozendict):
+    if isinstance(data, AttributesFrozendict):
         return AttributesFrozendict({encode_key(key): serialize_data(value) for key, value in data.items()})
-    elif isinstance(data, collections.Mapping):
+    if isinstance(data, collections.Mapping):
         return {encode_key(key): serialize_data(value) for key, value in data.items()}
-    elif isinstance(data, collections.Sequence) and not isinstance(data, six.string_types):
+    if isinstance(data, collections.Sequence) and not isinstance(data, six.string_types):
         return [serialize_data(value) for value in data]
-    else:
-        return data
+
+    return data
 
 
 def deserialize_data(data):
@@ -95,19 +97,21 @@ def deserialize_data(data):
     :param data: serialized data
     :return: the deserialized data with keys decoded and node instances loaded from UUID's
     """
+    # pylint: disable=too-many-return-statements
+
     if isinstance(data, AttributeDict):
         return AttributeDict({decode_key(key): deserialize_data(value) for key, value in data.items()})
-    elif isinstance(data, AttributesFrozendict):
+    if isinstance(data, AttributesFrozendict):
         return AttributesFrozendict({decode_key(key): deserialize_data(value) for key, value in data.items()})
-    elif isinstance(data, collections.Mapping):
+    if isinstance(data, collections.Mapping):
         return {decode_key(key): deserialize_data(value) for key, value in data.items()}
-    elif isinstance(data, collections.Sequence) and not isinstance(data, six.string_types):
+    if isinstance(data, collections.Sequence) and not isinstance(data, six.string_types):
         return [deserialize_data(value) for value in data]
-    elif isinstance(data, six.string_types) and data.startswith(_PREFIX_VALUE_NODE):
+    if isinstance(data, six.string_types) and data.startswith(_PREFIX_VALUE_NODE):
         return load_node(uuid=data[len(_PREFIX_VALUE_NODE):])
-    elif isinstance(data, six.string_types) and data.startswith(_PREFIX_VALUE_GROUP):
+    if isinstance(data, six.string_types) and data.startswith(_PREFIX_VALUE_GROUP):
         return load_group(uuid=data[len(_PREFIX_VALUE_GROUP):])
-    elif isinstance(data, six.string_types) and data.startswith(_PREFIX_VALUE_UUID):
+    if isinstance(data, six.string_types) and data.startswith(_PREFIX_VALUE_UUID):
         return uuid.UUID(data[len(_PREFIX_VALUE_UUID):])
-    else:
-        return data
+
+    return data

--- a/aiida/work/futures.py
+++ b/aiida/work/futures.py
@@ -13,8 +13,8 @@ from __future__ import print_function
 from __future__ import absolute_import
 import tornado.gen
 
-import kiwipy
 import plumpy
+import kiwipy
 
 __all__ = ['CalculationFuture']
 

--- a/aiida/work/futures.py
+++ b/aiida/work/futures.py
@@ -16,12 +16,10 @@ import tornado.gen
 import kiwipy
 import plumpy
 
-__all__ = ['Future', 'CalculationFuture']
-
-Future = plumpy.Future
+__all__ = ['CalculationFuture']
 
 
-class CalculationFuture(Future):
+class CalculationFuture(plumpy.Future):
     """
     A future that waits for a calculation to complete using both polling and
     listening for broadcast events if possible

--- a/aiida/work/futures.py
+++ b/aiida/work/futures.py
@@ -7,6 +7,7 @@
 # For further information on the license, see the LICENSE.txt file        #
 # For further information please visit http://www.aiida.net               #
 ###########################################################################
+# pylint: disable=cyclic-import
 """Futures that can poll or receive broadcasted messages while waiting for a task to be completed."""
 from __future__ import division
 from __future__ import print_function

--- a/aiida/work/persistence.py
+++ b/aiida/work/persistence.py
@@ -14,9 +14,10 @@ from __future__ import print_function
 from __future__ import absolute_import
 import logging
 import traceback
-import yaml
 
 import plumpy
+
+from aiida.utils import serialize
 
 __all__ = ['ObjectLoader', 'get_object_loader']
 
@@ -64,7 +65,7 @@ class AiiDAPersister(plumpy.Persister):
                 process, traceback.format_exc()))
         else:
             calc = process.calc
-            calc.set_checkpoint(yaml.dump(bundle))
+            calc.set_checkpoint(serialize.serialize(bundle))
 
         return bundle
 
@@ -89,7 +90,7 @@ class AiiDAPersister(plumpy.Persister):
         if checkpoint is None:
             raise plumpy.PersistenceError('Calculation<{}> does not have a saved checkpoint'.format(calculation.pk))
 
-        bundle = yaml.load(checkpoint)
+        bundle = serialize.deserialize(checkpoint)
         return bundle
 
     def get_checkpoints(self):

--- a/aiida/work/processes.py
+++ b/aiida/work/processes.py
@@ -182,7 +182,7 @@ class Process(plumpy.Process):
             killing = []
             for child in self.calc.called:
                 try:
-                    result = self.runner.rmq.kill_process(child.pk, 'Killed by parent<{}>'.format(self.calc.pk))
+                    result = self.runner.controller.kill_process(child.pk, 'Killed by parent<{}>'.format(self.calc.pk))
                     if isinstance(result, plumpy.Future):
                         killing.append(result)
                 except ConnectionClosed:
@@ -225,12 +225,11 @@ class Process(plumpy.Process):
         # Update the node attributes every time we enter a new state
 
     def on_entered(self, from_state):
-        super(Process, self).on_entered(from_state)
-        self._save_checkpoint()
         self.update_node_state(self._state)
-
+        self._save_checkpoint()
         # Update the latest process state change timestamp
         utils.set_process_state_change_timestamp(self)
+        super(Process, self).on_entered(from_state)
 
     @override
     def on_terminated(self):
@@ -753,7 +752,7 @@ class FunctionProcess(Process):
         self.calc.store_source_info(self._func)
 
     @override
-    def _run(self):
+    def run(self):
         args = []
 
         # Split the inputs into positional and keyword arguments

--- a/aiida/work/processes.py
+++ b/aiida/work/processes.py
@@ -7,6 +7,7 @@
 # For further information on the license, see the LICENSE.txt file        #
 # For further information please visit http://www.aiida.net               #
 ###########################################################################
+# pylint: disable=cyclic-import
 """The AiiDA process class"""
 
 from __future__ import division

--- a/aiida/work/rmq.py
+++ b/aiida/work/rmq.py
@@ -13,8 +13,7 @@ from __future__ import division
 from __future__ import print_function
 from __future__ import absolute_import
 import collections
-
-import yaml
+import functools
 
 from tornado import gen
 import kiwipy.rmq
@@ -22,7 +21,7 @@ from kiwipy import communications
 
 import plumpy
 
-from aiida.utils.serialize import serialize_data, deserialize_data
+from aiida.utils import serialize
 from aiida.work.exceptions import PastException
 
 __all__ = [
@@ -126,46 +125,6 @@ def get_task_exchange_name(prefix):
     return '{}.{}'.format(prefix, _TASK_EXCHANGE)
 
 
-def encode_response(response):
-    """
-    Used by kiwipy to encode a message for sending.  Because we can have nodes, we have
-    to convert these to PIDs before sending (we can't just send the live instance)
-
-    :param response: The message to encode
-    :return: The encoded message
-    :rtype: str
-    """
-    serialized = serialize_data(response)
-    return yaml.dump(serialized)
-
-
-def decode_response(response):
-    """
-    Used by kiwipy to decode a message that has been received.  We check for
-    any node PKs and convert these back into the corresponding node instance
-    using `load_node`.  Any other entries are left untouched.
-
-    .. see: `encode_response`
-
-    :param response: The response string to decode
-    :return: A data structure containing deserialized node instances
-    """
-    response = yaml.load(response)
-    return deserialize_data(response)
-
-
-def store_and_serialize_inputs(inputs):
-    """
-    Iterate over the values of the input dictionary, try to store them as if they were unstored
-    nodes and then return the serialized dictionary
-
-    :param inputs: dictionary where keys are potentially unstored node instances
-    :returns: a dictionary where nodes are serialized
-    """
-    _store_inputs(inputs)
-    return serialize_data(inputs)
-
-
 def _store_inputs(inputs):
     """
     Try to store the values in the input dictionary. For nested dictionaries, the values are stored by recursively.
@@ -224,7 +183,11 @@ class ProcessLauncher(plumpy.ProcessLauncher):
             raise gen.Return(future.result())
 
         result = yield super(ProcessLauncher, self)._continue(communicator, pid, nowait, tag)
-        raise gen.Return(result)
+
+        # Ensure that the result is serialized such that communication thread won't have to do database operations
+        serialized = serialize.serialize(result)
+
+        raise gen.Return(serialized)
 
 
 def create_controller(communicator=None):
@@ -272,8 +235,8 @@ def create_communicator(url=None, prefix=None, task_prefetch_count=_RMQ_TASK_PRE
     return kiwipy.rmq.RmqThreadCommunicator.connect(
         connection_params={'url': get_rmq_url()},
         message_exchange=message_exchange,
-        encoder=encode_response,
-        decoder=decode_response,
+        encoder=functools.partial(serialize.serialize, encoding='utf-8'),
+        decoder=serialize.deserialize,
         task_exchange=task_exchange,
         task_queue=task_queue,
         task_prefetch_count=task_prefetch_count,

--- a/aiida/work/rmq.py
+++ b/aiida/work/rmq.py
@@ -43,8 +43,8 @@ CommunicationTimeout = communications.TimeoutError  # pylint: disable=invalid-na
 # know how to avoid warnings. For more info see
 # https://github.com/aiidateam/aiida_core/issues/1142
 _RMQ_URL = 'amqp://127.0.0.1'
-_RMQ_TASK_PREFETCH_COUNT = 20
-_RMQ_HEARTBEAT_TIMEOUT = 600
+_RMQ_TASK_PREFETCH_COUNT = 100  # This value should become configurable per profile at some point
+_RMQ_HEARTBEAT_TIMEOUT = 600  # Maximum that can be set by client, with default RabbitMQ server configuration
 _LAUNCH_QUEUE = 'process.queue'
 _MESSAGE_EXCHANGE = 'messages'
 _TASK_EXCHANGE = 'tasks'

--- a/aiida/work/rmq.py
+++ b/aiida/work/rmq.py
@@ -17,15 +17,17 @@ import collections
 import yaml
 
 from tornado import gen
-import plumpy
 import kiwipy.rmq
 from kiwipy import communications
+
+import plumpy
 
 from aiida.utils.serialize import serialize_data, deserialize_data
 from aiida.work.exceptions import PastException
 
 __all__ = [
-    'RemoteException', 'CommunicationTimeout', 'DeliveryFailed', 'ProcessLauncher', 'create_controller', 'create_communicator'
+    'RemoteException', 'CommunicationTimeout', 'DeliveryFailed', 'ProcessLauncher', 'create_controller',
+    'create_communicator'
 ]
 
 RemoteException = plumpy.RemoteException
@@ -230,7 +232,7 @@ def create_controller(communicator=None):
     Create a RemoteProcessThreadController
 
     :param communicator: a :class:`~kiwipy.Communicator`
-    :return: a :class:`~aiida.work.rmq.RemoteProcessThreadController` instance
+    :return: a :class:`~plumpy.RemoteProcessThreadController` instance
     """
     if communicator is None:
         communicator = create_communicator()
@@ -248,13 +250,23 @@ def create_communicator(url=None, prefix=None, task_prefetch_count=_RMQ_TASK_PRE
     :return: the communicator instance
     :rtype: :class:`kiwipy.Communicator`
     """
+    from aiida.common.profile import get_profile
+
+    profile = get_profile()
+
     if url is None:
         url = get_rmq_url()
 
     if prefix is None:
         prefix = get_rmq_prefix()
 
+    # This needs to be here, because the verdi commands will call this function and when called in unit tests the
+    # testing_mode cannot be set.
+    if profile.is_test_profile:
+        testing_mode = True
+
     message_exchange = get_message_exchange_name(prefix)
+    task_exchange = get_task_exchange_name(prefix)
     task_queue = get_launch_queue_name(prefix)
 
     return kiwipy.rmq.RmqThreadCommunicator.connect(
@@ -262,6 +274,7 @@ def create_communicator(url=None, prefix=None, task_prefetch_count=_RMQ_TASK_PRE
         message_exchange=message_exchange,
         encoder=encode_response,
         decoder=decode_response,
+        task_exchange=task_exchange,
         task_queue=task_queue,
         task_prefetch_count=task_prefetch_count,
         testing_mode=testing_mode,

--- a/aiida/work/runners.py
+++ b/aiida/work/runners.py
@@ -227,7 +227,7 @@ class Runner(object):
             self.persister.save_checkpoint(process)
             process.close()
             # Do not wait for the future's result, because in the case of a single worker this would cock-block itself
-            self.controller.continue_process(process.pid, nowait=False)
+            self.controller.continue_process(process.pid, nowait=False, no_reply=True)
         else:
             # Run in this runner
             self.loop.add_callback(process.step_until_terminated)

--- a/aiida/work/runners.py
+++ b/aiida/work/runners.py
@@ -85,7 +85,8 @@ class Runner(object):
                  loop=None,
                  rmq_submit=False,
                  enable_persistence=True,
-                 persister=None):
+                 persister=None,
+                 testing_mode=False):
         self._loop = loop if loop is not None else tornado.ioloop.IOLoop()
         self._poll_interval = poll_interval
         self._rmq_submit = rmq_submit
@@ -96,7 +97,7 @@ class Runner(object):
             self._persister = persister if persister is not None else persistence.AiiDAPersister()
 
         if rmq_config is not None:
-            self._setup_rmq(**rmq_config)
+            self._setup_rmq(testing_mode=testing_mode, **rmq_config)
         elif self._rmq_submit:
             logger = logging.getLogger(__name__)
             logger.warning('Disabling rmq submission, no RMQ config provided')

--- a/aiida/work/runners.py
+++ b/aiida/work/runners.py
@@ -7,7 +7,7 @@
 # For further information on the license, see the LICENSE.txt file        #
 # For further information please visit http://www.aiida.net               #
 ###########################################################################
-# pylint: disable=global-statement
+# pylint: disable=cyclic-import,global-statement
 """Runners that can run and submit processes."""
 from __future__ import division
 from __future__ import print_function

--- a/aiida/work/runners.py
+++ b/aiida/work/runners.py
@@ -33,6 +33,7 @@ ResultAndNode = namedtuple('ResultAndNode', ['result', 'node'])
 ResultAndPid = namedtuple('ResultAndPid', ['result', 'pid'])
 
 RUNNER = None
+POLL_INTERVAL_DEFAULT = 30.
 
 
 def new_runner(**kwargs):
@@ -81,7 +82,7 @@ class Runner(object):
     # pylint: disable=too-many-arguments
     def __init__(self,
                  rmq_config=None,
-                 poll_interval=0.,
+                 poll_interval=POLL_INTERVAL_DEFAULT,
                  loop=None,
                  rmq_submit=False,
                  enable_persistence=True,

--- a/aiida/work/test_utils.py
+++ b/aiida/work/test_utils.py
@@ -24,7 +24,7 @@ class DummyProcess(Process):
         spec.inputs.dynamic = True
         spec.outputs.dynamic = True
 
-    def _run(self):
+    def run(self):
         pass
 
 
@@ -38,7 +38,7 @@ class AddProcess(Process):
         spec.input('b', required=True)
         spec.output('result', required=True)
 
-    def _run(self):
+    def run(self):
         self.out(self.inputs.a + self.inputs.b)
 
 
@@ -50,21 +50,21 @@ class BadOutput(Process):
         super(BadOutput, cls).define(spec)
         spec.outputs.dynamic = True
 
-    def _run(self):
+    def run(self):
         self.out("bad_output", 5)
 
 
 class ExceptionProcess(Process):
     """A Process that raises a RuntimeError when run."""
 
-    def _run(self):  # pylint: disable=no-self-use
+    def run(self):  # pylint: disable=no-self-use
         raise RuntimeError('CRASH')
 
 
 class WaitProcess(Process):
     """A Process that waits until it is asked to continue."""
 
-    def _run(self):
+    def run(self):
         return plumpy.Wait(self.next_step)
 
     def next_step(self):

--- a/aiida/work/workchain.py
+++ b/aiida/work/workchain.py
@@ -21,7 +21,6 @@ from aiida.common.extendeddicts import AttributeDict
 from aiida.common.lang import override
 from aiida.common.utils import classproperty
 from aiida.orm.utils import load_node, load_workflow
-from aiida.utils.serialize import serialize_data, deserialize_data
 
 from .awaitable import AwaitableTarget, AwaitableAction, construct_awaitable
 from .context import ToContext, assign_, append_
@@ -68,7 +67,7 @@ class WorkChain(Process):
     def save_instance_state(self, out_state, save_context):
         super(WorkChain, self).save_instance_state(out_state, save_context)
         # Save the context
-        out_state[self._CONTEXT] = serialize_data(self.ctx)
+        out_state[self._CONTEXT] = self.ctx
 
         # Ask the stepper to save itself
         if self._stepper is not None:
@@ -78,7 +77,7 @@ class WorkChain(Process):
     def load_instance_state(self, saved_state, load_context):
         super(WorkChain, self).load_instance_state(saved_state, load_context)
         # Load the context
-        self._context = AttributeDict(**deserialize_data(saved_state[self._CONTEXT]))
+        self._context = saved_state[self._CONTEXT]
 
         # Recreate the stepper
         self._stepper = None

--- a/aiida/work/workchain.py
+++ b/aiida/work/workchain.py
@@ -138,7 +138,7 @@ class WorkChain(Process):
             self.insert_awaitable(awaitable)
 
     @override
-    def _run(self):
+    def run(self):
         self._stepper = self.spec().get_outline().create_stepper(self)
         return self._do_step()
 

--- a/aiida/work/workchain.py
+++ b/aiida/work/workchain.py
@@ -11,6 +11,7 @@
 from __future__ import division
 from __future__ import print_function
 from __future__ import absolute_import
+import collections
 import functools
 import six
 
@@ -20,6 +21,7 @@ from aiida.common.exceptions import MultipleObjectsError, NotExistent
 from aiida.common.extendeddicts import AttributeDict
 from aiida.common.lang import override
 from aiida.common.utils import classproperty
+from aiida.orm import Node
 from aiida.orm.utils import load_node, load_workflow
 
 from .awaitable import AwaitableTarget, AwaitableAction, construct_awaitable
@@ -177,6 +179,36 @@ class WorkChain(Process):
                 return Wait(self._do_step, 'Waiting before next step')
 
             return Continue(self._do_step)
+
+    def _store_nodes(self, data):
+        """
+        Recurse through a data structure and store any unstored nodes that are found along the way
+
+        :param data: a data structure potentially containing unstored nodes
+        """
+        if isinstance(data, Node) and not data.is_stored:
+            data.store()
+        elif isinstance(data, collections.Mapping):
+            for _, value in data.items():
+                self._store_nodes(value)
+        elif isinstance(data, collections.Sequence) and not isinstance(data, six.string_types):
+            for value in data:
+                self._store_nodes(value)
+
+    @override
+    def on_exiting(self):
+        """
+        Ensure that any unstored nodes in the context are stored, before the state is exited
+
+        After the state is exited the next state will be entered and if persistence is enabled, a checkpoint will
+        be saved. If the context contains unstored nodes, the serialization necessary for checkpointing will fail.
+        """
+        super(WorkChain, self).on_exiting()
+        try:
+            self._store_nodes(self.ctx)
+        except Exception:  # pylint: disable=broad-except
+            # An uncaught exception here will have bizarre and disastrous consequences
+            self.logger.exception('exception in _store_nodes called in on_exiting')
 
     def on_wait(self, awaitables):
         super(WorkChain, self).on_wait(awaitables)

--- a/docs/requirements_for_rtd.txt
+++ b/docs/requirements_for_rtd.txt
@@ -36,7 +36,6 @@ flask-marshmallow==0.9.0
 futures; python_version=="2.7"
 ipython>=4.0,<6.0
 itsdangerous==0.24
-kiwipy==0.2.1
 marshmallow-sqlalchemy==0.13.2
 meld3==1.0.2
 mock==2.0.0
@@ -45,8 +44,7 @@ paramiko==2.4.2
 passlib==1.7.1
 pathlib2; python_version<"3.5"
 pgtest==1.1.0
-pika==0.12.0
-plumpy==0.10.6
+plumpy==0.11.2
 psutil==5.4.5
 pyblake2==1.1.2; python_version<"3.6"
 pymatgen==2018.4.20

--- a/docs/requirements_for_rtd.txt
+++ b/docs/requirements_for_rtd.txt
@@ -44,7 +44,7 @@ paramiko==2.4.2
 passlib==1.7.1
 pathlib2; python_version<"3.5"
 pgtest==1.1.0
-plumpy==0.11.2
+plumpy==0.11.3
 psutil==5.4.5
 pyblake2==1.1.2; python_version<"3.6"
 pymatgen==2018.4.20

--- a/docs/requirements_for_rtd.txt
+++ b/docs/requirements_for_rtd.txt
@@ -44,7 +44,7 @@ paramiko==2.4.2
 passlib==1.7.1
 pathlib2; python_version<"3.5"
 pgtest==1.1.0
-plumpy==0.11.3
+plumpy==0.11.4
 psutil==5.4.5
 pyblake2==1.1.2; python_version<"3.6"
 pymatgen==2018.4.20

--- a/docs/source/nitpick-exceptions
+++ b/docs/source/nitpick-exceptions
@@ -166,8 +166,6 @@ py:class  tornado.concurrent.Future
 
 py:class  IPython.core.magic.Magics
 
-#py:class  json.json
-
 py:class  HTMLParser.HTMLParser
 py:class  html.parser.HTMLParser
 
@@ -210,3 +208,8 @@ py:mod    click
 py:class  click.Choice
 
 py:func   click.Option.get_default
+
+py:class yaml.Dumper
+py:class yaml.Loader
+py:class yaml.dumper.Dumper
+py:class yaml.loader.Loader

--- a/docs/source/nitpick-exceptions
+++ b/docs/source/nitpick-exceptions
@@ -115,6 +115,8 @@ py:class  click.types.IntParamType
 py:class  click.types.StringParamType
 py:class  click.types.Path
 
+py:class  concurrent.futures._base.TimeoutError
+
 py:class  distutils.version.Version
 
 py:class  docutils.parsers.rst.Directive
@@ -141,6 +143,7 @@ py:class  plumpy.process_comms.ProcessLauncher
 py:class  plumpy.process_spec.ProcessSpec
 py:class  plumpy.Process
 py:class  plumpy.Communicator
+py:class  plumpy.RemoteProcessThreadController
 py:class  plumpy.Bundle
 py:class  plumpy.workchains.WorkChainSpec
 py:class  plumpy.persistence.Persister
@@ -156,6 +159,7 @@ py:meth   plumpy.process_spec.ProcessSpec.expose_outputs
 
 py:class  kiwipy.futures.Future
 py:class  kiwipy.communications.TimeoutError
+py:class  kiwipy.Communicator
 
 py:class  tornado.ioloop.IOLoop
 py:class  tornado.concurrent.Future

--- a/setup_requirements.py
+++ b/setup_requirements.py
@@ -44,7 +44,7 @@ install_requires = [
     'paramiko==2.4.2',
     'ecdsa==0.13',
     'ipython>=4.0,<6.0',  # Version of ipython non enforced, because some still prefer version 4 rather than the latest
-    'plumpy==0.11.2',
+    'plumpy==0.11.3',
     'circus==0.14.0',
     'tornado==4.5.3',  # As of 2018/03/06 Tornado released v5.0 which breaks circus 0.14.0
     'pyblake2==1.1.2; python_version<"3.6"',

--- a/setup_requirements.py
+++ b/setup_requirements.py
@@ -44,7 +44,7 @@ install_requires = [
     'paramiko==2.4.2',
     'ecdsa==0.13',
     'ipython>=4.0,<6.0',  # Version of ipython non enforced, because some still prefer version 4 rather than the latest
-    'plumpy==0.11.3',
+    'plumpy==0.11.4',
     'circus==0.14.0',
     'tornado==4.5.3',  # As of 2018/03/06 Tornado released v5.0 which breaks circus 0.14.0
     'pyblake2==1.1.2; python_version<"3.6"',
@@ -93,8 +93,8 @@ extras_require = {
         'pymatgen==2018.4.20',
         'ase==3.12.0',  # Updating breaks tests
         'PyMySQL==0.8.0',  # Required by ICSD tools
-        "PyCifRW==4.2.1; python_version < '3'", # Does not support python3
-        "PyCifRW==4.4; python_version >= '3'", # Does not support python2
+        "PyCifRW==4.2.1; python_version < '3'",  # Does not support python3
+        "PyCifRW==4.4; python_version >= '3'",  # Does not support python2
         'seekpath==1.8.1',
         'qe-tools==1.1.0',
     ],

--- a/setup_requirements.py
+++ b/setup_requirements.py
@@ -44,9 +44,7 @@ install_requires = [
     'paramiko==2.4.2',
     'ecdsa==0.13',
     'ipython>=4.0,<6.0',  # Version of ipython non enforced, because some still prefer version 4 rather than the latest
-    'pika==0.12.0',
-    'plumpy==0.10.6',
-    'kiwipy==0.2.1',
+    'plumpy==0.11.2',
     'circus==0.14.0',
     'tornado==4.5.3',  # As of 2018/03/06 Tornado released v5.0 which breaks circus 0.14.0
     'pyblake2==1.1.2; python_version<"3.6"',


### PR DESCRIPTION
This PR will update `plumpy` to version `0.11.4` which underneath runs on `kiwipy` version `0.3.*`. The biggest change is that the communications of a `Runner` now happen on a separate thread, while all the real operations and callbacks are scheduled on the main thread. This should ensure that even under heavy load, a (daemon) runner remains responsive to heartbeats and remote procedure calls (RPCs) from RabbitMQ. The missing of heartbeats and the subsequent cutting of the connection by RabbitMQ spawned a whole host of other problems that will now no longer surface.

Fixes #1994 
Fixes #2088 
Fixes #1748 
Fixes #1426 
Fixes #1821 
Fixes #1822 
Fixes #2157 
