### PR TITLE
Make `verdi` callable as sub command

### DIFF
--- a/aiida/backends/tests/__init__.py
+++ b/aiida/backends/tests/__init__.py
@@ -72,6 +72,7 @@ db_test_list = {
         'cmdline.commands.rehash': ['aiida.backends.tests.cmdline.commands.test_rehash'],
         'cmdline.commands.run': ['aiida.backends.tests.cmdline.commands.test_run'],
         'cmdline.commands.user': ['aiida.backends.tests.cmdline.commands.test_user'],
+        'cmdline.commands.verdi': ['aiida.backends.tests.cmdline.commands.test_verdi'],
         'cmdline.commands.work': ['aiida.backends.tests.cmdline.commands.test_work'],
         'cmdline.commands.workflow': ['aiida.backends.tests.cmdline.commands.test_workflow'],
         'cmdline.params.types.calculation': ['aiida.backends.tests.cmdline.params.types.test_calculation'],

--- a/aiida/backends/tests/cmdline/commands/test_run.py
+++ b/aiida/backends/tests/cmdline/commands/test_run.py
@@ -21,6 +21,7 @@ class TestVerdiRun(AiidaTestCase):
     """Tests for `verdi run`."""
 
     def setUp(self):
+        super(TestVerdiRun, self).setUp()
         self.cli_runner = CliRunner()
 
     def test_run_workfunction(self):

--- a/aiida/backends/tests/cmdline/commands/test_verdi.py
+++ b/aiida/backends/tests/cmdline/commands/test_verdi.py
@@ -1,0 +1,32 @@
+# -*- coding: utf-8 -*-
+###########################################################################
+# Copyright (c), The AiiDA team. All rights reserved.                     #
+# This file is part of the AiiDA code.                                    #
+#                                                                         #
+# The code is hosted on GitHub at https://github.com/aiidateam/aiida_core #
+# For further information on the license, see the LICENSE.txt file        #
+# For further information please visit http://www.aiida.net               #
+###########################################################################
+"""Tests for `verdi`."""
+from __future__ import division
+from __future__ import print_function
+from __future__ import absolute_import
+from click.testing import CliRunner
+
+from aiida import get_version
+from aiida.backends.testbase import AiidaTestCase
+from aiida.cmdline.commands import cmd_verdi
+
+
+class TestVerdi(AiidaTestCase):
+    """Tests for `verdi run`."""
+
+    def setUp(self):
+        super(TestVerdi, self).setUp()
+        self.cli_runner = CliRunner()
+
+    def test_verdi_version(self):
+        """Regression test for #2238: verify that `verdi --version` prints the current version"""
+        result = self.cli_runner.invoke(cmd_verdi.verdi, ['--version'])
+        self.assertIsNone(result.exception, result.output)
+        self.assertIn(get_version(), result.output)

--- a/aiida/cmdline/commands/cmd_verdi.py
+++ b/aiida/cmdline/commands/cmd_verdi.py
@@ -8,26 +8,26 @@
 # For further information please visit http://www.aiida.net               #
 ###########################################################################
 """The main `verdi` click group."""
-
 from __future__ import division
 from __future__ import print_function
 from __future__ import absolute_import
+
 import click
 
 
-@click.group()
+@click.group(invoke_without_command=True)
 @click.option(
     '-p', '--profile', metavar='PROFILE', help='Execute the command for this profile instead of the default profile.')
-@click.option('--version', is_flag=True, default=False, help='Print the version of AiiDA that is currently installed.')
+@click.option('--version', is_flag=True, is_eager=True, help='Print the version of AiiDA that is currently installed.')
 @click.pass_context
 def verdi(ctx, profile, version):
     """The command line interface of AiiDA."""
     import sys
-    import aiida
+    from aiida import get_version
     from aiida.cmdline.utils import echo
 
     if version:
-        echo.echo('AiiDA version {}'.format(aiida.__version__))
+        echo.echo('AiiDA version {}'.format(get_version()))
         sys.exit(0)
 
     if profile is not None:


### PR DESCRIPTION
Fixes #2239 

Because the `verdi` group was not marked as callable without
subcommand, the `--version` option was broken as it would throw
a `Missing command` error. Adding `invoke_without_command=True` to
the `verdi` group declaration and making the `--version` an eager
option will ensure it works without specifying a sub command.

A test has been added to test this functionality.