### PR TITLE
Rename node class for `WorkChains`

### DIFF
--- a/aiida/backends/tests/cmdline/commands/test_work.py
+++ b/aiida/backends/tests/cmdline/commands/test_work.py
@@ -18,8 +18,7 @@ from aiida.backends.testbase import AiidaTestCase
 from aiida.cmdline.commands import cmd_work
 from aiida.common.links import LinkType
 from aiida.common.log import LOG_LEVEL_REPORT
-from aiida.orm.node.process import WorkFunctionNode
-from aiida.orm.calculation.work import WorkCalculation
+from aiida.orm.node.process import WorkChainNode, WorkFunctionNode
 
 
 def get_result_lines(result):
@@ -35,7 +34,7 @@ class TestVerdiWork(AiidaTestCase):
 
     def test_status(self):
         """Test the status command."""
-        calc = WorkCalculation().store()
+        calc = WorkChainNode().store()
         result = self.cli_runner.invoke(cmd_work.work_status, [str(calc.pk)])
         self.assertIsNone(result.exception)
 
@@ -50,7 +49,7 @@ class TestVerdiWork(AiidaTestCase):
 
         calcs = []
 
-        # Create 6 WorkFunctionNodes and WorkCalculations (one for each ProcessState)
+        # Create 6 WorkFunctionNodes and WorkChainNodes (one for each ProcessState)
         for state in ProcessState:
 
             calc = WorkFunctionNode()
@@ -63,10 +62,10 @@ class TestVerdiWork(AiidaTestCase):
             calc.store()
             calcs.append(calc)
 
-            calc = WorkCalculation()
+            calc = WorkChainNode()
             calc._set_process_state(state)
 
-            # Set the WorkCalculation as failed
+            # Set the WorkChainNode as failed
             if state == ProcessState.FINISHED:
                 calc._set_exit_status(1)
 
@@ -121,9 +120,9 @@ class TestVerdiWork(AiidaTestCase):
 
     def test_report(self):
         """Test the report command."""
-        grandparent = WorkCalculation().store()
-        parent = WorkCalculation().store()
-        child = WorkCalculation().store()
+        grandparent = WorkChainNode().store()
+        parent = WorkChainNode().store()
+        child = WorkChainNode().store()
 
         parent.add_link_from(grandparent, link_type=LinkType.CALL)
         child.add_link_from(parent, link_type=LinkType.CALL)
@@ -156,7 +155,7 @@ class TestVerdiWork(AiidaTestCase):
             result = self.cli_runner.invoke(cmd_work.work_report, [str(grandparent.pk), flag, 'WARNING'])
             self.assertIsNone(result.exception)
             self.assertEquals(len(get_result_lines(result)), 1)
-            self.assertEquals(get_result_lines(result)[0], 'No log messages recorded for this work calculation')
+            self.assertEquals(get_result_lines(result)[0], 'No log messages recorded for this entry')
 
     def test_plugins(self):
         """Test the plugins command. As of writing there are no default plugins defined for aiida-core."""
@@ -165,8 +164,8 @@ class TestVerdiWork(AiidaTestCase):
 
     def test_work_show(self):
         """Test verdi work show"""
-        workchain_one = WorkCalculation().store()
-        workchain_two = WorkCalculation().store()
+        workchain_one = WorkChainNode().store()
+        workchain_two = WorkChainNode().store()
         workchains = [workchain_one, workchain_two]
 
         # Running without identifiers should not except and not print anything

--- a/aiida/backends/tests/cmdline/params/types/test_calculation.py
+++ b/aiida/backends/tests/cmdline/params/types/test_calculation.py
@@ -16,8 +16,8 @@ from click.testing import CliRunner
 from aiida.backends.testbase import AiidaTestCase
 from aiida.cmdline.params import options
 from aiida.cmdline.params.types import CalculationParamType
-from aiida.orm import Calculation, InlineCalculation, JobCalculation, WorkCalculation
-from aiida.orm.node.process import WorkFunctionNode
+from aiida.orm import Calculation, InlineCalculation, JobCalculation
+from aiida.orm.node.process import WorkChainNode, WorkFunctionNode
 from aiida.orm.utils.loaders import OrmEntityLoader
 
 
@@ -40,7 +40,7 @@ class TestCalculationParamType(AiidaTestCase):
         cls.entity_04 = WorkFunctionNode()
         cls.entity_05 = InlineCalculation()
         cls.entity_06 = JobCalculation()
-        cls.entity_07 = WorkCalculation()
+        cls.entity_07 = WorkChainNode()
 
         cls.entity_01.label = 'calculation_01'
         cls.entity_02.label = str(cls.entity_01.pk)

--- a/aiida/backends/tests/export_and_import.py
+++ b/aiida/backends/tests/export_and_import.py
@@ -808,7 +808,7 @@ class TestSimple(AiidaTestCase):
     def test_workcalculation_2(self):
         import shutil, os, tempfile
 
-        from aiida.orm.calculation.work import WorkCalculation
+        from aiida.orm.node.process import WorkChainNode
         from aiida.orm.data.float import Float
         from aiida.orm.data.int import Int
         from aiida.orm import load_node
@@ -820,8 +820,8 @@ class TestSimple(AiidaTestCase):
         temp_folder = tempfile.mkdtemp()
 
         try:
-            master = WorkCalculation().store()
-            slave = WorkCalculation().store()
+            master = WorkChainNode().store()
+            slave = WorkChainNode().store()
 
             input_1 = Int(3).store()
             input_2 = Int(5).store()
@@ -1548,13 +1548,13 @@ class TestLinks(AiidaTestCase):
 
         from aiida.orm.data.int import Int
         from aiida.orm.importexport import export
-        from aiida.orm.calculation.work import WorkCalculation
+        from aiida.orm.node.process import WorkChainNode
         from aiida.common.links import LinkType
 
         tmp_folder = tempfile.mkdtemp()
 
         try:
-            node_work = WorkCalculation().store()
+            node_work = WorkChainNode().store()
             node_input = Int(1).store()
             node_output = Int(2).store()
 
@@ -1588,7 +1588,7 @@ class TestLinks(AiidaTestCase):
         """
         from aiida.orm.data.base import Int
         from aiida.orm.calculation.job import JobCalculation
-        from aiida.orm.calculation.work import WorkCalculation
+        from aiida.orm.node.process import WorkChainNode
         from aiida.common.datastructures import calc_states
         from aiida.common.links import LinkType
 
@@ -1598,8 +1598,8 @@ class TestLinks(AiidaTestCase):
         # Node creation
         d1 = Int(1).store()
         d2 = Int(1).store()
-        wc1 = WorkCalculation().store()
-        wc2 = WorkCalculation().store()
+        wc1 = WorkChainNode().store()
+        wc2 = WorkChainNode().store()
 
         pw1 = JobCalculation()
         pw1.set_computer(self.computer)
@@ -1811,14 +1811,14 @@ class TestLinks(AiidaTestCase):
         from aiida.orm.data.base import Int
         from aiida.orm.importexport import export
         from aiida.orm.calculation.inline import InlineCalculation
-        from aiida.orm.calculation.work import WorkCalculation
+        from aiida.orm.node.process import WorkChainNode
         from aiida.common.links import LinkType
         from aiida.orm.querybuilder import QueryBuilder
         tmp_folder = tempfile.mkdtemp()
 
         try:
-            wc2 = WorkCalculation().store()
-            wc1 = WorkCalculation().store()
+            wc2 = WorkChainNode().store()
+            wc1 = WorkChainNode().store()
             c1 = InlineCalculation().store()
             ni1 = Int(1).store()
             ni2 = Int(2).store()
@@ -1901,13 +1901,13 @@ class TestLinks(AiidaTestCase):
 
         from aiida.orm.data.base import Int
         from aiida.orm.importexport import export
-        from aiida.orm.calculation.work import WorkCalculation
+        from aiida.orm.node.process import WorkChainNode
         from aiida.common.links import LinkType
         tmp_folder = tempfile.mkdtemp()
 
         try:
-            w1 = WorkCalculation().store()
-            w2 = WorkCalculation().store()
+            w1 = WorkChainNode().store()
+            w2 = WorkChainNode().store()
             i1 = Int(1).store()
             o1 = Int(2).store()
 
@@ -1952,7 +1952,7 @@ class TestLinks(AiidaTestCase):
 
         from aiida.orm.data.base import Int
         from aiida.orm.importexport import export
-        from aiida.orm.calculation.work import WorkCalculation
+        from aiida.orm.node.process import WorkChainNode
         from aiida.common.links import LinkType
         from aiida.orm.querybuilder import QueryBuilder
         from aiida.orm.node import Node
@@ -1960,8 +1960,8 @@ class TestLinks(AiidaTestCase):
         tmp_folder = tempfile.mkdtemp()
 
         try:
-            w1 = WorkCalculation().store()
-            w2 = WorkCalculation().store()
+            w1 = WorkChainNode().store()
+            w2 = WorkChainNode().store()
             i1 = Int(1).store()
             o1 = Int(2).store()
 

--- a/aiida/backends/tests/work/process.py
+++ b/aiida/backends/tests/work/process.py
@@ -59,7 +59,7 @@ class TestProcessNamespace(AiidaTestCase):
         self.assertTrue(isinstance(input_node, Int))
         self.assertEquals(input_node.value, 5)
 
-        # Check that the link of the WorkCalculation node has the correct link name
+        # Check that the link of the process node has the correct link name
         self.assertTrue('some_name_space_a' in proc.calc.get_inputs_dict())
         self.assertEquals(proc.calc.get_inputs_dict()['some_name_space_a'], 5)
 

--- a/aiida/backends/tests/work/run.py
+++ b/aiida/backends/tests/work/run.py
@@ -13,9 +13,9 @@ from __future__ import print_function
 from __future__ import absolute_import
 from aiida.backends.testbase import AiidaTestCase
 
-import aiida.orm
 from aiida.orm.data.int import Int
 from aiida.orm.data.str import Str
+from aiida.orm.node.process import ProcessNode
 from aiida.work.launch import run, run_get_node
 from aiida.work.test_utils import DummyProcess
 
@@ -34,4 +34,4 @@ class TestRun(AiidaTestCase):
     def test_run_get_node(self):
         inputs = {'a': Int(2), 'b': Str('test')}
         result, node = run_get_node(DummyProcess, **inputs)
-        self.assertIsInstance(node, aiida.orm.Calculation)
+        self.assertIsInstance(node, ProcessNode)

--- a/aiida/backends/tests/work/test_launch.py
+++ b/aiida/backends/tests/work/test_launch.py
@@ -11,8 +11,7 @@ from __future__ import division
 from __future__ import print_function
 from __future__ import absolute_import
 from aiida.backends.testbase import AiidaTestCase
-from aiida.orm.node.process import WorkFunctionNode
-from aiida.orm.calculation.work import WorkCalculation
+from aiida.orm.node.process import WorkChainNode, WorkFunctionNode
 from aiida.orm.data.int import Int
 from aiida.work import run, run_get_node, run_get_pid, Process, WorkChain, workfunction
 
@@ -72,7 +71,7 @@ class TestLaunchers(AiidaTestCase):
     def test_workchain_run_get_node(self):
         result, node = run_get_node(AddWorkChain, a=self.a, b=self.b)
         self.assertEquals(result['result'], self.result)
-        self.assertTrue(isinstance(node, WorkCalculation))
+        self.assertTrue(isinstance(node, WorkChainNode))
 
     def test_workchain_run_get_pid(self):
         result, pid = run_get_pid(AddWorkChain, a=self.a, b=self.b)
@@ -92,7 +91,7 @@ class TestLaunchers(AiidaTestCase):
         builder.b = self.b
         result, node = run_get_node(builder)
         self.assertEquals(result['result'], self.result)
-        self.assertTrue(isinstance(node, WorkCalculation))
+        self.assertTrue(isinstance(node, WorkChainNode))
 
     def test_workchain_builder_run_get_pid(self):
         builder = AddWorkChain.get_builder()

--- a/aiida/backends/tests/work/work_chain.py
+++ b/aiida/backends/tests/work/work_chain.py
@@ -377,15 +377,23 @@ class TestWorkchain(AiidaTestCase):
 
         test_case = self
 
-        class ReturnA(work.Process):
-            def run(self):
-                self.out('res', A)
-                return
+        class ReturnA(WorkChain):
+            @classmethod
+            def define(cls, spec):
+                super(ReturnA, cls).define(spec)
+                spec.outline(cls.result)
 
-        class ReturnB(work.Process):
-            def run(self):
+            def result(self):
+                self.out('res', A)
+
+        class ReturnB(WorkChain):
+            @classmethod
+            def define(cls, spec):
+                super(ReturnB, cls).define(spec)
+                spec.outline(cls.result)
+
+            def result(self):
                 self.out('res', B)
-                return
 
         class Wf(WorkChain):
             @classmethod
@@ -616,10 +624,14 @@ class TestWorkchain(AiidaTestCase):
 
         test_case = self
 
-        class SimpleWc(work.Process):
-            def run(self):
+        class SimpleWc(WorkChain):
+            @classmethod
+            def define(cls, spec):
+                super(SimpleWc, cls).define(spec)
+                spec.outline(cls.result)
+
+            def result(self):
                 self.out('_return', val)
-                return
 
         class Workchain(WorkChain):
             @classmethod

--- a/aiida/cmdline/commands/cmd_work.py
+++ b/aiida/cmdline/commands/cmd_work.py
@@ -42,13 +42,11 @@ def work_list(all_entries, process_state, exit_status, failed, past_days, limit,
     """Show a list of work calculations that are still running."""
     from tabulate import tabulate
     from aiida.cmdline.utils.common import print_last_process_state_change
-    from aiida.orm.node.process import WorkFunctionNode
-    from aiida.orm.calculation.work import WorkCalculation
-
-    node_types = (WorkCalculation, WorkFunctionNode)
+    from aiida.orm.node.process import WorkChainNode, WorkFunctionNode
 
     builder = CalculationQueryBuilder()
-    filters = builder.get_filters(all_entries, process_state, exit_status, failed, node_types=node_types)
+    filters = builder.get_filters(
+        all_entries, process_state, exit_status, failed, node_types=(WorkChainNode, WorkFunctionNode))
     query_set = builder.get_query_set(filters=filters, past_days=past_days, limit=limit)
     projected = builder.get_projected(query_set, projections=project)
 
@@ -65,8 +63,7 @@ def work_list(all_entries, process_state, exit_status, failed, past_days, limit,
 
 
 @verdi_work.command('report')
-@arguments.CALCULATIONS(
-    type=types.CalculationParamType(sub_classes=('aiida.calculations:work', 'aiida.calculations:function')))
+@arguments.WORKFLOWS(type=types.WorkflowParamType(sub_classes=('aiida.node:process.workflow.workchain',)))
 @click.option('-i', '--indent-size', type=int, default=2, help='set the number of spaces to indent each level by')
 @click.option(
     '-l',
@@ -75,7 +72,7 @@ def work_list(all_entries, process_state, exit_status, failed, past_days, limit,
     default='REPORT',
     help='filter the results by name of the log level')
 @click.option('-m', '--max-depth', 'max_depth', type=int, default=None, help='limit the number of levels to be printed')
-def work_report(calculations, levelname, indent_size, max_depth):
+def work_report(workflows, levelname, indent_size, max_depth):
     # pylint: disable=too-many-locals
     """
     Return a list of recorded log messages for the WorkChain with pk=PK
@@ -83,7 +80,7 @@ def work_report(calculations, levelname, indent_size, max_depth):
     import itertools
     from aiida.orm.backends import construct_backend
     from aiida.orm.querybuilder import QueryBuilder
-    from aiida.orm.calculation.work import WorkCalculation
+    from aiida.orm.node.process import WorkChainNode
 
     def get_report_messages(pk, depth, levelname):
         """Return list of log messages with given levelname and their depth for a node with a given pk."""
@@ -99,9 +96,9 @@ def work_report(calculations, levelname, indent_size, max_depth):
     def get_subtree(pk, level=0):
         """Get a nested tree of work calculation nodes and their nesting level starting from this pk."""
         builder = QueryBuilder()
-        builder.append(cls=WorkCalculation, filters={'id': pk}, tag='workcalculation')
+        builder.append(cls=WorkChainNode, filters={'id': pk}, tag='workcalculation')
         builder.append(
-            cls=WorkCalculation,
+            cls=WorkChainNode,
             project=['id'],
             # In the future, we should specify here the type of link
             # for now, CALL links are the only ones allowing calc-calc
@@ -120,9 +117,9 @@ def work_report(calculations, levelname, indent_size, max_depth):
         for subtree in tree[1]:
             print_subtree(subtree, prepend=prepend + "  ")
 
-    for calculation in calculations:
+    for workflow in workflows:
 
-        workchain_tree = get_subtree(calculation.pk)
+        workchain_tree = get_subtree(workflow.pk)
 
         if max_depth:
             report_list = [
@@ -135,7 +132,7 @@ def work_report(calculations, levelname, indent_size, max_depth):
         reports.sort(key=lambda r: r[0].time)
 
         if not reports:
-            echo.echo("No log messages recorded for this work calculation")
+            echo.echo("No log messages recorded for this entry")
             return
 
         object_ids = [entry[0].id for entry in reports]
@@ -157,28 +154,26 @@ def work_report(calculations, levelname, indent_size, max_depth):
 
 
 @verdi_work.command('show')
-@arguments.CALCULATIONS(
-    type=types.CalculationParamType(sub_classes=('aiida.calculations:work', 'aiida.calculations:function')))
+@arguments.WORKFLOWS()
 @decorators.with_dbenv()
-def work_show(calculations):
-    """Show a summary for one or multiple calculations."""
+def work_show(workflows):
+    """Show a summary for one or multiple workflows."""
     from aiida.cmdline.utils.common import get_node_info
 
-    for calculation in calculations:
-        echo.echo(get_node_info(calculation))
+    for workflow in workflows:
+        echo.echo(get_node_info(workflow))
 
 
 @verdi_work.command('status')
-@arguments.CALCULATIONS(
-    type=types.CalculationParamType(sub_classes=('aiida.calculations:work', 'aiida.calculations:function')))
-def work_status(calculations):
+@arguments.WORKFLOWS()
+def work_status(workflows):
     """
-    Print the status of work calculations
+    Print the status of work workflows
     """
     from aiida.utils.ascii_vis import format_call_graph
 
-    for calculation in calculations:
-        graph = format_call_graph(calculation)
+    for workflow in workflows:
+        graph = format_call_graph(workflow)
         echo.echo(graph)
 
 
@@ -214,102 +209,98 @@ def work_plugins(entry_point):
 
 
 @verdi_work.command('kill')
-@arguments.CALCULATIONS(
-    type=types.CalculationParamType(sub_classes=('aiida.calculations:work', 'aiida.calculations:function')))
+@arguments.WORKFLOWS()
 @decorators.deprecated_command("This command will be removed in a future release. Use 'verdi process kill' instead.")
-def work_kill(calculations):
+def work_kill(workflows):
     """
-    Kill work calculations
+    Kill work workflows
     """
     from aiida import work
     from aiida.work import RemoteException, DeliveryFailed, CommunicationTimeout
 
     controller = work.AiiDAManager.get_process_controller()
-    for calculation in calculations:
+    for workflow in workflows:
 
-        if calculation.is_terminated:
-            echo.echo_error('Process<{}> is already terminated'.format(calculation.pk))
+        if workflow.is_terminated:
+            echo.echo_error('Process<{}> is already terminated'.format(workflow.pk))
             continue
 
         try:
-            future = controller.kill_process(calculation.pk, msg='Killed through `verdi work kill`')
+            future = controller.kill_process(workflow.pk, msg='Killed through `verdi work kill`')
             result = future.result()
 
             if result:
-                echo.echo_success('killed Process<{}>'.format(calculation.pk))
+                echo.echo_success('killed Process<{}>'.format(workflow.pk))
             else:
-                echo.echo_error('problem killing Process<{}>'.format(calculation.pk))
+                echo.echo_error('problem killing Process<{}>'.format(workflow.pk))
         except CommunicationTimeout:
-            echo.echo_error('call to kill Process<{}> timed out'.format(calculation.pk))
+            echo.echo_error('call to kill Process<{}> timed out'.format(workflow.pk))
         except (RemoteException, DeliveryFailed) as exception:
-            echo.echo_error('failed to kill Process<{}>: {}'.format(calculation.pk, exception))
+            echo.echo_error('failed to kill Process<{}>: {}'.format(workflow.pk, exception))
 
 
 @verdi_work.command('pause')
-@arguments.CALCULATIONS(
-    type=types.CalculationParamType(sub_classes=('aiida.calculations:work', 'aiida.calculations:function')))
+@arguments.WORKFLOWS()
 @decorators.deprecated_command("This command will be removed in a future release. Use 'verdi process pause' instead.")
-def work_pause(calculations):
+def work_pause(workflows):
     """
-    Pause running work calculations
+    Pause running work workflows
     """
     from aiida import work
     from aiida.work import RemoteException, DeliveryFailed, CommunicationTimeout
 
     controller = work.AiiDAManager.get_process_controller()
-    for calculation in calculations:
+    for workflow in workflows:
 
-        if calculation.is_terminated:
-            echo.echo_error('Calculation<{}> is already terminated'.format(calculation.pk))
+        if workflow.is_terminated:
+            echo.echo_error('Calculation<{}> is already terminated'.format(workflow.pk))
             continue
 
         try:
-            if controller.pause_process(calculation.pk):
-                echo.echo_success('paused Calculation<{}>'.format(calculation.pk))
+            if controller.pause_process(workflow.pk):
+                echo.echo_success('paused Calculation<{}>'.format(workflow.pk))
             else:
-                echo.echo_error('problem pausing Calculation<{}>'.format(calculation.pk))
+                echo.echo_error('problem pausing Calculation<{}>'.format(workflow.pk))
         except CommunicationTimeout:
-            echo.echo_error('call to pause Process<{}> timed out'.format(calculation.pk))
+            echo.echo_error('call to pause Process<{}> timed out'.format(workflow.pk))
         except (RemoteException, DeliveryFailed) as exception:
-            echo.echo_error('failed to pause Calculation<{}>: {}'.format(calculation.pk, exception))
+            echo.echo_error('failed to pause Calculation<{}>: {}'.format(workflow.pk, exception))
 
 
 @verdi_work.command('play')
-@arguments.CALCULATIONS(
-    type=types.CalculationParamType(sub_classes=('aiida.calculations:work', 'aiida.calculations:function')))
+@arguments.WORKFLOWS()
 @decorators.deprecated_command("This command will be removed in a future release. Use 'verdi process play' instead.")
-def work_play(calculations):
+def work_play(workflows):
     """
-    Play paused work calculations
+    Play paused work workflows
     """
     from aiida.work import RemoteException, DeliveryFailed, CommunicationTimeout
     from aiida import work
 
     controller = work.AiiDAManager.get_process_controller()
-    for calculation in calculations:
+    for workflow in workflows:
 
-        if calculation.is_terminated:
-            echo.echo_error('Calculation<{}> is already terminated'.format(calculation.pk))
+        if workflow.is_terminated:
+            echo.echo_error('Calculation<{}> is already terminated'.format(workflow.pk))
             continue
 
         try:
-            if controller.play_process(calculation.pk):
-                echo.echo_success('played Calculation<{}>'.format(calculation.pk))
+            if controller.play_process(workflow.pk):
+                echo.echo_success('played Calculation<{}>'.format(workflow.pk))
             else:
-                echo.echo_critical('problem playing Calculation<{}>'.format(calculation.pk))
+                echo.echo_critical('problem playing Calculation<{}>'.format(workflow.pk))
         except CommunicationTimeout:
-            echo.echo_error('call to play Process<{}> timed out'.format(calculation.pk))
+            echo.echo_error('call to play Process<{}> timed out'.format(workflow.pk))
         except (RemoteException, DeliveryFailed) as exception:
-            echo.echo_critical('failed to play Calculation<{}>: {}'.format(calculation.pk, exception))
+            echo.echo_critical('failed to play Calculation<{}>: {}'.format(workflow.pk, exception))
 
 
 @verdi_work.command('watch')
-@arguments.CALCULATIONS(
-    type=types.CalculationParamType(sub_classes=('aiida.calculations:work', 'aiida.calculations:function')))
+@arguments.WORKFLOWS()
 @decorators.deprecated_command("This command will be removed in a future release. Use 'verdi process watch' instead.")
-def work_watch(calculations):
+def work_watch(workflows):
     """
-    Watch the state transitions for work calculations
+    Watch the state transitions for work workflows
     """
     from kiwipy import BroadcastFilter
     from aiida import work
@@ -319,7 +310,7 @@ def work_watch(calculations):
         echo.echo('pk={}, subject={}, body={}, correlation_id={}'.format(sender, subject, body, correlation_id))
 
     communicator = work.AiiDAManager.get_communicator()
-    for process in calculations:
+    for process in workflows:
 
         if process.is_terminated:
             echo.echo_error('Process<{}> is already terminated'.format(process.pk))

--- a/aiida/cmdline/params/arguments/__init__.py
+++ b/aiida/cmdline/params/arguments/__init__.py
@@ -44,9 +44,13 @@ NODE = OverridableArgument('node', type=types.NodeParamType())
 
 NODES = OverridableArgument('nodes', nargs=-1, type=types.NodeParamType())
 
-PROCESS = OverridableArgument('process', type=types.CalculationParamType())
+PROCESS = OverridableArgument('process', type=types.ProcessParamType())
 
-PROCESSES = OverridableArgument('processes', nargs=-1, type=types.CalculationParamType())
+PROCESSES = OverridableArgument('processes', nargs=-1, type=types.ProcessParamType())
+
+WORKFLOW = OverridableArgument('workflow', type=types.WorkflowParamType())
+
+WORKFLOWS = OverridableArgument('workflows', nargs=-1, type=types.WorkflowParamType())
 
 INPUT_FILE = OverridableArgument('input_file', metavar='INPUT_FILE', type=click.Path(exists=True))
 

--- a/aiida/cmdline/params/types/__init__.py
+++ b/aiida/cmdline/params/types/__init__.py
@@ -22,16 +22,18 @@ from .identifier import IdentifierParamType
 from .legacy_workflow import LegacyWorkflowParamType
 from .multiple import MultipleValueParamType
 from .node import NodeParamType
+from .process import ProcessParamType
 from .nonemptystring import NonEmptyStringParamType
 from .path import AbsolutePathParamType
 from .plugin import PluginParamType
 from .profile import ProfileParamType
 from .user import UserParamType
 from .test_module import TestModuleParamType
+from .workflow import WorkflowParamType
 
 __all__ = [
     'LazyChoice', 'IdentifierParamType', 'CalculationParamType', 'CodeParamType', 'ComputerParamType', 'DataParamType',
     'GroupParamType', 'NodeParamType', 'MpirunCommandParamType', 'MultipleValueParamType', 'NonEmptyStringParamType',
     'PluginParamType', 'AbsolutePathParamType', 'ShebangParamType', 'LegacyWorkflowParamType', 'UserParamType',
-    'TestModuleParamType', 'ProfileParamType'
+    'TestModuleParamType', 'ProfileParamType', 'WorkflowParamType', 'ProcessParamType'
 ]

--- a/aiida/cmdline/params/types/process.py
+++ b/aiida/cmdline/params/types/process.py
@@ -8,7 +8,7 @@
 # For further information please visit http://www.aiida.net               #
 ###########################################################################
 """
-Module for the calculation parameter type
+Module for the process node parameter type
 """
 
 from __future__ import division
@@ -17,12 +17,12 @@ from __future__ import absolute_import
 from .identifier import IdentifierParamType
 
 
-class CalculationParamType(IdentifierParamType):
+class ProcessParamType(IdentifierParamType):
     """
-    The ParamType for identifying Calculation entities or its subclasses
+    The ParamType for identifying ProcessNode entities or its subclasses
     """
 
-    name = 'Calculation'
+    name = 'Process'
 
     @property
     def orm_class_loader(self):
@@ -32,5 +32,5 @@ class CalculationParamType(IdentifierParamType):
 
         :return: the orm entity loader class for this ParamType
         """
-        from aiida.orm.utils.loaders import CalculationEntityLoader
-        return CalculationEntityLoader
+        from aiida.orm.utils.loaders import ProcessEntityLoader
+        return ProcessEntityLoader

--- a/aiida/cmdline/params/types/workflow.py
+++ b/aiida/cmdline/params/types/workflow.py
@@ -8,7 +8,7 @@
 # For further information please visit http://www.aiida.net               #
 ###########################################################################
 """
-Module for the calculation parameter type
+Module for the workflow parameter type
 """
 
 from __future__ import division
@@ -17,12 +17,12 @@ from __future__ import absolute_import
 from .identifier import IdentifierParamType
 
 
-class CalculationParamType(IdentifierParamType):
+class WorkflowParamType(IdentifierParamType):
     """
-    The ParamType for identifying Calculation entities or its subclasses
+    The ParamType for identifying WorkflowNode entities or its subclasses
     """
 
-    name = 'Calculation'
+    name = 'WorkflowNode'
 
     @property
     def orm_class_loader(self):
@@ -32,5 +32,5 @@ class CalculationParamType(IdentifierParamType):
 
         :return: the orm entity loader class for this ParamType
         """
-        from aiida.orm.utils.loaders import CalculationEntityLoader
-        return CalculationEntityLoader
+        from aiida.orm.utils.loaders import WorkflowEntityLoader
+        return WorkflowEntityLoader

--- a/aiida/cmdline/utils/common.py
+++ b/aiida/cmdline/utils/common.py
@@ -141,7 +141,7 @@ def get_node_info(node, include_summary=True):
     """
     from aiida.backends.utils import get_log_messages
     from aiida.common.links import LinkType
-    from aiida.orm.calculation.work import WorkCalculation
+    from aiida.orm.node.process import WorkChainNode
 
     if include_summary:
         result = get_node_summary(node)
@@ -191,7 +191,7 @@ def get_node_info(node, include_summary=True):
         table = []
         table_headers = ['Log messages']
         table.append(['There are {} log messages for this calculation'.format(len(log_messages))])
-        if isinstance(node, WorkCalculation):
+        if isinstance(node, WorkChainNode):
             table.append(["Run 'verdi work report {}' to see them".format(node.pk)])
         else:
             table.append(["Run 'verdi calculation logshow {}' to see them".format(node.pk)])

--- a/aiida/orm/__init__.py
+++ b/aiida/orm/__init__.py
@@ -34,7 +34,7 @@ authinfo = authinfos
 computer = computers
 user = users
 
-_local = 'JobCalculation', 'WorkCalculation', 'Code', 'CalculationFactory', 'DataFactory', 'WorkflowFactory', \
+_local = 'JobCalculation', 'Code', 'CalculationFactory', 'DataFactory', 'WorkflowFactory', \
          'Workflow', 'Group', 'user', 'Computer'
 
 __all__ = (_local +

--- a/aiida/orm/implementation/general/code.py
+++ b/aiida/orm/implementation/general/code.py
@@ -308,8 +308,9 @@ class AbstractCode(Node):
         An output of a code can only be a calculation
         """
         from aiida.orm.calculation import Calculation
+        from aiida.orm.node.process import ProcessNode
 
-        if not isinstance(dest, Calculation):
+        if not isinstance(dest, (Calculation, ProcessNode)):
             raise ValueError(
                 "The output of a code node can only be a calculation")
 

--- a/aiida/orm/importexport.py
+++ b/aiida/orm/importexport.py
@@ -1715,7 +1715,7 @@ def export_tree(what, folder,allowed_licenses=None, forbidden_licenses=None,
     """
     import aiida
     from aiida.orm import Node, Calculation, Data, Group, Code
-    from aiida.orm.node.process import ProcessNode, WorkflowNode, CalculationNode
+    from aiida.orm.node.process import ProcessNode, CalculationNode
     from aiida.common.links import LinkType
     from aiida.common.folders import RepositoryFolder
     from aiida.orm.querybuilder import QueryBuilder
@@ -1751,7 +1751,7 @@ def export_tree(what, folder,allowed_licenses=None, forbidden_licenses=None,
             # The Code node should be treated as a Data node
             if (issubclass(entry.__class__, Data) or issubclass(entry.__class__, Code)):
                 given_data_entry_ids.add(entry.pk)
-            elif issubclass(entry.__class__, Calculation):
+            elif issubclass(entry.__class__, (Calculation, ProcessNode)):
                 given_calculation_entry_ids.add(entry.pk)
         elif issubclass(entry.__class__, Computer):
             given_computer_entry_ids.add(entry.pk)

--- a/aiida/orm/utils/loaders.py
+++ b/aiida/orm/utils/loaders.py
@@ -287,6 +287,38 @@ class OrmEntityLoader(object):
         return identifier, identifier_type
 
 
+class ProcessEntityLoader(OrmEntityLoader):
+
+    @classproperty
+    def orm_base_class(cls):
+        """
+        Return the orm base class to which loaded entities should be mapped. Actual queries to load an entity
+        may further narrow the query set by defining a more specific set of orm classes, as long as each of
+        those is a strict sub class of the orm base class.
+
+        :returns: the orm base class
+        """
+        from aiida.orm.node.process import ProcessNode
+        return ProcessNode
+
+    @classmethod
+    def _get_query_builder_label_identifier(cls, identifier, classes):
+        """
+        Return the query builder instance that attempts to map the identifier onto an entity of the orm class,
+        defined for this loader class, interpreting the identifier as a LABEL like identifier
+
+        :param identifier: the LABEL identifier
+        :param classes: a tuple of orm classes to which the identifier should be mapped
+        :returns: the query builder instance that should retrieve the entity corresponding to the identifier
+        :raises ValueError: if the identifier is invalid
+        :raises NotExistent: if the orm base class does not support a LABEL like identifier
+        """
+        qb = QueryBuilder()
+        qb.append(cls=classes, tag='process', project=['*'], filters={'label': {'==': identifier}})
+
+        return qb
+
+
 class CalculationEntityLoader(OrmEntityLoader):
 
     @classproperty
@@ -315,6 +347,38 @@ class CalculationEntityLoader(OrmEntityLoader):
         """
         qb = QueryBuilder()
         qb.append(cls=classes, tag='calculation', project=['*'], filters={'label': {'==': identifier}})
+
+        return qb
+
+
+class WorkflowEntityLoader(OrmEntityLoader):
+
+    @classproperty
+    def orm_base_class(cls):
+        """
+        Return the orm base class to which loaded entities should be mapped. Actual queries to load an entity
+        may further narrow the query set by defining a more specific set of orm classes, as long as each of
+        those is a strict sub class of the orm base class.
+
+        :returns: the orm base class
+        """
+        from aiida.orm.node.process import WorkflowNode
+        return WorkflowNode
+
+    @classmethod
+    def _get_query_builder_label_identifier(cls, identifier, classes):
+        """
+        Return the query builder instance that attempts to map the identifier onto an entity of the orm class,
+        defined for this loader class, interpreting the identifier as a LABEL like identifier
+
+        :param identifier: the LABEL identifier
+        :param classes: a tuple of orm classes to which the identifier should be mapped
+        :returns: the query builder instance that should retrieve the entity corresponding to the identifier
+        :raises ValueError: if the identifier is invalid
+        :raises NotExistent: if the orm base class does not support a LABEL like identifier
+        """
+        qb = QueryBuilder()
+        qb.append(cls=classes, tag='workflow', project=['*'], filters={'label': {'==': identifier}})
 
         return qb
 

--- a/aiida/tools/dbexporters/tcod.py
+++ b/aiida/tools/dbexporters/tcod.py
@@ -442,8 +442,8 @@ def _collect_calculation_data(calc):
     from aiida.orm.data import Data
     from aiida.orm.calculation import Calculation
     from aiida.orm.calculation.job import JobCalculation
-    from aiida.orm.calculation.work import WorkCalculation
     from aiida.orm.calculation.inline import InlineCalculation
+    from aiida.orm.node.process import WorkflowNode
     import hashlib
     import os
     calcs_now = []
@@ -513,8 +513,8 @@ def _collect_calculation_data(calc):
             'sha1'    : hashlib.sha1(shell_script).hexdigest(),
             'type'    : 'file',
             })
-    elif isinstance(calc, WorkCalculation):
-        # We do not know how to recreate a WorkCalculation so we pass
+    elif isinstance(calc, WorkflowNode):
+        # We do not know how to recreate a WorkflowNode so we pass
         pass
     else:
         raise ValueError('calculation is of an unexpected type {}'.format(type(calc)))

--- a/aiida/utils/ascii_vis.py
+++ b/aiida/utils/ascii_vis.py
@@ -162,10 +162,10 @@ def calc_info(calc_node):
     from aiida.orm.node.process import WorkFunctionNode
     from aiida.orm.calculation.inline import InlineCalculation
     from aiida.orm.calculation.job import JobCalculation
-    from aiida.orm.calculation.work import WorkCalculation
+    from aiida.orm.node.process import WorkChainNode
     from aiida.work.processes import ProcessState
 
-    if isinstance(calc_node, WorkCalculation):
+    if isinstance(calc_node, WorkChainNode):
         plabel = calc_node.process_label
         pstate = calc_node.process_state
         winfo = calc_node.stepper_state_info

--- a/aiida/work/awaitable.py
+++ b/aiida/work/awaitable.py
@@ -14,7 +14,8 @@ from __future__ import print_function
 from __future__ import absolute_import
 from enum import Enum
 from plumpy.utils import AttributesDict
-from aiida.orm.calculation import Calculation
+from aiida.orm import Calculation
+from aiida.orm.node.process import ProcessNode
 from aiida.orm.workflow import Workflow
 
 __all__ = ['Awaitable', 'AwaitableTarget', 'AwaitableAction', 'construct_awaitable']
@@ -31,7 +32,7 @@ class AwaitableTarget(Enum):
     """
     Enum that describes the class of the target a given awaitable
     """
-    CALCULATION = 'calculation'
+    PROCESS = 'process'
     WORKFLOW = 'workflow'
 
 
@@ -55,14 +56,14 @@ def construct_awaitable(target):
         * action: the context action to be performed upon completion
         * outputs: a boolean that toggles whether the node itself
 
-    Currently the only awaitable classes are Calculation and Workflow
+    Currently the only awaitable classes are ProcessNode and Workflow
     The only awaitable actions are the Assign and Append operators
     """
     if isinstance(target, Awaitable):
         return target
 
-    if isinstance(target, Calculation):
-        awaitable_target = AwaitableTarget.CALCULATION
+    if isinstance(target, (Calculation, ProcessNode)):
+        awaitable_target = AwaitableTarget.PROCESS
     elif isinstance(target, Workflow):
         awaitable_target = AwaitableTarget.WORKFLOW
     else:

--- a/aiida/work/processes.py
+++ b/aiida/work/processes.py
@@ -32,8 +32,7 @@ from aiida.common.lang import override, protected
 from aiida.common.links import LinkType
 from aiida.common.log import LOG_LEVEL_REPORT
 from aiida import orm
-from aiida.orm.node.process import ProcessNode, WorkFunctionNode
-from aiida.orm.calculation.work import WorkCalculation
+from aiida.orm.node.process import ProcessNode, WorkflowNode, WorkFunctionNode
 from aiida.utils import serialize
 from aiida.work.ports import InputPort, PortNamespace
 from aiida.work.process_spec import ProcessSpec, ExitCode
@@ -93,7 +92,7 @@ class Process(plumpy.Process):
     # pylint: disable=too-many-public-methods
 
     _spec_type = ProcessSpec
-    _calc_class = WorkCalculation
+    _calc_class = ProcessNode
 
     SINGLE_RETURN_LINKNAME = 'result'
 
@@ -457,7 +456,7 @@ class Process(plumpy.Process):
 
             value.store()
 
-            if utils.is_work_calc_type(self.calc):
+            if isinstance(self.calc, WorkflowNode):
                 value.add_link_from(self.calc, label, LinkType.RETURN)
 
     @property

--- a/docs/source/concepts/processes.rst
+++ b/docs/source/concepts/processes.rst
@@ -26,7 +26,7 @@ The following table describes which processes exist in AiiDA and what node type 
 ===================   =======================       =====================
 Process               Database record               Used for
 ===================   =======================       =====================
-``WorkChain``         ``WorkCalculation``           Workchain
+``WorkChain``         ``WorkChainNode``             Workchain
 ``JobProcess``        ``JobCalculation``            Calculation
 ``FunctionProcess``   ``WorkFunctionNode``          Workfunction
 ``FunctionProcess``   ``InlineCalculation``         Inline calculation

--- a/docs/source/concepts/workflows.rst
+++ b/docs/source/concepts/workflows.rst
@@ -176,7 +176,7 @@ If you would also like to get a reference of the node that represents the ``Work
 .. include:: include/snippets/workflows/workchains/run_workchain_get_node_pid.py
     :code: python
 
-For the former, the ``node`` will be the ``WorkCalculation`` node that is used to represent the workchain in the database, whereas for the latter, the ``pid`` is the pk of that same node.
+For the former, the ``node`` will be the ``WorkChainNode`` node that is used to represent the workchain in the database, whereas for the latter, the ``pid`` is the pk of that same node.
 The ``run`` based functions can actually also be used for ``workfunctions``.
 Calling ``run`` with a workfunction, does exactly the same as running the workfunction directly as a normal python function and so doesn't gain anything new.
 However, if you are interested in also getting the calculation node or the pid of the process, in addition to the result of the function, calling the workfunction through ``run_get_node`` or ``run_get_pid`` is the correct solution.
@@ -248,7 +248,7 @@ When you have launched workflows, be it workfunctions or workchains, you may wan
 verdi work list
 ---------------
 Your first point of entry will be the ``verdi`` command ``verdi work list``.
-This command will print a list of all active ``WorkCalculation`` nodes, which are the database objects used by ``WorkChains`` and ``workfunctions`` to store the details of their execution in the database.
+This command will print a list of all active ``WorkflowNode`` nodes, which are the database objects used by ``WorkChains`` and ``workfunctions`` to store the details of their execution in the database.
 A typical example may look something like the following:
 
 .. code-block:: bash
@@ -261,8 +261,8 @@ A typical example may look something like the following:
 
     Total results: 2
 
-The 'State' column is a concatenation of the ``process_state`` and the ``exit_status`` of the ``WorkCalculation``.
-By default, the command will only show active items, i.e. ``WorkCalculations`` that have not yet reached a terminal state.
+The 'State' column is a concatenation of the ``process_state`` and the ``exit_status`` of the ``WorkflowNode``.
+By default, the command will only show active items, i.e. ``WorkflowNodes`` that have not yet reached a terminal state.
 If you want to also show the nodes in a terminal states, you can use the ``-a`` flag and call ``verdi work list -a``:
 
 .. code-block:: bash
@@ -347,17 +347,16 @@ In addition to the call tree, each node also shows its current process state and
 This tool can be very useful to inspect while a workchain is running at which step in the outline it currently is, as well as the status of all the children calculations it called.
 
 
-verdi calculation show
+verdi work show
 ----------------------
-Finally, there is a command that displays detailed information about the ``WorkCalculation``, such as its inputs, outputs and the calculations it called and was called by.
-Since the ``WorkCalculation`` is a sub class of the ``Calculation`` class, we can use the same command ``verdi calculation show`` that one would use to inspect the details of a ``JobCalculation``.
+Finally, there is a command that displays detailed information about the ``WorkflowNode``, such as its inputs, outputs and the calculations it called and was called by.
 An example output for a ``PwBaseWorkChain`` would look like the following:
 
 .. code-block:: bash
 
     Property       Value
     -------------  ------------------------------------
-    type           WorkCalculation
+    type           WorkChainNode
     pk             164
     uuid           08bc5a3c-da7d-44e0-a91c-dda9ddcb638b
     label
@@ -641,7 +640,7 @@ It takes a single argument, a string, that is the message that needs to be repor
         self.report('here we will submit a calculation')
 
 This will send that message to the internal logger of python, which will cause it to be picked up by the default AiiDA logger, but it will also trigger the database log handler, which will store the message in the database and link it to the node of the workchain.
-This allows the ``verdi work report`` command to retrieve all those messages that were fired using the ``report`` method for a specifc ``WorkCalculation`` node.
+This allows the ``verdi work report`` command to retrieve all those messages that were fired using the ``report`` method for a specific ``WorkflowNode``.
 Note that the report method, in addition to the pk of the workchain, will also automatically record the name of the workchain and the name of the outline step in which the report message was fired.
 This information will show up in the output of ``verdi work report``, so you never have to explicitly reference the workchain name, outline step name or date and time in the message itself.
 

--- a/docs/source/developer_guide/caching.rst
+++ b/docs/source/developer_guide/caching.rst
@@ -3,10 +3,10 @@ Caching: implementation details
 
 This section covers some details of the caching mechanism which are not discussed in the :ref:`user guide <caching>`. If you are developing a plugin and want to modify the caching behavior of your classes, we recommend you read :ref:`this section <caching_matches>` first.
 
-Disabling caching for ``WorkCalculation``
------------------------------------------
+Disabling caching for ``WorkflowNode``
+--------------------------------------
 
 As discussed in the :ref:`user guide <caching_provenance>`, nodes which can have ``RETURN`` links cannot be cached. This is enforced on two levels:
 
-* The ``_cacheable`` property is set to ``False`` in the :class:`.AbstractCalculation`, and only re-enabled in :class:`.AbstractJobCalculation` and :class:`InlineCalculation <aiida.orm.calculation.inline.InlineCalculation>`. This means that a ``WorkCalculation`` will not be cached.
-* The ``_store_from_cache`` method, which is used to "clone" an existing node, will raise an error if the existing node has any ``RETURN`` links. This extra safe-guard prevents cases where a user might incorrectly override the ``_cacheable`` property on a ``WorkCalculation`` subclass.
+* The ``_cacheable`` property is set to ``False`` in the :class:`.AbstractCalculation`, and only re-enabled in :class:`.AbstractJobCalculation` and :class:`InlineCalculation <aiida.orm.calculation.inline.InlineCalculation>`. This means that a ``WorkflowNode`` will not be cached.
+* The ``_store_from_cache`` method, which is used to "clone" an existing node, will raise an error if the existing node has any ``RETURN`` links. This extra safe-guard prevents cases where a user might incorrectly override the ``_cacheable`` property on a ``WorkflowNode`` subclass.

--- a/docs/source/link_types/index.rst
+++ b/docs/source/link_types/index.rst
@@ -1,9 +1,9 @@
 Node classes
 ------------
-There are two *Node* sub-classes, *Data* and *Calculation*. The *Code* nodes
+There are two *Node* sub-classes, *Data* and *ProcessNode*. The *Code* nodes
 can be considered as sub-classes of *Data* nodes. *JobCalculations*,
-*InlineCalulations* and the *WorkCalculations* are subclasses of the
-*Calculation* class.
+*InlineCalulations*, *WorkChainNode* and the *WorkFunctionNode* are subclasses of the
+*ProcessNode* class.
 
 AiIDA graph
 -----------
@@ -53,11 +53,11 @@ and **CALL**.
   implied with the conditions of a **RETURN** link (the implementation will be
   corrected to comply shortly).
 
-* The **CALL** link is always from a *Calculation* to another *Calculation*
-  node. A given *Calculation* node cannot be called by more than one
-  *Calculation* node. In practice, the caller cannot be a *JobCalculation* but
-  it is always a *WorkCalculation*. Instead called calculations can be of any
-  subclass of *Calculation*.
+* The **CALL** link is always from a *ProcessNode* to another *ProcessNode*
+  node. A given *ProcessNode* node cannot be called by more than one
+  *ProcessNode* node. In practice, the caller cannot be a *JobCalculation* but
+  it is always a *WorkflowNode*. Instead called calculations can be of any
+  subclass of *ProcessNode*.
 
 Graph navigation
 ----------------

--- a/docs/source/querying/querybuilder/usage.rst
+++ b/docs/source/querying/querybuilder/usage.rst
@@ -58,7 +58,7 @@ However, they have to be of the same ORM-type (I.e. all have to be subclasses of
 
     from aiida.orm.querybuilder import QueryBuilder
     qb = QueryBuilder()       # Instantiating instance. One instance -> one query
-    qb.append([JobCalculation, WorkCalculation]) # Setting first vertice of path, either Work or Job.
+    qb.append([JobCalculation, WorkChainNode]) # Setting first vertice of path, either WorkChainNode or Job.
 
 
 Retrieving results


### PR DESCRIPTION
Fixes #2168 

The node class used by `WorkChains` changed from `WorkCalculation` to `WorkChainNode`.