### PR TITLE
Return correct ORM AuthInfo class for `JobCalculation._get_authinfo`

### DIFF
--- a/aiida/backends/tests/calculation_node.py
+++ b/aiida/backends/tests/calculation_node.py
@@ -43,6 +43,7 @@ class TestCalcNode(AiidaTestCase):
     def setUpClass(cls):
         super(TestCalcNode, cls).setUpClass()
         from aiida.orm import JobCalculation
+        cls.computer.configure()
 
         cls.construction_options = {
             'resources': {
@@ -144,3 +145,15 @@ class TestCalcNode(AiidaTestCase):
             # Otherwise, if the option defines a default that is not `None`, verify that that is returned correctly
             elif 'default' in attributes and attributes['default'] is not None:
                 self.assertEqual(get_options[name], attributes['default'])
+
+    def test_get_authinfo(self):
+        """Test that we can get the AuthInfo object from the calculation instance."""
+        from aiida.orm import AuthInfo
+        authinfo = self.job_calculation._get_authinfo()
+        self.assertIsInstance(authinfo, AuthInfo)
+
+    def test_get_transport(self):
+        """Test that we can get the Transport object from the calculation instance."""
+        from aiida.transport import Transport
+        transport = self.job_calculation._get_transport()
+        self.assertIsInstance(transport, Transport)

--- a/aiida/orm/implementation/general/calculation/job/__init__.py
+++ b/aiida/orm/implementation/general/calculation/job/__init__.py
@@ -1646,12 +1646,13 @@ class AbstractJobCalculation(AbstractCalculation):
 
     def _get_authinfo(self):
         from aiida.common.exceptions import NotExistent
+        from aiida.orm.authinfos import AuthInfo
 
         computer = self.get_computer()
         if computer is None:
             raise NotExistent("No computer has been set for this calculation")
 
-        return self.backend.authinfos.get(computer=computer, user=self.get_user())
+        return AuthInfo.from_backend_entity(self.backend.authinfos.get(computer=computer, user=self.get_user()))
 
     def _get_transport(self):
         """


### PR DESCRIPTION
Fixes #2234 

The method returned the backend AuthInfo class, which does not have
the `get_transport` method that would be called for example in the
`_get_transport` method of the `JobCalculation` class. The fix is
to wrap the backend entity in the ORM class by calling

    `AuthInfo.from_backend_entity`

Added two regression tests for this bug.