### PR TITLE
Documented optional graphviz dependency and removed use of os.system() in draw_graph

### DIFF
--- a/aiida/cmdline/commands/cmd_graph.py
+++ b/aiida/cmdline/commands/cmd_graph.py
@@ -20,7 +20,10 @@ from aiida.cmdline.utils import decorators, echo
 
 @verdi.group('graph')
 def verdi_graph():
-    """Create visual representations of part of the provenance graph."""
+    """
+    Create visual representations of part of the provenance graph.
+    Requires that `graphviz<https://graphviz.org/download>` be installed.
+    """
     pass
 
 

--- a/aiida/cmdline/commands/cmd_graph.py
+++ b/aiida/cmdline/commands/cmd_graph.py
@@ -58,7 +58,7 @@ def generate(root_node, ancestor_depth, descendant_depth, outputs, inputs, outpu
         root_node,
         ancestor_depth=ancestor_depth,
         descendant_depth=descendant_depth,
-        format=output_format,
+        image_format=output_format,
         include_calculation_inputs=inputs,
         include_calculation_outputs=outputs)
     if exit_status:

--- a/docs/source/install/installation.rst
+++ b/docs/source/install/installation.rst
@@ -50,6 +50,11 @@ The installation instructions for these prerequisites will depend on the operati
 We provide basic instructions for :ref:`several operating systems<installation_os>`.
 Make sure you have successfully installed these prerequisites before continuing with the installation guide.
 
+A final optional dependancy of note is `graphviz`_ which is necessary for plotting the AiiDA provenance graphs
+via ``verdi graph``.
+
+.. _graphviz: https://www.graphviz.org/download 
+
 
 .. _install_aiida:
 
@@ -278,7 +283,7 @@ This will open a tab in your browser. Click on ``New -> Python 2`` and type::
 
     import aiida
 
-followed by ``Shit-Enter``. If no exception is thrown, you can use AiiDA in Jupyter.
+followed by ``Shift-Enter``. If no exception is thrown, you can use AiiDA in Jupyter.
 
 If you want to set the same environment as in a ``verdi shell``, add the following code in ``<your.home.folder>/.ipython/profile_default/ipython_config.py``::
 

--- a/docs/source/verdi/verdi_user_guide.rst
+++ b/docs/source/verdi/verdi_user_guide.rst
@@ -379,6 +379,7 @@ Create and manage export archives.
 ``verdi graph``
 ---------------
 Create graphical representations of part of the provenance graph.
+Requires that `graphviz <https://graphviz.org/download>`_ be installed. 
 
   * **generate**: generates a graph from a given root node either in a graphical or a  ``.dot`` format.
 


### PR DESCRIPTION
Fixes #835 and #2285. 

The use of verdi graph to generate a plot of part of the provenance graph requires the graphviz package, which was not documented other than in the source code. This pull request increases the visibility of this dependency in the docs and adds a more human-parsable error message suggest when it could be the case that graphviz is not installed.

Also replaces the use of os.system() in aiida.common.graph with subprocess.call to prevent shell script from being injected via verdi graph generate. 