### PR TITLE
[WIP] Add an archiving transport task for job processes

### DIFF
--- a/aiida/backends/tests/calculation_node.py
+++ b/aiida/backends/tests/calculation_node.py
@@ -157,3 +157,33 @@ class TestCalcNode(AiidaTestCase):
         from aiida.transport import Transport
         transport = self.job_calculation._get_transport()
         self.assertIsInstance(transport, Transport)
+
+    def test_set_archive_list(self):
+        """Test the setter and getter of the archive list attribute for the JobCalculation."""
+        with self.assertRaises(TypeError):
+            self.job_calculation._set_archive_list()
+
+        with self.assertRaises(TypeError):
+            self.job_calculation._set_archive_list([])
+
+        with self.assertRaises(TypeError):
+            self.job_calculation._set_archive_list([(None, None)])
+
+        with self.assertRaises(NotImplementedError):
+            self.job_calculation._set_archive_list([(self.computer, 'relative/path', '/absolute/path')])
+
+        with self.assertRaises(ValueError):
+            self.job_calculation._set_archive_list([(None, '/relative/path', '/absolute/path')])
+
+        with self.assertRaises(ValueError):
+            self.job_calculation._set_archive_list([(None, 'relative/path', 'absolute/path')])
+
+        archive_list = (
+            (None, u'relative/path1', u'/absolute/path1'),
+            (None, u'relative/path2', u'/absolute/path2')
+        )
+
+        self.job_calculation._set_archive_list(archive_list)
+
+        for spec in self.job_calculation._get_archive_list():
+            self.assertIn(tuple(spec), archive_list)

--- a/aiida/common/datastructures.py
+++ b/aiida/common/datastructures.py
@@ -141,6 +141,7 @@ class CalcInfo(DefaultFieldsAttributeDict):
         Each tuple represents a file that will be retrieved from cluster and saved in SinglefileData nodes
 
     * local_copy_list: a list of tuples with format ('localabspath', 'relativedestpath')
+    * archive_list: a list of tuples with format ('remote_machine', 'relative_source_path', 'absolute_target_path')
     * remote_copy_list: a list of tuples with format ('remotemachinename', 'remoteabspath', 'relativedestpath')
     * remote_symlink_list: a list of tuples with format ('remotemachinename', 'remoteabspath', 'relativedestpath')
     * codes_info: a list of dictionaries used to pass the info of the execution of a code
@@ -161,6 +162,7 @@ class CalcInfo(DefaultFieldsAttributeDict):
         'max_wallclock_seconds',
         'max_memory_kb',
         'rerunnable',
+        'archive_list',
         'retrieve_list',
         'retrieve_temporary_list',
         'retrieve_singlefile_list',


### PR DESCRIPTION
Fixes #2150 

A common use case for job calculations is that one wants to keep certain
files after it has finished, since they are necessary for restarts, but
one does not want to retrieve them from the remote since they can be rather
big. Instead, one wants to copy these files from the working directory, which
is often a scratch space, to a more permanent location.

Here we implement the `archive` transport task, that is optionally called after
the job has finished and before the retrieval task is triggered. If on the node
the `archive_list` attribute is defined, the worker will archive certain files
as specified to another folder on the remote and attach it as a remote folder
data to the calculation node.