### PR TITLE
Fix get_metadata name of AuthInfo class (#2221)

### DIFF
--- a/aiida/orm/authinfos.py
+++ b/aiida/orm/authinfos.py
@@ -119,7 +119,7 @@ class AuthInfo(entities.Entity):
 
         :return: a dictionary
         """
-        return self._backend_entity.get_metadata()
+        return self._backend_entity._get_metadata()
 
     def set_metadata(self, metadata):
         """


### PR DESCRIPTION
Fixes this error:

```
Error: * The test raised an exception!
** Full traceback:
   Traceback (most recent call last):
     File ".../aiida_core/aiida/cmdline/commands/cmd_computer.py", line 561, in computer_test
       succeeded = test(transport=trans, scheduler=sched, authinfo=authinfo)
     File ".../aiida_core/aiida/cmdline/commands/cmd_computer.py", line 145, in _computer_create_temp_file
       workdir = authinfo.get_workdir().format(username=remote_user)
     File ".../aiida_core/aiida/orm/authinfos.py", line 136, in get_workdir
       metadata = self.get_metadata()
     File ".../aiida_core/aiida/orm/authinfos.py", line 122, in get_metadata
       return self._backend_entity.get_metadata()
   AttributeError: 'DjangoAuthInfo' object has no attribute 'get_metadata'
Some tests failed! (1 out of 4 failed)
```

when running `verdi computer test ...`