### PR TITLE
Fix bug in `parse_formula` for formula's with leading or trailing whitespace

### DIFF
--- a/aiida/backends/tests/dataclasses.py
+++ b/aiida/backends/tests/dataclasses.py
@@ -589,23 +589,6 @@ _tag   {}
         self.assertEquals(
             symop_string_from_symop_matrix_tr([[-1, 0, 0], [0, 1, 0], [0, 0, 1]], [1, -1, 0]), "-x+1,y-1,z")
 
-    def test_parse_formula(self):
-        from aiida.orm.data.cif import parse_formula
-
-        self.assertEqual(parse_formula("C H"), {'C': 1, 'H': 1})
-
-        self.assertEqual(parse_formula("C5 H1"), {'C': 5, 'H': 1})
-
-        self.assertEqual(parse_formula("Ca5 Ho"), {'Ca': 5, 'Ho': 1})
-
-        self.assertEqual(parse_formula("H0.5 O"), {'H': 0.5, 'O': 1})
-
-        self.assertEqual(parse_formula("C0 O0"), {'C': 0, 'O': 0})
-
-        # Invalid literal for float()
-        with self.assertRaises(ValueError):
-            parse_formula("H0.5.2 O")
-
     @unittest.skipIf(not has_ase(), "Unable to import ase")
     @unittest.skipIf(not has_pycifrw(), "Unable to import PyCifRW")
     def test_attached_hydrogens(self):
@@ -719,12 +702,12 @@ _tag   {}
         from aiida.orm.data.cif import parse_formula
 
         self.assertEqual(parse_formula("C H"), {'C': 1, 'H': 1})
-
         self.assertEqual(parse_formula("C5 H1"), {'C': 5, 'H': 1})
-
         self.assertEqual(parse_formula("Ca5 Ho"), {'Ca': 5, 'Ho': 1})
-
         self.assertEqual(parse_formula("H0.5 O"), {'H': 0.5, 'O': 1})
+        self.assertEqual(parse_formula("C0 O0"), {'C': 0, 'O': 0})
+        self.assertEqual(parse_formula("C1 H1 "), {'C': 1, 'H': 1})  # Trailing spaces should be accepted
+        self.assertEqual(parse_formula(" C1 H1"), {'C': 1, 'H': 1})  # Leading spaces should be accepted
 
         # Invalid literal for float()
         with self.assertRaises(ValueError):

--- a/aiida/orm/data/cif.py
+++ b/aiida/orm/data/cif.py
@@ -403,6 +403,10 @@ def parse_formula(formula):
     contents = {}
     for part in re.split(r'\s+', formula):
         m = re.match(r'(\D+)([\.\d]+)?', part)
+
+        if m is None:
+            continue
+
         specie = m.group(1)
         quantity = m.group(2)
         if quantity is None:


### PR DESCRIPTION
FIxes #2185 

If a formula contains leading or trailing whitespace, one of the parts over
which the function loops will be empty, and so the regex match `m` will be
`None`. To prevent an `AttributeError` from being thrown when `group` is
called on `None` we check for it and continue.