### PR TITLE
Add temporary support for loading of new process node ORM classes

### DIFF
--- a/aiida/plugins/loader.py
+++ b/aiida/plugins/loader.py
@@ -36,6 +36,7 @@ def load_plugin(plugin_type, safe=False):
     from aiida.orm.calculation.job import JobCalculation
     from aiida.orm.data import Data
     from aiida.orm.node import Node
+    from aiida.orm.node.process import CalculationNode, WorkflowNode
 
     plugin = None
     base_class = Node
@@ -53,6 +54,8 @@ def load_plugin(plugin_type, safe=False):
         'calculation.': EntryPoint('aiida.calculations', Calculation),
         'code.': EntryPoint('aiida.code', Code),
         'data.': EntryPoint('aiida.data', Data),
+        'node.process.workflow.': EntryPoint('aiida.node', WorkflowNode),
+        'node.process.calculation.': EntryPoint('aiida.node', CalculationNode),
         'node.': EntryPoint('aiida.node', Node),
     })
 

--- a/setup.py
+++ b/setup.py
@@ -113,7 +113,14 @@ if __name__ == '__main__':
                 'orbital = aiida.orm.data.orbital:OrbitalData',
             ],
             'aiida.node': [
-                'node = aiida.orm.node:Node'
+                'node = aiida.orm.node:Node',
+                'process = aiida.orm.node.process.process:ProcessNode',
+                'process.calculation = aiida.orm.node.process.calculation.calculation:CalculationNode',
+                'process.workflow = aiida.orm.node.process.workflow.workflow:WorkflowNode',
+                'process.calculation.calcfunction = aiida.orm.node.process.calculation.calcfunction:CalcFunctionNode',
+                'process.calculation.calcjob = aiida.orm.node.process.calculation.calcjob:CalcJobNode',
+                'process.workflow.workchain = aiida.orm.node.process.workflow.workchain:WorkChainNode',
+                'process.workflow.workfunction = aiida.orm.node.process.workflow.workfunction:WorkFunctionNode',
             ],
             'aiida.cmdline': [],
             'aiida.parsers': [


### PR DESCRIPTION
Fixes #2187 

The loading of the correct ORM class for a given entry in the `DbNode` table
is based on the `type` column, but its interpretation is still in a half-way
state. The plugin loader will first attempt to reverse engineer it into an entry
point and if that works load the correspondingly class. If that fails, it is
interpreted as an internal class and will attempt to load it directly as a module
path.

Adding the new process node ORM classes, will need to be supported by the plugin
loader, so here we add their entry points. We do this in the `aiida:node` group
but note that in the future the entire system will be changed to solely rely on
entry points, at which the format of the `type` column can be changed to be a
fully qualified entry point string, just as the `process_type` column already is.