### PR TITLE
Rename node class for inline calculations

### DIFF
--- a/.ci/test_daemon.py
+++ b/.ci/test_daemon.py
@@ -29,7 +29,7 @@ from aiida.orm.calculation import JobCalculation
 from aiida.work.launch import run_get_node, submit
 from aiida.work.persistence import ObjectLoader
 from workchains import (
-    NestedWorkChain, DynamicNonDbInput, DynamicDbInput, DynamicMixedInput, ListEcho, InlineCalcRunnerWorkChain,
+    NestedWorkChain, DynamicNonDbInput, DynamicDbInput, DynamicMixedInput, ListEcho, CalcFunctionRunnerWorkChain,
     WorkFunctionRunnerWorkChain, NestedInputNamespace, SerializeWorkChain
 )
 
@@ -362,9 +362,9 @@ def main():
     pk = submit(WorkFunctionRunnerWorkChain, input=value).pk
     expected_results_workchains[pk] = value
 
-    print("Submitting a WorkChain which contains an InlineCalculation.")
+    print("Submitting a WorkChain which contains an calcfunction.")
     value = Str('test_string')
-    pk = submit(InlineCalcRunnerWorkChain, input=value).pk
+    pk = submit(CalcFunctionRunnerWorkChain, input=value).pk
     expected_results_workchains[pk] = value
 
     calculation_pks = sorted(expected_results_calculations.keys())

--- a/.ci/workchains.py
+++ b/.ci/workchains.py
@@ -139,13 +139,13 @@ class DynamicMixedInput(WorkChain):
         assert isinstance(input_db, Int)
         self.out('output', input_db + input_non_db)
 
-class InlineCalcRunnerWorkChain(WorkChain):
+class CalcFunctionRunnerWorkChain(WorkChain):
     """
     WorkChain which calls an InlineCalculation in its step.
     """
     @classmethod
     def define(cls, spec):
-        super(InlineCalcRunnerWorkChain, cls).define(spec)
+        super(CalcFunctionRunnerWorkChain, cls).define(spec)
 
         spec.input('input', valid_type=Str)
         spec.output('output', valid_type=Str)

--- a/aiida/backends/tests/cmdline/params/types/test_calculation.py
+++ b/aiida/backends/tests/cmdline/params/types/test_calculation.py
@@ -16,8 +16,8 @@ from click.testing import CliRunner
 from aiida.backends.testbase import AiidaTestCase
 from aiida.cmdline.params import options
 from aiida.cmdline.params.types import CalculationParamType
-from aiida.orm import Calculation, InlineCalculation, JobCalculation
-from aiida.orm.node.process import WorkChainNode, WorkFunctionNode
+from aiida.orm import Calculation, JobCalculation
+from aiida.orm.node.process import CalcFunctionNode, WorkChainNode, WorkFunctionNode
 from aiida.orm.utils.loaders import OrmEntityLoader
 
 
@@ -38,7 +38,7 @@ class TestCalculationParamType(AiidaTestCase):
         cls.entity_02 = Calculation().store()
         cls.entity_03 = Calculation().store()
         cls.entity_04 = WorkFunctionNode()
-        cls.entity_05 = InlineCalculation()
+        cls.entity_05 = CalcFunctionNode()
         cls.entity_06 = JobCalculation()
         cls.entity_07 = WorkChainNode()
 

--- a/aiida/backends/tests/export_and_import.py
+++ b/aiida/backends/tests/export_and_import.py
@@ -1810,8 +1810,7 @@ class TestLinks(AiidaTestCase):
         from aiida.orm import Node
         from aiida.orm.data.base import Int
         from aiida.orm.importexport import export
-        from aiida.orm.calculation.inline import InlineCalculation
-        from aiida.orm.node.process import WorkChainNode
+        from aiida.orm.node.process import CalcFunctionNode, WorkChainNode
         from aiida.common.links import LinkType
         from aiida.orm.querybuilder import QueryBuilder
         tmp_folder = tempfile.mkdtemp()
@@ -1819,7 +1818,7 @@ class TestLinks(AiidaTestCase):
         try:
             wc2 = WorkChainNode().store()
             wc1 = WorkChainNode().store()
-            c1 = InlineCalculation().store()
+            c1 = CalcFunctionNode().store()
             ni1 = Int(1).store()
             ni2 = Int(2).store()
             no1 = Int(1).store()

--- a/aiida/backends/tests/inline_calculation.py
+++ b/aiida/backends/tests/inline_calculation.py
@@ -14,13 +14,14 @@ from __future__ import absolute_import
 import io
 from aiida.backends.testbase import AiidaTestCase
 from aiida.common.caching import enable_caching
-from aiida.orm.calculation.inline import make_inline, InlineCalculation
+from aiida.orm.calculation.inline import make_inline
+from aiida.orm.node.process import CalcFunctionNode
 from aiida.orm.data.int import Int
 
 
-class TestInlineCalculation(AiidaTestCase):
+class TestCalcFunctionNode(AiidaTestCase):
     """
-    Tests for the InlineCalculation calculations.
+    Tests for the CalcFunctionNode calculations.
     """
 
     def setUp(self):
@@ -46,7 +47,7 @@ class TestInlineCalculation(AiidaTestCase):
 
     def test_exit_status(self):
         """
-        If an InlineCalculation reaches the FINISHED process state, it has to have been successful
+        If an CalcFunctionNode reaches the FINISHED process state, it has to have been successful
         which means that the exit status always has to be 0
         """
         calculation, result = self.incr_inline(inp=Int(11))
@@ -64,14 +65,14 @@ class TestInlineCalculation(AiidaTestCase):
             self.assertEqual(res['res'].value, i + 1)
 
     def test_caching(self):
-        with enable_caching(InlineCalculation):
+        with enable_caching(CalcFunctionNode):
             calc1, res1 = self.incr_inline(inp=Int(11))
             calc2, res2 = self.incr_inline(inp=Int(11))
             self.assertEquals(res1['res'].value, res2['res'].value, 12)
             self.assertEquals(calc1.get_extra('_aiida_cached_from', calc1.uuid), calc2.get_extra('_aiida_cached_from'))
 
     def test_caching_change_code(self):
-        with enable_caching(InlineCalculation):
+        with enable_caching(CalcFunctionNode):
             calc1, res1 = self.incr_inline(inp=Int(11))
 
             @make_inline

--- a/aiida/cmdline/commands/cmd_calculation.py
+++ b/aiida/cmdline/commands/cmd_calculation.py
@@ -34,7 +34,7 @@ def verdi_calculation():
 
 @verdi_calculation.command('gotocomputer')
 @arguments.CALCULATION(
-    type=types.CalculationParamType(sub_classes=('aiida.calculations:job', 'aiida.calculations:inline')))
+    type=types.NodeParamType(sub_classes=('aiida.calculations:job', 'aiida.node:process.calculation.calcfunction')))
 def calculation_gotocomputer(calculation):
     """
     Open a shell and go to the calculation folder on the computer
@@ -61,7 +61,7 @@ def calculation_gotocomputer(calculation):
 
 @verdi_calculation.command('list')
 @arguments.CALCULATIONS(
-    type=types.CalculationParamType(sub_classes=('aiida.calculations:job', 'aiida.calculations:inline')))
+    type=types.NodeParamType(sub_classes=('aiida.calculations:job', 'aiida.node:process.calculation.calcfunction')))
 @options.CALCULATION_STATE()
 @options.PROCESS_STATE()
 @options.EXIT_STATUS()
@@ -135,7 +135,7 @@ def calculation_list(calculations, past_days, groups, all_entries, calculation_s
 
 @verdi_calculation.command('res')
 @arguments.CALCULATION(
-    type=types.CalculationParamType(sub_classes=('aiida.calculations:job', 'aiida.calculations:inline')))
+    type=types.NodeParamType(sub_classes=('aiida.calculations:job', 'aiida.node:process.calculation.calcfunction')))
 @click.option('-f', '--format', 'fmt', type=click.STRING, default='json+date', help='format for the output')
 @click.option('-k', '--keys', 'keys', type=click.STRING, cls=options.MultipleValueOption, help='show only these keys')
 @decorators.with_dbenv()
@@ -158,7 +158,7 @@ def calculation_res(calculation, fmt, keys):
 
 @verdi_calculation.command('show')
 @arguments.CALCULATIONS(
-    type=types.CalculationParamType(sub_classes=('aiida.calculations:job', 'aiida.calculations:inline')))
+    type=types.NodeParamType(sub_classes=('aiida.calculations:job', 'aiida.node:process.calculation.calcfunction')))
 @decorators.with_dbenv()
 def calculation_show(calculations):
     """Show a summary for one or multiple calculations."""
@@ -170,7 +170,7 @@ def calculation_show(calculations):
 
 @verdi_calculation.command('logshow')
 @arguments.CALCULATIONS(
-    type=types.CalculationParamType(sub_classes=('aiida.calculations:job', 'aiida.calculations:inline')))
+    type=types.NodeParamType(sub_classes=('aiida.calculations:job', 'aiida.node:process.calculation.calcfunction')))
 @decorators.with_dbenv()
 def calculation_logshow(calculations):
     """Show the log for one or multiple calculations."""
@@ -214,7 +214,7 @@ def calculation_plugins(entry_point):
 
 @verdi_calculation.command('inputcat')
 @arguments.CALCULATION(
-    type=types.CalculationParamType(sub_classes=('aiida.calculations:job', 'aiida.calculations:inline')))
+    type=types.NodeParamType(sub_classes=('aiida.calculations:job', 'aiida.node:process.calculation.calcfunction')))
 @click.argument('path', type=click.STRING, required=False)
 @decorators.with_dbenv()
 def calculation_inputcat(calculation, path):
@@ -251,7 +251,7 @@ def calculation_inputcat(calculation, path):
 
 @verdi_calculation.command('outputcat')
 @arguments.CALCULATION(
-    type=types.CalculationParamType(sub_classes=('aiida.calculations:job', 'aiida.calculations:inline')))
+    type=types.NodeParamType(sub_classes=('aiida.calculations:job', 'aiida.node:process.calculation.calcfunction')))
 @click.argument('path', type=click.STRING, required=False)
 @decorators.with_dbenv()
 def calculation_outputcat(calculation, path):
@@ -295,7 +295,7 @@ def calculation_outputcat(calculation, path):
 @verdi_calculation.command('inputls')
 @decorators.with_dbenv()
 @arguments.CALCULATION(
-    type=types.CalculationParamType(sub_classes=('aiida.calculations:job', 'aiida.calculations:inline')))
+    type=types.NodeParamType(sub_classes=('aiida.calculations:job', 'aiida.node:process.calculation.calcfunction')))
 @click.argument('path', type=click.STRING, required=False)
 @click.option('-c', '--color', 'color', is_flag=True, default=False, help='color folders with a different color')
 def calculation_inputls(calculation, path, color):
@@ -321,7 +321,7 @@ def calculation_inputls(calculation, path, color):
 @verdi_calculation.command('outputls')
 @decorators.with_dbenv()
 @arguments.CALCULATION(
-    type=types.CalculationParamType(sub_classes=('aiida.calculations:job', 'aiida.calculations:inline')))
+    type=types.NodeParamType(sub_classes=('aiida.calculations:job', 'aiida.node:process.calculation.calcfunction')))
 @click.argument('path', type=click.STRING, required=False)
 @click.option('-c', '--color', 'color', is_flag=True, default=False, help='color folders with a different color')
 def calculation_outputls(calculation, path, color):
@@ -352,7 +352,7 @@ def calculation_outputls(calculation, path, color):
 @verdi_calculation.command('kill')
 @decorators.with_dbenv()
 @arguments.CALCULATIONS(
-    type=types.CalculationParamType(sub_classes=('aiida.calculations:job', 'aiida.calculations:inline')))
+    type=types.NodeParamType(sub_classes=('aiida.calculations:job', 'aiida.node:process.calculation.calcfunction')))
 @options.FORCE()
 @decorators.deprecated_command("This command will be removed in a future release. Use 'verdi process kill' instead.")
 def calculation_kill(calculations, force):
@@ -384,7 +384,7 @@ def calculation_kill(calculations, force):
 @verdi_calculation.command('cleanworkdir')
 @decorators.with_dbenv()
 @arguments.CALCULATIONS(
-    type=types.CalculationParamType(sub_classes=('aiida.calculations:job', 'aiida.calculations:inline')))
+    type=types.NodeParamType(sub_classes=('aiida.calculations:job', 'aiida.node:process.calculation.calcfunction')))
 @options.PAST_DAYS(default=None)
 @options.OLDER_THAN(default=None)
 @options.COMPUTERS(help='include only calculations that were ran on these computers')

--- a/aiida/orm/calculation/inline.py
+++ b/aiida/orm/calculation/inline.py
@@ -12,15 +12,16 @@ from __future__ import division
 from __future__ import print_function
 from __future__ import absolute_import
 import functools
-from aiida.orm.implementation.general.calculation.inline import InlineCalculation
 
-__all__ = 'InlineCalculation', 'make_inline', 'optional_inline'
+from aiida.orm.node.process import CalcFunctionNode
+
+__all__ = 'make_inline', 'optional_inline'
 
 
 def make_inline(func):
     """
     This make_inline wrapper/decorator takes a function with specific
-    requirements, runs it and stores the result as an InlineCalculation node.
+    requirements, runs it and stores the result as an CalcFunctionNode node.
     It will also store all other nodes, including any possibly unstored
     input node! The return value of the wrapped calculation will also be
     slightly changed, see below.
@@ -35,13 +36,13 @@ def make_inline(func):
     * checks that the result value is a dictionary, where the
       key are all strings and the values are all **unstored**
       data nodes
-    * creates an InlineCalculation node, links all the kwargs
+    * creates an CalcFunctionNode node, links all the kwargs
       as inputs and the returned nodes as outputs, using the
       keys as link labels
     * stores all the nodes (including, possibly, unstored input
       nodes given as kwargs)
     * returns a length-two tuple, where the first element is
-      the InlineCalculation node, and the second is the dictionary
+      the CalcFunctionNode node, and the second is the dictionary
       returned by the wrapped function
 
     To use this function, you can use it as a decorator of a
@@ -53,14 +54,14 @@ def make_inline(func):
 
     In this way, every time you call copy_inline, the wrapped version
     is actually called, and the return value will be a tuple with
-    the InlineCalculation instance, and the returned dictionary.
+    the CalcFunctionNode instance, and the returned dictionary.
     For instance, if ``s`` is a valid ``Data`` node, with the following
     lines::
 
         c, s_copy_dict = copy_inline(source=s)
         s_copy = s_copy_dict['copy']
 
-    ``c`` will contain the new ``InlineCalculation`` instance, ``s_copy`` the
+    ``c`` will contain the new ``CalcFunctionNode`` instance, ``s_copy`` the
     (stored) copy of ``s`` (with the side effect that, if ``s`` was not stored,
     after the function call it will be automatically stored).
 
@@ -79,7 +80,7 @@ def make_inline(func):
 
         s_copy_dict = copy_inline(s)
 
-    while if you want to wrap it, so that an ``InlineCalculation`` is created, and
+    while if you want to wrap it, so that an ``CalcFunctionNode`` is created, and
     everything is stored, you will run::
 
         c, s_copy_dict = make_inline(f)(s=s)
@@ -133,7 +134,7 @@ def make_inline(func):
 
     :param kwargs: all kwargs are passed to the wrapped function
     :return: a length-two tuple, where the first element is
-        the InlineCalculation node, and the second is the dictionary
+        the CalcFunctionNode node, and the second is the dictionary
         returned by the wrapped function. All nodes are stored.
     :raise TypeError: if the return value is not a dictionary, the
         keys are not strings, or the values
@@ -154,7 +155,7 @@ def make_inline(func):
             "The function name that is wrapped must end "
             "with '_inline', while its name is '{}'".format(function_name))
 
-    wf = workfunction(func, InlineCalculation)
+    wf = workfunction(func, CalcFunctionNode)
 
     @functools.wraps(func)
     def swap_result(*args, **kwargs):
@@ -167,8 +168,8 @@ def make_inline(func):
 def optional_inline(func):
     """
     optional_inline wrapper/decorator takes a function, which can be called
-    either as wrapped in InlineCalculation or a simple function, depending
-    on 'store' keyworded argument (True stands for InlineCalculation, False
+    either as wrapped in CalcFunctionNode or a simple function, depending
+    on 'store' keyworded argument (True stands for CalcFunctionNode, False
     for simple function). The wrapped function has to adhere to the
     requirements by make_inline wrapper/decorator.
 
@@ -178,7 +179,7 @@ def optional_inline(func):
         def copy_inline(source=None):
             return {'copy': source.copy()}
 
-    Function ``copy_inline`` will be wrapped in InlineCalculation when
+    Function ``copy_inline`` will be wrapped in CalcFunctionNode when
     invoked in following way::
 
         copy_inline(source=node,store=True)

--- a/aiida/orm/node/process/calculation/calcfunction.py
+++ b/aiida/orm/node/process/calculation/calcfunction.py
@@ -12,4 +12,5 @@ __all__ = ('CalcFunctionNode',)
 class CalcFunctionNode(FunctionCalculationMixin, CalculationNode):
     """ORM class for all nodes representing the execution of a calcfunction."""
     # pylint: disable=too-few-public-methods
-    pass
+
+    _cacheable = True

--- a/aiida/orm/querybuilder.py
+++ b/aiida/orm/querybuilder.py
@@ -469,7 +469,7 @@ class QueryBuilder(object):
         :param bool subclassing:
             Whether to include subclasses of the given class
             (default **True**).
-            E.g. Specifying a  Calculation as cls will include JobCalculations, InlineCalculations, etc..
+            E.g. Specifying a  ProcessNode as cls will include JobCalculations, WorkChainNode, CalcFunctionNode, etc..
         :param bool outerjoin:
             If True, (default is False), will do a left outerjoin
             instead of an inner join

--- a/aiida/utils/ascii_vis.py
+++ b/aiida/utils/ascii_vis.py
@@ -159,8 +159,7 @@ def _ctime(node):
 
 
 def calc_info(calc_node):
-    from aiida.orm.node.process import WorkFunctionNode
-    from aiida.orm.calculation.inline import InlineCalculation
+    from aiida.orm.node.process import CalcFunctionNode, WorkFunctionNode
     from aiida.orm.calculation.job import JobCalculation
     from aiida.orm.node.process import WorkChainNode
     from aiida.work.processes import ProcessState
@@ -179,7 +178,7 @@ def calc_info(calc_node):
         clabel = type(calc_node).__name__
         cstate = str(calc_node.get_state())
         s = u'{} <pk={}> [{}]'.format(clabel, calc_node.pk, cstate)
-    elif isinstance(calc_node, (WorkFunctionNode, InlineCalculation)):
+    elif isinstance(calc_node, (WorkFunctionNode, CalcFunctionNode)):
         plabel = calc_node.process_label
         pstate = calc_node.process_state
         s = u'{} <pk={}> [{}]'.format(plabel, calc_node.pk, pstate)

--- a/aiida/work/utils.py
+++ b/aiida/work/utils.py
@@ -218,12 +218,12 @@ def set_process_state_change_timestamp(process):
     """
     from aiida.backends.utils import set_global_setting
     from aiida.common.exceptions import UniquenessError
-    from aiida.orm.calculation.inline import InlineCalculation
+    from aiida.orm.node.process import CalcFunctionNode
     from aiida.orm.calculation.job import JobCalculation
     from aiida.orm.node.process import ProcessNode, WorkflowNode
     from aiida.utils import timezone
 
-    if isinstance(process.calc, (JobCalculation, InlineCalculation)):
+    if isinstance(process.calc, (JobCalculation, CalcFunctionNode)):
         process_type = 'calculation'
     elif isinstance(process.calc, WorkflowNode):
         process_type = 'work'

--- a/docs/source/concepts/processes.rst
+++ b/docs/source/concepts/processes.rst
@@ -29,15 +29,14 @@ Process               Database record               Used for
 ``WorkChain``         ``WorkChainNode``             Workchain
 ``JobProcess``        ``JobCalculation``            Calculation
 ``FunctionProcess``   ``WorkFunctionNode``          Workfunction
-``FunctionProcess``   ``InlineCalculation``         Inline calculation
+``FunctionProcess``   ``CalcFunctionNode``          Calcfunction
 ===================   =======================       =====================
 
 .. note::
     The concept of the ``Process`` is a later addition to AiiDA and in the beginning this division of 'how to run something` and 'serving as a record of what happened', did not exist.
     For example, historically speaking, the ``JobCalculation`` class fulfilled both of those tasks.
-    To not break the functionality of the historic ``JobCalculation`` and ``InlineCalculation``, their implementation was kept and ``Process`` wrappers were developed in the form of the ``JobProcess`` and the ``FunctionProcess``, respectively.
-    When a function, decorated with the ``make_inline`` decorator, is run, it is automatically wrapped into a ``FunctionProcess`` to make sure that is a process and gets all the necessary methods for the ``Runner`` to run it.
-    Similarly, the ``process()`` class method was implemented for the ``JobCalculation`` class, in order to automatically create a process wrapper for the calculation.
+    To not break the functionality of the historic ``JobCalculation``, its implementation was kept and a ``Process`` wrapper was developed in the form of the ``JobProcess``.
+    The ``process()`` class method was implemented for the ``JobCalculation`` class, in order to automatically create a process wrapper for the calculation.
 
 The good thing about this unification is that everything that is run in AiiDA has the same attributes concerning its running state.
 The most important attribute is the process state.

--- a/docs/source/developer_guide/caching.rst
+++ b/docs/source/developer_guide/caching.rst
@@ -8,5 +8,5 @@ Disabling caching for ``WorkflowNode``
 
 As discussed in the :ref:`user guide <caching_provenance>`, nodes which can have ``RETURN`` links cannot be cached. This is enforced on two levels:
 
-* The ``_cacheable`` property is set to ``False`` in the :class:`.AbstractCalculation`, and only re-enabled in :class:`.AbstractJobCalculation` and :class:`InlineCalculation <aiida.orm.calculation.inline.InlineCalculation>`. This means that a ``WorkflowNode`` will not be cached.
+* The ``_cacheable`` property is set to ``False`` in the :class:`.AbstractCalculation`, and only re-enabled in :class:`.AbstractJobCalculation` and :class:`CalcFunctionNode <aiida.orm.node.process.calculation.calcfunction.CalcFunctionNode>`. This means that a ``WorkflowNode`` will not be cached.
 * The ``_store_from_cache`` method, which is used to "clone" an existing node, will raise an error if the existing node has any ``RETURN`` links. This extra safe-guard prevents cases where a user might incorrectly override the ``_cacheable`` property on a ``WorkflowNode`` subclass.

--- a/docs/source/developer_guide/developers.rst
+++ b/docs/source/developer_guide/developers.rst
@@ -38,7 +38,7 @@ Python, without being submitted to a cluster.
 However, this operation takes one (or more) input data nodes, and creates new
 data nodes, the operation itself is not recorded in the database, and provenance
 is lost. In order to put a Calculation object inbetween, we define the
-:py:class:`InlineCalculation <aiida.orm.calculation.inline.InlineCalculation>`
+:py:class:`CalcFunctionNode <aiida.orm.node.process.CalcFunctionNode>`
 class, that is used as the class for these calculations that are run "in-line".
 
 We also provide a wrapper (that also works as a decorator of a function),

--- a/docs/source/developer_guide/tcod_exporter.rst
+++ b/docs/source/developer_guide/tcod_exporter.rst
@@ -26,7 +26,7 @@ No. Description                     Input                                       
 === =============================== ================================================================== ================================================================== ====== ============
 
 Type of each step's calculation
-(:py:class:`InlineCalculation <aiida.orm.calculation.inline.InlineCalculation>`
+(:py:class:`CalcFunctionNode <aiida.orm.node.process.CalcFunctionNode>`
 or :py:class:`JobCalculation <aiida.orm.implementation.general.calculation.job.AbstractJobCalculation>`)
 defined in column *Type*. Each step is described in more detail below:
 
@@ -54,7 +54,7 @@ defined in column *Type*. Each step is described in more detail below:
     re-running of calculations, outputs from the calculations and exported
     subset of AiiDA database. It's not quite clear what/how to record the
     metadata for calculations of type
-    :py:class:`InlineCalculation <aiida.orm.calculation.inline.InlineCalculation>`.
+    :py:class:`CalcFunctionNode <aiida.orm.node.process.CalcFunctionNode>`.
 * Depostition to the TCOD
     Deposition of the final
     :py:class:`CifData <aiida.orm.data.cif.CifData>` to the TCOD is

--- a/docs/source/restapi/index.rst
+++ b/docs/source/restapi/index.rst
@@ -591,7 +591,7 @@ Nodes
                 "label": "",
                 "mtime": "Fri, 29 Apr 2016 19:24:13 GMT",
                 "state": null,
-                "type": "calculation.inline.InlineCalculation.",
+                "type": "node.process.calculation.CalcFunctionNode.",
                 "uuid": "68d2ed6c-6f51-4546-8d10-7fe063525ab8"
               },
               {

--- a/docs/source/state/calculation_state.rst
+++ b/docs/source/state/calculation_state.rst
@@ -4,7 +4,7 @@ AiiDA calculations can be of two kinds:
 
 * :py:class:`JobCalculation <aiida.orm.implementation.general.calculation.job.AbstractJobCalculation>`: those who need to be run on a scheduler
 
-* :py:class:`InlineCalculation <aiida.orm.calculation.inline.InlineCalculation>`: rapid executions that are executed by the daemon itself, on your local machine.
+* :py:class:`CalcFunctionNode <aiida.orm.node.process.CalcFunctionNode>`: rapid executions that are executed by the daemon itself, on your local machine.
 
 In the following, we will refer to the JobCalculations as a Calculation for the sake of simplicity, unless we explicitly say otherwise. In the same way, the command ``verdi calculation`` refers to JobCalculations.
 

--- a/setup.py
+++ b/setup.py
@@ -76,7 +76,6 @@ if __name__ == '__main__':
             'aiida.calculations': [
                 'calculation = aiida.orm.calculation:Calculation',
                 'function = aiida.orm.calculation.function:FunctionCalculation',
-                'inline = aiida.orm.calculation.inline:InlineCalculation',
                 'job = aiida.orm.calculation.job:JobCalculation',
                 'work = aiida.orm.calculation.work:WorkCalculation',
                 'simpleplugins.arithmetic.add = aiida.orm.calculation.job.simpleplugins.arithmetic.add:ArithmeticAddCalculation',


### PR DESCRIPTION
Fixes #2170 

The node class changed from `InlineCalculation` to `CalcFunctionNode`.