### PR TITLE
[WIP] Make uuid columns unique in sqla

### DIFF
--- a/aiida/backends/djsite/db/migrations/0014_add_node_uuid_unique_constraint.py
+++ b/aiida/backends/djsite/db/migrations/0014_add_node_uuid_unique_constraint.py
@@ -31,8 +31,8 @@ def verify_node_uuid_uniqueness(apps, schema_editor):
 
     :raises: IntegrityError if database contains nodes with duplicate UUIDS.
     """
-    from aiida.manage.database.integrity import verify_node_uuid_uniqueness
-    verify_node_uuid_uniqueness()
+    from aiida.manage.database.integrity import verify_uuid_uniqueness
+    verify_uuid_uniqueness(table='db_dbnode')
 
 
 def reverse_code(apps, schema_editor):

--- a/aiida/backends/djsite/db/subtests/migrations.py
+++ b/aiida/backends/djsite/db/subtests/migrations.py
@@ -19,7 +19,7 @@ from django.db.migrations.executor import MigrationExecutor
 from django.db import connection
 from aiida.backends.testbase import AiidaTestCase
 from aiida.common.exceptions import IntegrityError
-from aiida.manage.database.integrity import deduplicate_node_uuids, verify_node_uuid_uniqueness
+from aiida.manage.database.integrity import deduplicate_node_uuids, verify_uuid_uniqueness
 from aiida.utils.capturing import Capturing
 
 
@@ -110,7 +110,7 @@ class TestDuplicateNodeUuidMigration(TestMigrations):
 
         # Verify that there are duplicate UUIDs by checking that the following function raises
         with self.assertRaises(IntegrityError):
-            verify_node_uuid_uniqueness()
+            verify_uuid_uniqueness(table='db_dbnode')
 
         # Now run the function responsible for solving duplicate UUIDs which would also be called by the user
         # through the `verdi database integrity duplicate-node-uuid` command
@@ -121,7 +121,7 @@ class TestDuplicateNodeUuidMigration(TestMigrations):
         from aiida.orm import load_node
 
         # If the duplicate UUIDs were successfully fixed, the following should not raise.
-        verify_node_uuid_uniqueness()
+        verify_uuid_uniqueness(table='db_dbnode')
 
         # Reload the nodes by PK and check that all UUIDs are now unique
         nodes_boolean = [load_node(node.pk) for node in self.nodes_boolean]

--- a/aiida/backends/general/abstractqueries.py
+++ b/aiida/backends/general/abstractqueries.py
@@ -33,16 +33,20 @@ class AbstractQueryManager(object):
         """
         pass
 
-    def get_duplicate_node_uuids(self):
+    def get_duplicate_uuids(self, table):
         """
-        Return a list of nodes that have an identical UUID
+        Return a list of rows with identical UUID
 
-        :return: list of tuples of (pk, uuid) of nodes with duplicate UUIDs
+        :param table: Database table with uuid column, e.g. 'db_dbnode'
+        :type str:
+
+        :return: list of tuples of (id, uuid) of rows with duplicate UUIDs
+        :rtype list:
         """
         query = """
-            SELECT s.id, s.uuid FROM (SELECT *, COUNT(*) OVER(PARTITION BY uuid) AS c FROM db_dbnode)
+            SELECT s.id, s.uuid FROM (SELECT *, COUNT(*) OVER(PARTITION BY uuid) AS c FROM {})
             AS s WHERE c > 1
-            """
+            """.format(table)
         return self.raw(query)
 
     def get_creation_statistics(

--- a/aiida/backends/sqlalchemy/migrations/versions/37f3d4882837_make_all_uuid_columns_unique.py
+++ b/aiida/backends/sqlalchemy/migrations/versions/37f3d4882837_make_all_uuid_columns_unique.py
@@ -1,0 +1,57 @@
+"""Make all uuid columns unique
+
+Revision ID: 37f3d4882837
+Revises: 162b99bca4a2
+Create Date: 2018-11-17 17:18:58.691209
+
+"""
+# pylint: disable=invalid-name
+
+from __future__ import absolute_import
+from alembic import op
+
+# Remove when https://github.com/PyCQA/pylint/issues/1931 is fixed
+# pylint: disable=no-member
+
+# revision identifiers, used by Alembic.
+revision = '37f3d4882837'
+down_revision = '162b99bca4a2'
+branch_labels = None
+depends_on = None
+
+tables = ['db_dbcomment', 'db_dbcomputer', 'db_dbgroup', 'db_dbworkflow']
+
+
+def verify_uuid_uniqueness(table):
+    """Check whether the database contains duplicate UUIDS.
+
+    Note that we have to redefine this method from aiida.manage.database.integrity.verify_node_uuid_uniqueness
+    because that uses the default database connection, while here the one created by Alembic should be used instead.
+
+    :raises: IntegrityError if database contains nodes with duplicate UUIDS.
+    """
+    from sqlalchemy.sql import text
+    from aiida.common.exceptions import IntegrityError
+
+    query = text(
+        'SELECT s.id, s.uuid FROM (SELECT *, COUNT(*) OVER(PARTITION BY uuid) AS c FROM {}) AS s WHERE c > 1'.format(
+            table))
+    conn = op.get_bind()
+    duplicates = conn.execute(query).fetchall()
+
+    if duplicates:
+        raise IntegrityError('Your table \'{}\' contains entries with duplicate UUIDS'.format(table))
+        #'run `verdi database integrity duplicate-node-uuid` to return to a consistent state')
+
+
+def upgrade():
+
+    for table in tables:
+        verify_uuid_uniqueness(table)
+        op.create_unique_constraint(table + '_uuid_key', table, ['uuid'])
+
+
+def downgrade():
+
+    for table in tables:
+        op.drop_constraint(table + '_uuid_key', table)

--- a/aiida/backends/sqlalchemy/migrations/versions/37f3d4882837_make_all_uuid_columns_unique.py
+++ b/aiida/backends/sqlalchemy/migrations/versions/37f3d4882837_make_all_uuid_columns_unique.py
@@ -11,7 +11,7 @@ from __future__ import absolute_import
 from alembic import op
 
 # Remove when https://github.com/PyCQA/pylint/issues/1931 is fixed
-# pylint: disable=no-member
+# pylint: disable=no-member,no-name-in-module,import-error
 
 # revision identifiers, used by Alembic.
 revision = '37f3d4882837'

--- a/aiida/backends/sqlalchemy/models/comment.py
+++ b/aiida/backends/sqlalchemy/models/comment.py
@@ -19,7 +19,7 @@ from sqlalchemy.dialects.postgresql import UUID
 
 from aiida.utils import timezone
 from aiida.backends.sqlalchemy.models.base import Base
-from aiida.backends.sqlalchemy.models.utils import uuid_func
+from aiida.common.utils import get_new_uuid
 
 
 class DbComment(Base):
@@ -27,7 +27,7 @@ class DbComment(Base):
 
     id = Column(Integer, primary_key=True)
 
-    uuid = Column(UUID(as_uuid=True), default=uuid_func)
+    uuid = Column(UUID(as_uuid=True), default=get_new_uuid)
     dbnode_id = Column(
         Integer,
         ForeignKey(

--- a/aiida/backends/sqlalchemy/models/comment.py
+++ b/aiida/backends/sqlalchemy/models/comment.py
@@ -27,7 +27,7 @@ class DbComment(Base):
 
     id = Column(Integer, primary_key=True)
 
-    uuid = Column(UUID(as_uuid=True), default=get_new_uuid)
+    uuid = Column(UUID(as_uuid=True), default=get_new_uuid, unique=True)
     dbnode_id = Column(
         Integer,
         ForeignKey(

--- a/aiida/backends/sqlalchemy/models/computer.py
+++ b/aiida/backends/sqlalchemy/models/computer.py
@@ -32,7 +32,7 @@ class DbComputer(Base):
 
     id = Column(Integer, primary_key=True)
 
-    uuid = Column(UUID(as_uuid=True), default=get_new_uuid)
+    uuid = Column(UUID(as_uuid=True), default=get_new_uuid, unique=True)
     name = Column(String(255), unique=True, nullable=False)
     hostname = Column(String(255))
 

--- a/aiida/backends/sqlalchemy/models/computer.py
+++ b/aiida/backends/sqlalchemy/models/computer.py
@@ -22,7 +22,7 @@ from sqlalchemy.orm.exc import NoResultFound, MultipleResultsFound
 from sqlalchemy.dialects.postgresql import UUID, JSONB
 
 from aiida.backends.sqlalchemy.models.base import Base
-from aiida.backends.sqlalchemy.models.utils import uuid_func
+from aiida.common.utils import get_new_uuid
 
 from aiida.common.exceptions import NotExistent, DbContentError, ConfigurationError
 
@@ -32,7 +32,7 @@ class DbComputer(Base):
 
     id = Column(Integer, primary_key=True)
 
-    uuid = Column(UUID(as_uuid=True), default=uuid_func)
+    uuid = Column(UUID(as_uuid=True), default=get_new_uuid)
     name = Column(String(255), unique=True, nullable=False)
     hostname = Column(String(255))
 

--- a/aiida/backends/sqlalchemy/models/group.py
+++ b/aiida/backends/sqlalchemy/models/group.py
@@ -38,7 +38,7 @@ class DbGroup(Base):
 
     id = Column(Integer, primary_key=True)
 
-    uuid = Column(UUID(as_uuid=True), default=get_new_uuid)
+    uuid = Column(UUID(as_uuid=True), default=get_new_uuid, unique=True)
     name = Column(String(255), index=True)
 
     type = Column(String(255), default="", index=True)

--- a/aiida/backends/sqlalchemy/models/group.py
+++ b/aiida/backends/sqlalchemy/models/group.py
@@ -20,7 +20,7 @@ from sqlalchemy.dialects.postgresql import UUID
 
 from aiida.utils import timezone
 from aiida.backends.sqlalchemy.models.base import Base
-from aiida.backends.sqlalchemy.models.utils import uuid_func
+from aiida.common.utils import get_new_uuid
 
 table_groups_nodes = Table(
     'db_dbgroup_dbnodes',
@@ -38,7 +38,7 @@ class DbGroup(Base):
 
     id = Column(Integer, primary_key=True)
 
-    uuid = Column(UUID(as_uuid=True), default=uuid_func)
+    uuid = Column(UUID(as_uuid=True), default=get_new_uuid)
     name = Column(String(255), index=True)
 
     type = Column(String(255), default="", index=True)

--- a/aiida/backends/sqlalchemy/models/node.py
+++ b/aiida/backends/sqlalchemy/models/node.py
@@ -24,7 +24,7 @@ from sqlalchemy_utils.types.choice import ChoiceType
 
 from aiida.utils import timezone
 from aiida.backends.sqlalchemy.models.base import Base, _QueryProperty, _AiidaQuery
-from aiida.backends.sqlalchemy.models.utils import uuid_func
+from aiida.common.utils import get_new_uuid
 from aiida.backends.sqlalchemy.utils import flag_modified
 
 from aiida.common.exceptions import DbContentError
@@ -40,7 +40,7 @@ class DbNode(Base):
     aiida_query = _QueryProperty(_AiidaQuery)
 
     id = Column(Integer, primary_key=True)
-    uuid = Column(UUID(as_uuid=True), default=uuid_func, unique=True)
+    uuid = Column(UUID(as_uuid=True), default=get_new_uuid, unique=True)
     type = Column(String(255), index=True)
     process_type = Column(String(255), index=True)
     label = Column(String(255), index=True, nullable=True,

--- a/aiida/backends/sqlalchemy/models/utils.py
+++ b/aiida/backends/sqlalchemy/models/utils.py
@@ -11,16 +11,11 @@
 from __future__ import division
 from __future__ import print_function
 from __future__ import absolute_import
-import uuid
 
 import six
 
-from aiida.backends.settings import AIIDANODES_UUID_VERSION
 from aiida.common.exceptions import ValidationError
 from aiida.common.exceptions import NotExistent
-
-
-uuid_func = getattr(uuid, "uuid" + str(AIIDANODES_UUID_VERSION))
 
 # The separator for sub-fields (for JSON stored values).Keys are not allowed
 # to contain the separator even if the

--- a/aiida/backends/sqlalchemy/models/workflow.py
+++ b/aiida/backends/sqlalchemy/models/workflow.py
@@ -36,7 +36,7 @@ class DbWorkflow(Base):
     aiida_query = _QueryProperty(_AiidaQuery)
 
     id = Column(Integer, primary_key=True)
-    uuid = Column(UUID(as_uuid=True), default=get_new_uuid)
+    uuid = Column(UUID(as_uuid=True), default=get_new_uuid, unique=True)
 
     ctime = Column(DateTime(timezone=True), default=timezone.now)
     mtime = Column(DateTime(timezone=True), default=timezone.now)

--- a/aiida/backends/sqlalchemy/models/workflow.py
+++ b/aiida/backends/sqlalchemy/models/workflow.py
@@ -22,7 +22,7 @@ from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy_utils.types.choice import ChoiceType
 
 from aiida.backends.sqlalchemy.models.base import Base, _QueryProperty, _AiidaQuery
-from aiida.backends.sqlalchemy.models.utils import uuid_func
+from aiida.common.utils import get_new_uuid
 from aiida.common.datastructures import (wf_states, wf_data_types,
                                          wf_data_value_types, wf_default_call)
 from aiida.utils import timezone
@@ -36,7 +36,7 @@ class DbWorkflow(Base):
     aiida_query = _QueryProperty(_AiidaQuery)
 
     id = Column(Integer, primary_key=True)
-    uuid = Column(UUID(as_uuid=True), default=uuid_func)
+    uuid = Column(UUID(as_uuid=True), default=get_new_uuid)
 
     ctime = Column(DateTime(timezone=True), default=timezone.now)
     mtime = Column(DateTime(timezone=True), default=timezone.now)

--- a/aiida/orm/implementation/django/dummy_model.py
+++ b/aiida/orm/implementation/django/dummy_model.py
@@ -39,7 +39,7 @@ from aiida.common.setup import get_profile_config
 from aiida.backends import settings
 
 # MISC
-from aiida.backends.sqlalchemy.models.utils import uuid_func
+from aiida.common.utils import get_new_uuid
 from aiida.utils import timezone
 
 Base = declarative_base()
@@ -89,7 +89,7 @@ class DbComputer(Base):
 
     id = Column(Integer, primary_key=True)
 
-    uuid = Column(UUID(as_uuid=True), default=uuid_func)
+    uuid = Column(UUID(as_uuid=True), default=get_new_uuid)
     name = Column(String(255), unique=True, nullable=False)
     hostname = Column(String(255))
 
@@ -161,7 +161,7 @@ class DbGroup(Base):
 
     id = Column(Integer, primary_key=True)
 
-    uuid = Column(UUID(as_uuid=True), default=uuid_func)
+    uuid = Column(UUID(as_uuid=True), default=get_new_uuid)
     name = Column(String(255), index=True)
 
     type = Column(String(255), default="", index=True)
@@ -198,7 +198,7 @@ class DbGroup(Base):
 class DbNode(Base):
     __tablename__ = "db_dbnode"
     id = Column(Integer, primary_key=True)
-    uuid = Column(UUID(as_uuid=True), default=uuid_func)
+    uuid = Column(UUID(as_uuid=True), default=get_new_uuid)
     type = Column(String(255), index=True)
     process_type = Column(String(255), index=True)
     label = Column(String(255), index=True, nullable=True)

--- a/setup_requirements.py
+++ b/setup_requirements.py
@@ -114,7 +114,7 @@ extras_require = {
     'dev_precommit': [
         'pre-commit==1.8.2',
         'yapf==0.23.0',
-        'prospector==0.12.11',
+        'prospector==1.1.5',
         'pylint==1.9.3',
         'pylint-django==0.11.1',
         'pep8-naming==0.3.3',


### PR DESCRIPTION
 * replace superfluous aiida.backends.sqlalchemy.models.utils.uuid_func with aiida.common.utils.get_new_uuid
 * make uuid columns unique in sqla as well
   * @giovannipizzi Running the alembic command produced an empty migration, i.e. I copied the code from the corresponding migration for the uuid of DbNode. Not sure whether this is expected behavior
* methods to check for duplicate uuids now generalized to take table as argument
 * upgrade prospector - prospector 1.1.5 finally works with pylint <2 again https://github.com/PyCQA/prospector/issues/266

Todo:
 - [ ] decide: do we need to check for duplicate uuids also for the other tables?    
    I added the check now but do not yet provide a way to resolve the problem if there is one.
 - [ ] (?) If we do need to handle the deduplication manually, understand what is needed here (I guess these classes are less complicated than Node)
 - [ ] (?) Add test in sqla that there are no remaining migrations
