### PR TITLE
Various speedups for verdi cmdline

### DIFF
--- a/.ci/Dockerfile
+++ b/.ci/Dockerfile
@@ -78,7 +78,7 @@ RUN updatedb
 
 # update pip and setuptools to get a relatively-recent version
 # This can be updated in the future
-RUN pip install pip==10.0.1 setuptools==39.0.1
+RUN pip install pip==18.1 setuptools==40.6.2
 
 # Put the doubler script
 COPY doubler.sh /usr/local/bin/

--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -154,7 +154,7 @@ pipeline {
             //        // For now I'm not doing it as it's ~3 MB every time
             //        // NOTE MOREOVER that one should run 'zip -r html.zip html' in the
             //        // coverage folder, first
-            //        archiveArtifacts artifacts: 'coverage/html.zip', fingerprint: true
+            //        archiveArtifacts artifacts: '.ci/coverage/html.zip', fingerprint: true
             //    }
             // }
         }

--- a/.gitignore
+++ b/.gitignore
@@ -16,8 +16,6 @@
 .eggs
 
 # files created by coverage
-*\,cover
-coverage/
 .cache
 .pytest_cache
 .coverage

--- a/aiida/backends/tests/__init__.py
+++ b/aiida/backends/tests/__init__.py
@@ -12,20 +12,9 @@ from __future__ import print_function
 from __future__ import absolute_import
 
 from six.moves import range
-
-try:
-    from reentry.default_manager import PluginManager
-    # I don't use the default manager as it has scan_for_not_found=True
-    # by default, which re-runs scan if no entrypoints are found (which is
-    # quite possible if no aiida.tests entrypoints are registered)
-    epm = PluginManager(scan_for_not_found=False)
-except ImportError:
-    import pkg_resources as epm
-
+from aiida.plugins.entry_point import ENTRYPOINT_MANAGER
 from aiida.backends.profile import BACKEND_SQLA, BACKEND_DJANGO
 
-# TODO: define only folders in which tests should be put, and each
-#       file defines a new test
 db_test_list = {
     BACKEND_DJANGO: {
         'generic': ['aiida.backends.djsite.db.subtests.generic'],
@@ -133,7 +122,7 @@ def get_db_test_names():
 
     # This is a temporary solution to be able to run tests in plugins. Once the plugin fixtures
     # have been made working and are released, we can replace this logic with them
-    for ep in [ep for ep in epm.iter_entry_points(group='aiida.tests')]:
+    for ep in [ep for ep in ENTRYPOINT_MANAGER.iter_entry_points(group='aiida.tests')]:
         retlist.append(ep.name)
 
     # Explode the list so that if I have a.b.c,
@@ -184,7 +173,7 @@ def get_db_test_list():
 
     # This is a temporary solution to be able to run tests in plugins. Once the plugin fixtures
     # have been made working and are released, we can replace this logic with them
-    for ep in [ep for ep in epm.iter_entry_points(group='aiida.tests')]:
+    for ep in [ep for ep in ENTRYPOINT_MANAGER.iter_entry_points(group='aiida.tests')]:
         retdict[ep.name].append(ep.module_name)
 
     # Explode the dictionary so that if I have a.b.c,

--- a/aiida/backends/tests/__init__.py
+++ b/aiida/backends/tests/__init__.py
@@ -14,7 +14,11 @@ from __future__ import absolute_import
 from six.moves import range
 
 try:
-    from reentry import manager as epm
+    from reentry.default_manager import PluginManager
+    # I don't use the default manager as it has scan_for_not_found=True
+    # by default, which re-runs scan if no entrypoints are found (which is
+    # quite possible if no aiida.tests entrypoints are registered)
+    epm = PluginManager(scan_for_not_found=False)
 except ImportError:
     import pkg_resources as epm
 

--- a/aiida/cmdline/commands/cmd_devel.py
+++ b/aiida/cmdline/commands/cmd_devel.py
@@ -170,6 +170,7 @@ def devel_run_daemon():
 @verdi_devel.command('tests')
 @click.argument('paths', nargs=-1, type=TestModuleParamType(), required=False)
 @options.VERBOSE(help='Print the class and function name for each test.')
+@decorators.with_dbenv()
 def devel_tests(paths, verbose):  # pylint: disable=too-many-locals,too-many-statements,too-many-branches
     """Run the unittest suite or parts of it."""
     import os

--- a/aiida/cmdline/commands/cmd_devel.py
+++ b/aiida/cmdline/commands/cmd_devel.py
@@ -26,7 +26,6 @@ def verdi_devel():
     pass
 
 
-@decorators.with_dbenv()
 def get_valid_test_paths():
     """
     Return a dictionary with the available test folders
@@ -171,7 +170,6 @@ def devel_run_daemon():
 @verdi_devel.command('tests')
 @click.argument('paths', nargs=-1, type=TestModuleParamType(), required=False)
 @options.VERBOSE(help='Print the class and function name for each test.')
-@decorators.with_dbenv()
 def devel_tests(paths, verbose):  # pylint: disable=too-many-locals,too-many-statements,too-many-branches
     """Run the unittest suite or parts of it."""
     import os

--- a/aiida/cmdline/commands/cmd_profile.py
+++ b/aiida/cmdline/commands/cmd_profile.py
@@ -31,10 +31,17 @@ def verdi_profile():
 @verdi_profile.command('list')
 def profile_list():
     """Displays list of all available profiles."""
-    from aiida.common.setup import get_profiles_list, AIIDA_CONFIG_FOLDER
+    from aiida.common.setup import get_config, get_profiles_list, AIIDA_CONFIG_FOLDER
     from aiida.common.exceptions import ConfigurationError
+    from aiida.common.exceptions import MissingConfigurationError
 
     echo.echo_info('configuration folder: {}'.format(AIIDA_CONFIG_FOLDER))
+
+    try:
+        get_config()
+    except MissingConfigurationError:
+        echo.echo_info("no configuration file found, run 'verdi quicksetup' first")
+        return
 
     try:
         default_profile = get_default_profile_name()

--- a/aiida/cmdline/commands/cmd_verdi.py
+++ b/aiida/cmdline/commands/cmd_verdi.py
@@ -25,13 +25,16 @@ def verdi(ctx, profile, version):
     import sys
     import aiida
     from aiida.cmdline.utils import echo
+    from aiida.backends import settings
+    from aiida.common import setup
 
     if version:
         echo.echo('AiiDA version {}'.format(aiida.__version__))
         sys.exit(0)
 
-    if profile is not None:
-        from aiida.backends import settings
+    if profile is None:
+        settings.AIIDADB_PROFILE = setup.get_default_profile_name()
+    else:
         settings.AIIDADB_PROFILE = profile
 
     ctx.help_option_names = ['-h', '--help']

--- a/aiida/cmdline/params/types/test_module.py
+++ b/aiida/cmdline/params/types/test_module.py
@@ -13,8 +13,6 @@ from __future__ import print_function
 from __future__ import absolute_import
 import click
 
-from aiida.cmdline.utils.decorators import with_dbenv
-
 
 class TestModuleParamType(click.ParamType):
     """Parameter type to represent a unittest module."""
@@ -45,11 +43,6 @@ class TestModuleParamType(click.ParamType):
 
         return test_modules
 
-    @with_dbenv()
-    def convert(self, value, param, ctx):
-        return value
-
-    @with_dbenv()
     def complete(self, ctx, incomplete):  # pylint: disable=unused-argument,no-self-use
         """
         Return possible completions based on an incomplete value

--- a/aiida/common/setup.py
+++ b/aiida/common/setup.py
@@ -290,8 +290,8 @@ def set_default_profile(profile, force_rewrite=False):
     if current_default_profile is None or force_rewrite:
         confs['default_profile'] = profile
 
-    backup_config()
-    store_config(confs)
+        backup_config()
+        store_config(confs)
 
 
 def get_default_profile():
@@ -544,7 +544,7 @@ def create_configuration(profile='default'):
     # to modify it.
     updating_existing_prof = False
     if this_existing_confs:
-        print("The following configuration found corresponding to " "profile {}.".format(profile))
+        print("The following configuration found corresponding to profile {}.".format(profile))
         for k, v in this_existing_confs.items():
             if k in key_explanation:
                 print("{}: {}".format(key_explanation.get(k), v))

--- a/aiida/control/profile.py
+++ b/aiida/control/profile.py
@@ -13,7 +13,6 @@ from __future__ import division
 from __future__ import print_function
 from __future__ import absolute_import
 import os
-import sys
 
 from aiida.cmdline.utils import echo
 
@@ -46,24 +45,16 @@ def setup_profile(profile, only_config, set_default=False, non_interactive=False
 
     # Create the directories to store the configuration files
     create_base_dirs()
-    if settings.AIIDADB_PROFILE and profile:
-        sys.exit('the profile argument cannot be used if verdi is called with -p option: {} and {}'.format(
-            settings.AIIDADB_PROFILE, profile))
-    gprofile = settings.AIIDADB_PROFILE or profile
-    if gprofile == profile:
-        settings.AIIDADB_PROFILE = profile
-    if not settings.AIIDADB_PROFILE:
-        settings.AIIDADB_PROFILE = 'default'
 
-    # used internally later
-    gprofile = settings.AIIDADB_PROFILE
+    # we need to overwrite this variable for the following to work
+    settings.AIIDADB_PROFILE = profile
 
     created_conf = None
     # ask and store the configuration of the DB
     if non_interactive:
         try:
             created_conf = create_config_noninteractive(
-                profile=gprofile,
+                profile=profile,
                 backend=kwargs['backend'],
                 email=kwargs['email'],
                 db_host=kwargs['db_host'],
@@ -83,12 +74,12 @@ def setup_profile(profile, only_config, set_default=False, non_interactive=False
                     exception.args[0]))
     else:
         try:
-            created_conf = create_configuration(profile=gprofile)
+            created_conf = create_configuration(profile=profile)
         except ValueError as exception:
             echo.echo_critical("Error during configuration: {}".format(exception))
 
-        # Set default DB profile
-        set_default_profile(gprofile, force_rewrite=False)
+    # Set default DB profile
+    set_default_profile(profile, force_rewrite=False)
 
     if only_user_config:
         echo.echo("Only user configuration requested, skipping the migrate command")
@@ -117,7 +108,7 @@ def setup_profile(profile, only_config, set_default=False, non_interactive=False
 
             try:
                 from aiida.backends.djsite.utils import pass_to_django_manage
-                pass_to_django_manage([EXECNAME, 'migrate'], profile=gprofile)
+                pass_to_django_manage([EXECNAME, 'migrate'], profile=profile)
             finally:
                 os.umask(old_umask)
 

--- a/aiida/manage/manager.py
+++ b/aiida/manage/manager.py
@@ -13,7 +13,6 @@ from __future__ import print_function
 from __future__ import absolute_import
 
 import functools
-import plumpy
 
 from aiida import utils
 from aiida import common
@@ -142,6 +141,7 @@ class Manager(object):
         :return: the process controller instance
         :rtype: :class:`plumpy.RemoteProcessThreadController`
         """
+        import plumpy
         if self._process_controller is None:
             self._process_controller = plumpy.RemoteProcessThreadController(self.get_communicator())
 
@@ -206,6 +206,7 @@ class Manager(object):
         :return: a runner configured to work in the daemon configuration
         :rtype: :class:`aiida.work.Runner`
         """
+        import plumpy
         from aiida.work import rmq, persistence
         runner = self.create_runner(rmq_submit=True, loop=loop)
         runner_loop = runner.loop

--- a/aiida/plugins/entry_point.py
+++ b/aiida/plugins/entry_point.py
@@ -16,9 +16,13 @@ import traceback
 import six
 
 try:
-    from reentry import manager as epm
+    from reentry.default_manager import PluginManager
+    # I don't use the default manager as it has scan_for_not_found=True
+    # by default, which re-runs scan if no entrypoints are found (which is
+    # quite possible if no aiida.tests entrypoints are registered)
+    ENTRYPOINT_MANAGER = PluginManager(scan_for_not_found=False)
 except ImportError:
-    import pkg_resources as epm
+    import pkg_resources as ENTRYPOINT_MANAGER
 
 from aiida.common.exceptions import MissingEntryPointError, MultipleEntryPointError, LoadingEntryPointError
 
@@ -212,7 +216,7 @@ def get_entry_points(group):
     :param group: the entry point group
     :return: a list of entry points
     """
-    return [ep for ep in epm.iter_entry_points(group=group)]
+    return [ep for ep in ENTRYPOINT_MANAGER.iter_entry_points(group=group)]
 
 
 def get_entry_point(group, name):
@@ -251,8 +255,8 @@ def get_entry_point_from_class(class_module, class_name):
         class_path = class_name[len(prefix):]
         class_module, class_name = class_path.rsplit('.', 1)
 
-    for group in epm.get_entry_map().keys():
-        for entry_point in epm.iter_entry_points(group):
+    for group in ENTRYPOINT_MANAGER.get_entry_map().keys():
+        for entry_point in ENTRYPOINT_MANAGER.iter_entry_points(group):
 
             if entry_point.module_name != class_module:
                 continue

--- a/setup.json
+++ b/setup.json
@@ -177,7 +177,7 @@
       "process.workflow.workchain = aiida.orm.node.process.workflow.workchain:WorkChainNode",
       "process.workflow.workfunction = aiida.orm.node.process.workflow.workfunction:WorkFunctionNode"
     ],
-    "aiida.cmdline": [],
+    "aiida.cmdline.data": [],
     "aiida.parsers": [
       "arithmetic.add = aiida.parsers.plugins.arithmetic.add:ArithmeticAddParser",
       "templatereplacer.doubler = aiida.parsers.plugins.templatereplacer.doubler:TemplatereplacerDoublerParser"


### PR DESCRIPTION
Fixes #376 and fixes #2261 

In particular when completing tests.
Thanks to @ltalirz
This fixes #376 (again...).
Fixes include:
- using a new instance of the reentry manager that prevents
  automatic reentry scans
- removed unuseful with_dbenv decorators from 'verdi devel tests' and
  from the TestModuleParamType of click
- prevent unnecessary imports of plumpy that is a bit slow to import

Also, we fixed the place where AIIDADB_PROFILE is set in the
main `verdi` click command, to set it also when a default
profile is used (this was probably the reason of the unneeded
with_dbenv calls)