### PR TITLE
Fix 2183 Update QB Relationship Indicators

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -45,7 +45,6 @@
         aiida/backends/djsite/queries.py|
         aiida/backends/djsite/settings/__init__.py|
         aiida/backends/djsite/settings/settings_profile.py|
-        aiida/backends/djsite/settings/settings.py|
         aiida/backends/djsite/settings/wsgi.py|
         aiida/backends/general/abstractqueries.py|
         aiida/backends/__init__.py|
@@ -192,7 +191,6 @@
         aiida/common/orbital/__init__.py|
         aiida/common/orbital/realhydrogen.py|
         aiida/common/profile.py|
-        aiida/common/setup.py|
         aiida/common/test_extendeddicts.py|
         aiida/common/test_logging.py|
         aiida/common/test_utils.py|
@@ -201,7 +199,6 @@
         aiida/daemon/runner.py|
         aiida/daemon/timestamps.py|
         aiida/daemon/workflowmanager.py|
-        aiida/__init__.py|
         aiida/orm/authinfo.py|
         aiida/orm/autogroup.py|
         aiida/orm/backend.py|
@@ -214,7 +211,6 @@
         aiida/orm/data/array/__init__.py|
         aiida/orm/data/array/kpoints.py|
         aiida/orm/data/array/projection.py|
-        aiida/orm/data/array/trajectory.py|
         aiida/orm/data/array/xy.py|
         aiida/orm/data/base.py|
         aiida/orm/data/bool.py|

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -208,7 +208,6 @@
         aiida/orm/calculation/job/__init__.py|
         aiida/orm/code.py|
         aiida/orm/data/array/bands.py|
-        aiida/orm/data/array/__init__.py|
         aiida/orm/data/array/kpoints.py|
         aiida/orm/data/array/projection.py|
         aiida/orm/data/array/xy.py|

--- a/aiida/__init__.py
+++ b/aiida/__init__.py
@@ -7,6 +7,19 @@
 # For further information on the license, see the LICENSE.txt file        #
 # For further information please visit http://www.aiida.net               #
 ###########################################################################
+"""
+AiiDA is a flexible and scalable informatics' infrastructure to manage,
+preserve, and disseminate the simulations, data, and workflows of
+modern-day computational science.
+
+Able to store the full provenance of each object, and based on a
+tailored database built for efficient data mining of heterogeneous results,
+AiiDA gives the user the ability to interact seamlessly with any number of
+remote HPC resources and codes, thanks to its flexible plugin interface
+and workflow engine for the automation of complex sequences of simulations.
+
+More information at http://www.aiida.net
+"""
 from __future__ import division
 from __future__ import print_function
 from __future__ import absolute_import
@@ -14,21 +27,31 @@ import warnings
 
 from aiida.common.log import configure_logging
 from aiida.common.setup import get_property
+import aiida.common.warnings
 
-__copyright__ = u"Copyright (c), This file is part of the AiiDA platform. For further information please visit http://www.aiida.net/. All rights reserved."
+__copyright__ = (u"Copyright (c), This file is part of the AiiDA platform. "
+                 u"For further information please visit http://www.aiida.net/. All rights reserved.")
 __license__ = "MIT license, see LICENSE.txt file."
 __version__ = "1.0.0a4"
 __authors__ = "The AiiDA team."
-__paper__ = """G. Pizzi, A. Cepellotti, R. Sabatini, N. Marzari, and B. Kozinsky, "AiiDA: automated interactive infrastructure and database for computational science", Comp. Mat. Sci 111, 218-230 (2016); http://dx.doi.org/10.1016/j.commatsci.2015.09.013 - http://www.aiida.net."""
-__paper_short__ = """G. Pizzi et al., Comp. Mat. Sci 111, 218 (2016)."""
+__paper__ = (u'G. Pizzi, A. Cepellotti, R. Sabatini, N. Marzari, and B. Kozinsky,'
+             u'"AiiDA: automated interactive infrastructure and database for computational science", '
+             u'Comp. Mat. Sci 111, 218-230 (2016); http://dx.doi.org/10.1016/j.commatsci.2015.09.013 '
+             u'- http://www.aiida.net.')
+__paper_short__ = 'G. Pizzi et al., Comp. Mat. Sci 111, 218 (2016).'
 
 # Configure the default logging
 configure_logging()
 
 if get_property("warnings.showdeprecations"):
-    # print out the warnings coming from deprecation
-    # in Python 2.7 it is suppressed by default
-    warnings.simplefilter('default', DeprecationWarning)
+    # If the user does not want to get AiiDA deprecation warnings,
+    # we disable them - this can be achieved with::
+    #   verdi devel setproperty warnings.showdeprecations False
+    # Note that the AiidaDeprecationWarning does NOT inherit from DeprecationWarning
+    warnings.simplefilter('default', aiida.common.warnings.AiidaDeprecationWarning)  # pylint: disable=no-member
+    # This should default to 'once', i.e. once per different message
+else:
+    warnings.simplefilter('ignore', aiida.common.warnings.AiidaDeprecationWarning)  # pylint: disable=no-member
 
 
 def try_load_dbenv(*argc, **argv):
@@ -45,16 +68,16 @@ def load_dbenv(*argc, **argv):
     """
     Alias for `load_dbenv` from `aiida.backends.utils`
     """
-    from aiida.backends.utils import load_dbenv
-    return load_dbenv(*argc, **argv)
+    from aiida.backends.utils import load_dbenv as _load_dbenv
+    return _load_dbenv(*argc, **argv)
 
 
 def is_dbenv_loaded(*argc, **argv):
     """
     Alias for `is_dbenv_loaded` from `aiida.backends.utils`
     """
-    from aiida.backends.utils import is_dbenv_loaded
-    return is_dbenv_loaded(*argc, **argv)
+    from aiida.backends.utils import is_dbenv_loaded as _is_dbenv_loaded
+    return _is_dbenv_loaded(*argc, **argv)
 
 
 def get_strict_version():
@@ -63,7 +86,7 @@ def get_strict_version():
 
     :returns: StrictVersion instance with the current version
     """
-    from distutils.version import StrictVersion
+    from distutils.version import StrictVersion  # pylint: disable=import-error,no-name-in-module
     return StrictVersion(__version__)
 
 

--- a/aiida/backends/djsite/settings/settings.py
+++ b/aiida/backends/djsite/settings/settings.py
@@ -7,7 +7,9 @@
 # For further information on the license, see the LICENSE.txt file        #
 # For further information please visit http://www.aiida.net               #
 ###########################################################################
-# Django settings for the AiiDA project.
+"""
+Django settings for the AiiDA project.
+"""
 from __future__ import division
 from __future__ import print_function
 from __future__ import absolute_import
@@ -16,32 +18,27 @@ import os
 
 from aiida.common.exceptions import ConfigurationError, MissingConfigurationError
 
-# get_property is used to read properties stored in the config json
-from aiida.common.setup import (get_config, get_secret_key, get_property,
-                                get_profile_config, parse_repository_uri)
+from aiida.common.setup import (get_config, get_secret_key, get_profile_config, parse_repository_uri)
 from aiida.backends import settings
 from aiida.utils.timezone import get_current_timezone
 
 # Assumes that parent directory of aiida is root for
 # things like templates/, SQL/ etc.  If not, change what follows...
 
-
 AIIDA_DIR = os.path.dirname(os.path.abspath(__file__))
 BASE_DIR = os.path.split(AIIDA_DIR)[0]
 sys.path = [BASE_DIR] + sys.path
 
 try:
-    confs = get_config()
+    CONFS = get_config()
 except MissingConfigurationError:
-    raise MissingConfigurationError(
-        "Please run the AiiDA Installation, no config found")
+    raise MissingConfigurationError("Please run the AiiDA Installation, no config found")
 
 if settings.AIIDADB_PROFILE is None:
-    raise ConfigurationError(
-        "settings.AIIDADB_PROFILE not defined, did you load django"
-        "through the AiiDA load_dbenv()?")
+    raise ConfigurationError("settings.AIIDADB_PROFILE not defined, did you load django"
+                             "through the AiiDA load_dbenv()?")
 
-PROFILE_CONF = get_profile_config(settings.AIIDADB_PROFILE, conf_dict=confs)
+PROFILE_CONF = get_profile_config(settings.AIIDADB_PROFILE, conf_dict=CONFS)
 
 DATABASES = {
     'default': {
@@ -59,9 +56,8 @@ DATABASES = {
 try:
     REPOSITORY_URI = PROFILE_CONF['AIIDADB_REPOSITORY_URI']
 except KeyError:
-    raise ConfigurationError(
-        "Please setup correctly the REPOSITORY_URI variable to "
-        "a suitable directory on which you have write permissions.")
+    raise ConfigurationError("Please setup correctly the REPOSITORY_URI variable to "
+                             "a suitable directory on which you have write permissions.")
 
 # Note: this variable might disappear in the future
 REPOSITORY_PROTOCOL, REPOSITORY_PATH = parse_repository_uri(REPOSITORY_URI)
@@ -77,10 +73,9 @@ elif REPOSITORY_PROTOCOL == 'file':
             os.makedirs(REPOSITORY_PATH)
         except OSError:
             # Possibly here due to permission problems
-            raise ConfigurationError(
-                "Please setup correctly the REPOSITORY_PATH variable to "
-                "a suitable directory on which you have write permissions. "
-                "(I was not able to create the directory.)")
+            raise ConfigurationError("Please setup correctly the REPOSITORY_PATH variable to "
+                                     "a suitable directory on which you have write permissions. "
+                                     "(I was not able to create the directory.)")
 else:
     raise ConfigurationError("Only file protocol supported")
 
@@ -114,7 +109,6 @@ LANGUAGE_CODE = 'en-us'
 # Local time zone for this installation. Always choose the system timezone
 TIME_ZONE = get_current_timezone().zone
 
-
 SITE_ID = 1
 
 # If you set this to False, Django will make some optimizations so as not
@@ -141,7 +135,8 @@ TEMPLATES = [
                 'django.contrib.auth.context_processors.auth',
                 'django.contrib.messages.context_processors.messages',
             ],
-            'debug': DEBUG,
+            'debug':
+            DEBUG,
         },
     },
 ]

--- a/aiida/backends/general/abstractqueries.py
+++ b/aiida/backends/general/abstractqueries.py
@@ -116,7 +116,7 @@ class AbstractQueryManager(object):
         q.append(Node, project=['id', 'ctime', 'type'], tag='node')
 
         if user_pk is not None:
-            q.append(User, creator_of='node', project='email', filters={'pk': user_pk})
+            q.append(User, with_node='node', project='email', filters={'pk': user_pk})
         qb_res = q.all()
 
         # total count
@@ -156,7 +156,7 @@ class AbstractQueryManager(object):
             n_days_ago = now - datetime.timedelta(days=args.past_days)
             bdata_filters.update({"ctime": {'>=': n_days_ago}})
 
-        qb.append(BandsData, tag="bdata", created_by="creator",
+        qb.append(BandsData, tag="bdata", with_user="creator",
                   filters=bdata_filters,
                   project=["id", "label", "ctime"]
                   )

--- a/aiida/backends/tests/dataclasses.py
+++ b/aiida/backends/tests/dataclasses.py
@@ -2744,7 +2744,7 @@ class TestArrayData(AiidaTestCase):
         n.set_array('third', third)
 
         # Check if the arrays are there
-        self.assertEquals(set(['first', 'second', 'third']), set(n.arraynames()))
+        self.assertEquals(set(['first', 'second', 'third']), set(n.get_arraynames()))
         self.assertAlmostEquals(abs(first - n.get_array('first')).max(), 0.)
         self.assertAlmostEquals(abs(second - n.get_array('second')).max(), 0.)
         self.assertAlmostEquals(abs(third - n.get_array('third')).max(), 0.)
@@ -2765,7 +2765,7 @@ class TestArrayData(AiidaTestCase):
         n.set_array('first', first)
 
         # Check if the arrays are there, and if I am getting the new one
-        self.assertEquals(set(['first', 'second']), set(n.arraynames()))
+        self.assertEquals(set(['first', 'second']), set(n.get_arraynames()))
         self.assertAlmostEquals(abs(first - n.get_array('first')).max(), 0.)
         self.assertAlmostEquals(abs(second - n.get_array('second')).max(), 0.)
         self.assertEquals(first.shape, n.get_shape('first'))
@@ -2774,14 +2774,14 @@ class TestArrayData(AiidaTestCase):
         n.store()
 
         # Same checks, after storing
-        self.assertEquals(set(['first', 'second']), set(n.arraynames()))
+        self.assertEquals(set(['first', 'second']), set(n.get_arraynames()))
         self.assertAlmostEquals(abs(first - n.get_array('first')).max(), 0.)
         self.assertAlmostEquals(abs(second - n.get_array('second')).max(), 0.)
         self.assertEquals(first.shape, n.get_shape('first'))
         self.assertEquals(second.shape, n.get_shape('second'))
 
         # Same checks, again (this is checking the caching features)
-        self.assertEquals(set(['first', 'second']), set(n.arraynames()))
+        self.assertEquals(set(['first', 'second']), set(n.get_arraynames()))
         self.assertAlmostEquals(abs(first - n.get_array('first')).max(), 0.)
         self.assertAlmostEquals(abs(second - n.get_array('second')).max(), 0.)
         self.assertEquals(first.shape, n.get_shape('first'))
@@ -2789,7 +2789,7 @@ class TestArrayData(AiidaTestCase):
 
         # Same checks, after reloading
         n2 = load_node(uuid=n.uuid)
-        self.assertEquals(set(['first', 'second']), set(n2.arraynames()))
+        self.assertEquals(set(['first', 'second']), set(n2.get_arraynames()))
         self.assertAlmostEquals(abs(first - n2.get_array('first')).max(), 0.)
         self.assertAlmostEquals(abs(second - n2.get_array('second')).max(), 0.)
         self.assertEquals(first.shape, n2.get_shape('first'))
@@ -2797,7 +2797,7 @@ class TestArrayData(AiidaTestCase):
 
         # Same checks, after reloading with UUID
         n2 = load_node(n.uuid, sub_classes=(ArrayData,))
-        self.assertEquals(set(['first', 'second']), set(n2.arraynames()))
+        self.assertEquals(set(['first', 'second']), set(n2.get_arraynames()))
         self.assertAlmostEquals(abs(first - n2.get_array('first')).max(), 0.)
         self.assertAlmostEquals(abs(second - n2.get_array('second')).max(), 0.)
         self.assertEquals(first.shape, n2.get_shape('first'))
@@ -2811,7 +2811,7 @@ class TestArrayData(AiidaTestCase):
 
         # Again same checks, to verify that the attempts to delete/overwrite
         # arrays did not damage the node content
-        self.assertEquals(set(['first', 'second']), set(n.arraynames()))
+        self.assertEquals(set(['first', 'second']), set(n.get_arraynames()))
         self.assertAlmostEquals(abs(first - n.get_array('first')).max(), 0.)
         self.assertAlmostEquals(abs(second - n.get_array('second')).max(), 0.)
         self.assertEquals(first.shape, n.get_shape('first'))

--- a/aiida/backends/tests/export_and_import.py
+++ b/aiida/backends/tests/export_and_import.py
@@ -168,14 +168,14 @@ class TestSpecificImport(AiidaTestCase):
             # Check that there is a StructureData that is an output of a CalculationNode
             qb = QueryBuilder()
             qb.append(CalculationNode, project=['uuid'], tag='calculation')
-            qb.append(StructureData, output_of='calculation')
+            qb.append(StructureData, with_incoming='calculation')
             self.assertGreater(len(qb.all()), 0)
 
             # Check that there is a RemoteData that is a child and parent of a CalculationNode
             qb = QueryBuilder()
             qb.append(CalculationNode, tag='parent')
-            qb.append(RemoteData, project=['uuid'], output_of='parent', tag='remote')
-            qb.append(CalculationNode, output_of='remote')
+            qb.append(RemoteData, project=['uuid'], with_incoming='parent', tag='remote')
+            qb.append(CalculationNode, with_incoming='remote')
             self.assertGreater(len(qb.all()), 0)
 
 
@@ -874,7 +874,7 @@ class TestSimple(AiidaTestCase):
             qb.append(ParameterData, tag='p', project='*')
             qb.append(CalculationNode, tag='c', project='*', edge_tag='p2c', edge_project=('label', 'type'))
             qb.append(ArrayData, tag='a', project='*', edge_tag='c2a', edge_project=('label', 'type'))
-            qb.append(Group, filters={'name': groupname}, project='*', tag='g', group_of='a')
+            qb.append(Group, filters={'name': groupname}, project='*', tag='g', with_node='a')
             # I want the query to contain something!
             self.assertTrue(qb.count() > 0)
             # The hash is given from the preservable entries in an export-import cycle,
@@ -1177,7 +1177,7 @@ class TestComputer(AiidaTestCase):
             # computer.
             qb = QueryBuilder()
             qb.append(Computer, tag='comp')
-            qb.append(CalcJobNode, has_computer='comp', project=['label'])
+            qb.append(CalcJobNode, with_computer='comp', project=['label'])
             self.assertEqual(qb.count(), 2, "Two calculations should be "
                                             "found.")
             ret_labels = set(_ for [_] in qb.all())
@@ -1401,7 +1401,7 @@ class TestComputer(AiidaTestCase):
             qb = QueryBuilder()
             qb.append(CalcJobNode, project=['label'], tag='jcalc')
             qb.append(Computer, project=['name'],
-                      computer_of='jcalc')
+                      with_node='jcalc')
             self.assertEqual(qb.count(), 3, "Three combinations expected.")
             res = qb.all()
             self.assertIn([calc1_label, comp1_name], res,
@@ -1538,7 +1538,7 @@ class TestLinks(AiidaTestCase):
         qb = QueryBuilder()
         qb.append(Node, project='uuid', tag='input')
         qb.append(Node, project='uuid', tag='output',
-                  edge_project=['label', 'type'], output_of='input')
+                  edge_project=['label', 'type'], with_incoming='input')
         return qb.all()
 
     def test_input_and_create_links(self):

--- a/aiida/backends/tests/query.py
+++ b/aiida/backends/tests/query.py
@@ -199,7 +199,7 @@ class TestQueryBuilder(AiidaTestCase):
                 {
                     'cls': Node,
                     'tag': 'n2',
-                    'output_of': 'n1'
+                    'with_incoming': 'n1'
                 }
             ],
             'filters': {
@@ -234,7 +234,7 @@ class TestQueryBuilder(AiidaTestCase):
                 {
                     'cls': Node,
                     'tag': 'n2',
-                    'output_of': 'n1'
+                    'with_incoming': 'n1'
                 }
             ],
             'filters': {
@@ -412,15 +412,15 @@ class TestQueryBuilder(AiidaTestCase):
         from aiida.orm.computers import Computer
         qb = QueryBuilder()
         qb.append(Node, tag='n1')
-        qb.append(Node, tag='n2', edge_tag='e1', output_of='n1')
-        qb.append(Node, tag='n3', edge_tag='e2', output_of='n2')
-        qb.append(Computer, computer_of='n3', tag='c1', edge_tag='nonsense')
+        qb.append(Node, tag='n2', edge_tag='e1', with_incoming='n1')
+        qb.append(Node, tag='n3', edge_tag='e2', with_incoming='n2')
+        qb.append(Computer, with_node='n3', tag='c1', edge_tag='nonsense')
         self.assertEqual(qb.get_used_tags(), ['n1', 'n2', 'e1', 'n3', 'e2', 'c1', 'nonsense'])
 
         # Now I am testing the default tags,
         qb = QueryBuilder().append(StructureData).append(ProcessNode).append(
             StructureData).append(
-            ParameterData, input_of=ProcessNode)
+            ParameterData, with_outgoing=ProcessNode)
         self.assertEqual(qb.get_used_tags(), [
             'StructureData_1', 'ProcessNode_1',
             'StructureData_1--ProcessNode_1', 'StructureData_2',
@@ -520,7 +520,7 @@ class TestQueryBuilderCornerCases(AiidaTestCase):
         qb = QueryBuilder()
         qb.append(ProcessNode, project=['id'], tag='calc')
         qb.append(Computer, project=['id', 'transport_params'],
-                  outerjoin=True, computer_of='calc')
+                  outerjoin=True, with_node='calc')
         qb.all()
 
         # Checking the correct retrieval of _metadata which is
@@ -528,7 +528,7 @@ class TestQueryBuilderCornerCases(AiidaTestCase):
         qb = QueryBuilder()
         qb.append(ProcessNode, project=['id'], tag='calc')
         qb.append(Computer, project=['id', '_metadata'],
-                  outerjoin=True, computer_of='calc')
+                  outerjoin=True, with_node='calc')
         qb.all()
 
 
@@ -797,7 +797,7 @@ class QueryBuilderJoinsTests(AiidaTestCase):
         # Search for the group of the user
         qb = orm.QueryBuilder()
         qb.append(orm.User, tag='user', filters={'id': {'==': user.id}})
-        qb.append(orm.Group, belongs_to='user',
+        qb.append(orm.Group, with_user='user',
                   filters={'id': {'==': group.id}})
         self.assertEquals(qb.count(), 1, "The expected group that belongs to "
                                          "the selected user was not found.")
@@ -805,7 +805,7 @@ class QueryBuilderJoinsTests(AiidaTestCase):
         # Search for the user that owns a group
         qb = orm.QueryBuilder()
         qb.append(orm.Group, tag='group', filters={'id': {'==': group.id}})
-        qb.append(orm.User, owner_of='group', filters={'id': {'==': user.id}})
+        qb.append(orm.User, with_group='group', filters={'id': {'==': user.id}})
 
         self.assertEquals(qb.count(), 1, "The expected user that owns the "
                                          "selected group was not found.")

--- a/aiida/cmdline/commands/cmd_code.py
+++ b/aiida/cmdline/commands/cmd_code.py
@@ -289,12 +289,12 @@ def code_list(computer, input_plugin, all_entries, all_users, show_owner):
         qb.append(Code, tag="code", filters=qb_code_filters, project=["id", "label"])
         # We have a user assigned to the code so we can ask for the
         # presence of a user even if there is no user filter
-        qb.append(orm.User, creator_of="code", project=["email"], filters=qb_user_filters)
+        qb.append(orm.User, with_node="code", project=["email"], filters=qb_user_filters)
         # We also add the filter on computer. This will automatically
         # return codes that have a computer (and of course satisfy the
         # other filters). The codes that have a computer attached are the
         # remote codes.
-        qb.append(orm.Computer, computer_of="code", project=["name"], filters=qb_computer_filters)
+        qb.append(orm.Computer, with_node="code", project=["name"], filters=qb_computer_filters)
         qb.order_by({Code: {'id': 'asc'}})
         print_list_res(qb, show_owner)
 
@@ -306,8 +306,8 @@ def code_list(computer, input_plugin, all_entries, all_users, show_owner):
         qb.append(Code, tag="code", filters=qb_code_filters, project=["id", "label"])
         # We have a user assigned to the code so we can ask for the
         # presence of a user even if there is no user filter
-        qb.append(orm.User, creator_of="code", project=["email"], filters=qb_user_filters)
-        qb.append(orm.Computer, computer_of="code", project=["name"])
+        qb.append(orm.User, with_node="code", project=["email"], filters=qb_user_filters)
+        qb.append(orm.Computer, with_node="code", project=["name"])
         qb.order_by({Code: {'id': 'asc'}})
         print_list_res(qb, show_owner)
 
@@ -323,7 +323,7 @@ def code_list(computer, input_plugin, all_entries, all_users, show_owner):
         qb.append(Code, tag="code", filters=qb_code_filters, project=["id", "label"])
         # We have a user assigned to the code so we can ask for the
         # presence of a user even if there is no user filter
-        qb.append(orm.User, creator_of="code", project=["email"], filters=qb_user_filters)
+        qb.append(orm.User, with_node="code", project=["email"], filters=qb_user_filters)
         qb.order_by({Code: {'id': 'asc'}})
         print_list_res(qb, show_owner)
 

--- a/aiida/cmdline/commands/cmd_data/cmd_array.py
+++ b/aiida/cmdline/commands/cmd_data/cmd_array.py
@@ -30,6 +30,6 @@ def array_show(data):
 
     for node in data:
         the_dict = {}
-        for arrayname in node.arraynames():
+        for arrayname in node.get_arraynames():
             the_dict[arrayname] = node.get_array(arrayname).tolist()
         echo_dictionary(the_dict, 'json+date')

--- a/aiida/cmdline/commands/cmd_data/cmd_list.py
+++ b/aiida/cmdline/commands/cmd_data/cmd_list.py
@@ -55,13 +55,13 @@ def query(datatype, project, past_days, group_pks, all_users):
         n_days_ago = now - datetime.timedelta(days=past_days)
         data_filters.update({"ctime": {'>=': n_days_ago}})
 
-    qbl.append(datatype, tag="data", created_by="creator", filters=data_filters, project=project)
+    qbl.append(datatype, tag="data", with_user="creator", filters=data_filters, project=project)
 
     # If there is a group restriction
     if group_pks is not None:
         group_filters = dict()
         group_filters.update({"id": {"in": group_pks}})
-        qbl.append(orm.Group, tag="group", filters=group_filters, group_of="data")
+        qbl.append(orm.Group, tag="group", filters=group_filters, with_node="data")
 
     qbl.order_by({datatype: {'ctime': 'asc'}})
 

--- a/aiida/cmdline/commands/cmd_data/cmd_upf.py
+++ b/aiida/cmdline/commands/cmd_data/cmd_upf.py
@@ -73,7 +73,7 @@ def upf_listfamilies(elements, with_description):
         query.add_filter(UpfData, {'attributes.element': {'in': elements}})
     query.append(
         orm.Group,
-        group_of='upfdata',
+        with_node='upfdata',
         tag='group',
         project=["name", "description"],
         filters={"type": {
@@ -87,7 +87,7 @@ def upf_listfamilies(elements, with_description):
             group_desc = res.get("group").get("description")
             query = orm.QueryBuilder()
             query.append(orm.Group, tag='thisgroup', filters={"name": {'like': group_name}})
-            query.append(UpfData, project=["id"], member_of='thisgroup')
+            query.append(UpfData, project=["id"], with_group='thisgroup')
 
             if with_description:
                 description_string = ": {}".format(group_desc)

--- a/aiida/cmdline/commands/cmd_node.py
+++ b/aiida/cmdline/commands/cmd_node.py
@@ -159,7 +159,7 @@ def show(nodes, print_groups):
             # pylint: disable=invalid-name
             qb = QueryBuilder()
             qb.append(Node, tag='node', filters={'id': {'==': node.pk}})
-            qb.append(Group, tag='groups', group_of='node', project=['id', 'name'])
+            qb.append(Group, tag='groups', with_node='node', project=['id', 'name'])
 
             echo.echo("#### GROUPS:")
 

--- a/aiida/cmdline/utils/common.py
+++ b/aiida/cmdline/utils/common.py
@@ -287,7 +287,7 @@ def get_workchain_report(node, levelname, indent_size=4, max_depth=None):
             # In the future, we should specify here the type of link
             # for now, CALL links are the only ones allowing calc-calc
             # (we here really want instead to follow CALL links)
-            output_of='workcalculation',
+            with_incoming='workcalculation',
             tag='subworkchains')
         result = list(itertools.chain(*builder.distinct().all()))
 

--- a/aiida/common/graph.py
+++ b/aiida/common/graph.py
@@ -116,7 +116,7 @@ def draw_graph(origin_node,
             # This query gives me all the inputs of this node, and link labels and types!
             input_query = QueryBuilder()
             input_query.append(Node, filters={'id': node.pk}, tag='n')
-            input_query.append(Node, input_of='n', edge_project=('id', 'label', 'type'), project='*', tag='inp')
+            input_query.append(Node, with_outgoing='n', edge_project=('id', 'label', 'type'), project='*', tag='inp')
             for inp, link_id, link_label, link_type in input_query.iterall():
                 # I removed this check, to me there is no way that this link was already referred to!
                 # if link_id not in links:
@@ -131,7 +131,7 @@ def draw_graph(origin_node,
                 # Query for the outputs, giving me also link labels and types:
                 output_query = QueryBuilder()
                 output_query.append(Node, filters={'id': node.pk}, tag='n')
-                output_query.append(Node, output_of='n', edge_project=('id', 'label', 'type'), project='*', tag='out')
+                output_query.append(Node, with_incoming='n', edge_project=('id', 'label', 'type'), project='*', tag='out')
                 # Iterate through results
                 for out, link_id, link_label, link_type in output_query.iterall():
                     # This link might have been drawn already, because the output is maybe
@@ -160,7 +160,7 @@ def draw_graph(origin_node,
             # Query for the outputs:
             output_query = QueryBuilder()
             output_query.append(Node, filters={'id': node.pk}, tag='n')
-            output_query.append(Node, output_of='n', edge_project=('id', 'label', 'type'), project='*', tag='out')
+            output_query.append(Node, with_incoming='n', edge_project=('id', 'label', 'type'), project='*', tag='out')
 
             for out, link_id, link_label, link_type in output_query.iterall():
                 # Draw the link
@@ -172,7 +172,7 @@ def draw_graph(origin_node,
             if include_calculation_inputs and isinstance(node, ProcessNode):
                 input_query = QueryBuilder()
                 input_query.append(Node, filters={'id': node.pk}, tag='n')
-                input_query.append(Node, input_of='n', edge_project=('id', 'label', 'type'), project='*', tag='inp')
+                input_query.append(Node, with_outgoing='n', edge_project=('id', 'label', 'type'), project='*', tag='inp')
                 for inp, link_id, link_label, link_type in input_query.iterall():
                     # Also here, maybe it's just better not to check?
                     if link_id not in links:

--- a/aiida/common/hashing.py
+++ b/aiida/common/hashing.py
@@ -105,7 +105,7 @@ try:
     using_sysrandom = True
 except NotImplementedError:
     import warnings
-    warnings.warn('A secure pseudo-random number generator is not available '
+    warnings.warn('A secure pseudo-random number generator is not available '  # pylint: disable=no-member
                   'on your system. Falling back to Mersenne Twister.')
     using_sysrandom = False  # pylint: disable=invalid-name
 

--- a/aiida/common/log.py
+++ b/aiida/common/log.py
@@ -46,7 +46,6 @@ class NotInTestingFilter(logging.Filter):
         return not settings.TESTING_MODE
 
 
-# A logging handler that will store the log record in the database DbLog table
 class DBLogHandler(logging.Handler):
     """A custom db log handler for writing logs tot he database"""
 
@@ -79,7 +78,7 @@ class DBLogHandler(logging.Handler):
             # Django settings module loaded. Then,
             # This ignore should be a no-op.
             pass
-        except Exception:
+        except Exception:  # pylint: disable=broad-except
             # To avoid loops with the error handler, I just print.
             # Hopefully, though, this should not happen!
             import traceback
@@ -165,6 +164,9 @@ LOGGING = {
             'handlers': ['console'],
             'level': 'ERROR',
             'propagate': False,
+        },
+        'py.warnings': {
+            'handlers': ['console'],
         },
     },
 }

--- a/aiida/common/setup.py
+++ b/aiida/common/setup.py
@@ -16,7 +16,6 @@ import uuid
 import logging
 import aiida.utils.json as json
 
-
 import six
 from six.moves import input
 
@@ -43,7 +42,7 @@ else:
 CONFIG_FNAME = 'config.json'
 CONFIG_INDENT_SIZE = 4
 
-SECRET_KEY_FNAME = 'secret_key.dat'
+SECRET_KEY_FNAME = 'secret_key.dat'  # noqa
 
 WORKFLOWS_SUBDIR = 'workflows'
 
@@ -769,8 +768,8 @@ class _NoDefaultValue(object):
 # 4. The default value, if no setting is found
 # 5. A list of valid values, or None if no such list makes sense
 _property_table = {
-    "runner.poll.interval": ("runner_poll_interval", "int", "The polling interval in seconds to be used by process runners",
-                       1, None),
+    "runner.poll.interval": ("runner_poll_interval", "int",
+                             "The polling interval in seconds to be used by process runners", 1, None),
     "daemon.timeout": ("daemon_timeout", "int", "The timeout in seconds for calls to the circus client",
                        DEFAULT_DAEMON_TIMEOUT, None),
     "verdishell.modules": ("modules_for_verdi_shell", "string",
@@ -800,9 +799,10 @@ _property_table = {
     "logging.kiwipy_loglevel":
     ("logging_kiwipy_log_level", "string", "Minimum level to log to the file ~/.aiida/daemon/log/aiida_daemon.log "
      "for the 'kiwipy' logger", "WARNING", ["CRITICAL", "ERROR", "WARNING", "REPORT", "INFO", "DEBUG"]),
-    "logging.paramiko_loglevel":
-    ("logging_paramiko_log_level", "string", "Minimum level to log to the file ~/.aiida/daemon/log/aiida_daemon.log "
-     "for the 'paramiko' logger", "WARNING", ["CRITICAL", "ERROR", "WARNING", "REPORT", "INFO", "DEBUG"]),
+    "logging.paramiko_loglevel": ("logging_paramiko_log_level", "string",
+                                  "Minimum level to log to the file ~/.aiida/daemon/log/aiida_daemon.log "
+                                  "for the 'paramiko' logger", "WARNING",
+                                  ["CRITICAL", "ERROR", "WARNING", "REPORT", "INFO", "DEBUG"]),
     "logging.alembic_loglevel": ("logging_alembic_log_level", "string", "Minimum level to log to the console",
                                  "WARNING", ["CRITICAL", "ERROR", "WARNING", "REPORT", "INFO", "DEBUG"]),
     "logging.sqlalchemy_loglevel": ("logging_sqlalchemy_loglevel", "string", "Minimum level to log to the console",
@@ -820,8 +820,8 @@ _property_table = {
                                    None),
     "tcod.depositor_author_email": ("tcod_depositor_author_email", "string", "E-mail address for TCOD depositions",
                                     None, None),
-    "warnings.showdeprecations": ("show_deprecations", "bool", "Boolean whether to print deprecation warnings", False,
-                                  None)
+    "warnings.showdeprecations": ("show_deprecations", "bool", "Boolean whether to print AiiDA deprecation warnings",
+                                  True, None)
 }
 
 

--- a/aiida/common/warnings.py
+++ b/aiida/common/warnings.py
@@ -1,0 +1,28 @@
+# -*- coding: utf-8 -*-
+###########################################################################
+# Copyright (c), The AiiDA team. All rights reserved.                     #
+# This file is part of the AiiDA code.                                    #
+#                                                                         #
+# The code is hosted on GitHub at https://github.com/aiidateam/aiida_core #
+# For further information on the license, see the LICENSE.txt file        #
+# For further information please visit http://www.aiida.net               #
+###########################################################################
+"""
+Define warnings that can be thrown by AiiDA
+"""
+from __future__ import division
+from __future__ import print_function
+from __future__ import absolute_import
+
+
+class AiidaDeprecationWarning(Warning):
+    """
+    Class for AiiDA deprecations.
+
+    It does *not* inherit, on purpose, from `DeprecationWarning` as
+    this would be filtered out by default.
+    Enabled by default, you can disable it by running in the shell::
+
+      verdi devel setproperty warnings.showdeprecations False
+    """
+    pass

--- a/aiida/orm/calculation/inline.py
+++ b/aiida/orm/calculation/inline.py
@@ -145,8 +145,11 @@ def make_inline(func):
         are not catched.
 
     .. deprecated:: 1.0.0
+       Use the ``@calcfunction`` decorator instead.
     """
     import warnings
+    # If we call this DeprecationWarning, pycharm will properly strike out the function
+    from aiida.common.warnings import AiidaDeprecationWarning as DeprecationWarning  # pylint: disable=redefined-builtin
     warnings.warn('this function has been deprecated, use `aiida.work.calcfunction` instead', DeprecationWarning)
 
     from aiida.work import workfunction
@@ -196,8 +199,11 @@ def optional_inline(func):
     In any way the ``copy_inline`` will return the same results.
 
     .. deprecated:: 1.0.0
+       Use the ``@calcfunction`` decorator instead
     """
     import warnings
+    # If we call this DeprecationWarning, pycharm will properly strike out the function
+    from aiida.common.warnings import AiidaDeprecationWarning as DeprecationWarning  # pylint: disable=redefined-builtin
     warnings.warn('this function has been deprecated, use `aiida.work.calcfunction` instead', DeprecationWarning)
 
     def wrapped_function(*args, **kwargs):

--- a/aiida/orm/data/__init__.py
+++ b/aiida/orm/data/__init__.py
@@ -63,7 +63,8 @@ class Data(Node):
 
     def __copy__(self):
         """Copying a Data node is not supported, use copy.deepcopy or call Data.clone()."""
-        raise NotImplementedError('copying a Data node is not supported, use copy.deepcopy')
+        from aiida.common.exceptions import InvalidOperation
+        raise InvalidOperation('copying a Data node is not supported, use copy.deepcopy')
 
     def __deepcopy__(self, memo):
         """
@@ -71,8 +72,9 @@ class Data(Node):
 
         :returns: an unstored clone of this Data node
         """
+        from aiida.common.exceptions import InvalidOperation
         if self.is_stored:
-            raise NotImplementedError('deep copying a stored Data node is not supported, use Data.clone() instead')
+            raise InvalidOperation('deep copying a stored Data node is not supported, use Data.clone() instead')
 
         return self.clone()
 

--- a/aiida/orm/data/array/bands.py
+++ b/aiida/orm/data/array/bands.py
@@ -651,6 +651,7 @@ class BandsData(KpointsData):
             Use 'dat_multicolumn' format instead
         """
         import warnings
+        from aiida.common.warnings import AiidaDeprecationWarning as DeprecationWarning  # pylint: disable=redefined-builtin
         warnings.warn(
             "dat_1 format is deprecated, use dat_multicolumn instead",
             DeprecationWarning)
@@ -691,6 +692,7 @@ class BandsData(KpointsData):
             Use 'dat_block' format instead
         """
         import warnings
+        from aiida.common.warnings import AiidaDeprecationWarning as DeprecationWarning  # pylint: disable=redefined-builtin
         warnings.warn(
             "dat_2 format is deprecated, use dat_blocks instead",
             DeprecationWarning)

--- a/aiida/orm/data/array/kpoints.py
+++ b/aiida/orm/data/array/kpoints.py
@@ -527,7 +527,8 @@ class KpointsData(ArrayData):
         .. deprecated:: 0.11
         """
         import warnings
-        warnings.warn('this method has been deprecated, see {}'.format(DEPRECATION_DOCS_URL), DeprecationWarning)
+        from aiida.common.warnings import AiidaDeprecationWarning as DeprecationWarning  # pylint: disable=redefined-builtin
+        warnings.warn('the bravais_lattice method has been deprecated, see {}'.format(DEPRECATION_DOCS_URL), DeprecationWarning)
         return self.get_attr('bravais_lattice')
 
     @bravais_lattice.setter
@@ -538,7 +539,8 @@ class KpointsData(ArrayData):
         .. deprecated:: 0.11
         """
         import warnings
-        warnings.warn('this method has been deprecated, see {}'.format(DEPRECATION_DOCS_URL), DeprecationWarning)
+        from aiida.common.warnings import AiidaDeprecationWarning as DeprecationWarning  # pylint: disable=redefined-builtin
+        warnings.warn('the bravais_lattice method has been deprecated, see {}'.format(DEPRECATION_DOCS_URL), DeprecationWarning)
         self._set_bravais_lattice(value)
 
     def _set_bravais_lattice(self, value):
@@ -548,7 +550,8 @@ class KpointsData(ArrayData):
         .. deprecated:: 0.11
         """
         import warnings
-        warnings.warn('this method has been deprecated, see {}'.format(DEPRECATION_DOCS_URL), DeprecationWarning)
+        from aiida.common.warnings import AiidaDeprecationWarning as DeprecationWarning  # pylint: disable=redefined-builtin
+        warnings.warn('the _set_bravais_lattice method has been deprecated, see {}'.format(DEPRECATION_DOCS_URL), DeprecationWarning)
 
         import copy
         if not isinstance(value, dict):
@@ -592,7 +595,8 @@ class KpointsData(ArrayData):
         :return bravais_lattice: the dictionary containing the symmetry info
         """
         import warnings
-        warnings.warn('this method has been deprecated, see {}'.format(DEPRECATION_DOCS_URL), DeprecationWarning)
+        from aiida.common.warnings import AiidaDeprecationWarning as DeprecationWarning  # pylint: disable=redefined-builtin
+        warnings.warn('the _get_or_create_bravais_lattice method has been deprecated, see {}'.format(DEPRECATION_DOCS_URL), DeprecationWarning)
 
         try:
             bravais_lattice = self.bravais_lattice
@@ -640,7 +644,8 @@ class KpointsData(ArrayData):
 
         """
         import warnings
-        warnings.warn('this method has been deprecated, see {}'.format(DEPRECATION_DOCS_URL), DeprecationWarning)
+        from aiida.common.warnings import AiidaDeprecationWarning as DeprecationWarning  # pylint: disable=redefined-builtin
+        warnings.warn('the set_kpoints_path method has been deprecated, see {}'.format(DEPRECATION_DOCS_URL), DeprecationWarning)
 
         from aiida.tools.data.array.kpoints.legacy import get_explicit_kpoints_path
 
@@ -680,7 +685,8 @@ class KpointsData(ArrayData):
                 with extra parameters used by the get_special_points method)
         """
         import warnings
-        warnings.warn('this method has been deprecated, see {}'.format(DEPRECATION_DOCS_URL), DeprecationWarning)
+        from aiida.common.warnings import AiidaDeprecationWarning as DeprecationWarning  # pylint: disable=redefined-builtin
+        warnings.warn('the _find_bravais_info method has been deprecated, see {}'.format(DEPRECATION_DOCS_URL), DeprecationWarning)
 
         from aiida.tools.data.array.kpoints.legacy import find_bravais_info
         return find_bravais_info(
@@ -713,7 +719,8 @@ class KpointsData(ArrayData):
              eventual variation
         """
         import warnings
-        warnings.warn('this method has been deprecated, see {}'.format(DEPRECATION_DOCS_URL), DeprecationWarning)
+        from aiida.common.warnings import AiidaDeprecationWarning as DeprecationWarning  # pylint: disable=redefined-builtin
+        warnings.warn('the find_bravais_lattice method has been deprecated, see {}'.format(DEPRECATION_DOCS_URL), DeprecationWarning)
 
         if not self.is_stored:
             bravais_lattice = self._find_bravais_info(epsilon_length=epsilon_length,
@@ -757,7 +764,8 @@ class KpointsData(ArrayData):
         :note: We assume that the cell given by the cell property is the primitive unit cell
         """
         import warnings
-        warnings.warn('this method has been deprecated, see {}'.format(DEPRECATION_DOCS_URL), DeprecationWarning)
+        from aiida.common.warnings import AiidaDeprecationWarning as DeprecationWarning  # pylint: disable=redefined-builtin
+        warnings.warn('the get_special_points method has been deprecated, see {}'.format(DEPRECATION_DOCS_URL), DeprecationWarning)
 
         from aiida.tools.data.array.kpoints.legacy import get_kpoints_path
         point_coords, path, bravais_info = get_kpoints_path(

--- a/aiida/orm/data/array/trajectory.py
+++ b/aiida/orm/data/array/trajectory.py
@@ -7,6 +7,9 @@
 # For further information on the license, see the LICENSE.txt file        #
 # For further information please visit http://www.aiida.net               #
 ###########################################################################
+"""
+AiiDA class to deal with crystal structure trajectories.
+"""
 from __future__ import division
 from __future__ import absolute_import
 from __future__ import print_function
@@ -25,8 +28,6 @@ def _get_aiida_structure_inline(trajectory, parameters):
 
     .. note:: requires ASE module.
     """
-    from aiida.orm.data.structure import StructureData
-
     kwargs = {}
     if parameters is not None:
         kwargs = parameters.get_dict()
@@ -41,7 +42,7 @@ class TrajectoryData(ArrayData):
     possibly with velocities).
     """
 
-    def _internal_validate(self, stepids, cells, symbols, positions, times, velocities):
+    def _internal_validate(self, stepids, cells, symbols, positions, times, velocities):  # pylint: disable=too-many-arguments,too-many-locals,no-self-use,too-many-branches
         """
         Internal function to validate the type and shape of the arrays. See
         the documentation of py:meth:`.set_trajectory` for a description of the
@@ -70,8 +71,7 @@ class TrajectoryData(ArrayData):
         if stepids.shape != (numsteps,):
             raise ValueError("TrajectoryData.stepids must be a 1d array")
         if cells.shape != (numsteps, 3, 3):
-            raise ValueError("TrajectoryData.cells must have shape (s,3,3), "
-                             "with s=number of steps")
+            raise ValueError("TrajectoryData.cells must have shape (s,3,3), " "with s=number of steps")
         numatoms = symbols.size
         if symbols.shape != (numatoms,):
             raise ValueError("TrajectoryData.symbols must be a 1d array")
@@ -80,15 +80,14 @@ class TrajectoryData(ArrayData):
                              "with s=number of steps and n=number of symbols")
         if times is not None:
             if times.shape != (numsteps,):
-                raise ValueError("TrajectoryData.times must have shape (s,), "
-                                 "with s=number of steps")
+                raise ValueError("TrajectoryData.times must have shape (s,), " "with s=number of steps")
         if velocities is not None:
             if velocities.shape != (numsteps, numatoms, 3):
                 raise ValueError("TrajectoryData.velocities, if not None, must "
                                  "have shape (s,n,3), "
                                  "with s=number of steps and n=number of symbols")
 
-    def set_trajectory(self, stepids, cells, symbols, positions, times=None, velocities=None):
+    def set_trajectory(self, stepids, cells, symbols, positions, times=None, velocities=None):  # pylint: disable=too-many-arguments
         r"""
         Store the whole trajectory, after checking that types and dimensions
         are correct.
@@ -174,11 +173,9 @@ class TrajectoryData(ArrayData):
         stepids = numpy.arange(len(structurelist))
         cells = numpy.array([x.cell for x in structurelist])
         symbols_first = [str(s.kind_name) for s in structurelist[0].sites]
-        for symbols_now in [[str(s.kind_name) for s in structurelist[i].sites]
-                            for i in stepids]:
+        for symbols_now in [[str(s.kind_name) for s in structurelist[i].sites] for i in stepids]:
             if symbols_first != symbols_now:
-                raise ValueError("Symbol lists have to be the same for "
-                                 "all of the supplied structures")
+                raise ValueError("Symbol lists have to be the same for " "all of the supplied structures")
         symbols = numpy.array(symbols_first)
         positions = numpy.array([[list(s.position) for s in x.sites] for x in structurelist])
         self.set_trajectory(stepids, cells, symbols, positions)
@@ -192,16 +189,12 @@ class TrajectoryData(ArrayData):
         from aiida.common.exceptions import ValidationError
 
         try:
-            self._internal_validate(self.get_stepids(),
-                                    self.get_cells(),
-                                    self.get_symbols(), self.get_positions(),
-                                    self.get_times(),
-                                    self.get_velocities())
+            self._internal_validate(self.get_stepids(), self.get_cells(), self.get_symbols(), self.get_positions(),
+                                    self.get_times(), self.get_velocities())
         # Should catch TypeErrors, ValueErrors, and KeyErrors for missing arrays
         except Exception as exception:
             raise ValidationError("The TrajectoryData did not validate. "
-                                  "Error: {} with message {}".format(
-                type(exception).__name__, exception))
+                                  "Error: {} with message {}".format(type(exception).__name__, exception))
 
     @property
     def numsteps(self):
@@ -222,17 +215,6 @@ class TrajectoryData(ArrayData):
             return self.get_shape('symbols')[0]
         except (AttributeError, KeyError, IndexError):
             return 0
-
-    def get_steps(self):
-        """
-        .. deprecated:: 0.7
-           Use :meth:`get_stepids` instead.
-        """
-        import warnings
-        warnings.warn(
-            "get_steps is deprecated, use get_stepids instead",
-            DeprecationWarning)
-        return self.get_stepids()
 
     def get_stepids(self):
         """
@@ -294,17 +276,6 @@ class TrajectoryData(ArrayData):
         except (AttributeError, KeyError):
             return None
 
-    def get_step_index(self, step):
-        """
-        .. deprecated:: 0.7
-           Use :meth:`get_index_from_stepid` instead.
-        """
-        import warnings
-        warnings.warn(
-            "get_step_index is deprecated, use get_index_from_stepid instead",
-            DeprecationWarning)
-        return self.get_index_from_stepid(stepid=step)
-
     def get_index_from_stepid(self, stepid):
         """
         Given a value for the stepid (i.e., a value among those of the ``steps``
@@ -360,20 +331,8 @@ class TrajectoryData(ArrayData):
         time = self.get_times()
         if time is not None:
             time = time[index]
-        return (self.get_stepids()[index], time, self.get_cells()[index, :, :],
-                self.get_symbols(), self.get_positions()[index, :, :], vel)
-
-
-    def step_to_structure(self, index, custom_kinds=None):
-        """
-        .. deprecated:: 0.7
-           Use :meth:`get_step_structure` instead.
-        """
-        import warnings
-        warnings.warn(
-            "step_to_structure is deprecated, use get_step_structure instead",
-            DeprecationWarning)
-        return self.get_step_structure(index=index, custom_kinds=custom_kinds)
+        return (self.get_stepids()[index], time, self.get_cells()[index, :, :], self.get_symbols(),
+                self.get_positions()[index, :, :], vel)
 
     def get_step_structure(self, index, custom_kinds=None):
         """
@@ -411,29 +370,27 @@ class TrajectoryData(ArrayData):
                                     "be a aiida.orm.data.structure.Kind object")
                 kind_names.append(k.name)
             if len(kind_names) != len(set(kind_names)):
-                raise ValueError("Multiple kinds with the same name passed "
-                                 "as custom_kinds")
+                raise ValueError("Multiple kinds with the same name passed " "as custom_kinds")
             if set(kind_names) != set(symbols):
                 raise ValueError("If you pass custom_kinds, you have to "
                                  "pass one Kind object for each symbol "
                                  "that is present in the trajectory. You "
-                                 "passed {}, but the symbols are {}".format(
-                    sorted(kind_names), sorted(symbols)))
+                                 "passed {}, but the symbols are {}".format(sorted(kind_names), sorted(symbols)))
 
         struc = StructureData(cell=cell)
         if custom_kinds is not None:
-            for k in custom_kinds:
-                struc.append_kind(k)
-            for s, p in zip(symbols, positions):
-                struc.append_site(Site(kind_name=s, position=p))
+            for _k in custom_kinds:
+                struc.append_kind(_k)
+            for _s, _p in zip(symbols, positions):
+                struc.append_site(Site(kind_name=_s, position=_p))
         else:
-            for s, p in zip(symbols, positions):
+            for _s, _p in zip(symbols, positions):
                 # Automatic species generation
-                struc.append_atom(symbols=s, position=p)
+                struc.append_atom(symbols=_s, position=_p)
 
         return struc
 
-    def _prepare_xsf(self, index=None, main_file_name=""):
+    def _prepare_xsf(self, index=None, main_file_name=""):  # pylint: disable=unused-argument
         """
         Write the given trajectory to a string of format XSF (for XCrySDen).
         """
@@ -447,8 +404,7 @@ class TrajectoryData(ArrayData):
         # Do the checks once and for all here:
         structure = self.get_step_structure(index=0)
         if structure.is_alloy() or structure.has_vacancies():
-            raise NotImplementedError("XSF for alloys or systems with "
-                                      "vacancies not implemented.")
+            raise NotImplementedError("XSF for alloys or systems with " "vacancies not implemented.")
         cells = self.get_cells()
         positions = self.get_positions()
         symbols = self.get_symbols()
@@ -456,30 +412,29 @@ class TrajectoryData(ArrayData):
         nat = len(symbols)
 
         for idx in indices:
-            return_string += "PRIMVEC {}\n".format(idx+1)
+            return_string += "PRIMVEC {}\n".format(idx + 1)
             #~ structure = self.get_step_structure(index=idx)
             #~ sites = structure.sites
             #~ if structure.is_alloy() or structure.has_vacancies():
-                #~ raise NotImplementedError("XSF for alloys or systems with "
-                                          #~ "vacancies not implemented.")
+            #~ raise NotImplementedError("XSF for alloys or systems with "
+            #~ "vacancies not implemented.")
             for cell_vector in cells[idx]:
                 return_string += " ".join(["{:18.5f}".format(i) for i in cell_vector])
                 return_string += "\n"
-            return_string += "PRIMCOORD {}\n".format(idx+1)
-            return_string += "{} 1\n" .format(nat)
+            return_string += "PRIMCOORD {}\n".format(idx + 1)
+            return_string += "{} 1\n".format(nat)
             for atn, pos in zip(atomic_numbers_list, positions[idx]):
                 try:
-                    return_string += "{} {:18.10f} {:18.10f} {:18.10f}\n".format(atn, pos[0], pos[1], pos[2] )
+                    return_string += "{} {:18.10f} {:18.10f} {:18.10f}\n".format(atn, pos[0], pos[1], pos[2])
                 except:
                     print(atn, pos)
                     raise
         return return_string.encode('utf-8'), {}
 
-    def _prepare_cif(self, trajectory_index=None, main_file_name=""):
+    def _prepare_cif(self, trajectory_index=None, main_file_name=""):  # pylint: disable=unused-argument
         """
         Write the given trajectory to a string of format CIF.
         """
-        import CifFile
         from aiida.orm.data.cif \
             import ase_loops, cif_from_ase, pycifrw_from_cif
         from aiida.common.utils import HiddenPrints
@@ -490,18 +445,17 @@ class TrajectoryData(ArrayData):
             indices = [trajectory_index]
         for idx in indices:
             structure = self.get_step_structure(idx)
-            ciffile = pycifrw_from_cif(cif_from_ase(structure.get_ase()),
-                                       ase_loops)
+            ciffile = pycifrw_from_cif(cif_from_ase(structure.get_ase()), ase_loops)
             with HiddenPrints():
                 cif = cif + ciffile.WriteOut()
         return cif.encode('utf-8'), {}
 
-    def _prepare_tcod(self, main_file_name="", **kwargs):
+    def _prepare_tcod(self, main_file_name="", **kwargs):  # pylint: disable=unused-argument
         """
         Write the given trajectory to a string of format TCOD CIF.
         """
         from aiida.tools.dbexporters.tcod import export_cif
-        return export_cif(self,**kwargs), {}
+        return export_cif(self, **kwargs), {}
 
     def _get_aiida_structure(self, store=False, **kwargs):
         """
@@ -516,7 +470,7 @@ class TrajectoryData(ArrayData):
 
         param = ParameterData(dict=kwargs)
 
-        ret_dict = _get_aiida_structure_inline(trajectory=self, parameters=param, store_provenance=store)
+        ret_dict = _get_aiida_structure_inline(trajectory=self, parameters=param, store_provenance=store)  # pylint: disable=unexpected-keyword-arg
         return ret_dict['structure']
 
     def _get_cif(self, index=None, **kwargs):
@@ -524,7 +478,7 @@ class TrajectoryData(ArrayData):
         Creates :py:class:`aiida.orm.data.cif.CifData`
         """
         struct = self._get_aiida_structure(index=index, **kwargs)
-        cif = struct._get_cif(**kwargs)
+        cif = struct._get_cif(**kwargs)  # pylint: disable=protected-access
         return cif
 
     def _parse_xyz_pos(self, inputstring):
@@ -562,9 +516,8 @@ class TrajectoryData(ArrayData):
         if numsites == 0:
             raise ValidationError("symbols must be set before importing positional data")
 
-        positions = array([
-            [list(position) for _, position in atoms]
-                    for _, _, atoms in xyz_parser_iterator(inputstring)])
+        positions = array(
+            [[list(position) for _, position in atoms] for _, _, atoms in xyz_parser_iterator(inputstring)])
 
         if positions.shape != (numsteps, numsites, 3):
             raise ValueError("TrajectoryData.positions must have shape (s,n,3), "
@@ -594,9 +547,8 @@ class TrajectoryData(ArrayData):
         if numsites == 0:
             raise ValidationError("symbols must be set before importing positional data")
 
-        velocities = array([
-            [list(velocity) for _, velocity in atoms]
-                    for _, _, atoms in xyz_parser_iterator(inputstring)])
+        velocities = array(
+            [[list(velocity) for _, velocity in atoms] for _, _, atoms in xyz_parser_iterator(inputstring)])
 
         if velocities.shape != (numsteps, numsites, 3):
             raise ValueError("TrajectoryData.positions must have shape (s,n,3), "
@@ -605,8 +557,7 @@ class TrajectoryData(ArrayData):
 
         self.set_array('velocities', velocities)
 
-
-    def show_mpl_pos(self, **kwargs):
+    def show_mpl_pos(self, **kwargs):  # pylint: disable=too-many-locals
         """
         Shows the positions as a function of time, separate for XYZ coordinates
 
@@ -621,12 +572,9 @@ class TrajectoryData(ArrayData):
             A list of indices of that atoms that can be displayed.
             If not specified, all atoms of the correct species are displayed.
         :param bool dont_block: If True, interpreter is not blocked when figure is displayed.
-
-        :todo: save to file?
         """
         from ase.data import atomic_numbers
         from aiida.common.exceptions import InputValidationError
-
 
         # Reading the arrays I need:
         positions = self.get_positions()
@@ -645,8 +593,8 @@ class TrajectoryData(ArrayData):
 
         # Getting the keyword input
         stepsize = kwargs.pop('stepsize', 1)
-        maxtime  = kwargs.pop('maxtime', times[-1])
-        mintime  = kwargs.pop('mintime', times[0])
+        maxtime = kwargs.pop('maxtime', times[-1])
+        mintime = kwargs.pop('mintime', times[0])
         element_list = kwargs.pop('elements', None)
         index_list = kwargs.pop('indices', None)
         dont_block = kwargs.pop('dont_block', False)
@@ -661,18 +609,15 @@ class TrajectoryData(ArrayData):
         else:
             raise InputValidationError("Unknown color spec {}".format(colors))
         if kwargs:
-            raise InputValidationError(
-                    "Unrecognized keyword {}".format(kwargs.keys())
-            )
+            raise InputValidationError("Unrecognized keyword {}".format(kwargs.keys()))
 
         if element_list is None:
             # If not all elements are allowed
             allowed_elements = set(symbols)
         else:
             # A subset of elements are allowed
-            # TODO: maybe a check
             allowed_elements = set(element_list)
-        color_dict = {s:colors[atomic_numbers[s]] for s in set(symbols)}
+        color_dict = {s: colors[atomic_numbers[s]] for s in set(symbols)}
         # Here I am trying to find out the atoms to show
         if index_list is None:
             # If not index_list was provided, I will see if an element_list
@@ -682,40 +627,47 @@ class TrajectoryData(ArrayData):
             indices_to_show = index_list
             # I refrain from checking if indices are ok, will crash if not...
 
-
         # The color_list is a list of colors (RGB) that I will
         # pass, so the different species give different colors in the plot
-        # TODO: Color fading for different atoms:
         color_list = [color_dict[s] for s in symbols]
 
         # Reducing array size based on stepsize variable
-        T = times[::stepsize]
-        P = positions[::stepsize]
+        _times = times[::stepsize]
+        _positions = positions[::stepsize]
 
         # Calling
         plot_positions_XYZ(
-            T, P, indices_to_show, color_list, label,
-            positions_unit, times_unit,
-            dont_block, mintime, maxtime,
+            _times,
+            _positions,
+            indices_to_show,
+            color_list,
+            label,
+            positions_unit,
+            times_unit,
+            dont_block,
+            mintime,
+            maxtime,
         )
 
-
-    def show_mpl_heatmap(self, **kwargs):
+    def show_mpl_heatmap(self, **kwargs):  # pylint: disable=invalid-name,too-many-arguments,too-many-locals,too-many-statements,too-many-branches
+        """
+        Show a heatmap of the trajectory with matplotlib.
+        """
         import numpy as np
         from scipy import stats
         try:
             from mayavi import mlab
         except ImportError:
-            raise ImportError(
-                "Unable to import the mayavi package, that is required to"
-                "use the plotting feature you requested. "
-                "Please install it first and then call this command again "
-                "(note that the installation of mayavi is quite complicated "
-                "and requires that you already installed the python numpy "
-                "package, as well as the vtk package")
+            raise ImportError("Unable to import the mayavi package, that is required to"
+                              "use the plotting feature you requested. "
+                              "Please install it first and then call this command again "
+                              "(note that the installation of mayavi is quite complicated "
+                              "and requires that you already installed the python numpy "
+                              "package, as well as the vtk package")
         from ase.data.colors import jmol_colors
-        from ase.data import covalent_radii, atomic_numbers
-        from aiida.common.exceptions import InputValidationError
+        from ase.data import atomic_numbers
+
+        # pylint: disable=invalid-name
 
         def collapse_into_unit_cell(point, cell):
             """
@@ -726,11 +678,10 @@ class TrajectoryData(ArrayData):
             the point back"""
             invcell = np.matrix(cell).T.I
             # point in crystal coordinates
-            points_in_crystal = np.dot(invcell,point).tolist()[0]
+            points_in_crystal = np.dot(invcell, point).tolist()[0]
             #point collapsed into unit cell
-            points_in_unit_cell = [i%1 for i in points_in_crystal]
+            points_in_unit_cell = [i % 1 for i in points_in_crystal]
             return np.dot(cell.T, points_in_unit_cell).tolist()
-
 
         elements = kwargs.pop('elements', None)
         mintime = kwargs.pop('mintime', None)
@@ -739,18 +690,16 @@ class TrajectoryData(ArrayData):
         contours = np.array(kwargs.pop('contours', None) or (0.1, 0.5))
         sampling_stepsize = int(kwargs.pop('sampling_stepsize', None) or 0)
 
-
         times = self.get_times()
         if mintime is None:
             minindex = 0
         else:
-            minindex =  np.argmax(times>mintime)
+            minindex = np.argmax(times > mintime)
         if maxtime is None:
             maxindex = len(times)
         else:
             maxindex = np.argmin(times < maxtime)
         positions = self.get_positions()[minindex:maxindex:stepsize]
-
 
         try:
             if self.get_attr('units|positions') in ('bohr', 'atomic'):
@@ -764,19 +713,20 @@ class TrajectoryData(ArrayData):
             elements = set(symbols)
 
         cell = np.array(self.get_cells()[0])
-        storage_dict = {s:{} for s in elements}
+        storage_dict = {s: {} for s in elements}
         for ele in elements:
-                storage_dict[ele] = [np.array([]),np.array([]),np.array([])]
+            storage_dict[ele] = [np.array([]), np.array([]), np.array([])]
         for iat, ele in enumerate(symbols):
             if ele in elements:
                 for idim in range(3):
-                    storage_dict[ele][idim] = np.concatenate((storage_dict[ele][idim], positions[:,iat,idim].flatten()))
+                    storage_dict[ele][idim] = np.concatenate((storage_dict[ele][idim],
+                                                              positions[:, iat, idim].flatten()))
 
         for ele in elements:
             storage_dict[ele] = np.array(storage_dict[ele]).T
             storage_dict[ele] = np.array([collapse_into_unit_cell(pos, cell) for pos in storage_dict[ele]]).T
 
-        white = (1,1,1)
+        white = (1, 1, 1)
         mlab.figure(bgcolor=white, size=(1080, 720))
 
         for i1, a in enumerate(cell):
@@ -786,34 +736,28 @@ class TrajectoryData(ArrayData):
                 for c in [np.zeros(3), cell[i3]]:
                     p1 = b + c
                     p2 = p1 + a
-                    mlab.plot3d(
-                            [p1[0], p2[0]],
-                            [p1[1], p2[1]],
-                            [p1[2], p2[2]],
-                            tube_radius=0.1
-                        )
-
+                    mlab.plot3d([p1[0], p2[0]], [p1[1], p2[1]], [p1[2], p2[2]], tube_radius=0.1)
 
         for ele, data in storage_dict.items():
             kde = stats.gaussian_kde(data, bw_method=0.15)
 
-            x = data[0,:]
-            y = data[1,:]
-            z = data[2,:]
-            xmin, ymin, zmin = x.min(), y.min(), z.min()
-            xmax, ymax, zmax = x.max(), y.max(), z.max()
+            _x = data[0, :]
+            _y = data[1, :]
+            _z = data[2, :]
+            xmin, ymin, zmin = _x.min(), _y.min(), _z.min()
+            xmax, ymax, zmax = _x.max(), _y.max(), _z.max()
 
-            xi, yi, zi = np.mgrid[xmin:xmax:60j, ymin:ymax:30j, zmin:zmax:30j]
-            coords = np.vstack([item.ravel() for item in [xi, yi, zi]])
-            density = kde(coords).reshape(xi.shape)
+            _xi, _yi, _zi = np.mgrid[xmin:xmax:60j, ymin:ymax:30j, zmin:zmax:30j]  # pylint: disable=invalid-slice-index
+            coords = np.vstack([item.ravel() for item in [_xi, _yi, _zi]])
+            density = kde(coords).reshape(_xi.shape)
 
             # Plot scatter with mayavi
             #~ figure = mlab.figure('DensityPlot')
-            grid = mlab.pipeline.scalar_field(xi, yi, zi, density)
+            grid = mlab.pipeline.scalar_field(_xi, _yi, _zi, density)
             #~ min = density.min()
             maxdens = density.max()
             #~ mlab.pipeline.volume(grid, vmin=min, vmax=min + .5*(max-min))
-            surf = mlab.pipeline.iso_surface(grid, opacity=0.5, colormap='cool', contours=(maxdens*contours).tolist())
+            surf = mlab.pipeline.iso_surface(grid, opacity=0.5, colormap='cool', contours=(maxdens * contours).tolist())
             lut = surf.module_manager.scalar_lut_manager.lut.table.to_array()
 
             # The lut is a 255x4 array, with the columns representing RGBA
@@ -821,78 +765,101 @@ class TrajectoryData(ArrayData):
 
             # We modify the alpha channel to add a transparency gradient
             lut[:, -1] = np.linspace(100, 255, 256)
-            lut[:,0:3] = 255*jmol_colors[atomic_numbers[ele]]
+            lut[:, 0:3] = 255 * jmol_colors[atomic_numbers[ele]]
             # and finally we put this LUT back in the surface object. We could have
             # added any 255*4 array rather than modifying an existing LUT.
             surf.module_manager.scalar_lut_manager.lut.table = lut
 
             if sampling_stepsize > 0:
                 mlab.points3d(
-                        x[::sampling_stepsize], y[::sampling_stepsize], z[::sampling_stepsize],
-                        color=tuple(jmol_colors[atomic_numbers[ele]].tolist()),
-                        scale_mode='none', scale_factor=0.3, opacity=0.3
-                    )
-
+                    _x[::sampling_stepsize],
+                    _y[::sampling_stepsize],
+                    _z[::sampling_stepsize],
+                    color=tuple(jmol_colors[atomic_numbers[ele]].tolist()),
+                    scale_mode='none',
+                    scale_factor=0.3,
+                    opacity=0.3)
 
         mlab.view(azimuth=155, elevation=70, distance='auto')
         mlab.show()
 
 
-def plot_positions_XYZ(
-            times, positions, indices_to_show, color_list, label,
-            positions_unit='A', times_unit='ps', dont_block=False,
-            mintime=None, maxtime=None, label_sparsity=10):
+def plot_positions_XYZ(  # pylint: disable=too-many-arguments,too-many-locals,invalid-name
+        times,
+        positions,
+        indices_to_show,
+        color_list,
+        label,
+        positions_unit='A',
+        times_unit='ps',
+        dont_block=False,
+        mintime=None,
+        maxtime=None,
+        label_sparsity=10):
+    """
+    Plot with matplotlib the positions of the coordinates of the atoms
+    over time for a trajectory
 
-        from matplotlib import pyplot as plt
-        from matplotlib.gridspec import GridSpec
-        import numpy as np
-        from random import choice
+    :param times: array of times
+    :param positions: array of positions
+    :param indices_to_show: list of indices of to show (0, 1, 2 for X, Y, Z)
+    :param color_list: list of valid color specifications for matplotlib
+    :param label: label for this plot to put in the title
+    :param positions_unit: label for the units of positions (for the x label)
+    :param times_unit: label for the units of times (for the y label)
+    :param dont_block: passed to plt.show() as ``block=not dont_block``
+    :param mintime: if specified, cut the time axis at the specified min value
+    :param maxtime: if specified, cut the time axis at the specified max value
+    :param label_sparsity: how often to put a label with the pair (t, coord)
+    """
+    from matplotlib import pyplot as plt
+    from matplotlib.gridspec import GridSpec
+    import numpy as np
 
-        tlim = [times[0], times[-1]]
-        index_range = [0, len(times)]
-        if mintime is not None:
-            tlim[0] = mintime
-            index_range[0] = np.argmax(times>mintime)
-        if maxtime is not None:
-            tlim[1] = maxtime
-            index_range[1] = np.argmin(times<maxtime)
+    tlim = [times[0], times[-1]]
+    index_range = [0, len(times)]
+    if mintime is not None:
+        tlim[0] = mintime
+        index_range[0] = np.argmax(times > mintime)
+    if maxtime is not None:
+        tlim[1] = maxtime
+        index_range[1] = np.argmin(times < maxtime)
 
-        trajectories = zip(*positions.tolist())  # only used in enumerate() below
-        cmap =  plt.get_cmap('jet_r')
-        fig = plt.figure(figsize = (12,7))
+    trajectories = zip(*positions.tolist())  # only used in enumerate() below
+    fig = plt.figure(figsize=(12, 7))
 
-        plt.suptitle(r'Trajectory of %s' % label, fontsize=16)
-        nr_of_axes = 3
-        gs = GridSpec(nr_of_axes,1, hspace = 0.0)
+    plt.suptitle(r'Trajectory of {}'.format(label), fontsize=16)
+    nr_of_axes = 3
+    gridspec = GridSpec(nr_of_axes, 1, hspace=0.0)
 
-        ax1 = fig.add_subplot(gs[0])
-        plt.ylabel(r'X Position $\left[{}\right]$'.format(positions_unit))
-        plt.xticks([])
-        plt.xlim(*tlim)
-        ax2 = fig.add_subplot(gs[1])
-        plt.ylabel(r'Y Position $\left[{}\right]$'.format(positions_unit))
-        plt.xticks([])
-        plt.xlim(*tlim)
-        ax3 = fig.add_subplot(gs[2])
-        plt.ylabel(r'Z Position $\left[{}\right]$'.format(positions_unit))
-        plt.xlabel('Time [{}]'.format(times_unit))
-        plt.xlim(*tlim)
-        sparse_indices = np.linspace(*index_range, num=label_sparsity, dtype=int)
+    ax1 = fig.add_subplot(gridspec[0])
+    plt.ylabel(r'X Position $\left[{}\right]$'.format(positions_unit))
+    plt.xticks([])
+    plt.xlim(*tlim)
+    ax2 = fig.add_subplot(gridspec[1])
+    plt.ylabel(r'Y Position $\left[{}\right]$'.format(positions_unit))
+    plt.xticks([])
+    plt.xlim(*tlim)
+    ax3 = fig.add_subplot(gridspec[2])
+    plt.ylabel(r'Z Position $\left[{}\right]$'.format(positions_unit))
+    plt.xlabel('Time [{}]'.format(times_unit))
+    plt.xlim(*tlim)
+    sparse_indices = np.linspace(*index_range, num=label_sparsity, dtype=int)
 
-        for index, traj in enumerate(trajectories):
-            if index not in indices_to_show:
-                continue
-            color =  color_list[index]
-            X,Y,Z = list(zip(*traj))
-            ax1.plot(times, X, color=color)
-            ax2.plot(times, Y, color=color)
-            ax3.plot(times, Z, color=color)
-            for i in sparse_indices:
-                ax1.text(times[i], X[i], str(index), color=color, fontsize=5)
-                ax2.text(times[i], Y[i], str(index), color=color, fontsize=5)
-                ax3.text(times[i], Z[i], str(index), color=color, fontsize=5)
-        for ax in ax1, ax2, ax3:
-            yticks = ax.yaxis.get_major_ticks()
-            yticks[0].label1.set_visible(False)
+    for index, traj in enumerate(trajectories):
+        if index not in indices_to_show:
+            continue
+        color = color_list[index]
+        _x, _y, _z = list(zip(*traj))
+        ax1.plot(times, _x, color=color)
+        ax2.plot(times, _y, color=color)
+        ax3.plot(times, _z, color=color)
+        for i in sparse_indices:
+            ax1.text(times[i], _x[i], str(index), color=color, fontsize=5)
+            ax2.text(times[i], _x[i], str(index), color=color, fontsize=5)
+            ax3.text(times[i], _x[i], str(index), color=color, fontsize=5)
+    for axes in ax1, ax2, ax3:
+        yticks = axes.yaxis.get_major_ticks()
+        yticks[0].label1.set_visible(False)
 
-        plt.show(block=not(dont_block))
+    plt.show(block=not dont_block)

--- a/aiida/orm/data/code.py
+++ b/aiida/orm/data/code.py
@@ -152,7 +152,7 @@ class Code(Data):
         qb = QueryBuilder()
         qb.append(cls, filters={'label': {'==': label}}, project=['*'], tag='code')
         if machinename:
-            qb.append(Computer, filters={'name': {'==': machinename}}, computer_of='code')
+            qb.append(Computer, filters={'name': {'==': machinename}}, with_node='code')
 
         if qb.count() == 0:
             raise NotExistent("'{}' is not a valid code " "name.".format(label))
@@ -471,6 +471,7 @@ class Code(Data):
         :raise ValueError: if no default plugin was specified in the code.
         """
         import warnings
+        from aiida.common.warnings import AiidaDeprecationWarning as DeprecationWarning  # pylint: disable=redefined-builtin
         warnings.warn(
             'directly creating and submitting calculations is deprecated, use the {}\nSee:{}'.format(
                 'ProcessBuilder', DEPRECATION_DOCS_URL), DeprecationWarning)

--- a/aiida/orm/groups.py
+++ b/aiida/orm/groups.py
@@ -310,7 +310,8 @@ class Group(entities.Entity):
           in any case already stored) and created is a boolean saying
         """
         import warnings
-        warnings.warn('this method has been deprecated use Group.objects.get_or_create() instead', DeprecationWarning)
+        from aiida.common.warnings import AiidaDeprecationWarning as DeprecationWarning  # pylint: disable=redefined-builtin
+        warnings.warn('this method has been deprecated use Group.objects.get_or_create() instead', DeprecationWarning)  # pylint: disable=no-member
 
         return cls.objects(backend).get_or_create(**kwargs)
 

--- a/aiida/orm/implementation/general/node.py
+++ b/aiida/orm/implementation/general/node.py
@@ -1709,7 +1709,7 @@ class AbstractNode(object):
                 if current_autogroup.is_to_be_grouped(self):
                     group_name = current_autogroup.get_group_name()
                     if group_name is not None:
-                        g = Group.get_or_create(
+                        g = Group.objects.get_or_create(
                             name=group_name, type_string=VERDIAUTOGROUP_TYPE)[0]
                         g.add_nodes(self)
 

--- a/aiida/orm/implementation/sqlalchemy/node.py
+++ b/aiida/orm/implementation/sqlalchemy/node.py
@@ -142,7 +142,8 @@ class Node(AbstractNode):
 
     @classmethod
     def query(cls, *args, **kwargs):
-        raise NotImplementedError("The node query method is not supported in " "SQLAlchemy. Please use QueryBuilder.")
+        from aiida.common.exceptions import FeatureNotAvailable
+        raise FeatureNotAvailable("The node query method is not supported in " "SQLAlchemy. Please use QueryBuilder.")
 
     @property
     def type(self):

--- a/aiida/orm/importexport.py
+++ b/aiida/orm/importexport.py
@@ -1603,19 +1603,19 @@ def fill_in_query(partial_query, originating_entity_str, current_entity_str,
 
     relationship_dic = {
         "Node": {
-            "Computer": "has_computer",
-            "Group": "member_of",
-            "User": "created_by"
+            "Computer": "with_computer",
+            "Group": "with_group",
+            "User": "with_user"
         },
         "Group": {
-            "Node": "group_of"
+            "Node": "with_node"
         },
         "Computer": {
-            "Node": "computer_of"
+            "Node": "with_node"
         },
         "User": {
-            "Node": "creator_of",
-            "Group": "owner_of"
+            "Node": "with_node",
+            "Group": "with_group"
         }
     }
 
@@ -1757,7 +1757,7 @@ def export_tree(what, folder,allowed_licenses=None, forbidden_licenses=None,
             # INPUT(Data, ProcessNode) - Reversed
             qb = QueryBuilder()
             qb.append(Data, tag='predecessor', project=['id'])
-            qb.append(ProcessNode, output_of='predecessor',
+            qb.append(ProcessNode, with_incoming='predecessor',
                       filters={'id': {'==': curr_node_id}},
                       edge_filters={
                           'type': {
@@ -1770,7 +1770,7 @@ def export_tree(what, folder,allowed_licenses=None, forbidden_licenses=None,
                 qb = QueryBuilder()
                 qb.append(Data, tag='predecessor', project=['id'],
                           filters={'id': {'==': curr_node_id}})
-                qb.append(ProcessNode, output_of='predecessor',
+                qb.append(ProcessNode, with_incoming='predecessor',
                           edge_filters={
                               'type': {
                                   '==': LinkType.INPUT.value}})
@@ -1781,7 +1781,7 @@ def export_tree(what, folder,allowed_licenses=None, forbidden_licenses=None,
             qb = QueryBuilder()
             qb.append(ProcessNode, tag='predecessor',
                       filters={'id': {'==': curr_node_id}})
-            qb.append(Data, output_of='predecessor', project=['id'],
+            qb.append(Data, with_incoming='predecessor', project=['id'],
                       edge_filters={
                           'type': {
                               'in': [LinkType.CREATE.value,
@@ -1793,7 +1793,7 @@ def export_tree(what, folder,allowed_licenses=None, forbidden_licenses=None,
             if create_reversed:
                 qb = QueryBuilder()
                 qb.append(ProcessNode, tag='predecessor')
-                qb.append(Data, output_of='predecessor', project=['id'],
+                qb.append(Data, with_incoming='predecessor', project=['id'],
                           filters={'id': {'==': curr_node_id}},
                           edge_filters={
                               'type': {
@@ -1805,7 +1805,7 @@ def export_tree(what, folder,allowed_licenses=None, forbidden_licenses=None,
             if return_reversed:
                 qb = QueryBuilder()
                 qb.append(ProcessNode, tag='predecessor')
-                qb.append(Data, output_of='predecessor', project=['id'],
+                qb.append(Data, with_incoming='predecessor', project=['id'],
                           filters={'id': {'==': curr_node_id}},
                           edge_filters={
                               'type': {
@@ -1817,7 +1817,7 @@ def export_tree(what, folder,allowed_licenses=None, forbidden_licenses=None,
             qb = QueryBuilder()
             qb.append(ProcessNode, tag='predecessor',
                       filters={'id': {'==': curr_node_id}})
-            qb.append(ProcessNode, output_of='predecessor', project=['id'],
+            qb.append(ProcessNode, with_incoming='predecessor', project=['id'],
                       edge_filters={
                           'type': {
                               '==': LinkType.CALL.value}})
@@ -1828,7 +1828,7 @@ def export_tree(what, folder,allowed_licenses=None, forbidden_licenses=None,
             if call_reversed:
                 qb = QueryBuilder()
                 qb.append(ProcessNode, tag='predecessor')
-                qb.append(ProcessNode, output_of='predecessor', project=['id'],
+                qb.append(ProcessNode, with_incoming='predecessor', project=['id'],
                           filters={'id': {'==': curr_node_id}},
                           edge_filters={
                               'type': {
@@ -1852,7 +1852,7 @@ def export_tree(what, folder,allowed_licenses=None, forbidden_licenses=None,
             if create_reversed:
                 qb = QueryBuilder()
                 qb.append(ProcessNode, tag='predecessor', project=['id'])
-                qb.append(Data, output_of='predecessor',
+                qb.append(Data, with_incoming='predecessor',
                           filters={'id': {'==': curr_node_id}},
                           edge_filters={
                               'type': {
@@ -2002,7 +2002,7 @@ def export_tree(what, folder,allowed_licenses=None, forbidden_licenses=None,
             links_qb.append(ProcessNode,
                             project=['uuid'], tag='output',
                             edge_filters={'type':{'==':LinkType.INPUT.value}},
-                            edge_project=['label', 'type'], output_of='input')
+                            edge_project=['label', 'type'], with_incoming='input')
             for input_uuid, output_uuid, link_label, link_type in links_qb.iterall():
                 val = {
                     'input': str(input_uuid),
@@ -2020,7 +2020,7 @@ def export_tree(what, folder,allowed_licenses=None, forbidden_licenses=None,
                         project=['uuid'], tag='output',
                         filters={'id': {'in': all_nodes_pk}},
                         edge_filters={'type':{'==':LinkType.INPUT.value}},
-                        edge_project=['label', 'type'], output_of='input')
+                        edge_project=['label', 'type'], with_incoming='input')
         for input_uuid, output_uuid, link_label, link_type in links_qb.iterall():
             val = {
                 'input': str(input_uuid),
@@ -2038,7 +2038,7 @@ def export_tree(what, folder,allowed_licenses=None, forbidden_licenses=None,
         links_qb.append(Data,
                         project=['uuid'], tag='output',
                         edge_filters={'type': {'==': LinkType.CREATE.value}},
-                        edge_project=['label', 'type'], output_of='input')
+                        edge_project=['label', 'type'], with_incoming='input')
         for input_uuid, output_uuid, link_label, link_type in links_qb.iterall():
             val = {
                 'input': str(input_uuid),
@@ -2057,7 +2057,7 @@ def export_tree(what, folder,allowed_licenses=None, forbidden_licenses=None,
             links_qb.append(Data,
                             project=['uuid'], tag='output',
                             edge_filters={'type': {'==': LinkType.CREATE.value}},
-                            edge_project=['label', 'type'], output_of='input')
+                            edge_project=['label', 'type'], with_incoming='input')
             for input_uuid, output_uuid, link_label, link_type in links_qb.iterall():
                 val = {
                     'input': str(input_uuid),
@@ -2075,7 +2075,7 @@ def export_tree(what, folder,allowed_licenses=None, forbidden_licenses=None,
         links_qb.append(Data,
                         project=['uuid'], tag='output',
                         edge_filters={'type': {'==': LinkType.RETURN.value}},
-                        edge_project=['label', 'type'], output_of='input')
+                        edge_project=['label', 'type'], with_incoming='input')
         for input_uuid, output_uuid, link_label, link_type in links_qb.iterall():
             val = {
                 'input': str(input_uuid),
@@ -2094,7 +2094,7 @@ def export_tree(what, folder,allowed_licenses=None, forbidden_licenses=None,
                             project=['uuid'], tag='output',
                             filters={'id': {'in': all_nodes_pk}},
                             edge_filters={'type': {'==': LinkType.RETURN.value}},
-                            edge_project=['label', 'type'], output_of='input')
+                            edge_project=['label', 'type'], with_incoming='input')
             for input_uuid, output_uuid, link_label, link_type in links_qb.iterall():
                 val = {
                     'input': str(input_uuid),
@@ -2113,7 +2113,7 @@ def export_tree(what, folder,allowed_licenses=None, forbidden_licenses=None,
         links_qb.append(ProcessNode,
                         project=['uuid'], tag='output',
                         edge_filters={'type': {'==': LinkType.CALL.value}},
-                        edge_project=['label', 'type'], output_of='input')
+                        edge_project=['label', 'type'], with_incoming='input')
         for input_uuid, output_uuid, link_label, link_type in links_qb.iterall():
             val = {
                 'input': str(input_uuid),
@@ -2133,7 +2133,7 @@ def export_tree(what, folder,allowed_licenses=None, forbidden_licenses=None,
                             project=['uuid'], tag='output',
                             filters={'id': {'in': all_nodes_pk}},
                             edge_filters={'type': {'==': LinkType.CALL.value}},
-                            edge_project=['label', 'type'], output_of='input')
+                            edge_project=['label', 'type'], with_incoming='input')
             for input_uuid, output_uuid, link_label, link_type in links_qb.iterall():
                 val = {
                     'input': str(input_uuid),
@@ -2156,7 +2156,7 @@ def export_tree(what, folder,allowed_licenses=None, forbidden_licenses=None,
                                  filters={'id': {'==': curr_group}},
                                  project=['uuid'], tag='group')
             group_uuid_qb.append(entity_names_to_entities[NODE_ENTITY_NAME],
-                                 project=['uuid'], member_of='group')
+                                 project=['uuid'], with_group='group')
             for res in group_uuid_qb.iterall():
                 if str(res[0]) in groups_uuid:
                     groups_uuid[str(res[0])].append(str(res[1]))

--- a/aiida/orm/node/process/calculation/calcjob.py
+++ b/aiida/orm/node/process/calculation/calcjob.py
@@ -659,6 +659,7 @@ class CalcJobNode(CalculationNode):
 
         :param str val: the queue name
         """
+        from aiida.common.warnings import AiidaDeprecationWarning as DeprecationWarning  # pylint: disable=redefined-builtin
         warnings.warn('explicit option getter/setter methods are deprecated, use get_option and set_option',
                       DeprecationWarning)
         if val is not None:
@@ -670,6 +671,7 @@ class CalcJobNode(CalculationNode):
 
         :param str val: the account name
         """
+        from aiida.common.warnings import AiidaDeprecationWarning as DeprecationWarning  # pylint: disable=redefined-builtin
         warnings.warn('explicit option getter/setter methods are deprecated, use get_option and set_option',
                       DeprecationWarning)
         if val is not None:
@@ -681,6 +683,7 @@ class CalcJobNode(CalculationNode):
 
         :param str val: the quality of service
         """
+        from aiida.common.warnings import AiidaDeprecationWarning as DeprecationWarning  # pylint: disable=redefined-builtin
         warnings.warn('explicit option getter/setter methods are deprecated, use get_option and set_option',
                       DeprecationWarning)
         if val is not None:
@@ -693,6 +696,7 @@ class CalcJobNode(CalculationNode):
 
         :param bool val: load the environment if True
         """
+        from aiida.common.warnings import AiidaDeprecationWarning as DeprecationWarning  # pylint: disable=redefined-builtin
         warnings.warn('explicit option getter/setter methods are deprecated, use get_option and set_option',
                       DeprecationWarning)
         self._set_attr('import_sys_environment', bool(val))
@@ -704,6 +708,7 @@ class CalcJobNode(CalculationNode):
 
         :return: a boolean. If True the system environment will be load.
         """
+        from aiida.common.warnings import AiidaDeprecationWarning as DeprecationWarning  # pylint: disable=redefined-builtin
         warnings.warn('explicit option getter/setter methods are deprecated, use get_option and set_option',
                       DeprecationWarning)
         return self.get_attr('import_sys_environment', True)
@@ -717,6 +722,7 @@ class CalcJobNode(CalculationNode):
         In the remote-computer submission script, it's going to export
         variables as ``export 'keys'='values'``
         """
+        from aiida.common.warnings import AiidaDeprecationWarning as DeprecationWarning  # pylint: disable=redefined-builtin
         warnings.warn('explicit option getter/setter methods are deprecated, use get_option and set_option',
                       DeprecationWarning)
         if not isinstance(env_vars_dict, dict):
@@ -738,6 +744,7 @@ class CalcJobNode(CalculationNode):
         Return an empty dictionary if no special environment variables have
         to be set for this calculation.
         """
+        from aiida.common.warnings import AiidaDeprecationWarning as DeprecationWarning  # pylint: disable=redefined-builtin
         warnings.warn('explicit option getter/setter methods are deprecated, use get_option and set_option',
                       DeprecationWarning)
         return self.get_attr('custom_environment_variables', {})
@@ -748,6 +755,7 @@ class CalcJobNode(CalculationNode):
 
         :param val: the values of priority as accepted by the cluster scheduler.
         """
+        from aiida.common.warnings import AiidaDeprecationWarning as DeprecationWarning  # pylint: disable=redefined-builtin
         warnings.warn('explicit option getter/setter methods are deprecated, use get_option and set_option',
                       DeprecationWarning)
         self._set_attr('priority', six.text_type(val))
@@ -758,6 +766,7 @@ class CalcJobNode(CalculationNode):
 
         :param val: an integer. Default=None
         """
+        from aiida.common.warnings import AiidaDeprecationWarning as DeprecationWarning  # pylint: disable=redefined-builtin
         warnings.warn('explicit option getter/setter methods are deprecated, use get_option and set_option',
                       DeprecationWarning)
         self._set_attr('max_memory_kb', int(val))
@@ -768,6 +777,7 @@ class CalcJobNode(CalculationNode):
 
         :return: an integer
         """
+        from aiida.common.warnings import AiidaDeprecationWarning as DeprecationWarning  # pylint: disable=redefined-builtin
         warnings.warn('explicit option getter/setter methods are deprecated, use get_option and set_option',
                       DeprecationWarning)
         return self.get_attr('max_memory_kb', None)
@@ -778,6 +788,7 @@ class CalcJobNode(CalculationNode):
 
         :param val: An integer. Default=None
         """
+        from aiida.common.warnings import AiidaDeprecationWarning as DeprecationWarning  # pylint: disable=redefined-builtin
         warnings.warn('explicit option getter/setter methods are deprecated, use get_option and set_option',
                       DeprecationWarning)
         self._set_attr('max_wallclock_seconds', int(val))
@@ -789,6 +800,7 @@ class CalcJobNode(CalculationNode):
         :return: an integer
         :rtype: int
         """
+        from aiida.common.warnings import AiidaDeprecationWarning as DeprecationWarning  # pylint: disable=redefined-builtin
         warnings.warn('explicit option getter/setter methods are deprecated, use get_option and set_option',
                       DeprecationWarning)
         return self.get_attr('max_wallclock_seconds', None)
@@ -802,6 +814,7 @@ class CalcJobNode(CalculationNode):
         (scheduler type can be found with
         calc.get_computer().get_scheduler_type() )
         """
+        from aiida.common.warnings import AiidaDeprecationWarning as DeprecationWarning  # pylint: disable=redefined-builtin
         warnings.warn('explicit option getter/setter methods are deprecated, use get_option and set_option',
                       DeprecationWarning)
         # Note: for the time being, resources are only validated during the
@@ -816,6 +829,7 @@ class CalcJobNode(CalculationNode):
 
         :param val: A boolean. Default=True
         """
+        from aiida.common.warnings import AiidaDeprecationWarning as DeprecationWarning  # pylint: disable=redefined-builtin
         warnings.warn('explicit option getter/setter methods are deprecated, use get_option and set_option',
                       DeprecationWarning)
         self._set_attr('withmpi', val)
@@ -826,6 +840,7 @@ class CalcJobNode(CalculationNode):
 
         :return: a boolean. Default=True.
         """
+        from aiida.common.warnings import AiidaDeprecationWarning as DeprecationWarning  # pylint: disable=redefined-builtin
         warnings.warn('explicit option getter/setter methods are deprecated, use get_option and set_option',
                       DeprecationWarning)
         return self.get_attr('withmpi', True)
@@ -839,6 +854,7 @@ class CalcJobNode(CalculationNode):
 
         :return: a dictionary
         """
+        from aiida.common.warnings import AiidaDeprecationWarning as DeprecationWarning  # pylint: disable=redefined-builtin
         warnings.warn('explicit option getter/setter methods are deprecated, use get_option and set_option',
                       DeprecationWarning)
         resources_dict = self.get_attr('jobresource_params', {})
@@ -857,6 +873,7 @@ class CalcJobNode(CalculationNode):
 
         :return: a string or None.
         """
+        from aiida.common.warnings import AiidaDeprecationWarning as DeprecationWarning  # pylint: disable=redefined-builtin
         warnings.warn('explicit option getter/setter methods are deprecated, use get_option and set_option',
                       DeprecationWarning)
         return self.get_attr('queue_name', None)
@@ -867,6 +884,7 @@ class CalcJobNode(CalculationNode):
 
         :return: a string or None.
         """
+        from aiida.common.warnings import AiidaDeprecationWarning as DeprecationWarning  # pylint: disable=redefined-builtin
         warnings.warn('explicit option getter/setter methods are deprecated, use get_option and set_option',
                       DeprecationWarning)
         return self.get_attr('account', None)
@@ -877,6 +895,7 @@ class CalcJobNode(CalculationNode):
 
         :return: a string or None.
         """
+        from aiida.common.warnings import AiidaDeprecationWarning as DeprecationWarning  # pylint: disable=redefined-builtin
         warnings.warn('explicit option getter/setter methods are deprecated, use get_option and set_option',
                       DeprecationWarning)
         return self.get_attr('qos', None)
@@ -887,6 +906,7 @@ class CalcJobNode(CalculationNode):
 
         :return: a string or None
         """
+        from aiida.common.warnings import AiidaDeprecationWarning as DeprecationWarning  # pylint: disable=redefined-builtin
         warnings.warn('explicit option getter/setter methods are deprecated, use get_option and set_option',
                       DeprecationWarning)
         return self.get_attr('priority', None)
@@ -897,6 +917,7 @@ class CalcJobNode(CalculationNode):
         which is going to be prepended in the scheduler-job script, just before
         the code execution.
         """
+        from aiida.common.warnings import AiidaDeprecationWarning as DeprecationWarning  # pylint: disable=redefined-builtin
         warnings.warn('explicit option getter/setter methods are deprecated, use get_option and set_option',
                       DeprecationWarning)
         return self.get_attr("prepend_text", "")
@@ -911,6 +932,7 @@ class CalcJobNode(CalculationNode):
 
         :param val: a (possibly multiline) string
         """
+        from aiida.common.warnings import AiidaDeprecationWarning as DeprecationWarning  # pylint: disable=redefined-builtin
         warnings.warn('explicit option getter/setter methods are deprecated, use get_option and set_option',
                       DeprecationWarning)
         self._set_attr("prepend_text", six.text_type(val))
@@ -921,6 +943,7 @@ class CalcJobNode(CalculationNode):
         which is going to be appended in the scheduler-job script, just after
         the code execution.
         """
+        from aiida.common.warnings import AiidaDeprecationWarning as DeprecationWarning  # pylint: disable=redefined-builtin
         warnings.warn('explicit option getter/setter methods are deprecated, use get_option and set_option',
                       DeprecationWarning)
         return self.get_attr("append_text", "")
@@ -933,6 +956,7 @@ class CalcJobNode(CalculationNode):
 
         :param val: a (possibly multiline) string
         """
+        from aiida.common.warnings import AiidaDeprecationWarning as DeprecationWarning  # pylint: disable=redefined-builtin
         warnings.warn('explicit option getter/setter methods are deprecated, use get_option and set_option',
                       DeprecationWarning)
         self._set_attr("append_text", six.text_type(val))
@@ -947,6 +971,7 @@ class CalcJobNode(CalculationNode):
         inserted: with this method, the string is inserted before any
         non-scheduler command.
         """
+        from aiida.common.warnings import AiidaDeprecationWarning as DeprecationWarning  # pylint: disable=redefined-builtin
         warnings.warn('explicit option getter/setter methods are deprecated, use get_option and set_option',
                       DeprecationWarning)
         self._set_attr("custom_scheduler_commands", six.text_type(val))
@@ -961,6 +986,7 @@ class CalcJobNode(CalculationNode):
         :return: the custom scheduler command, or an empty string if no
           custom command was defined.
         """
+        from aiida.common.warnings import AiidaDeprecationWarning as DeprecationWarning  # pylint: disable=redefined-builtin
         warnings.warn('explicit option getter/setter methods are deprecated, use get_option and set_option',
                       DeprecationWarning)
         return self.get_attr("custom_scheduler_commands", "")
@@ -974,6 +1000,7 @@ class CalcJobNode(CalculationNode):
 
         Return an empty list if no parameters have been defined.
         """
+        from aiida.common.warnings import AiidaDeprecationWarning as DeprecationWarning  # pylint: disable=redefined-builtin
         warnings.warn('explicit option getter/setter methods are deprecated, use get_option and set_option',
                       DeprecationWarning)
         return self.get_attr("mpirun_extra_params", [])
@@ -988,6 +1015,7 @@ class CalcJobNode(CalculationNode):
         :param extra_params: must be a list of strings, one for each
             extra parameter
         """
+        from aiida.common.warnings import AiidaDeprecationWarning as DeprecationWarning  # pylint: disable=redefined-builtin
         warnings.warn('explicit option getter/setter methods are deprecated, use get_option and set_option',
                       DeprecationWarning)
         if extra_params is None:
@@ -1014,6 +1042,7 @@ class CalcJobNode(CalculationNode):
         :param parser: a string identifying the module of the parser.
               Such module must be located within the folder 'aiida/parsers/plugins'
         """
+        from aiida.common.warnings import AiidaDeprecationWarning as DeprecationWarning  # pylint: disable=redefined-builtin
         warnings.warn('explicit option getter/setter methods are deprecated, use get_option and set_option',
                       DeprecationWarning)
         self._set_attr('parser', parser)
@@ -1026,6 +1055,7 @@ class CalcJobNode(CalculationNode):
 
         :return: a string.
         """
+        from aiida.common.warnings import AiidaDeprecationWarning as DeprecationWarning  # pylint: disable=redefined-builtin
         warnings.warn('explicit option getter/setter methods are deprecated, use get_option and set_option',
                       DeprecationWarning)
 
@@ -1487,10 +1517,10 @@ class CalcJobNode(CalculationNode):
         qb.append(cls, filters=calculation_filters, tag='calculation')
 
         if group_filters is not None:
-            qb.append(type='group', filters=group_filters, group_of='calculation')
+            qb.append(type='group', filters=group_filters, with_node='calculation')
 
-        qb.append(type='computer', computer_of='calculation', tag='computer')
-        qb.append(type='user', creator_of="calculation", tag="user")
+        qb.append(type='computer', with_node='calculation', tag='computer')
+        qb.append(type='user', with_node="calculation", tag="user")
 
         projections_dict = {'calculation': [], 'user': [], 'computer': []}
 
@@ -1698,8 +1728,8 @@ class CalcJobNode(CalculationNode):
 
         qb = QueryBuilder()
         qb.append(type="computer", tag='computer', filters=computerfilter)
-        qb.append(cls, filters=calcfilter, tag='calc', has_computer='computer')
-        qb.append(type="user", tag='user', filters=userfilter, creator_of="calc")
+        qb.append(cls, filters=calcfilter, tag='calc', with_computer='computer')
+        qb.append(type="user", tag='user', filters=userfilter, with_node="calc")
 
         if only_computer_user_pairs:
             qb.add_projection("computer", "*")
@@ -1759,6 +1789,7 @@ class CalcJobNode(CalculationNode):
         import warnings
         from aiida.work.job_processes import ContinueCalcJob
         from aiida.work.launch import submit
+        from aiida.common.warnings import AiidaDeprecationWarning as DeprecationWarning  # pylint: disable=redefined-builtin
         warnings.warn('directly creating and submitting calculations is deprecated, use the {}\nSee:{}'.format(
             'ProcessBuilder', DEPRECATION_DOCS_URL), DeprecationWarning)
 

--- a/aiida/orm/querybuilder.py
+++ b/aiida/orm/querybuilder.py
@@ -1476,7 +1476,8 @@ class QueryBuilder(object):
 
     def _get_function_map(self):
         d = {
-            'input_of': self._join_inputs,
+            'with_incoming': self._join_outputs,
+            'input_of': deprecate(self._join_inputs, xxx),
             'output_of': self._join_outputs,
             'slave_of': self._join_slaves,  # not implemented
             'master_of': self._join_masters,  # not implemented
@@ -1494,6 +1495,11 @@ class QueryBuilder(object):
         }
         return d
 
+    def deprecate(f, xxx):
+        import warning
+        warning.warn()
+        return f
+    
     def _get_connecting_node(self, index, joining_keyword=None, joining_value=None, **kwargs):
         """
         :param querydict:

--- a/aiida/orm/utils/loaders.py
+++ b/aiida/orm/utils/loaders.py
@@ -420,7 +420,7 @@ class CodeEntityLoader(OrmEntityLoader):
         qb.append(cls=classes, tag='code', project=['*'], filters={'label': {'==': label}})
 
         if machinename:
-            qb.append(Computer, filters={'name': {'==': machinename}}, computer_of='code')
+            qb.append(Computer, filters={'name': {'==': machinename}}, with_node='code')
 
         return qb
 

--- a/aiida/orm/utils/remote.py
+++ b/aiida/orm/utils/remote.py
@@ -79,8 +79,8 @@ def get_calcjob_remote_paths(pks=None, past_days=None, older_than=None, computer
 
     qb = orm.QueryBuilder()
     qb.append(CalcJobNode, tag='calc', project=['attributes.remote_workdir'], filters=filters_calc)
-    qb.append(orm.Computer, computer_of='calc', tag='computer', project=['*'], filters=filters_computer)
-    qb.append(orm.User, creator_of='calc', filters={'email': user.email})
+    qb.append(orm.Computer, with_node='calc', tag='computer', project=['*'], filters=filters_computer)
+    qb.append(orm.User, with_node='calc', filters={'email': user.email})
 
     if qb.count() == 0:
         return None

--- a/aiida/restapi/translator/base.py
+++ b/aiida/restapi/translator/base.py
@@ -93,7 +93,7 @@ class BaseTranslator(object):
         self._query_help = {
             "path": [{
                 "type": self._qb_type,
-                "label": self.__label__
+                "tag": self.__label__
             }],
             "filters": {},
             "project": {},
@@ -462,9 +462,9 @@ class BaseTranslator(object):
             results = [res[label] for res in self.qbobj.dict()]
 
         # TODO think how to make it less hardcoded
-        if self._result_type == 'input_of':
+        if self._result_type == 'with_outgoing':
             return {'inputs': results}
-        elif self._result_type == 'output_of':
+        elif self._result_type == 'with_incoming':
             return {'outputs': results}
 
         return {self.__label__: results}

--- a/aiida/restapi/translator/node.py
+++ b/aiida/restapi/translator/node.py
@@ -145,9 +145,9 @@ class NodeTranslator(BaseTranslator):
         if query_type == "default":
             pass
         elif query_type == "inputs":
-            self._result_type = 'input_of'
+            self._result_type = 'with_outgoing'
         elif query_type == "outputs":
-            self._result_type = "output_of"
+            self._result_type = "with_incoming"
         elif query_type == "attributes":
             self._content_type = "attributes"
             self._alist = alist
@@ -174,10 +174,10 @@ class NodeTranslator(BaseTranslator):
             raise InputValidationError("invalid result/content value: {}".format(query_type))
 
         ## Add input/output relation to the query help
-        if self._result_type is not self.__label__:
+        if self._result_type != self.__label__:
             self._query_help["path"].append({
                 "type": "node.Node.",
-                "label": self._result_type,
+                "tag": self._result_type,
                 self._result_type: self.__label__
             })
 
@@ -606,7 +606,7 @@ class NodeTranslator(BaseTranslator):
         # get all inputs
         qb_obj = QueryBuilder()
         qb_obj.append(Node, tag="main", project=['*'], filters=self._id_filter)
-        qb_obj.append(Node, tag="in", project=['*'], edge_project=['label'], input_of='main')
+        qb_obj.append(Node, tag="in", project=['*'], edge_project=['label'], with_outgoing='main')
 
         if qb_obj.count() > 0:
             for node_input in qb_obj.iterdict():
@@ -645,7 +645,7 @@ class NodeTranslator(BaseTranslator):
         # get all outputs
         qb_obj = QueryBuilder()
         qb_obj.append(Node, tag="main", project=['*'], filters=self._id_filter)
-        qb_obj.append(Node, tag="out", project=['*'], edge_project=['label'], output_of='main')
+        qb_obj.append(Node, tag="out", project=['*'], edge_project=['label'], with_incoming='main')
         if qb_obj.count() > 0:
             for output in qb_obj.iterdict():
                 node = output['out']['*']

--- a/aiida/settings.py
+++ b/aiida/settings.py
@@ -27,17 +27,17 @@ if settings.AIIDADB_PROFILE is None:
     raise ConfigurationError("AIIDADB_PROFILE not defined, did you load django "
                              "through the AiiDA load_dbenv()?")
 
-profile_conf = get_profile_config(settings.AIIDADB_PROFILE, conf_dict=confs)
+PROFILE_CONF = get_profile_config(settings.AIIDADB_PROFILE, conf_dict=confs)
 
 # put all database specific portions of settings here
-BACKEND = profile_conf.get('AIIDADB_BACKEND', 'django')
-DBENGINE = profile_conf.get('AIIDADB_ENGINE', '')
-DBNAME = profile_conf.get('AIIDADB_NAME', '')
-DBUSER = profile_conf.get('AIIDADB_USER', '')
-DBPASS = profile_conf.get('AIIDADB_PASS', '')
-DBHOST = profile_conf.get('AIIDADB_HOST', '')
-DBPORT = profile_conf.get('AIIDADB_PORT', '')
-REPOSITORY_URI = profile_conf.get('AIIDADB_REPOSITORY_URI', '')
+BACKEND = PROFILE_CONF.get('AIIDADB_BACKEND', 'django')
+DBENGINE = PROFILE_CONF.get('AIIDADB_ENGINE', '')
+DBNAME = PROFILE_CONF.get('AIIDADB_NAME', '')
+DBUSER = PROFILE_CONF.get('AIIDADB_USER', '')
+DBPASS = PROFILE_CONF.get('AIIDADB_PASS', '')
+DBHOST = PROFILE_CONF.get('AIIDADB_HOST', '')
+DBPORT = PROFILE_CONF.get('AIIDADB_PORT', '')
+REPOSITORY_URI = PROFILE_CONF.get('AIIDADB_REPOSITORY_URI', '')
 
 
 # Checks on the REPOSITORY_* variables

--- a/aiida/tools/dbimporters/plugins/test_icsd.py
+++ b/aiida/tools/dbimporters/plugins/test_icsd.py
@@ -41,13 +41,13 @@ def has_icsd_config():
     :return: True if the currently loaded profile has a ICSD configuration
     """
 
-    from aiida.settings import profile_conf
+    from aiida.settings import PROFILE_CONF
 
     required_keywords = {
         'ICSD_SERVER_URL', 'ICSD_MYSQL_HOST', 'ICSD_MYSQL_USER', 'ICSD_MYSQL_PASSWORD', 'ICSD_MYSQL_DB'
     }
 
-    return required_keywords <= set(profile_conf.keys())
+    return required_keywords <= set(PROFILE_CONF.keys())
 
 
 @unittest.skipUnless(has_mysqldb() and has_icsd_config(), "ICSD configuration in profile required")
@@ -60,14 +60,14 @@ class TestIcsd(AiidaTestCase):
         """
         Set up IcsdDbImporter for web and mysql db query.
         """
-        from aiida.settings import profile_conf
+        from aiida.settings import PROFILE_CONF
 
-        self.server = profile_conf['ICSD_SERVER_URL']
-        self.host = profile_conf['ICSD_MYSQL_HOST']
-        self.user = profile_conf['ICSD_MYSQL_USER']
-        self.password = profile_conf['ICSD_MYSQL_PASSWORD']
-        self.dbname = profile_conf['ICSD_MYSQL_DB']
-        self.dbport = profile_conf.get('ICSD_MYSQL_PORT', 3306)
+        self.server = PROFILE_CONF['ICSD_SERVER_URL']
+        self.host = PROFILE_CONF['ICSD_MYSQL_HOST']
+        self.user = PROFILE_CONF['ICSD_MYSQL_USER']
+        self.password = PROFILE_CONF['ICSD_MYSQL_PASSWORD']
+        self.dbname = PROFILE_CONF['ICSD_MYSQL_DB']
+        self.dbport = PROFILE_CONF.get('ICSD_MYSQL_PORT', 3306)
 
         self.importerdb = icsd.IcsdDbImporter(server=self.server, host=self.host)
         self.importerweb = icsd.IcsdDbImporter(server=self.server, host=self.host, querydb=False)

--- a/aiida/tools/dbimporters/plugins/test_materialsproject.py
+++ b/aiida/tools/dbimporters/plugins/test_materialsproject.py
@@ -21,8 +21,8 @@ from aiida.backends.testbase import AiidaTestCase
 
 
 def run_materialsproject_api_tests():
-    from aiida.settings import profile_conf
-    return profile_conf.get('run_materialsproject_api_tests', False)
+    from aiida.settings import PROFILE_CONF
+    return PROFILE_CONF.get('run_materialsproject_api_tests', False)
 
 
 class TestMaterialsProject(AiidaTestCase):

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -390,7 +390,7 @@ epub_copyright = copyright
 
 # Warnings to ignore when using the -n (nitpicky) option
 # We should ignore any python built-in exception, for instance
-nitpick_ignore = []
+nitpick_ignore = [('py:class','Warning'), ('py:class', 'exceptions.Warning')]
 
 for line in open('nitpick-exceptions'):
     if line.strip() == "" or line.startswith("#"):

--- a/docs/source/developer_guide/developers.rst
+++ b/docs/source/developer_guide/developers.rst
@@ -474,13 +474,23 @@ In case a method is renamed or removed, this is the procedure to follow:
 
      import warnings
 
-     warnings.warn(
-         "OLDMETHODNAME is deprecated, use NEWMETHODNAME instead",
-         DeprecationWarning)
+     # If we call this DeprecationWarning, pycharm will properly strike out the function
+     from aiida.common.warnings import AiidaDeprecationWarning as DeprecationWarning  # pylint: disable=redefined-builtin
+     warnings.warn("<Deprecation warning here - MAKE IT SPECIFIC TO THIS DEPRECATION, as it will be shown only once per different message>", DeprecationWarning)
+        
+     # <REST OF THE FUNCTION HERE>
+ 
+   (of course replace the parts between ``< >`` symbols with the
+   correct strings).
 
-   (of course, replace ``OLDMETHODNAME`` and ``NEWMETHODNAME`` with the
-   correct string, and adapt the strings to the correct content if you are
-   only removing a function, or just adding a new one).
+   The advantage of the method above is:
+
+   - pycharm will still show the method crossed out
+   - Our ``AiidaDeprecationWarning`` does not inherit from ``DeprecationWarning``, so it will not be "hidden" by python
+   - User can disable our warnings (and only those) by using AiiDA
+     properties with::
+       
+       verdi devel setproperty warnings.showdeprecations False
 
 Changing the config.json structure
 ++++++++++++++++++++++++++++++++++

--- a/docs/source/link_types/index.rst
+++ b/docs/source/link_types/index.rst
@@ -65,7 +65,7 @@ The links can be followed in both possible directions (forward & reverse) using
 the QueryBuilder. This requires to define additional “names” for each direction
 of the link, and they are documented at the
 :doc:`QueryBuilder section <../querying/querybuilder/usage>`. For example,
-if there is an **INPUT** link from data D to calculation C, D is the
-“input_of” C, or equivalently D is the “output_of” C. Currently, in the
-QueryBuilder, input_of and output_of refer to any link type, where C is the
-head of the arrow and D is the tail.
+if there is an **INPUT** link from data D to calculation C, D is “with_outgoing” C, 
+or equivalently C is "with_incoming” D. Currently, in the QueryBuilder, with_incoming 
+and with_outgoing refer to any link type, where C is the head of the arrow and 
+D is the tail.

--- a/docs/source/querying/querybuilder/usage.rst
+++ b/docs/source/querying/querybuilder/usage.rst
@@ -273,7 +273,7 @@ Let's join a node to its output, e.g. StructureData and CalcJobNode (as output):
 
     qb = QueryBuilder()
     qb.append(StructureData, tag='structure')
-    qb.append(CalcJobNode, output_of='structure')
+    qb.append(CalcJobNode, with_incoming='structure')
 
 In above example we are querying structures and calculations, with the predicate that the
 calculation is an output of the structure (the same as saying that the structure is an input to the calculation)
@@ -285,33 +285,33 @@ to a previous entity by using one of the keywords in the above table
 and as a value the tag of the vertice that it has a relationship with.
 There are several relationships that entities in Aiida can have:
 
-+------------------+---------------+------------------+-------------------------------------------------+
-| **Entity from**  | **Entity to** | **Relationship** | **Explanation**                                 |
-+==================+===============+==================+=================================================+
-| Node             | Node          | *input_of*       | One node as input of another node               |
-+------------------+---------------+------------------+-------------------------------------------------+
-| Node             | Node          | *output_of*      | One node as output of another node              |
-+------------------+---------------+------------------+-------------------------------------------------+
-| Node             | Node          | *ancestor_of*    | One node as the ancestor of another node (Path) |
-+------------------+---------------+------------------+-------------------------------------------------+
-| Node             | Node          | *descendant_of*  | One node as descendant of another node (Path)   |
-+------------------+---------------+------------------+-------------------------------------------------+
-| Node             | Group         | *group_of*       | The group of a node                             |
-+------------------+---------------+------------------+-------------------------------------------------+
-| Group            | Node          | *member_of*      | The node is a member of a group                 |
-+------------------+---------------+------------------+-------------------------------------------------+
-| Node             | Computer      | *computer_of*    | The computer of a node                          |
-+------------------+---------------+------------------+-------------------------------------------------+
-| Computer         | Node          | *has_computer*   | The node of a computer                          |
-+------------------+---------------+------------------+-------------------------------------------------+
-| Node             | User          | *creator_of*     | The creator of a node is a user                 |
-+------------------+---------------+------------------+-------------------------------------------------+
-| User             | Node          | *created_by*     | The node was created by a user                  |
-+------------------+---------------+------------------+-------------------------------------------------+
-| User             | Group         | *belongs_to*     | The node was created by a user                  |
-+------------------+---------------+------------------+-------------------------------------------------+
-| Group            | User          | *owner_of*       | The node was created by a user                  |
-+------------------+---------------+------------------+-------------------------------------------------+
++------------------+---------------+------------------+-----------------------------+-------------------------------------------------+
+| **Entity from**  | **Entity to** | **Relationship** | **Deprecated Relationship** | **Explanation**                                 |
++==================+===============+==================+=============================+=================================================+
+| Node             | Node          | *with_outgoing*  | *input_of*                  | One node as input of another node               |
++------------------+---------------+------------------+-----------------------------+-------------------------------------------------+
+| Node             | Node          | *with_incoming*  | *output_of*                 | One node as output of another node              |
++------------------+---------------+------------------+-----------------------------+-------------------------------------------------+
+| Node             | Node          | *ancestor_of*    |                             | One node as the ancestor of another node (Path) |
++------------------+---------------+------------------+-----------------------------+-------------------------------------------------+
+| Node             | Node          | *descendant_of*  |                             | One node as descendant of another node (Path)   |
++------------------+---------------+------------------+-----------------------------+-------------------------------------------------+
+| Node             | Group         | *with_node*      | *group_of*                  | The group of a node                             |
++------------------+---------------+------------------+-----------------------------+-------------------------------------------------+
+| Group            | Node          | *with_group*     | *member_of*                 | The node is a member of a group                 |
++------------------+---------------+------------------+-----------------------------+-------------------------------------------------+
+| Node             | Computer      | *with_node*      | *computer_of*               | The computer of a node                          |
++------------------+---------------+------------------+-----------------------------+-------------------------------------------------+
+| Computer         | Node          | *with_computer*  | *has_computer*              | The node of a computer                          |
++------------------+---------------+------------------+-----------------------------+-------------------------------------------------+
+| Node             | User          | *with_node*      | *creator_of*                | The creator of a node is a user                 |
++------------------+---------------+------------------+-----------------------------+-------------------------------------------------+
+| User             | Node          | *with_user*      | *created_by*                | The node was created by a user                  |
++------------------+---------------+------------------+-----------------------------+-------------------------------------------------+
+| User             | Group         | *with_user*      | *belongs_to*                | The node was created by a user                  |
++------------------+---------------+------------------+-----------------------------+-------------------------------------------------+
+| Group            | User          | *with_group*     | *owner_of*                  | The node was created by a user                  |
++------------------+---------------+------------------+-----------------------------+-------------------------------------------------+
 
 
 Some more examples::
@@ -319,18 +319,18 @@ Some more examples::
     # StructureData as an input of a job calculation
     qb = QueryBuilder()
     qb.append(CalcJobNode, tag='calc')
-    qb.append(StructureData, input_of='calc')
+    qb.append(StructureData, with_outgoing='calc')
 
     # StructureData and ParameterData as inputs to a calculation
     qb = QueryBuilder()
     qb.append(CalcJobNode, tag='calc')
-    qb.append(StructureData, input_of='calc')
-    qb.append(ParameterDataData, input_of='calc')
+    qb.append(StructureData, with_outgoing='calc')
+    qb.append(ParameterDataData, with_outgoing='calc')
 
     # Filtering the remote data instance by the computer it ran on (name)
     qb = QueryBuilder()
     qb.append(RemoteData, tag='remote')
-    qb.append(Computer, computer_of='remote', filters={'name':{'==':'mycomputer'}})
+    qb.append(Computer, with_node='remote', filters={'name':{'==':'mycomputer'}})
 
     # Find all descendants of a structure with a certain uuid
     qb = QueryBuilder()
@@ -524,7 +524,7 @@ for the wavefunctions has a value above 30.0 Ry::
     qb.append(PwCalculation, project=['*'], tag='calc')
     qb.append(
         ParameterData,
-        input_of='calc',
+        with_outgoing='calc',
         filters={'attributes.SYSTEM.ecutwfc':{'>':30.0}},
         project=[
             'attributes.SYSTEM.ecutwfc',
@@ -567,14 +567,14 @@ You need to tell the QueryBuilder that::
     )
     qb.append(
         PwCalculation,
-        output_of='strucure',
+        with_incoming='strucure',
         project=['*'],
         tag='calc'
     )
     qb.append(
         ParameterData,
         filters={'attributes.SYSTEM.ecutwfc':{'>':30.0}},
-        input_of='calc',
+        with_outgoing='calc',
         tag='params'
     )
 
@@ -587,7 +587,7 @@ Cheats
 A few cheats to save some typing:
 
 *   The default edge specification, if no keyword is provided, is always
-    *output_of* the previous vertice.
+    *with_incoming* the previous vertice.
 *   Equality filters ('==') can be shortened, as will be shown below.
 *   Tags are not necessary, you can simply use the class as a label.
     This works as long as the same Aiida-class is not used again
@@ -606,7 +606,7 @@ A shorter version of the previous example::
     qb.append(
         ParameterData,
         filters={'attributes.SYSTEM.ecutwfc':{'>':30.0}},
-        input_of=PwCalculation
+        with_outgoing=PwCalculation
     )
 
 
@@ -722,8 +722,7 @@ Working with edges
 Another feature that had to be added are projections, filters and labels on
 the edges of the graphs, that is to say links or paths between nodes.
 It works the same way, just that the keyword is preceeded by '*link*'.
-Let's take the above example, but put a filter on the label of the link,
-project the label and label::
+Let's take the above example, but put a filter on the label of the link and project the link label::
 
     qb = QueryBuilder()
     qb.append(
@@ -864,16 +863,16 @@ What do you have to specify:
         of the path with tag "struc1"::
 
             edge_specification = queryhelp['path'][3]
-            edge_specification['output_of'] = 2
-            edge_specification['output_of'] = StructureData
-            edge_specification['output_of'] = 'struc1'
-            edge_specification['input_of']  = 2
-            edge_specification['input_of']  = StructureData
-            edge_specification['input_of']  = 'struc1'
+            edge_specification['with_incoming'] = 2
+            edge_specification['with_incoming'] = StructureData
+            edge_specification['with_incoming'] = 'struc1'
+            edge_specification['with_outgoing']  = 2
+            edge_specification['with_outgoing']  = StructureData
+            edge_specification['with_outgoing']  = 'struc1'
 
     *   queryhelp_item['direction'] = integer
 
-        If any of the above specs ("input_of", "output_of")
+        If any of the above specs ("with_outgoing", "with_incoming")
         were not specified, the key "direction" is looked for.
         Directions are defined as distances in the tree.
         1 is defined as one step down the tree along a link.
@@ -915,7 +914,7 @@ What do you have to specify:
                     },
                     {
                         'cls':ParameterData,
-                        'input_of':PwCalculation
+                        'with_outgoing':PwCalculation
                     }
                 ]
             }
@@ -1035,9 +1034,9 @@ What do you have to specify:
 .. ~             ParameterData,
 .. ~             {'cls':PwCalculation, 'tag':'md'},
 .. ~             {'cls':Trajectory},
-.. ~             {'cls':StructureData, 'input_of':'md'},
-.. ~             {'cls':Relax, 'input_of':StructureData},
-.. ~             {'cls':StructureData,'tag':'struc2','input_of':Relax}
+.. ~             {'cls':StructureData, 'with_outgoing':'md'},
+.. ~             {'cls':Relax, 'with_outgoing':StructureData},
+.. ~             {'cls':StructureData,'tag':'struc2','with_outgoing':Relax}
 .. ~         ],
 .. ~         'project':{
 .. ~             ParameterData:{'attributes.IONS.tempw':{'cast':'f'}},
@@ -1119,14 +1118,14 @@ Let's take an example that we had and add a few filters on the link::
         }
     }
 
-Notice that the label for the link, by default, is the labels of the two connecting
+Notice that the tag for the link, by default, is the tag of the two connecting
 nodes delimited by two dashes '--'.
 The order does not matter, the following queryhelp would results in the same query::
 
     queryhelp = {
         'path':[
-            {'cls':Relax, 'label':'relax'},         # Relaxation with structure as output
-            {'cls':StructureData, 'label':'structure'}
+            {'cls':Relax, 'tag':'relax'},         # Relaxation with structure as output
+            {'cls':StructureData, 'tag':'structure'}
         ],
         'filters':{
             'structure':{
@@ -1145,8 +1144,8 @@ The order does not matter, the following queryhelp would results in the same que
         }
     }
 
-If you dislike that way to label the link, you can choose the linklabel in the
-path when definining the entity to join::
+If you dislike that way to tag the link, you can choose the tag for the edge in the
+path when definining the entity to join using ``edge_tag``::
 
     queryhelp = {
         'path':[
@@ -1154,7 +1153,7 @@ path when definining the entity to join::
             {
                 'cls':StructureData,
                 'label':'structure',
-                'edge_tag':'ThisIsMyLinkLabel'     # Definining the linklabel
+                'edge_tag':'ThisIsMyLinkTag'     # Definining the link tag
             }
         ],
         'filters':{
@@ -1162,13 +1161,13 @@ path when definining the entity to join::
                 'time':{'>': t},
                 'id':{'>': 50}
             },
-            'ThisIsMyLinkLabel':{                  # Using this linklabel
+            'ThisIsMyLinkTag':{                  # Using this link tag
                 'time':{'>': t},
                 'label':{'like':'output_%'},
             }
         },
         'project':{
-            'ThisIsMyLinkLabel':['label'],
+            'ThisIsMyLinkTag':['label'],
             'structure':['label'],
             'relax':['label', 'state'],
         }


### PR DESCRIPTION
Fixes #2183 . 

Changes the existing QueryBuilder join types from` input_of `and `output_of` to `with_outgoing` and `with_incoming` respectively. For now, `ancestor_of`, `descendant_of ` remain in use. The remaining join types are changed to `with_{entity}` where the type of join performed depends contextually on the class passed in the qb.append() method. For example:
`QueryBuilder().append(User, tag='u').append(Group, with_user='u').all()`
Throughout the code, the old relationships have been replaced.

The old methods, if used, now print a deprecation warning, provided by the new `AiidaDeprecationWarning` class, from `aiida.common.warnings`. This warning has the advantage of working with pycharm and not being swallowed like `DeprecationWarning`. All deprecation warnings in the code have now been replaced by this new warning and the documentation has been updated.