### PR TITLE
Compile the scripts before calling exec in `verdi run`

### DIFF
--- a/aiida/backends/tests/__init__.py
+++ b/aiida/backends/tests/__init__.py
@@ -70,6 +70,7 @@ db_test_list = {
         'cmdline.commands.process': ['aiida.backends.tests.cmdline.commands.test_process'],
         'cmdline.commands.profile': ['aiida.backends.tests.cmdline.commands.test_profile'],
         'cmdline.commands.rehash': ['aiida.backends.tests.cmdline.commands.test_rehash'],
+        'cmdline.commands.run': ['aiida.backends.tests.cmdline.commands.test_run'],
         'cmdline.commands.user': ['aiida.backends.tests.cmdline.commands.test_user'],
         'cmdline.commands.work': ['aiida.backends.tests.cmdline.commands.test_work'],
         'cmdline.commands.workflow': ['aiida.backends.tests.cmdline.commands.test_workflow'],

--- a/aiida/backends/tests/cmdline/commands/test_run.py
+++ b/aiida/backends/tests/cmdline/commands/test_run.py
@@ -1,0 +1,68 @@
+# -*- coding: utf-8 -*-
+###########################################################################
+# Copyright (c), The AiiDA team. All rights reserved.                     #
+# This file is part of the AiiDA code.                                    #
+#                                                                         #
+# The code is hosted on GitHub at https://github.com/aiidateam/aiida_core #
+# For further information on the license, see the LICENSE.txt file        #
+# For further information please visit http://www.aiida.net               #
+###########################################################################
+"""Tests for `verdi run`."""
+from __future__ import division
+from __future__ import print_function
+from __future__ import absolute_import
+from click.testing import CliRunner
+
+from aiida.backends.testbase import AiidaTestCase
+from aiida.cmdline.commands import cmd_run
+
+
+class TestVerdiRun(AiidaTestCase):
+    """Tests for `verdi run`."""
+
+    def setUp(self):
+        self.cli_runner = CliRunner()
+
+    def test_run_workfunction(self):
+        """Regression test for #2165
+
+        If the script that is passed to `verdi run` is not compiled correctly, running workfunctions from the script
+        that are defined within the script will fail, as the inspect module will not correctly be able to determin
+        the full path of the source file.
+        """
+        import tempfile
+        from aiida.orm import load_node
+        from aiida.orm.calculation.function import FunctionCalculation
+
+        script_content = """
+#!/usr/bin/env python
+from aiida.work import workfunction
+
+@workfunction
+def wf():
+    pass
+
+if __name__ == '__main__':
+    result, node = wf.run_get_node()
+    print(node.pk)
+        """
+
+        # If `verdi run` is not setup correctly, the script above when run with `verdi run` will fail, because when
+        # the engine will try to create the node for the workfunction and create a copy of its sourcefile, namely the
+        # script itself, it will use `inspect.getsourcefile` which will return None
+        with tempfile.NamedTemporaryFile(mode='w+') as fhandle:
+            fhandle.write(script_content)
+            fhandle.flush()
+
+            options = [fhandle.name]
+            result = self.cli_runner.invoke(cmd_run.run, options)
+            self.assertIsNone(result.exception, result.output)
+
+            # Try to load the function calculation node from the printed pk in the output
+            pk = int(result.output)
+            node = load_node(pk)
+
+            # Verify that the node has the correct function name and content
+            self.assertTrue(isinstance(node, FunctionCalculation))
+            self.assertEqual(node.function_name, 'wf')
+            self.assertEqual(open(node.function_source_file, 'r').read(), script_content)

--- a/aiida/cmdline/commands/cmd_run.py
+++ b/aiida/cmdline/commands/cmd_run.py
@@ -108,10 +108,8 @@ def run(scriptname, varargs, group, group_name, exclude, excludesubclasses, incl
             with update_environment(new_argv=new_argv):
                 # Add local folder to sys.path
                 sys.path.insert(0, os.path.abspath(os.curdir))
-                # Pass only globals_dict
-                # Disable yapf to keep Python 3 style here.
-                # Python 3 does not support a file handle for the first argument anymore.
-                exec(handle.read(), globals_dict)  # yapf:disable # pylint: disable=exec-used
+                # Compile the script for execution and pass it to exec with the globals_dict
+                exec(compile(handle.read(), scriptname, 'exec'), globals_dict)  # yapf: disable # pylint: disable=exec-used
         except SystemExit:
             # Script called sys.exit()
             # Re-raise the exception to have the error code properly returned at the end


### PR DESCRIPTION
Fixes #2165 

This extra step is necessary for python modules like `inspect` to
function normally. Without this change, running a script with `verdi run`
that defines a workfunction and then runs it would fail, because inspect
would fail to determine the path of the source file of the workfunction,
i.e. the script that was passed to `verdi run`. This change fixes that.