### PR TITLE
Set default polling interval for Runners to 1 second

### DIFF
--- a/aiida/work/runners.py
+++ b/aiida/work/runners.py
@@ -33,7 +33,7 @@ ResultAndNode = namedtuple('ResultAndNode', ['result', 'node'])
 ResultAndPid = namedtuple('ResultAndPid', ['result', 'pid'])
 
 RUNNER = None
-POLL_INTERVAL_DEFAULT = 30.
+POLL_INTERVAL_DEFAULT = 1.
 
 
 def new_runner(**kwargs):


### PR DESCRIPTION
In a recent change this parameter was corrected from 0 to 30 seconds to
prevent the daemon workers from spinning the processors too much, but
this really slows down the tests. Until resources like runners and
communicators are created in a central place, that allows settings to be
determined based on the active profile, e.g. with special settings for
test profiles, we need to revert this to 1 second. This will allow the
tests to run reasonably fast, without overloading processors too much.