### PR TITLE
Revert current database revision after migration unittests

### DIFF
--- a/aiida/backends/djsite/db/subtests/migrations.py
+++ b/aiida/backends/djsite/db/subtests/migrations.py
@@ -51,6 +51,12 @@ class TestMigrations(AiidaTestCase):
 
         self.apps = executor.loader.project_state(self.migrate_to).apps
 
+    def tearDown(self):
+        from ..migrations import LATEST_MIGRATION
+        self.migrate_to = [(self.app, LATEST_MIGRATION)]
+        executor = MigrationExecutor(connection)
+        executor.migrate(self.migrate_to)
+
     def setUpBeforeMigration(self, apps):
         pass
 


### PR DESCRIPTION
Fixes #2161 

After running a migration unittest that changes the revision of the test database
one should ensure that after the tests finishes, the current revision is applied.