### PR TITLE
Put in an explicit check raising when calculations call another process

### DIFF
--- a/aiida/backends/tests/work/test_calcfunctions.py
+++ b/aiida/backends/tests/work/test_calcfunctions.py
@@ -13,6 +13,7 @@ from __future__ import print_function
 from __future__ import absolute_import
 
 from aiida.backends.testbase import AiidaTestCase
+from aiida.common import exceptions
 from aiida.common.caching import enable_caching
 from aiida.common.links import LinkType
 from aiida.orm.data.int import Int
@@ -104,3 +105,13 @@ class TestCalcFunction(AiidaTestCase):
         self.assertFalse(data.is_stored)
         self.assertFalse(node.is_stored)
         self.assertEqual(result, data + 1)
+
+    def test_calculation_cannot_call(self):
+        """Verify that calling another process from within a calcfunction raises as it is forbidden."""
+
+        @calcfunction
+        def test_calcfunction_caller(data):
+            self.test_calcfunction(data)
+
+        with self.assertRaises(exceptions.InvalidOperation):
+            test_calcfunction_caller(self.default_int)

--- a/aiida/common/exceptions.py
+++ b/aiida/common/exceptions.py
@@ -7,11 +7,11 @@
 # For further information on the license, see the LICENSE.txt file        #
 # For further information please visit http://www.aiida.net               #
 ###########################################################################
-
-
 from __future__ import division
 from __future__ import print_function
 from __future__ import absolute_import
+
+
 class AiidaException(Exception):
     """
     Base class for all AiiDA exceptions.

--- a/aiida/work/processes.py
+++ b/aiida/work/processes.py
@@ -491,10 +491,14 @@ class Process(plumpy.Process):
         parent_calc = self.get_parent_calc()
 
         if parent_calc:
+
+            if isinstance(parent_calc, CalculationNode):
+                raise exceptions.InvalidOperation('calling processes from a calculation type process is forbidden.')
+
             if isinstance(self.calc, CalculationNode):
                 self.calc.add_incoming(parent_calc, LinkType.CALL_CALC, 'CALL_CALC')
 
-            if isinstance(self.calc, WorkflowNode):
+            elif isinstance(self.calc, WorkflowNode):
                 self.calc.add_incoming(parent_calc, LinkType.CALL_WORK, 'CALL_WORK')
 
         self._setup_db_inputs()


### PR DESCRIPTION
Fixes #2248 

By definition, calculation type processes cannot call other processes.
This was already indirectly guarded against by the link validation
process. If one attempted to add a `CALL` link from a `CalulationNode`,
the link validation would raise a `ValueError`. However, it is more
instructive for the user to catch this problem before attempting to add
the link. Therefore, when setting up the database record for a process,
if a parent process is available, we ensure that it is not a calculation
type process, or we raise an `InvalidOperation` exception. A test is
added for a `calcfunction` calling another `calcfunction`.