### PR TITLE
Rename node class for workfunctions

### DIFF
--- a/aiida/backends/tests/cmdline/commands/test_run.py
+++ b/aiida/backends/tests/cmdline/commands/test_run.py
@@ -32,7 +32,7 @@ class TestVerdiRun(AiidaTestCase):
         """
         import tempfile
         from aiida.orm import load_node
-        from aiida.orm.calculation.function import FunctionCalculation
+        from aiida.orm.node.process import WorkFunctionNode
 
         script_content = """
 #!/usr/bin/env python
@@ -63,6 +63,6 @@ if __name__ == '__main__':
             node = load_node(pk)
 
             # Verify that the node has the correct function name and content
-            self.assertTrue(isinstance(node, FunctionCalculation))
+            self.assertTrue(isinstance(node, WorkFunctionNode))
             self.assertEqual(node.function_name, 'wf')
             self.assertEqual(open(node.function_source_file, 'r').read(), script_content)

--- a/aiida/backends/tests/cmdline/commands/test_work.py
+++ b/aiida/backends/tests/cmdline/commands/test_work.py
@@ -18,7 +18,7 @@ from aiida.backends.testbase import AiidaTestCase
 from aiida.cmdline.commands import cmd_work
 from aiida.common.links import LinkType
 from aiida.common.log import LOG_LEVEL_REPORT
-from aiida.orm.calculation.function import FunctionCalculation
+from aiida.orm.node.process import WorkFunctionNode
 from aiida.orm.calculation.work import WorkCalculation
 
 
@@ -50,13 +50,13 @@ class TestVerdiWork(AiidaTestCase):
 
         calcs = []
 
-        # Create 6 FunctionCalculations and WorkCalculations (one for each ProcessState)
+        # Create 6 WorkFunctionNodes and WorkCalculations (one for each ProcessState)
         for state in ProcessState:
 
-            calc = FunctionCalculation()
+            calc = WorkFunctionNode()
             calc._set_process_state(state)
 
-            # Set the FunctionCalculation as successful
+            # Set the WorkFunctionNode as successful
             if state == ProcessState.FINISHED:
                 calc._set_exit_status(0)
 

--- a/aiida/backends/tests/cmdline/params/types/test_calculation.py
+++ b/aiida/backends/tests/cmdline/params/types/test_calculation.py
@@ -16,7 +16,8 @@ from click.testing import CliRunner
 from aiida.backends.testbase import AiidaTestCase
 from aiida.cmdline.params import options
 from aiida.cmdline.params.types import CalculationParamType
-from aiida.orm import Calculation, FunctionCalculation, InlineCalculation, JobCalculation, WorkCalculation
+from aiida.orm import Calculation, InlineCalculation, JobCalculation, WorkCalculation
+from aiida.orm.node.process import WorkFunctionNode
 from aiida.orm.utils.loaders import OrmEntityLoader
 
 
@@ -36,7 +37,7 @@ class TestCalculationParamType(AiidaTestCase):
         cls.entity_01 = Calculation().store()
         cls.entity_02 = Calculation().store()
         cls.entity_03 = Calculation().store()
-        cls.entity_04 = FunctionCalculation()
+        cls.entity_04 = WorkFunctionNode()
         cls.entity_05 = InlineCalculation()
         cls.entity_06 = JobCalculation()
         cls.entity_07 = WorkCalculation()

--- a/aiida/backends/tests/work/test_launch.py
+++ b/aiida/backends/tests/work/test_launch.py
@@ -11,7 +11,7 @@ from __future__ import division
 from __future__ import print_function
 from __future__ import absolute_import
 from aiida.backends.testbase import AiidaTestCase
-from aiida.orm.calculation.function import FunctionCalculation
+from aiida.orm.node.process import WorkFunctionNode
 from aiida.orm.calculation.work import WorkCalculation
 from aiida.orm.data.int import Int
 from aiida.work import run, run_get_node, run_get_pid, Process, WorkChain, workfunction
@@ -58,7 +58,7 @@ class TestLaunchers(AiidaTestCase):
     def test_workfunction_run_get_node(self):
         result, node = run_get_node(add, a=self.a, b=self.b)
         self.assertEquals(result, self.result)
-        self.assertTrue(isinstance(node, FunctionCalculation))
+        self.assertTrue(isinstance(node, WorkFunctionNode))
 
     def test_workfunction_run_get_pid(self):
         result, pid = run_get_pid(add, a=self.a, b=self.b)

--- a/aiida/backends/tests/work/test_workfunctions.py
+++ b/aiida/backends/tests/work/test_workfunctions.py
@@ -16,7 +16,7 @@ from aiida.orm.data.bool import get_true_node
 from aiida.orm.data.int import Int
 from aiida.orm.data.str import Str
 from aiida.orm import load_node
-from aiida.orm.calculation.function import FunctionCalculation
+from aiida.orm.node.process import WorkFunctionNode
 from aiida.work import run, run_get_node, submit, workfunction, Process, ExitCode
 
 DEFAULT_INT = 256
@@ -241,7 +241,7 @@ class TestWf(AiidaTestCase):
         result, node = run_get_node(self.wf_return_true)
         self.assertTrue(result)
         self.assertEqual(result, get_true_node())
-        self.assertTrue(isinstance(node, FunctionCalculation))
+        self.assertTrue(isinstance(node, WorkFunctionNode))
 
         with self.assertRaises(AssertionError):
             submit(self.wf_return_true)

--- a/aiida/cmdline/commands/cmd_work.py
+++ b/aiida/cmdline/commands/cmd_work.py
@@ -42,10 +42,10 @@ def work_list(all_entries, process_state, exit_status, failed, past_days, limit,
     """Show a list of work calculations that are still running."""
     from tabulate import tabulate
     from aiida.cmdline.utils.common import print_last_process_state_change
-    from aiida.orm.calculation.function import FunctionCalculation
+    from aiida.orm.node.process import WorkFunctionNode
     from aiida.orm.calculation.work import WorkCalculation
 
-    node_types = (WorkCalculation, FunctionCalculation)
+    node_types = (WorkCalculation, WorkFunctionNode)
 
     builder = CalculationQueryBuilder()
     filters = builder.get_filters(all_entries, process_state, exit_status, failed, node_types=node_types)

--- a/aiida/cmdline/utils/query/calculation.py
+++ b/aiida/cmdline/utils/query/calculation.py
@@ -89,6 +89,7 @@ class CalculationQueryBuilder(object):
         import datetime
 
         from aiida.orm.calculation import Calculation
+        from aiida.orm.node.process import ProcessNode
         from aiida.orm.querybuilder import QueryBuilder
         from aiida.utils import timezone
 
@@ -101,7 +102,7 @@ class CalculationQueryBuilder(object):
             filters['ctime'] = {'>': timezone.now() - datetime.timedelta(days=past_days)}
 
         builder = QueryBuilder()
-        builder.append(cls=Calculation, filters=filters, project=projected_attributes, tag='calculation')
+        builder.append(cls=(Calculation, ProcessNode), filters=filters, project=projected_attributes, tag='calculation')
 
         if order_by is not None:
             builder.order_by({'calculation': order_by})

--- a/aiida/orm/calculation/__init__.py
+++ b/aiida/orm/calculation/__init__.py
@@ -14,6 +14,5 @@ from __future__ import absolute_import
 from aiida.orm.implementation.calculation import Calculation, JobCalculation
 from .inline import *
 from .work import WorkCalculation
-from .function import FunctionCalculation
 
-__all__ = ['Calculation', 'JobCalculation', 'WorkCalculation', 'FunctionCalculation'] + inline.__all__
+__all__ = ['Calculation', 'JobCalculation', 'WorkCalculation'] + inline.__all__

--- a/aiida/orm/data/__init__.py
+++ b/aiida/orm/data/__init__.py
@@ -150,12 +150,13 @@ class Data(Node):
     @override
     def add_link_from(self, src, label=None, link_type=LinkType.UNSPECIFIED):
         from aiida.orm.calculation import Calculation
+        from aiida.orm.node.process import ProcessNode
 
         if link_type is LinkType.CREATE and \
                         len(self.get_inputs(link_type=LinkType.CREATE)) > 0:
             raise ValueError("At most one CREATE node can enter a data node")
 
-        if not isinstance(src, Calculation):
+        if not isinstance(src, (Calculation, ProcessNode)):
             raise ValueError("Links entering a data object can only be of type calculation")
 
         return super(Data, self).add_link_from(src, label, link_type)
@@ -168,7 +169,8 @@ class Data(Node):
         An output of a data can only be a calculation
         """
         from aiida.orm.calculation import Calculation
-        if not isinstance(dest, Calculation):
+        from aiida.orm.node.process import ProcessNode
+        if not isinstance(dest, (Calculation, ProcessNode)):
             raise ValueError("The output of a data node can only be a calculation")
 
         return super(Data, self)._linking_as_output(dest, link_type)

--- a/aiida/orm/implementation/general/calculation/__init__.py
+++ b/aiida/orm/implementation/general/calculation/__init__.py
@@ -543,12 +543,13 @@ class AbstractCalculation(Sealable):
         :raise: ValueError if a link from self to dest is not allowed.
         """
         from aiida.orm.data import Data
+        from aiida.orm.node.process import ProcessNode
 
         if link_type is LinkType.CREATE or link_type is LinkType.RETURN:
             if not isinstance(dest, Data):
                 raise ValueError('The output of a calculation node can only be a data node')
         elif link_type is LinkType.CALL:
-            if not isinstance(dest, AbstractCalculation):
+            if not isinstance(dest, (AbstractCalculation, ProcessNode)):
                 raise ValueError('Call links can only link two calculations')
         else:
             raise ValueError('Calculation cannot have links of type {} as output'.format(link_type))
@@ -569,12 +570,13 @@ class AbstractCalculation(Sealable):
         """
         from aiida.orm.code import Code
         from aiida.orm.data import Data
+        from aiida.orm.node.process import ProcessNode
 
         if link_type is LinkType.INPUT:
             if not isinstance(src, (Data, Code)):
                 raise ValueError('Nodes entering calculation as input link can only be of type data or code')
         elif link_type is LinkType.CALL:
-            if not isinstance(src, AbstractCalculation):
+            if not isinstance(src, (AbstractCalculation, ProcessNode)):
                 raise ValueError('Call links can only link two calculations')
         else:
             raise ValueError('Calculation cannot have links of type {} as input'.format(link_type))

--- a/aiida/orm/importexport.py
+++ b/aiida/orm/importexport.py
@@ -1715,6 +1715,7 @@ def export_tree(what, folder,allowed_licenses=None, forbidden_licenses=None,
     """
     import aiida
     from aiida.orm import Node, Calculation, Data, Group, Code
+    from aiida.orm.node.process import ProcessNode, WorkflowNode, CalculationNode
     from aiida.common.links import LinkType
     from aiida.common.folders import RepositoryFolder
     from aiida.orm.querybuilder import QueryBuilder
@@ -1785,7 +1786,7 @@ def export_tree(what, folder,allowed_licenses=None, forbidden_licenses=None,
             # INPUT(Data, Calculation) - Reversed
             qb = QueryBuilder()
             qb.append(Data, tag='predecessor', project=['id'])
-            qb.append(Calculation, output_of='predecessor',
+            qb.append((Calculation, ProcessNode), output_of='predecessor',
                       filters={'id': {'==': curr_node_id}},
                       edge_filters={
                           'type': {
@@ -1795,7 +1796,7 @@ def export_tree(what, folder,allowed_licenses=None, forbidden_licenses=None,
             # The same until Code becomes a subclass of Data
             qb = QueryBuilder()
             qb.append(Code, tag='predecessor', project=['id'])
-            qb.append(Calculation, output_of='predecessor',
+            qb.append((Calculation, ProcessNode), output_of='predecessor',
                       filters={'id': {'==': curr_node_id}},
                       edge_filters={
                           'type': {
@@ -1809,7 +1810,7 @@ def export_tree(what, folder,allowed_licenses=None, forbidden_licenses=None,
                 qb = QueryBuilder()
                 qb.append(Data, tag='predecessor', project=['id'],
                           filters={'id': {'==': curr_node_id}})
-                qb.append(Calculation, output_of='predecessor',
+                qb.append((Calculation, ProcessNode), output_of='predecessor',
                           edge_filters={
                               'type': {
                                   '==': LinkType.INPUT.value}})
@@ -1819,7 +1820,7 @@ def export_tree(what, folder,allowed_licenses=None, forbidden_licenses=None,
                 qb = QueryBuilder()
                 qb.append(Code, tag='predecessor', project=['id'],
                           filters={'id': {'==': curr_node_id}})
-                qb.append(Calculation, output_of='predecessor',
+                qb.append((Calculation, ProcessNode), output_of='predecessor',
                           edge_filters={
                               'type': {
                                   '==': LinkType.INPUT.value}})
@@ -1829,7 +1830,7 @@ def export_tree(what, folder,allowed_licenses=None, forbidden_licenses=None,
 
             # CREATE/RETURN(Calculation, Data) - Forward
             qb = QueryBuilder()
-            qb.append(Calculation, tag='predecessor',
+            qb.append((Calculation, ProcessNode), tag='predecessor',
                       filters={'id': {'==': curr_node_id}})
             qb.append(Data, output_of='predecessor', project=['id'],
                       edge_filters={
@@ -1840,7 +1841,7 @@ def export_tree(what, folder,allowed_licenses=None, forbidden_licenses=None,
             given_data_entry_ids.update(res - to_be_exported)
             # The same until Code becomes a subclass of Data
             qb = QueryBuilder()
-            qb.append(Calculation, tag='predecessor',
+            qb.append((Calculation, ProcessNode), tag='predecessor',
                       filters={'id': {'==': curr_node_id}})
             qb.append(Code, output_of='predecessor', project=['id'],
                       edge_filters={
@@ -1854,7 +1855,7 @@ def export_tree(what, folder,allowed_licenses=None, forbidden_licenses=None,
             # CREATE(Calculation, Data) - Reversed
             if create_reversed:
                 qb = QueryBuilder()
-                qb.append(Calculation, tag='predecessor')
+                qb.append((Calculation, ProcessNode), tag='predecessor')
                 qb.append(Data, output_of='predecessor', project=['id'],
                           filters={'id': {'==': curr_node_id}},
                           edge_filters={
@@ -1864,7 +1865,7 @@ def export_tree(what, folder,allowed_licenses=None, forbidden_licenses=None,
                 given_data_entry_ids.update(res - to_be_exported)
                 # The same until Code becomes a subclass of Data
                 qb = QueryBuilder()
-                qb.append(Calculation, tag='predecessor')
+                qb.append((Calculation, ProcessNode), tag='predecessor')
                 qb.append(Code, output_of='predecessor', project=['id'],
                           filters={'id': {'==': curr_node_id}},
                           edge_filters={
@@ -1877,7 +1878,7 @@ def export_tree(what, folder,allowed_licenses=None, forbidden_licenses=None,
             # RETURN(Calculation, Data) - Reversed
             if return_reversed:
                 qb = QueryBuilder()
-                qb.append(Calculation, tag='predecessor')
+                qb.append((Calculation, ProcessNode), tag='predecessor')
                 qb.append(Data, output_of='predecessor', project=['id'],
                           filters={'id': {'==': curr_node_id}},
                           edge_filters={
@@ -1887,7 +1888,7 @@ def export_tree(what, folder,allowed_licenses=None, forbidden_licenses=None,
                 given_data_entry_ids.update(res - to_be_exported)
                 # The same until Code becomes a subclass of Data
                 qb = QueryBuilder()
-                qb.append(Calculation, tag='predecessor')
+                qb.append((Calculation, ProcessNode), tag='predecessor')
                 qb.append(Code, output_of='predecessor', project=['id'],
                           filters={'id': {'==': curr_node_id}},
                           edge_filters={
@@ -1898,9 +1899,9 @@ def export_tree(what, folder,allowed_licenses=None, forbidden_licenses=None,
 
             # CALL(Calculation, Calculation) - Forward
             qb = QueryBuilder()
-            qb.append(Calculation, tag='predecessor',
+            qb.append((Calculation, ProcessNode), tag='predecessor',
                       filters={'id': {'==': curr_node_id}})
-            qb.append(Calculation, output_of='predecessor', project=['id'],
+            qb.append((Calculation, ProcessNode), output_of='predecessor', project=['id'],
                       edge_filters={
                           'type': {
                               '==': LinkType.CALL.value}})
@@ -1911,8 +1912,8 @@ def export_tree(what, folder,allowed_licenses=None, forbidden_licenses=None,
             # CALL(Calculation, Calculation) - Reversed
             if call_reversed:
                 qb = QueryBuilder()
-                qb.append(Calculation, tag='predecessor')
-                qb.append(Calculation, output_of='predecessor', project=['id'],
+                qb.append((Calculation, ProcessNode), tag='predecessor')
+                qb.append((Calculation, ProcessNode), output_of='predecessor', project=['id'],
                           filters={'id': {'==': curr_node_id}},
                           edge_filters={
                               'type': {
@@ -1935,7 +1936,7 @@ def export_tree(what, folder,allowed_licenses=None, forbidden_licenses=None,
             # CREATE(Calculation, Data) - Reversed
             if create_reversed:
                 qb = QueryBuilder()
-                qb.append(Calculation, tag='predecessor', project=['id'])
+                qb.append((Calculation, ProcessNode), tag='predecessor', project=['id'])
                 qb.append(Data, output_of='predecessor',
                           filters={'id': {'==': curr_node_id}},
                           edge_filters={
@@ -1945,7 +1946,7 @@ def export_tree(what, folder,allowed_licenses=None, forbidden_licenses=None,
                 given_calculation_entry_ids.update(res - to_be_exported)
                 # The same until Code becomes a subclass of Data
                 qb = QueryBuilder()
-                qb.append(Calculation, tag='predecessor', project=['id'])
+                qb.append((Calculation, ProcessNode), tag='predecessor', project=['id'])
                 qb.append(Code, output_of='predecessor',
                           filters={'id': {'==': curr_node_id}},
                           edge_filters={
@@ -2093,7 +2094,7 @@ def export_tree(what, folder,allowed_licenses=None, forbidden_licenses=None,
             links_qb.append(Data,
                             project=['uuid'], tag='input',
                             filters = {'id': {'in': all_nodes_pk}})
-            links_qb.append(Calculation,
+            links_qb.append((Calculation, ProcessNode),
                             project=['uuid'], tag='output',
                             edge_filters={'type':{'==':LinkType.INPUT.value}},
                             edge_project=['label', 'type'], output_of='input')
@@ -2111,7 +2112,7 @@ def export_tree(what, folder,allowed_licenses=None, forbidden_licenses=None,
             links_qb.append(Code,
                             project=['uuid'], tag='input',
                             filters = {'id': {'in': all_nodes_pk}})
-            links_qb.append(Calculation,
+            links_qb.append((Calculation, ProcessNode),
                             project=['uuid'], tag='output',
                             edge_filters={'type':{'==':LinkType.INPUT.value}},
                             edge_project=['label', 'type'], output_of='input')
@@ -2128,7 +2129,7 @@ def export_tree(what, folder,allowed_licenses=None, forbidden_licenses=None,
         links_qb = QueryBuilder()
         links_qb.append(Data,
                         project=['uuid'], tag='input')
-        links_qb.append(Calculation,
+        links_qb.append((Calculation, ProcessNode),
                         project=['uuid'], tag='output',
                         filters={'id': {'in': all_nodes_pk}},
                         edge_filters={'type':{'==':LinkType.INPUT.value}},
@@ -2146,7 +2147,7 @@ def export_tree(what, folder,allowed_licenses=None, forbidden_licenses=None,
         links_qb = QueryBuilder()
         links_qb.append(Code,
                         project=['uuid'], tag='input')
-        links_qb.append(Calculation,
+        links_qb.append((Calculation, ProcessNode),
                         project=['uuid'], tag='output',
                         filters={'id': {'in': all_nodes_pk}},
                         edge_filters={
@@ -2163,7 +2164,7 @@ def export_tree(what, folder,allowed_licenses=None, forbidden_licenses=None,
 
         # CREATE (Calculation, Data) - Forward, by the Calculation node
         links_qb = QueryBuilder()
-        links_qb.append(Calculation,
+        links_qb.append((Calculation, ProcessNode),
                         project=['uuid'], tag='input',
                         filters={'id': {'in': all_nodes_pk}})
         links_qb.append(Data,
@@ -2183,7 +2184,7 @@ def export_tree(what, folder,allowed_licenses=None, forbidden_licenses=None,
         # This case will not happen (with the current setup - a code is not
         # created by a calculation) but it is addded for completeness
         links_qb = QueryBuilder()
-        links_qb.append(Calculation,
+        links_qb.append((Calculation, ProcessNode),
                         project=['uuid'], tag='input',
                         filters={'id': {'in': all_nodes_pk}})
         links_qb.append(Code,
@@ -2203,7 +2204,7 @@ def export_tree(what, folder,allowed_licenses=None, forbidden_licenses=None,
         # CREATE (Calculation, Data) - Backward, by the Data node
         if create_reversed:
             links_qb = QueryBuilder()
-            links_qb.append(Calculation,
+            links_qb.append((Calculation, ProcessNode),
                             project=['uuid'], tag='input',
                             filters={'id': {'in': all_nodes_pk}})
             links_qb.append(Data,
@@ -2224,7 +2225,7 @@ def export_tree(what, folder,allowed_licenses=None, forbidden_licenses=None,
         # created by a calculation) but it is addded for completeness
         if create_reversed:
             links_qb = QueryBuilder()
-            links_qb.append(Calculation,
+            links_qb.append((Calculation, ProcessNode),
                             project=['uuid'], tag='input',
                             filters={'id': {'in': all_nodes_pk}})
             links_qb.append(Data,
@@ -2242,7 +2243,7 @@ def export_tree(what, folder,allowed_licenses=None, forbidden_licenses=None,
 
         # RETURN (Calculation, Data) - Forward, by the Calculation node
         links_qb = QueryBuilder()
-        links_qb.append(Calculation,
+        links_qb.append((Calculation, ProcessNode),
                         project=['uuid'], tag='input',
                         filters={'id': {'in': all_nodes_pk}})
         links_qb.append(Data,
@@ -2261,7 +2262,7 @@ def export_tree(what, folder,allowed_licenses=None, forbidden_licenses=None,
         # RETURN (Calculation, Data) - Backward, by the Data node
         if return_reversed:
             links_qb = QueryBuilder()
-            links_qb.append(Calculation,
+            links_qb.append((Calculation, ProcessNode),
                             project=['uuid'], tag='input')
             links_qb.append(Data,
                             project=['uuid'], tag='output',
@@ -2280,10 +2281,10 @@ def export_tree(what, folder,allowed_licenses=None, forbidden_licenses=None,
         # CALL (Calculation [caller], Calculation [called]) - Forward, by
         # the Calculation node
         links_qb = QueryBuilder()
-        links_qb.append(Calculation,
+        links_qb.append((Calculation, ProcessNode),
                         project=['uuid'], tag='input',
                         filters={'id': {'in': all_nodes_pk}})
-        links_qb.append(Calculation,
+        links_qb.append((Calculation, ProcessNode),
                         project=['uuid'], tag='output',
                         edge_filters={'type': {'==': LinkType.CALL.value}},
                         edge_project=['label', 'type'], output_of='input')
@@ -2300,9 +2301,9 @@ def export_tree(what, folder,allowed_licenses=None, forbidden_licenses=None,
         # by the Calculation [called] node
         if call_reversed:
             links_qb = QueryBuilder()
-            links_qb.append(Calculation,
+            links_qb.append((Calculation, ProcessNode),
                             project=['uuid'], tag='input')
-            links_qb.append(Calculation,
+            links_qb.append((Calculation, ProcessNode),
                             project=['uuid'], tag='output',
                             filters={'id': {'in': all_nodes_pk}},
                             edge_filters={'type': {'==': LinkType.CALL.value}},

--- a/aiida/orm/node/process/process.py
+++ b/aiida/orm/node/process/process.py
@@ -408,11 +408,13 @@ class ProcessNode(Sealable, Node):
         :param dest: a `Node` instance
         :raise: ValueError if a link from self to `dest` is not allowed.
         """
+        from aiida.orm.calculation import Calculation
+
         if link_type is LinkType.CREATE or link_type is LinkType.RETURN:
             if not isinstance(dest, Data):
                 raise ValueError('The output of a process node can only be a data node')
         elif link_type is LinkType.CALL:
-            if not isinstance(dest, ProcessNode):
+            if not isinstance(dest, (Calculation, ProcessNode)):
                 raise ValueError('Call links can only link two process nodes: {}'.format(type(dest)))
         else:
             raise ValueError('a process node cannot have links of type {} as output'.format(link_type))
@@ -430,11 +432,13 @@ class ProcessNode(Sealable, Node):
         :param str label: name of the link, default is None
         :param link_type: the type of link, must be one of the enum values form :class:`~aiida.common.links.LinkType`
         """
+        from aiida.orm.calculation import Calculation
+
         if link_type is LinkType.INPUT:
             if not isinstance(src, (Data, Code)):
                 raise ValueError('Nodes entering processes as input link can only be of type data or code')
         elif link_type is LinkType.CALL:
-            if not isinstance(src, ProcessNode):
+            if not isinstance(src, (Calculation, ProcessNode)):
                 raise ValueError('Call links can only link two process nodes: {}'.format(type(src)))
         else:
             raise ValueError('Process node cannot have links of type {} as input'.format(link_type))

--- a/aiida/utils/ascii_vis.py
+++ b/aiida/utils/ascii_vis.py
@@ -159,7 +159,7 @@ def _ctime(node):
 
 
 def calc_info(calc_node):
-    from aiida.orm.calculation.function import FunctionCalculation
+    from aiida.orm.node.process import WorkFunctionNode
     from aiida.orm.calculation.inline import InlineCalculation
     from aiida.orm.calculation.job import JobCalculation
     from aiida.orm.calculation.work import WorkCalculation
@@ -179,7 +179,7 @@ def calc_info(calc_node):
         clabel = type(calc_node).__name__
         cstate = str(calc_node.get_state())
         s = u'{} <pk={}> [{}]'.format(clabel, calc_node.pk, cstate)
-    elif isinstance(calc_node, (FunctionCalculation, InlineCalculation)):
+    elif isinstance(calc_node, (WorkFunctionNode, InlineCalculation)):
         plabel = calc_node.process_label
         pstate = calc_node.process_state
         s = u'{} <pk={}> [{}]'.format(plabel, calc_node.pk, pstate)

--- a/aiida/work/processes.py
+++ b/aiida/work/processes.py
@@ -32,7 +32,7 @@ from aiida.common.lang import override, protected
 from aiida.common.links import LinkType
 from aiida.common.log import LOG_LEVEL_REPORT
 from aiida import orm
-from aiida.orm.calculation.function import FunctionCalculation
+from aiida.orm.node.process import ProcessNode, WorkFunctionNode
 from aiida.orm.calculation.work import WorkCalculation
 from aiida.utils import serialize
 from aiida.work.ports import InputPort, PortNamespace
@@ -110,7 +110,7 @@ class Process(plumpy.Process):
         spec.input('store_provenance', valid_type=bool, default=True, non_db=True)
         spec.input('description', valid_type=six.string_types[0], required=False, non_db=True)
         spec.input('label', valid_type=six.string_types[0], required=False, non_db=True)
-        spec.inputs.valid_type = (orm.Data, orm.Calculation)
+        spec.inputs.valid_type = (orm.Data, orm.Calculation, ProcessNode)
         spec.outputs.valid_type = (orm.Data,)
 
     @classmethod
@@ -508,7 +508,7 @@ class Process(plumpy.Process):
 
         for name, input_value in self._flat_inputs().items():
 
-            if isinstance(input_value, orm.Calculation):
+            if isinstance(input_value, (orm.Calculation, ProcessNode)):
                 input_value = utils.get_or_create_output_group(input_value)
 
             if not input_value.is_stored:
@@ -669,7 +669,7 @@ class Process(plumpy.Process):
 class FunctionProcess(Process):
     """Function process class used for turning functions into a Process"""
     _func_args = None
-    _calc_node_class = FunctionCalculation
+    _calc_node_class = WorkFunctionNode
 
     @staticmethod
     def _func(*_args, **_kwargs):
@@ -699,7 +699,7 @@ class FunctionProcess(Process):
         first_default_pos = nargs - ndefaults
 
         if calc_node_class is None:
-            calc_node_class = FunctionCalculation
+            calc_node_class = WorkFunctionNode
 
         if varargs is not None:
             raise ValueError('variadic arguments are not supported')

--- a/aiida/work/utils.py
+++ b/aiida/work/utils.py
@@ -20,7 +20,8 @@ import tornado.ioloop
 from tornado import concurrent, gen
 
 from aiida.common.links import LinkType
-from aiida.orm.calculation import Calculation, WorkCalculation, FunctionCalculation
+from aiida.orm.calculation import Calculation, WorkCalculation
+from aiida.orm.node.process import WorkFunctionNode
 from aiida.orm.data.frozendict import FrozenDict
 
 __all__ = 'RefObjectStore', 'interruptable_task', 'InterruptableFuture'
@@ -28,7 +29,7 @@ __all__ = 'RefObjectStore', 'interruptable_task', 'InterruptableFuture'
 LOGGER = logging.getLogger(__name__)
 PROCESS_STATE_CHANGE_KEY = 'process|state_change|{}'
 PROCESS_STATE_CHANGE_DESCRIPTION = 'The last time a process of type {}, changed state'
-PROCESS_CALC_TYPES = (WorkCalculation, FunctionCalculation)
+PROCESS_CALC_TYPES = (WorkCalculation, WorkFunctionNode)
 
 
 class InterruptableFuture(concurrent.Future):
@@ -169,7 +170,7 @@ def is_work_calc_type(calc_node):
         1. JobCalculation
         2. InlineCalculation
         3. WorkCalculation
-        4. FunctionCalculation
+        4. WorkFunctionNode
 
     1 & 2 can be considered the 'old' way of doing things, even though they are still
     in use while 3 & 4 are the 'new' way.  In loose terms the main difference is that
@@ -201,7 +202,9 @@ def get_or_create_output_group(calculation):
 
     :param calculation: Calculation
     """
-    if not isinstance(calculation, Calculation):
+    from aiida.orm.node.process import ProcessNode
+
+    if not isinstance(calculation, (Calculation, ProcessNode)):
         raise TypeError("Can only create output groups for type Calculation")
 
     outputs = calculation.get_outputs_dict(link_type=LinkType.CREATE)

--- a/aiida/work/workfunctions.py
+++ b/aiida/work/workfunctions.py
@@ -34,7 +34,7 @@ def workfunction(func, calc_node_class=None):
     >>> print(r)
     9
     >>> r.get_inputs_dict() # doctest: +SKIP
-    {u'result': <FunctionCalculation: uuid: ce0c63b3-1c84-4bb8-ba64-7b70a36adf34 (pk: 3567)>}
+    {u'result': <WorkFunctionNode: uuid: ce0c63b3-1c84-4bb8-ba64-7b70a36adf34 (pk: 3567)>}
     >>> r.get_inputs_dict()['result'].get_inputs()
     [4, 5]
 

--- a/docs/source/concepts/processes.rst
+++ b/docs/source/concepts/processes.rst
@@ -23,14 +23,14 @@ A good thing to remember is that while it is running, we are dealing with the ``
 The ``WorkChain`` is not the only process in AiiDA and each process uses a different node class as its database record.
 The following table describes which processes exist in AiiDA and what node type they use as a database record. 
 
-===================   =======================   =====================
-Process               Database record           Used for
-===================   =======================   =====================
-``WorkChain``         ``WorkCalculation``       Workchain
-``JobProcess``        ``JobCalculation``        Calculation
-``FunctionProcess``   ``FunctionCalculation``   Workfunction
-``FunctionProcess``   ``InlineCalculation``     Inline calculation
-===================   =======================   =====================
+===================   =======================       =====================
+Process               Database record               Used for
+===================   =======================       =====================
+``WorkChain``         ``WorkCalculation``           Workchain
+``JobProcess``        ``JobCalculation``            Calculation
+``FunctionProcess``   ``WorkFunctionNode``          Workfunction
+``FunctionProcess``   ``InlineCalculation``         Inline calculation
+===================   =======================       =====================
 
 .. note::
     The concept of the ``Process`` is a later addition to AiiDA and in the beginning this division of 'how to run something` and 'serving as a record of what happened', did not exist.

--- a/docs/source/concepts/workflows.rst
+++ b/docs/source/concepts/workflows.rst
@@ -803,7 +803,7 @@ Consider the following example:
         return ExitCode(418, 'I am a teapot')
 
 The execution of the workfunction will be immediately terminated as soon as the tuple is returned, and the exit status and message will be set to ``418`` and ``I am a teapot``, respectively.
-Since no output nodes are returned, the ``FunctionCalculation`` node will have no outputs and the value returned from the function call will be an empty dictionary.
+Since no output nodes are returned, the ``WorkFunctionNode`` node will have no outputs and the value returned from the function call will be an empty dictionary.
 
 Modular workflow design
 -----------------------


### PR DESCRIPTION
The node class used by workfunction changed from `FunctionCalculation` to
`WorkFunctionNode`.