### PR TITLE
Fixes #1249 Removed pika log level

### DIFF
--- a/aiida/common/log.py
+++ b/aiida/common/log.py
@@ -160,11 +160,6 @@ LOGGING = {
             'propagate': False,
             'qualname': 'sqlalchemy.engine',
         },
-        'pika': {
-            'handlers': ['console'],
-            'level': 'ERROR',
-            'propagate': False,
-        },
         'py.warnings': {
             'handlers': ['console'],
         },


### PR DESCRIPTION
This was added before, see #1249, but this no longer happens
as we're using separate a thread for the pika event loop and what's more
the issue has, I believe, been resolved with pika 1.0 which we now use.