### PR TITLE
Make UUID columns unique in sqla

### DIFF
--- a/aiida/backends/djsite/db/migrations/0014_add_node_uuid_unique_constraint.py
+++ b/aiida/backends/djsite/db/migrations/0014_add_node_uuid_unique_constraint.py
@@ -31,8 +31,8 @@ def verify_node_uuid_uniqueness(apps, schema_editor):
 
     :raises: IntegrityError if database contains nodes with duplicate UUIDS.
     """
-    from aiida.manage.database.integrity.duplicate_uuid import verify_node_uuid_uniqueness
-    verify_node_uuid_uniqueness()
+    from aiida.manage.database.integrity.duplicate_uuid import verify_uuid_uniqueness
+    verify_uuid_uniqueness(table='db_dbnode')
 
 
 def reverse_code(apps, schema_editor):
@@ -51,7 +51,7 @@ class Migration(migrations.Migration):
         migrations.AlterField(
             model_name='dbnode',
             name='uuid',
-            field=models.CharField(max_length=36,default=get_new_uuid, unique=True),
+            field=models.CharField(max_length=36, default=get_new_uuid, unique=True),
         ),
         upgrade_schema_version(REVISION, DOWN_REVISION)
     ]

--- a/aiida/backends/djsite/db/migrations/0018_django_1_11.py
+++ b/aiida/backends/djsite/db/migrations/0018_django_1_11.py
@@ -15,6 +15,29 @@ from aiida.backends.djsite.db.migrations import upgrade_schema_version
 REVISION = '1.0.18'
 DOWN_REVISION = '1.0.17'
 
+tables = ['db_dbcomment', 'db_dbcomputer', 'db_dbgroup', 'db_dbworkflow']
+
+
+def _verify_uuid_uniqueness(apps, schema_editor):
+    """Check whether the respective tables contain rows with duplicate UUIDS.
+
+    Note that we have to redefine this method from aiida.manage.database.integrity
+    because the migrations.RunPython command that will invoke this function, will pass two arguments and therefore
+    this wrapper needs to have a different function signature.
+
+    :raises: IntegrityError if database contains rows with duplicate UUIDS.
+    """
+    # pylint: disable=unused-argument
+    from aiida.manage.database.integrity.duplicate_uuid import verify_uuid_uniqueness
+
+    for table in tables:
+        verify_uuid_uniqueness(table=table)
+
+
+def reverse_code(apps, schema_editor):
+    # pylint: disable=unused-argument
+    pass
+
 
 class Migration(migrations.Migration):
     """Migration for upgrade to django 1.11
@@ -31,6 +54,7 @@ class Migration(migrations.Migration):
     ]
 
     operations = [
+        migrations.RunPython(_verify_uuid_uniqueness, reverse_code=reverse_code),
         migrations.AlterField(
             model_name='dbcomment',
             name='uuid',

--- a/aiida/backends/djsite/db/migrations/0020_provenance_redesign.py
+++ b/aiida/backends/djsite/db/migrations/0020_provenance_redesign.py
@@ -15,14 +15,7 @@ DOWN_REVISION = '1.0.19'
 
 
 def migrate_infer_calculation_entry_point(apps, schema_editor):
-    """Check whether the database contains nodes with duplicate UUIDS.
-
-    Note that we have to redefine this method from aiida.manage.database.integrity.verify_node_uuid_uniqueness
-    because the migrations.RunPython command that will invoke this function, will pass two arguments and therefore
-    this wrapper needs to have a different function signature.
-
-    :raises: IntegrityError if database contains nodes with duplicate UUIDS.
-    """
+    """Set the process type for calculation nodes by inferring it from their type string."""
     from aiida.manage.database.integrity import write_database_integrity_violation
     from aiida.manage.database.integrity.plugins import infer_calculation_entry_point
     from aiida.plugins.entry_point import ENTRY_POINT_STRING_SEPARATOR
@@ -54,7 +47,7 @@ def migrate_infer_calculation_entry_point(apps, schema_editor):
 
 
 def detect_unexpected_links(apps, schema_editor):
-    """Scan the database for any links that are unexpected.from
+    """Scan the database for any links that are unexpected.
 
     The checks will verify that there are no outgoing `call` or `return` links from calculation nodes and that if a
     workflow node has a `create` link, it has at least an accompanying return link to the same data node, or it has a

--- a/aiida/backends/djsite/db/subtests/migrations.py
+++ b/aiida/backends/djsite/db/subtests/migrations.py
@@ -19,7 +19,7 @@ from django.db.migrations.executor import MigrationExecutor
 from django.db import connection
 from aiida.backends.testbase import AiidaTestCase
 from aiida.common.exceptions import IntegrityError
-from aiida.manage.database.integrity.duplicate_uuid import deduplicate_node_uuids, verify_node_uuid_uniqueness
+from aiida.manage.database.integrity.duplicate_uuid import deduplicate_node_uuids, verify_uuid_uniqueness
 
 
 class TestMigrations(AiidaTestCase):
@@ -136,7 +136,7 @@ class TestDuplicateNodeUuidMigration(TestMigrations):
 
         # Verify that there are duplicate UUIDs by checking that the following function raises
         with self.assertRaises(IntegrityError):
-            verify_node_uuid_uniqueness()
+            verify_uuid_uniqueness(table='db_dbnode')
 
         # Now run the function responsible for solving duplicate UUIDs which would also be called by the user
         # through the `verdi database integrity detect-duplicate-node-uuid` command
@@ -147,7 +147,7 @@ class TestDuplicateNodeUuidMigration(TestMigrations):
         from aiida.orm import load_node
 
         # If the duplicate UUIDs were successfully fixed, the following should not raise.
-        verify_node_uuid_uniqueness()
+        verify_uuid_uniqueness(table='db_dbnode')
 
         # Reload the nodes by PK and check that all UUIDs are now unique
         nodes_boolean = [load_node(node.pk) for node in self.nodes_boolean]

--- a/aiida/backends/general/abstractqueries.py
+++ b/aiida/backends/general/abstractqueries.py
@@ -11,7 +11,7 @@ from __future__ import division
 from __future__ import print_function
 from __future__ import absolute_import
 
-from abc import ABCMeta, abstractmethod
+from abc import ABCMeta
 import six
 
 
@@ -25,16 +25,20 @@ class AbstractQueryManager(object):
         """
         self._backend = backend
 
-    def get_duplicate_node_uuids(self):
+    def get_duplicate_uuids(self, table):
         """
-        Return a list of nodes that have an identical UUID
+        Return a list of rows with identical UUID
 
-        :return: list of tuples of (pk, uuid) of nodes with duplicate UUIDs
+        :param table: Database table with uuid column, e.g. 'db_dbnode'
+        :type str:
+
+        :return: list of tuples of (id, uuid) of rows with duplicate UUIDs
+        :rtype list:
         """
         query = """
-            SELECT s.id, s.uuid FROM (SELECT *, COUNT(*) OVER(PARTITION BY uuid) AS c FROM db_dbnode)
+            SELECT s.id, s.uuid FROM (SELECT *, COUNT(*) OVER(PARTITION BY uuid) AS c FROM {})
             AS s WHERE c > 1
-            """
+            """.format(table)
         return self._backend.execute_raw(query)
 
     def get_creation_statistics(

--- a/aiida/backends/sqlalchemy/migrations/versions/239cea6d2452_provenance_redesign.py
+++ b/aiida/backends/sqlalchemy/migrations/versions/239cea6d2452_provenance_redesign.py
@@ -31,14 +31,7 @@ depends_on = None
 
 
 def migrate_infer_calculation_entry_point():
-    """Check whether the database contains nodes with duplicate UUIDS.
-
-    Note that we have to redefine this method from aiida.manage.database.integrity.verify_node_uuid_uniqueness
-    because the migrations.RunPython command that will invoke this function, will pass two arguments and therefore
-    this wrapper needs to have a different function signature.
-
-    :raises: IntegrityError if database contains nodes with duplicate UUIDS.
-    """
+    """Set the process type for calculation nodes by inferring it from their type string."""
     from sqlalchemy.orm.session import Session
 
     from aiida.backends.sqlalchemy.models.node import DbNode
@@ -76,7 +69,7 @@ def migrate_infer_calculation_entry_point():
 
 
 def detect_unexpected_links():
-    """Scan the database for any links that are unexpected.from
+    """Scan the database for any links that are unexpected.
 
     The checks will verify that there are no outgoing `call` or `return` links from calculation nodes and that if a
     workflow node has a `create` link, it has at least an accompanying return link to the same data node, or it has a

--- a/aiida/backends/sqlalchemy/migrations/versions/37f3d4882837_make_all_uuid_columns_unique.py
+++ b/aiida/backends/sqlalchemy/migrations/versions/37f3d4882837_make_all_uuid_columns_unique.py
@@ -40,8 +40,9 @@ def verify_uuid_uniqueness(table):
     duplicates = conn.execute(query).fetchall()
 
     if duplicates:
-        raise IntegrityError('Your table \'{}\' contains entries with duplicate UUIDS'.format(table))
-        #'run `verdi database integrity duplicate-node-uuid` to return to a consistent state')
+        command = '`verdi database integrity detect-duplicate-uuid {table}`'.format(table=table)
+        raise IntegrityError('Your table "{}"" contains entries with duplicate UUIDS.\nRun {} '
+                             'to return to a consistent state'.format(table, command))
 
 
 def upgrade():

--- a/aiida/backends/sqlalchemy/migrations/versions/37f3d4882837_make_all_uuid_columns_unique.py
+++ b/aiida/backends/sqlalchemy/migrations/versions/37f3d4882837_make_all_uuid_columns_unique.py
@@ -1,0 +1,57 @@
+"""Make all uuid columns unique
+
+Revision ID: 37f3d4882837
+Revises: 6a5c2ea1439d
+Create Date: 2018-11-17 17:18:58.691209
+
+"""
+# pylint: disable=invalid-name
+
+from __future__ import absolute_import
+from alembic import op
+
+# Remove when https://github.com/PyCQA/pylint/issues/1931 is fixed
+# pylint: disable=no-member,no-name-in-module,import-error
+
+# revision identifiers, used by Alembic.
+revision = '37f3d4882837'
+down_revision = '6a5c2ea1439d'
+branch_labels = None
+depends_on = None
+
+tables = ['db_dbcomment', 'db_dbcomputer', 'db_dbgroup', 'db_dbworkflow']
+
+
+def verify_uuid_uniqueness(table):
+    """Check whether the database contains duplicate UUIDS.
+
+    Note that we have to redefine this method from aiida.manage.database.integrity.verify_uuid_uniqueness
+    because that uses the default database connection, while here the one created by Alembic should be used instead.
+
+    :raises: IntegrityError if database contains nodes with duplicate UUIDS.
+    """
+    from sqlalchemy.sql import text
+    from aiida.common.exceptions import IntegrityError
+
+    query = text(
+        'SELECT s.id, s.uuid FROM (SELECT *, COUNT(*) OVER(PARTITION BY uuid) AS c FROM {}) AS s WHERE c > 1'.format(
+            table))
+    conn = op.get_bind()
+    duplicates = conn.execute(query).fetchall()
+
+    if duplicates:
+        raise IntegrityError('Your table \'{}\' contains entries with duplicate UUIDS'.format(table))
+        #'run `verdi database integrity duplicate-node-uuid` to return to a consistent state')
+
+
+def upgrade():
+
+    for table in tables:
+        verify_uuid_uniqueness(table)
+        op.create_unique_constraint(table + '_uuid_key', table, ['uuid'])
+
+
+def downgrade():
+
+    for table in tables:
+        op.drop_constraint(table + '_uuid_key', table)

--- a/aiida/backends/sqlalchemy/migrations/versions/62fe0d36de90_add_node_uuid_unique_constraint.py
+++ b/aiida/backends/sqlalchemy/migrations/versions/62fe0d36de90_add_node_uuid_unique_constraint.py
@@ -44,8 +44,10 @@ def verify_node_uuid_uniqueness():
     duplicates = conn.execute(query).fetchall()
 
     if duplicates:
-        raise IntegrityError('your database contains nodes with duplicate UUIDS: run '
-                             '`verdi database integrity detect-duplicate-node-uuid` to return to a consistent state')
+        table = 'db_dbnode'
+        command = '`verdi database integrity detect-duplicate-uuid {table}`'.format(table)
+        raise IntegrityError('Your table "{}" contains entries with duplicate UUIDS.\nRun {} '
+                             'to return to a consistent state'.format(table, command))
 
 
 def upgrade():

--- a/aiida/backends/sqlalchemy/models/comment.py
+++ b/aiida/backends/sqlalchemy/models/comment.py
@@ -19,7 +19,7 @@ from sqlalchemy.dialects.postgresql import UUID
 
 from aiida.common import timezone
 from aiida.backends.sqlalchemy.models.base import Base
-from aiida.backends.sqlalchemy.models.utils import uuid_func
+from aiida.common.utils import get_new_uuid
 
 
 class DbComment(Base):
@@ -27,7 +27,7 @@ class DbComment(Base):
 
     id = Column(Integer, primary_key=True)
 
-    uuid = Column(UUID(as_uuid=True), default=uuid_func)
+    uuid = Column(UUID(as_uuid=True), default=get_new_uuid, unique=True)
     dbnode_id = Column(
         Integer,
         ForeignKey(

--- a/aiida/backends/sqlalchemy/models/computer.py
+++ b/aiida/backends/sqlalchemy/models/computer.py
@@ -22,7 +22,7 @@ from sqlalchemy.orm.exc import NoResultFound, MultipleResultsFound
 from sqlalchemy.dialects.postgresql import UUID, JSONB
 
 from aiida.backends.sqlalchemy.models.base import Base
-from aiida.backends.sqlalchemy.models.utils import uuid_func
+from aiida.common.utils import get_new_uuid
 
 from aiida.common.exceptions import NotExistent, DbContentError, ConfigurationError
 
@@ -32,7 +32,7 @@ class DbComputer(Base):
 
     id = Column(Integer, primary_key=True)
 
-    uuid = Column(UUID(as_uuid=True), default=uuid_func)
+    uuid = Column(UUID(as_uuid=True), default=get_new_uuid, unique=True)
     name = Column(String(255), unique=True, nullable=False)
     hostname = Column(String(255))
 

--- a/aiida/backends/sqlalchemy/models/group.py
+++ b/aiida/backends/sqlalchemy/models/group.py
@@ -20,7 +20,7 @@ from sqlalchemy.dialects.postgresql import UUID
 
 from aiida.common import timezone
 from .base import Base
-from .utils import uuid_func
+from aiida.common.utils import get_new_uuid
 
 table_groups_nodes = Table(
     'db_dbgroup_dbnodes',
@@ -38,7 +38,7 @@ class DbGroup(Base):
 
     id = Column(Integer, primary_key=True)
 
-    uuid = Column(UUID(as_uuid=True), default=uuid_func)
+    uuid = Column(UUID(as_uuid=True), default=get_new_uuid, unique=True)
     label = Column(String(255), index=True)
 
     type_string = Column(String(255), default="", index=True)

--- a/aiida/backends/sqlalchemy/models/log.py
+++ b/aiida/backends/sqlalchemy/models/log.py
@@ -11,16 +11,16 @@ from __future__ import division
 from __future__ import print_function
 from __future__ import absolute_import
 
-from sqlalchemy.schema import Column
-from sqlalchemy.types import Integer, DateTime, String, Text
+from sqlalchemy import ForeignKey
 from sqlalchemy.dialects.postgresql import UUID, JSONB
 from sqlalchemy.orm import relationship, backref
-from sqlalchemy import ForeignKey
+from sqlalchemy.schema import Column
+from sqlalchemy.types import Integer, DateTime, String, Text
 
-from aiida.common import timezone
 from aiida.backends.sqlalchemy.models.base import Base
-
-from .utils import uuid_func
+from aiida.common import timezone
+from aiida.common.utils import get_new_uuid
+from aiida.common.exceptions import ValidationError
 
 
 class DbLog(Base):
@@ -28,7 +28,7 @@ class DbLog(Base):
     __tablename__ = 'db_dblog'
 
     id = Column(Integer, primary_key=True)
-    uuid = Column(UUID(as_uuid=True), default=uuid_func, unique=True)
+    uuid = Column(UUID(as_uuid=True), default=get_new_uuid, unique=True)
     time = Column(DateTime(timezone=True), default=timezone.now)
     loggername = Column(String(255), index=True)
     levelname = Column(String(255), index=True)

--- a/aiida/backends/sqlalchemy/models/node.py
+++ b/aiida/backends/sqlalchemy/models/node.py
@@ -23,7 +23,7 @@ from sqlalchemy.dialects.postgresql import UUID, JSONB
 
 from aiida.common import timezone
 from aiida.backends.sqlalchemy.models.base import Base
-from aiida.backends.sqlalchemy.models.utils import uuid_func
+from aiida.common.utils import get_new_uuid
 from aiida.backends.sqlalchemy.utils import flag_modified
 from aiida.backends.sqlalchemy.models.user import DbUser
 from aiida.backends.sqlalchemy.models.computer import DbComputer
@@ -33,7 +33,7 @@ class DbNode(Base):
     __tablename__ = "db_dbnode"
 
     id = Column(Integer, primary_key=True)
-    uuid = Column(UUID(as_uuid=True), default=uuid_func, unique=True)
+    uuid = Column(UUID(as_uuid=True), default=get_new_uuid, unique=True)
     type = Column(String(255), index=True)
     process_type = Column(String(255), index=True)
     label = Column(String(255), index=True, nullable=True,

--- a/aiida/backends/sqlalchemy/models/utils.py
+++ b/aiida/backends/sqlalchemy/models/utils.py
@@ -11,16 +11,11 @@
 from __future__ import division
 from __future__ import print_function
 from __future__ import absolute_import
-import uuid
 
 import six
 
-from aiida.backends.settings import AIIDANODES_UUID_VERSION
 from aiida.common.exceptions import ValidationError
 from aiida.common.exceptions import NotExistent
-
-
-uuid_func = getattr(uuid, "uuid" + str(AIIDANODES_UUID_VERSION))
 
 # The separator for sub-fields (for JSON stored values).Keys are not allowed
 # to contain the separator even if the

--- a/aiida/backends/sqlalchemy/models/workflow.py
+++ b/aiida/backends/sqlalchemy/models/workflow.py
@@ -23,9 +23,9 @@ from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy_utils.types.choice import ChoiceType
 
 from aiida.backends.sqlalchemy.models.base import Base, _QueryProperty, _AiidaQuery
-from aiida.backends.sqlalchemy.models.utils import uuid_func
+from aiida.common import json
 from aiida.common import timezone
-import aiida.common.json as json
+from aiida.common.utils import get_new_uuid
 
 import six
 
@@ -91,7 +91,7 @@ class DbWorkflow(Base):
     aiida_query = _QueryProperty(_AiidaQuery)
 
     id = Column(Integer, primary_key=True)
-    uuid = Column(UUID(as_uuid=True), default=uuid_func)
+    uuid = Column(UUID(as_uuid=True), default=get_new_uuid, unique=True)
 
     ctime = Column(DateTime(timezone=True), default=timezone.now)
     mtime = Column(DateTime(timezone=True), default=timezone.now, onupdate=timezone.now)

--- a/aiida/manage/database/integrity/duplicate_uuid.py
+++ b/aiida/manage/database/integrity/duplicate_uuid.py
@@ -11,35 +11,41 @@
 from __future__ import division
 from __future__ import print_function
 from __future__ import absolute_import
-import uuid as UUID
 
 from aiida.manage import get_manager
 from aiida.common.exceptions import IntegrityError
 
-__all__ = ('verify_node_uuid_uniqueness', 'get_duplicate_node_uuids', 'deduplicate_node_uuids')
+__all__ = ('verify_uuid_uniqueness', 'get_duplicate_uuids', 'deduplicate_node_uuids')
 
 
-def verify_node_uuid_uniqueness():
-    """Check whether the database contains nodes with duplicate UUIDS.
+def get_duplicate_uuids(table):
+    """Retrieve rows with duplicate UUIDS.
 
-    :raises: IntegrityError if database contains nodes with duplicate UUIDS.
-    """
-    duplicates = get_duplicate_node_uuids()
+    :param table: Database table with uuid column, e.g. 'db_dbnode'
+    :type str:
 
-    if duplicates:
-        raise IntegrityError('your database contains nodes with duplicate UUIDS: run '
-                             '`verdi database integrity detect-duplicate-node-uuid` to return to a consistent state')
-
-
-def get_duplicate_node_uuids():
-    """Retrieve nodes with duplicate UUIDS.
-
-    :return: list of tuples of (pk, uuid) of nodes with duplicate UUIDs
+    :return: list of tuples of (id, uuid) of rows with duplicate UUIDs
     """
     backend = get_manager().get_backend()
-    duplicates = backend.query_manager.get_duplicate_node_uuids()
+    duplicates = backend.query_manager.get_duplicate_uuids(table=table)
 
     return duplicates
+
+
+def verify_uuid_uniqueness(table):
+    """Check whether database table contains rows with duplicate UUIDS.
+
+    :param table: Database table with uuid column, e.g. 'db_dbnode'
+    :type str:
+
+    :raises: IntegrityError if table contains rows with duplicate UUIDS.
+    """
+    duplicates = get_duplicate_uuids(table=table)
+
+    if duplicates:
+        raise IntegrityError(
+            'Table {} contains rows with duplicate UUIDS: '
+            'run `verdi database integrity duplicate-node-uuid` to return to a consistent state'.format(table))
 
 
 def deduplicate_node_uuids(dry_run=True):
@@ -57,14 +63,12 @@ def deduplicate_node_uuids(dry_run=True):
     """
     from collections import defaultdict
 
-    from aiida.backends.settings import AIIDANODES_UUID_VERSION
     from aiida.orm import load_node
-
-    uuid_generator = getattr(UUID, 'uuid{}'.format(AIIDANODES_UUID_VERSION))
+    from aiida.common.utils import get_new_uuid
 
     mapping = defaultdict(list)
 
-    for pk, uuid in get_duplicate_node_uuids():
+    for pk, uuid in get_duplicate_uuids(table='db_dbnode'):
         mapping[uuid].append(int(pk))
 
     def copy_repo_folder(node_source, uuid):
@@ -93,7 +97,7 @@ def deduplicate_node_uuids(dry_run=True):
                 continue
 
             node = load_node(pk)
-            uuid_new = str(uuid_generator())
+            uuid_new = str(get_new_uuid())
 
             if dry_run:
                 messages.append('would update UUID of Node<{}> from {} to {}'.format(pk, uuid_old, uuid_new))

--- a/aiida/orm/implementation/django/dummy_model.py
+++ b/aiida/orm/implementation/django/dummy_model.py
@@ -35,8 +35,8 @@ from sqlalchemy.ext.hybrid import hybrid_property
 from sqlalchemy.dialects.postgresql import UUID
 
 # MISC
-from aiida.backends.sqlalchemy.models.utils import uuid_func
 from aiida.common import timezone
+from aiida.common.utils import get_new_uuid
 
 Base = declarative_base()
 
@@ -85,7 +85,7 @@ class DbComputer(Base):
 
     id = Column(Integer, primary_key=True)
 
-    uuid = Column(UUID(as_uuid=True), default=uuid_func)
+    uuid = Column(UUID(as_uuid=True), default=get_new_uuid)
     name = Column(String(255), unique=True, nullable=False)
     hostname = Column(String(255))
 
@@ -127,7 +127,7 @@ class DbGroup(Base):
 
     id = Column(Integer, primary_key=True)
 
-    uuid = Column(UUID(as_uuid=True), default=uuid_func)
+    uuid = Column(UUID(as_uuid=True), default=get_new_uuid)
     label = Column(String(255), index=True)
 
     type_string = Column(String(255), default="", index=True)
@@ -149,7 +149,7 @@ class DbGroup(Base):
 class DbNode(Base):
     __tablename__ = "db_dbnode"
     id = Column(Integer, primary_key=True)
-    uuid = Column(UUID(as_uuid=True), default=uuid_func)
+    uuid = Column(UUID(as_uuid=True), default=get_new_uuid)
     type = Column(String(255), index=True)
     process_type = Column(String(255), index=True)
     label = Column(String(255), index=True, nullable=True)
@@ -231,7 +231,7 @@ class DbLog(Base):
 
     id = Column(Integer, primary_key=True)
 
-    uuid = Column(UUID(as_uuid=True), default=uuid_func)
+    uuid = Column(UUID(as_uuid=True), default=get_new_uuid)
 
     time = Column(DateTime(timezone=True), default=timezone.now)
     loggername = Column(String(255), index=True)
@@ -248,7 +248,7 @@ class DbComment(Base):
     __tablename__ = "db_dbcomment"
 
     id = Column(Integer, primary_key=True)
-    uuid = Column(UUID(as_uuid=True), default=uuid_func)
+    uuid = Column(UUID(as_uuid=True), default=get_new_uuid)
     dbnode_id = Column(Integer, ForeignKey('db_dbnode.id', ondelete="CASCADE", deferrable=True, initially="DEFERRED"))
 
     ctime = Column(DateTime(timezone=True), default=timezone.now)


### PR DESCRIPTION
In django, all uuid columns are now unique. This does the same for sqlalchemy.

 - [x] make uuid columns in sqlalchemy unique
 - [x] checks for non-unique entries in the DB
 - [x] generalize fixes that are in place for Node to other tables
