### PR TITLE
Ensure correct types of `LinkTriples` returned by `Node.get_stored_link_triples`

### DIFF
--- a/aiida/backends/tests/export_and_import.py
+++ b/aiida/backends/tests/export_and_import.py
@@ -1634,17 +1634,17 @@ class TestLinks(AiidaTestCase):
         pw1.add_incoming(wc2, LinkType.CALL_CALC, 'call')
         pw1._set_state(calc_states.PARSING)
 
-        d3.add_incoming(pw1, LinkType.CREATE, 'create')
-        d3.add_incoming(wc2, LinkType.RETURN, 'return')
+        d3.add_incoming(pw1, LinkType.CREATE, 'create1')
+        d3.add_incoming(wc2, LinkType.RETURN, 'return1')
 
-        d4.add_incoming(pw1, LinkType.CREATE, 'create')
-        d4.add_incoming(wc2, LinkType.RETURN, 'return')
+        d4.add_incoming(pw1, LinkType.CREATE, 'create2')
+        d4.add_incoming(wc2, LinkType.RETURN, 'return2')
 
         pw2.add_incoming(d4, LinkType.INPUT_CALC, 'input')
         pw2._set_state(calc_states.PARSING)
 
-        d5.add_incoming(pw2, LinkType.CREATE, 'create')
-        d6.add_incoming(pw2, LinkType.CREATE, 'create')
+        d5.add_incoming(pw2, LinkType.CREATE, 'create5')
+        d6.add_incoming(pw2, LinkType.CREATE, 'create6')
 
         # Return the generated nodes
         graph_nodes = [d1, d2, d3, d4, d5, d6, pw1, pw2, wc1, wc2]
@@ -1845,12 +1845,12 @@ class TestLinks(AiidaTestCase):
             c1.add_incoming(ni2, LinkType.INPUT_CALC, 'ni2-to-c1')
 
             # Connecting the first output node to wc1 & c1
-            no1.add_incoming(wc1, LinkType.RETURN, 'output')
-            no1.add_incoming(c1, LinkType.CREATE, 'output')
+            no1.add_incoming(wc1, LinkType.RETURN, 'output1')
+            no1.add_incoming(c1, LinkType.CREATE, 'output1')
 
             # Connecting the second output node to wc1 & c1
-            no2.add_incoming(wc1, LinkType.RETURN, 'output')
-            no2.add_incoming(c1, LinkType.CREATE, 'output')
+            no2.add_incoming(wc1, LinkType.RETURN, 'output2')
+            no2.add_incoming(c1, LinkType.CREATE, 'output2')
 
             # Getting the input, create, return and call links
             qb = QueryBuilder()

--- a/aiida/backends/tests/orm/node/test_node.py
+++ b/aiida/backends/tests/orm/node/test_node.py
@@ -7,7 +7,9 @@ from __future__ import absolute_import
 from aiida.backends.testbase import AiidaTestCase
 from aiida.common.links import LinkType
 from aiida.orm.data import Data
+from aiida.orm.node import Node
 from aiida.orm.node.process import CalculationNode, WorkflowNode
+from aiida.orm.utils.links import LinkTriple
 
 
 class TestNodeLinks(AiidaTestCase):
@@ -17,6 +19,26 @@ class TestNodeLinks(AiidaTestCase):
         super(TestNodeLinks, self).setUp()
         self.node_source = CalculationNode()
         self.node_target = Data()
+
+    def test_get_stored_link_triples(self):
+        """Validate the `get_stored_link_triples` method."""
+        data = Data().store()
+        calculation = CalculationNode().store()
+
+        calculation.add_incoming(data, LinkType.INPUT_CALC, 'input')
+        stored_triples = calculation.get_stored_link_triples()
+
+        self.assertEqual(len(stored_triples), 1)
+
+        link_triple = stored_triples[0]
+
+        # Verify the type and value of the tuple elements
+        self.assertTrue(isinstance(link_triple, LinkTriple))
+        self.assertTrue(isinstance(link_triple.node, Node))
+        self.assertTrue(isinstance(link_triple.link_type, LinkType))
+        self.assertEqual(link_triple.node.uuid, data.uuid)
+        self.assertEqual(link_triple.link_type, LinkType.INPUT_CALC)
+        self.assertEqual(link_triple.link_label, 'input')
 
     def test_validate_incoming_ipsum(self):
         """Test the `validate_incoming` method with respect to linking ourselves."""

--- a/aiida/backends/tests/tcodexporter.py
+++ b/aiida/backends/tests/tcodexporter.py
@@ -207,13 +207,13 @@ class TestTcodDbExporter(AiidaTestCase):
         calc._set_state(calc_states.PARSING)
         fd.add_incoming(calc, LinkType.CREATE, calc._get_linkname_retrieved())
 
-        pd.add_incoming(calc, LinkType.CREATE, "calc")
+        pd.add_incoming(calc, LinkType.CREATE, "create1")
         pd.store()
 
         with self.assertRaises(ValueError):
             export_cif(c, parameters=pd)
 
-        c.add_incoming(calc, LinkType.CREATE, "calc")
+        c.add_incoming(calc, LinkType.CREATE, "create2")
         export_cif(c, parameters=pd)
 
         values = export_values(c, parameters=pd)

--- a/aiida/orm/implementation/general/node.py
+++ b/aiida/orm/implementation/general/node.py
@@ -759,7 +759,7 @@ class AbstractNode(object):
             builder.append(node_class, with_outgoing='main', project=['*'],
                 edge_project=['type', 'label'], edge_filters=edge_filters)
 
-        return [links.LinkTriple(entry[0], entry[1], entry[2]) for entry in builder.all()]
+        return [links.LinkTriple(entry[0], LinkType(entry[1]), entry[2]) for entry in builder.all()]
 
     def _replace_link_from(self, source, link_type, link_label):
         """

--- a/aiida/orm/importexport.py
+++ b/aiida/orm/importexport.py
@@ -1859,7 +1859,7 @@ def export_tree(what, folder,allowed_licenses=None, forbidden_licenses=None,
             if return_reversed:
                 qb = QueryBuilder()
                 qb.append(ProcessNode, tag='predecessor', project=['id'])
-                qb.append(Data, output_of='predecessor',
+                qb.append(Data, with_incoming='predecessor',
                           filters={'id': {'==': curr_node_id}},
                           edge_filters={
                               'type': {


### PR DESCRIPTION
Fixes #2291 

The `Node.get_stored_link_triples` was using `LinkTriple` instances where the
type of the `link_type` element was not of `LinkType` but of string, as it was
directly using the string value returned by the query builder for the `type`
column of the `DbLink` table. By wrapping this value in `LinkType` the returned
`LinkTriples` once again have the correct type for all its elements.