### PR TITLE
Make Groups great again

### DIFF
--- a/aiida/backends/djsite/db/migrations/0021_dbgroup_name_to_label_type_to_type_string.py
+++ b/aiida/backends/djsite/db/migrations/0021_dbgroup_name_to_label_type_to_type_string.py
@@ -1,9 +1,11 @@
 # -*- coding: utf-8 -*-
-# pylint: disable=invalid-name
+# pylint: disable=invalid-name,too-few-public-methods
 """Migration that renames name and type columns to label and type_string"""
 
 from __future__ import unicode_literals
 from __future__ import absolute_import
+
+# pylint: disable=no-name-in-module,import-error
 from django.db import migrations
 from aiida.backends.djsite.db.migrations import upgrade_schema_version
 

--- a/aiida/backends/djsite/db/migrations/0021_dbgroup_name_to_label_type_to_type_string.py
+++ b/aiida/backends/djsite/db/migrations/0021_dbgroup_name_to_label_type_to_type_string.py
@@ -1,0 +1,37 @@
+# -*- coding: utf-8 -*-
+# pylint: disable=invalid-name
+"""Migration that renames name and type columns to label and type_string"""
+
+from __future__ import unicode_literals
+from __future__ import absolute_import
+from django.db import migrations
+from aiida.backends.djsite.db.migrations import upgrade_schema_version
+
+REVISION = '1.0.21'
+DOWN_REVISION = '1.0.20'
+
+
+class Migration(migrations.Migration):
+    """Migration that renames name and type columns to label and type_string"""
+
+    dependencies = [
+        ('db', '0020_provenance_redesign'),
+    ]
+
+    operations = [
+        migrations.RenameField(
+            model_name='dbgroup',
+            old_name='name',
+            new_name='label',
+        ),
+        migrations.RenameField(
+            model_name='dbgroup',
+            old_name='type',
+            new_name='type_string',
+        ),
+        migrations.AlterUniqueTogether(
+            name='dbgroup',
+            unique_together=set([('label', 'type_string')]),
+        ),
+        upgrade_schema_version(REVISION, DOWN_REVISION)
+    ]

--- a/aiida/backends/djsite/db/migrations/0022_dbgroup_type_string_change_content.py
+++ b/aiida/backends/djsite/db/migrations/0022_dbgroup_type_string_change_content.py
@@ -1,9 +1,11 @@
 # -*- coding: utf-8 -*-
-# pylint: disable=invalid-name
+# pylint: disable=invalid-name,too-few-public-methods
 """Migration after the update of group_types"""
 
 from __future__ import unicode_literals
 from __future__ import absolute_import
+
+# pylint: disable=no-name-in-module,import-error
 from django.db import migrations
 from aiida.backends.djsite.db.migrations import upgrade_schema_version
 

--- a/aiida/backends/djsite/db/migrations/0022_dbgroup_type_string_change_content.py
+++ b/aiida/backends/djsite/db/migrations/0022_dbgroup_type_string_change_content.py
@@ -1,0 +1,37 @@
+# -*- coding: utf-8 -*-
+# pylint: disable=invalid-name
+"""Migration after the update of group_types"""
+
+from __future__ import unicode_literals
+from __future__ import absolute_import
+from django.db import migrations
+from aiida.backends.djsite.db.migrations import upgrade_schema_version
+
+REVISION = '1.0.22'
+DOWN_REVISION = '1.0.21'
+
+forward_sql = [
+    """UPDATE db_dbgroup SET type_string = 'user' WHERE type_string = '';""",
+    """UPDATE db_dbgroup SET type_string = 'data.upf' WHERE type_string = 'data.upf.family';""",
+    """UPDATE db_dbgroup SET type_string = 'auto.import' WHERE type_string = 'aiida.import';""",
+    """UPDATE db_dbgroup SET type_string = 'auto.run' WHERE type_string = 'autogroup.run';""",
+]
+
+reverse_sql = [
+    """UPDATE db_dbgroup SET type_string = '' WHERE type_string = 'user';""",
+    """UPDATE db_dbgroup SET type_string = 'data.upf.family' WHERE type_string = 'data.upf';""",
+    """UPDATE db_dbgroup SET type_string = 'aiida.import' WHERE type_string = 'auto.import';""",
+    """UPDATE db_dbgroup SET type_string = 'autogroup.run' WHERE type_string = 'auto.run';""",
+]
+
+
+class Migration(migrations.Migration):
+    """Migration after the update of group_types"""
+    dependencies = [
+        ('db', '0021_dbgroup_name_to_label_type_to_type_string'),
+    ]
+
+    operations = [
+        migrations.RunSQL(sql='\n'.join(forward_sql), reverse_sql='\n'.join(reverse_sql)),
+        upgrade_schema_version(REVISION, DOWN_REVISION),
+    ]

--- a/aiida/backends/djsite/db/migrations/__init__.py
+++ b/aiida/backends/djsite/db/migrations/__init__.py
@@ -11,7 +11,7 @@ from __future__ import division
 from __future__ import print_function
 from __future__ import absolute_import
 
-LATEST_MIGRATION = '0020_provenance_redesign'
+LATEST_MIGRATION = '0022_dbgroup_type_string_change_content'
 
 def _update_schema_version(version, apps, schema_editor):
     from aiida.backends.djsite.utils import set_db_schema_version

--- a/aiida/backends/djsite/db/models.py
+++ b/aiida/backends/djsite/db/models.py
@@ -1264,10 +1264,10 @@ class DbGroup(m.Model):
     """
     uuid = m.UUIDField(default=get_new_uuid, unique=True)
     # max_length is required by MySql to have indexes and unique constraints
-    name = m.CharField(max_length=255, db_index=True)
-    # The type of group: a user group, a pseudopotential group,...
-    # User groups have type equal to an empty string
-    type = m.CharField(default="", max_length=255, db_index=True)
+    label = m.CharField(max_length=255, db_index=True)
+    # The type_string of group: a user group, a pseudopotential group,...
+    # User groups have type_string equal to an empty string
+    type_string = m.CharField(default="", max_length=255, db_index=True)
     dbnodes = m.ManyToManyField('DbNode', related_name='dbgroups')
     # Creation time
     time = m.DateTimeField(default=timezone.now, editable=False)
@@ -1279,13 +1279,10 @@ class DbGroup(m.Model):
                         related_name='dbgroups')
 
     class Meta:
-        unique_together = (("name", "type"),)
+        unique_together = (("label", "type_string"),)
 
     def __str__(self):
-        if self.type:
-            return '<DbGroup [type: {}] "{}">'.format(self.type, self.name)
-        else:
-            return '<DbGroup [user-defined] "{}">'.format(self.name)
+        return '<DbGroup [type_string: {}] "{}">'.format(self.type_string, self.label)
 
 
 @python_2_unicode_compatible

--- a/aiida/backends/djsite/db/subtests/generic.py
+++ b/aiida/backends/djsite/db/subtests/generic.py
@@ -66,9 +66,9 @@ class TestGroupsDjango(AiidaTestCase):
 
         default_user = backend.users.create("{}@aiida.net".format(self.id())).store()
 
-        g1 = backend.groups.create(name='testquery1', user=default_user).store()
+        g1 = backend.groups.create(label='testquery1', user=default_user).store()
         self.addCleanup(lambda: backend.groups.delete(g1.id))
-        g2 = backend.groups.create(name='testquery2', user=default_user).store()
+        g2 = backend.groups.create(label='testquery2', user=default_user).store()
         self.addCleanup(lambda: backend.groups.delete(g2.id))
 
         n1 = Data().store()
@@ -80,7 +80,7 @@ class TestGroupsDjango(AiidaTestCase):
         g2.add_nodes([n1, n3])
 
         newuser = backend.users.create(email='test@email.xx')
-        g3 = backend.groups.create(name='testquery3', user=newuser).store()
+        g3 = backend.groups.create(label='testquery3', user=newuser).store()
         self.addCleanup(lambda: backend.groups.delete(g3.id))
 
         # I should find it
@@ -126,33 +126,33 @@ class TestGroupsDjango(AiidaTestCase):
         """
         backend = self.backend
 
-        name_group_a = 'group_a'
-        name_group_c = 'group_c'
+        label_group_a = 'group_a'
+        label_group_c = 'group_c'
 
         default_user = backend.users.create("{}@aiida.net".format(self.id())).store()
 
-        group_a = backend.groups.create(name=name_group_a, description='I am the Original G', user=default_user).store()
+        group_a = backend.groups.create(label=label_group_a, description='I am the Original G', user=default_user).store()
         self.addCleanup(lambda: backend.groups.delete(group_a.id))
 
         # Before storing everything should be fine
-        group_b = backend.groups.create(name=name_group_a, description='They will try to rename me', user=default_user)
-        group_c = backend.groups.create(name=name_group_c, description='They will try to rename me', user=default_user)
+        group_b = backend.groups.create(label=label_group_a, description='They will try to rename me', user=default_user)
+        group_c = backend.groups.create(label=label_group_c, description='They will try to rename me', user=default_user)
 
         # Storing for duplicate group name should trigger UniquenessError
         with self.assertRaises(exceptions.IntegrityError):
             group_b.store()
 
         # Before storing everything should be fine
-        group_c.name = name_group_a
+        group_c.label = label_group_a
 
         # Reverting to unique name before storing
-        group_c.name = name_group_c
+        group_c.label = label_group_c
         group_c.store()
         self.addCleanup(lambda: backend.groups.delete(group_c.id))
 
         # After storing name change to existing should raise
         with self.assertRaises(exceptions.IntegrityError):
-            group_c.name = name_group_a
+            group_c.label = label_group_a
 
     def test_creation_from_dbgroup(self):
         backend = self.backend
@@ -161,7 +161,7 @@ class TestGroupsDjango(AiidaTestCase):
 
         default_user = backend.users.create("{}@aiida.net".format(self.id())).store()
 
-        g = backend.groups.create(name='testgroup_from_dbgroup', user=default_user).store()
+        g = backend.groups.create(label='testgroup_from_dbgroup', user=default_user).store()
         self.addCleanup(lambda: backend.groups.delete(g.id))
 
         g.store()
@@ -175,9 +175,7 @@ class TestGroupsDjango(AiidaTestCase):
 
 
 class TestDbExtrasDjango(AiidaTestCase):
-    """
-    Test DbAttributes.
-    """
+    """Test DbAttributes."""
 
     def test_replacement_1(self):
         from aiida.backends.djsite.db.models import DbExtra

--- a/aiida/backends/sqlalchemy/migrations/versions/b8b23ddefad4_dbgroup_name_to_label_type_to_type_string.py
+++ b/aiida/backends/sqlalchemy/migrations/versions/b8b23ddefad4_dbgroup_name_to_label_type_to_type_string.py
@@ -1,0 +1,60 @@
+# -*- coding: utf-8 -*-
+###########################################################################
+# Copyright (c), The AiiDA team. All rights reserved.                     #
+# This file is part of the AiiDA code.                                    #
+#                                                                         #
+# The code is hosted on GitHub at https://github.com/aiidateam/aiida_core #
+# For further information on the license, see the LICENSE.txt file        #
+# For further information please visit http://www.aiida.net               #
+###########################################################################
+# pylint: disable=invalid-name,no-member
+"""DbGroup class: Rename name with label and type with type_string
+
+Revision ID: b8b23ddefad4
+Revises: 162b99bca4a2
+Create Date: 2018-12-06 15:25:32.865136
+
+"""
+from __future__ import absolute_import
+# pylint: disable=no-name-in-module,import-error
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = 'b8b23ddefad4'
+down_revision = '239cea6d2452'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    """The upgrade migration actions."""
+    # dropping
+    op.drop_constraint('db_dbgroup_name_type_key', 'db_dbgroup')
+    op.drop_index('ix_db_dbgroup_name', 'db_dbgroup')
+    op.drop_index('ix_db_dbgroup_type', 'db_dbgroup')
+
+    # renaming
+    op.alter_column('db_dbgroup', 'name', new_column_name='label')
+    op.alter_column('db_dbgroup', 'type', new_column_name='type_string')
+
+    # creating
+    op.create_unique_constraint('db_dbgroup_label_type_string_key', 'db_dbgroup', ['label', 'type_string'])
+    op.create_index('ix_db_dbgroup_label', 'db_dbgroup', ['label'])
+    op.create_index('ix_db_dbgroup_type_string', 'db_dbgroup', ['type_string'])
+
+
+def downgrade():
+    """The downgrade migration actions."""
+    # dropping
+    op.drop_constraint('db_dbgroup_label_type_string_key', 'db_dbgroup')
+    op.drop_index('ix_db_dbgroup_label', 'db_dbgroup')
+    op.drop_index('ix_db_dbgroup_type_string', 'db_dbgroup')
+
+    # renaming
+    op.alter_column('db_dbgroup', 'label', new_column_name='name')
+    op.alter_column('db_dbgroup', 'type_string', new_column_name='type')
+
+    # creating
+    op.create_unique_constraint('db_dbgroup_name_type_key', 'db_dbgroup', ['name', 'type'])
+    op.create_index('ix_db_dbgroup_name', 'db_dbgroup', ['name'])
+    op.create_index('ix_db_dbgroup_type', 'db_dbgroup', ['type'])

--- a/aiida/backends/sqlalchemy/migrations/versions/e72ad251bcdb_dbgroup_class_change_type_string_values.py
+++ b/aiida/backends/sqlalchemy/migrations/versions/e72ad251bcdb_dbgroup_class_change_type_string_values.py
@@ -1,3 +1,13 @@
+# -*- coding: utf-8 -*-
+###########################################################################
+# Copyright (c), The AiiDA team. All rights reserved.                     #
+# This file is part of the AiiDA code.                                    #
+#                                                                         #
+# The code is hosted on GitHub at https://github.com/aiidateam/aiida_core #
+# For further information on the license, see the LICENSE.txt file        #
+# For further information please visit http://www.aiida.net               #
+###########################################################################
+# pylint: disable=invalid-name,no-member
 """DbGroup class: change type_string values
 
 Revision ID: e72ad251bcdb
@@ -6,6 +16,7 @@ Create Date: 2018-12-06 19:34:47.732890
 
 """
 from __future__ import absolute_import
+# pylint: disable=no-name-in-module,import-error
 from alembic import op
 from sqlalchemy.sql import text
 

--- a/aiida/backends/sqlalchemy/migrations/versions/e72ad251bcdb_dbgroup_class_change_type_string_values.py
+++ b/aiida/backends/sqlalchemy/migrations/versions/e72ad251bcdb_dbgroup_class_change_type_string_values.py
@@ -1,0 +1,42 @@
+"""DbGroup class: change type_string values
+
+Revision ID: e72ad251bcdb
+Revises: b8b23ddefad4
+Create Date: 2018-12-06 19:34:47.732890
+
+"""
+from __future__ import absolute_import
+from alembic import op
+from sqlalchemy.sql import text
+
+forward_sql = [
+    """UPDATE db_dbgroup SET type_string = 'user' WHERE type_string = '';""",
+    """UPDATE db_dbgroup SET type_string = 'data.upf' WHERE type_string = 'data.upf.family';""",
+    """UPDATE db_dbgroup SET type_string = 'auto.import' WHERE type_string = 'aiida.import';""",
+    """UPDATE db_dbgroup SET type_string = 'auto.run' WHERE type_string = 'autogroup.run';""",
+]
+
+reverse_sql = [
+    """UPDATE db_dbgroup SET type_string = '' WHERE type_string = 'user';""",
+    """UPDATE db_dbgroup SET type_string = 'data.upf.family' WHERE type_string = 'data.upf';""",
+    """UPDATE db_dbgroup SET type_string = 'aiida.import' WHERE type_string = 'auto.import';""",
+    """UPDATE db_dbgroup SET type_string = 'autogroup.run' WHERE type_string = 'auto.run';""",
+]
+
+# revision identifiers, used by Alembic.
+revision = 'e72ad251bcdb'
+down_revision = 'b8b23ddefad4'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    conn = op.get_bind()
+    statement = text('\n'.join(forward_sql))
+    conn.execute(statement)
+
+
+def downgrade():
+    conn = op.get_bind()
+    statement = text('\n'.join(reverse_sql))
+    conn.execute(statement)

--- a/aiida/backends/sqlalchemy/models/group.py
+++ b/aiida/backends/sqlalchemy/models/group.py
@@ -39,9 +39,9 @@ class DbGroup(Base):
     id = Column(Integer, primary_key=True)
 
     uuid = Column(UUID(as_uuid=True), default=uuid_func)
-    name = Column(String(255), index=True)
+    label = Column(String(255), index=True)
 
-    type = Column(String(255), default="", index=True)
+    type_string = Column(String(255), default="", index=True)
 
     time = Column(DateTime(timezone=True), default=timezone.now)
     description = Column(Text, nullable=True)
@@ -52,7 +52,7 @@ class DbGroup(Base):
     dbnodes = relationship('DbNode', secondary=table_groups_nodes, backref="dbgroups", lazy='dynamic')
 
     __table_args__ = (
-        UniqueConstraint('name', 'type'),
+        UniqueConstraint('label', 'type_string'),
     )
 
     Index('db_dbgroup_dbnodes_dbnode_id_idx', table_groups_nodes.c.dbnode_id)
@@ -63,7 +63,4 @@ class DbGroup(Base):
         return self.id
 
     def __str__(self):
-        if self.type:
-            return '<DbGroup [type: {}] "{}">'.format(self.type, self.name)
-
-        return '<DbGroup [user-defined] "{}">'.format(self.name)
+        return '<DbGroup [type: {}] "{}">'.format(self.type_string, self.label)

--- a/aiida/backends/tests/cmdline/commands/test_calcjob.py
+++ b/aiida/backends/tests/cmdline/commands/test_calcjob.py
@@ -48,7 +48,7 @@ class TestVerdiCalculation(AiidaTestCase):
             workdir='/tmp/aiida').store()
 
         cls.code = orm.Code(remote_computer_exec=(cls.computer, '/bin/true')).store()
-        cls.group = orm.Group(name='test_group').store()
+        cls.group = orm.Group(label='test_group').store()
         cls.node = Data().store()
         cls.calcs = []
 

--- a/aiida/backends/tests/cmdline/commands/test_calculation.py
+++ b/aiida/backends/tests/cmdline/commands/test_calculation.py
@@ -52,7 +52,7 @@ class TestVerdiCalculation(AiidaTestCase):
             workdir='/tmp/aiida').store()
 
         cls.code = orm.Code(remote_computer_exec=(cls.computer, '/bin/true')).store()
-        cls.group = orm.Group(name='test_group').store()
+        cls.group = orm.Group(label='test_group').store()
         cls.node = Data().store()
         cls.calcs = []
 

--- a/aiida/backends/tests/cmdline/commands/test_data.py
+++ b/aiida/backends/tests/cmdline/commands/test_data.py
@@ -343,11 +343,11 @@ class TestVerdiDataBands(AiidaTestCase, TestVerdiDataListable):
         b = connect_structure_bands(s)
 
         # Create 2 groups and add the data to one of them
-        g_ne = Group(name='non_empty_group')
+        g_ne = Group(label='non_empty_group')
         g_ne.store()
         g_ne.add_nodes(b)
 
-        g_e = Group(name='empty_group')
+        g_e = Group(label='empty_group')
         g_e.store()
 
         return {
@@ -531,11 +531,11 @@ class TestVerdiDataTrajectory(AiidaTestCase, TestVerdiDataListable, TestVerdiDat
         n.store()
 
         # Create 2 groups and add the data to one of them
-        g_ne = Group(name='non_empty_group')
+        g_ne = Group(label='non_empty_group')
         g_ne.store()
         g_ne.add_nodes(n)
 
-        g_e = Group(name='empty_group')
+        g_e = Group(label='empty_group')
         g_e.store()
 
         return {
@@ -628,11 +628,11 @@ class TestVerdiDataStructure(AiidaTestCase, TestVerdiDataListable, TestVerdiData
         struc.store()
 
         # Create 2 groups and add the data to one of them
-        g_ne = Group(name='non_empty_group')
+        g_ne = Group(label='non_empty_group')
         g_ne.store()
         g_ne.add_nodes(struc)
 
-        g_e = Group(name='empty_group')
+        g_e = Group(label='empty_group')
         g_e.store()
 
         return {
@@ -745,11 +745,11 @@ class TestVerdiDataCif(AiidaTestCase, TestVerdiDataListable, TestVerdiDataExport
             a = CifData(file=filename, source={'version': '1234', 'db_name': 'COD', 'id': '0000001'})
             a.store()
 
-            g_ne = Group(name='non_empty_group')
+            g_ne = Group(label='non_empty_group')
             g_ne.store()
             g_ne.add_nodes(a)
 
-            g_e = Group(name='empty_group')
+            g_e = Group(label='empty_group')
             g_e.store()
 
         return {

--- a/aiida/backends/tests/cmdline/commands/test_export.py
+++ b/aiida/backends/tests/cmdline/commands/test_export.py
@@ -72,7 +72,7 @@ class TestVerdiExport(AiidaTestCase):
             workdir='/tmp/aiida').store()
 
         cls.code = orm.Code(remote_computer_exec=(cls.computer, '/bin/true')).store()
-        cls.group = orm.Group(name='test_group').store()
+        cls.group = orm.Group(label='test_group').store()
         cls.node = orm.Data().store()
 
         # some of the export tests write in the current directory,

--- a/aiida/backends/tests/cmdline/commands/test_group.py
+++ b/aiida/backends/tests/cmdline/commands/test_group.py
@@ -18,7 +18,7 @@ from click.testing import CliRunner
 import traceback
 from aiida.backends.testbase import AiidaTestCase
 from aiida.cmdline.commands.cmd_group import (group_list, group_create, group_delete, group_rename, group_description,
-                                              group_addnodes, group_removenodes, group_show)
+                                              group_addnodes, group_removenodes, group_show, group_copy)
 
 
 class TestVerdiGroupSetup(AiidaTestCase):
@@ -31,7 +31,7 @@ class TestVerdiGroupSetup(AiidaTestCase):
         super(TestVerdiGroupSetup, cls).setUpClass(*args, **kwargs)
         from aiida.orm import Group
         for grp in ["dummygroup1", "dummygroup2", "dummygroup3", "dummygroup4"]:
-            Group(name=grp).store()
+            Group(label=grp).store()
 
     def setUp(self):
         """
@@ -85,10 +85,13 @@ class TestVerdiGroupSetup(AiidaTestCase):
         self.assertIsNone(result.exception, result.output)
         self.assertIn('Usage', result.output)
 
+        # verdi group copy
+        result = self.cli_runner.invoke(group_copy, options)
+        self.assertIsNone(result.exception, result.output)
+        self.assertIn('Usage', result.output)
+
     def test_create(self):
-        """
-        Test group create command
-        """
+        """Test group create command."""
         result = self.cli_runner.invoke(group_create, ["dummygroup5"])
         self.assertClickResultNoException(result)
 
@@ -99,14 +102,19 @@ class TestVerdiGroupSetup(AiidaTestCase):
         self.assertIn("dummygroup5", result.output)
 
     def test_list(self):
-        """
-        Test group list command
-        """
+        """Test group list command."""
         result = self.cli_runner.invoke(group_list)
         self.assertClickResultNoException(result)
 
         for grp in ["dummygroup1", "dummygroup2"]:
             self.assertIn(grp, result.output)
+
+    def test_copy(self):
+        """Test group copy command."""
+        result = self.cli_runner.invoke(group_copy, ["dummygroup1", "dummygroup2"])
+        self.assertClickResultNoException(result)
+
+        self.assertIn("Success", result.output)
 
     def test_delete(self):
         """
@@ -128,7 +136,7 @@ class TestVerdiGroupSetup(AiidaTestCase):
         self.assertClickResultNoException(result)
 
         for grpline in [
-            "Group name", "dummygroup1", "Group type", "<user-defined>", "Group description", "<no description>"
+            "Group label", "dummygroup1", "Group type_string", "user", "Group description", "<no description>"
         ]:
             self.assertIn(grpline, result.output)
 

--- a/aiida/backends/tests/cmdline/commands/test_node.py
+++ b/aiida/backends/tests/cmdline/commands/test_node.py
@@ -342,11 +342,11 @@ class TestVerdiDataBands(AiidaTestCase, TestVerdiDataListable):
         b = connect_structure_bands(s)
 
         # Create 2 groups and add the data to one of them
-        g_ne = orm.Group(name='non_empty_group')
+        g_ne = orm.Group(label='non_empty_group')
         g_ne.store()
         g_ne.add_nodes(b)
 
-        g_e = orm.Group(name='empty_group')
+        g_e = orm.Group(label='empty_group')
         g_e.store()
 
         return {
@@ -531,11 +531,11 @@ class TestVerdiDataTrajectory(AiidaTestCase, TestVerdiDataListable, TestVerdiDat
         n.store()
 
         # Create 2 groups and add the data to one of them
-        g_ne = orm.Group(name='non_empty_group')
+        g_ne = orm.Group(label='non_empty_group')
         g_ne.store()
         g_ne.add_nodes(n)
 
-        g_e = orm.Group(name='empty_group')
+        g_e = orm.Group(label='empty_group')
         g_e.store()
 
         return {
@@ -628,11 +628,11 @@ class TestVerdiDataStructure(AiidaTestCase, TestVerdiDataListable, TestVerdiData
         struc.store()
 
         # Create 2 groups and add the data to one of them
-        g_ne = orm.Group(name='non_empty_group')
+        g_ne = orm.Group(label='non_empty_group')
         g_ne.store()
         g_ne.add_nodes(struc)
 
-        g_e = orm.Group(name='empty_group')
+        g_e = orm.Group(label='empty_group')
         g_e.store()
 
         return {
@@ -748,11 +748,11 @@ class TestVerdiDataCif(AiidaTestCase, TestVerdiDataListable, TestVerdiDataExport
             a = CifData(file=filename, source={'version': '1234', 'db_name': 'COD', 'id': '0000001'})
             a.store()
 
-            g_ne = orm.Group(name='non_empty_group')
+            g_ne = orm.Group(label='non_empty_group')
             g_ne.store()
             g_ne.add_nodes(a)
 
-            g_e = orm.Group(name='empty_group')
+            g_e = orm.Group(label='empty_group')
             g_e.store()
 
         return {

--- a/aiida/backends/tests/cmdline/params/types/test_group.py
+++ b/aiida/backends/tests/cmdline/params/types/test_group.py
@@ -29,9 +29,9 @@ class TestGroupParamType(AiidaTestCase):
         super(TestGroupParamType, cls).setUpClass()
 
         cls.param = GroupParamType()
-        cls.entity_01 = Group(name='group_01').store()
-        cls.entity_02 = Group(name=str(cls.entity_01.pk)).store()
-        cls.entity_03 = Group(name=str(cls.entity_01.uuid)).store()
+        cls.entity_01 = Group(label='group_01').store()
+        cls.entity_02 = Group(label=str(cls.entity_01.pk)).store()
+        cls.entity_03 = Group(label=str(cls.entity_01.uuid)).store()
 
     def test_get_by_id(self):
         """
@@ -53,7 +53,7 @@ class TestGroupParamType(AiidaTestCase):
         """
         Verify that using the LABEL will retrieve the correct entity
         """
-        identifier = '{}'.format(self.entity_01.name)
+        identifier = '{}'.format(self.entity_01.label)
         result = self.param.convert(identifier, None, None)
         self.assertEquals(result.uuid, self.entity_01.uuid)
 
@@ -64,11 +64,11 @@ class TestGroupParamType(AiidaTestCase):
         Verify that using an ambiguous identifier gives precedence to the ID interpretation
         Appending the special ambiguity breaker character will force the identifier to be treated as a LABEL
         """
-        identifier = '{}'.format(self.entity_02.name)
+        identifier = '{}'.format(self.entity_02.label)
         result = self.param.convert(identifier, None, None)
         self.assertEquals(result.uuid, self.entity_01.uuid)
 
-        identifier = '{}{}'.format(self.entity_02.name, OrmEntityLoader.LABEL_AMBIGUITY_BREAKER_CHARACTER)
+        identifier = '{}{}'.format(self.entity_02.label, OrmEntityLoader.LABEL_AMBIGUITY_BREAKER_CHARACTER)
         result = self.param.convert(identifier, None, None)
         self.assertEquals(result.uuid, self.entity_02.uuid)
 
@@ -79,10 +79,10 @@ class TestGroupParamType(AiidaTestCase):
         Verify that using an ambiguous identifier gives precedence to the UUID interpretation
         Appending the special ambiguity breaker character will force the identifier to be treated as a LABEL
         """
-        identifier = '{}'.format(self.entity_03.name)
+        identifier = '{}'.format(self.entity_03.label)
         result = self.param.convert(identifier, None, None)
         self.assertEquals(result.uuid, self.entity_01.uuid)
 
-        identifier = '{}{}'.format(self.entity_03.name, OrmEntityLoader.LABEL_AMBIGUITY_BREAKER_CHARACTER)
+        identifier = '{}{}'.format(self.entity_03.label, OrmEntityLoader.LABEL_AMBIGUITY_BREAKER_CHARACTER)
         result = self.param.convert(identifier, None, None)
         self.assertEquals(result.uuid, self.entity_03.uuid)

--- a/aiida/backends/tests/generic.py
+++ b/aiida/backends/tests/generic.py
@@ -136,12 +136,12 @@ class TestGroupHashing(AiidaTestCase):
         from aiida.orm.groups import Group
         from aiida.orm.querybuilder import QueryBuilder
 
-        g = Group(name='test_group')
+        g = Group(label='test_group')
         g.store()
 
         # Search for the UUID of the stored group
         qb = QueryBuilder()
-        qb.append(Group, project=['uuid'], filters={'name': {'==': 'test_group'}})
+        qb.append(Group, project=['uuid'], filters={'label': {'==': 'test_group'}})
         [uuid] = qb.first()
 
         # Look the node with the previously returned UUID
@@ -163,7 +163,7 @@ class TestGroups(AiidaTestCase):
         n = orm.Data()
         stored_n = orm.Data().store()
 
-        g = orm.Group(name='testgroup')
+        g = orm.Group(label='testgroup')
         self.addCleanup(lambda: orm.Group.objects.delete(g.id))
 
         with self.assertRaises(ModificationNotAllowed):
@@ -195,11 +195,11 @@ class TestGroups(AiidaTestCase):
 
         n = orm.Data().store()
 
-        g1 = Group(name='testgroupdescription1', description="g1").store()
+        g1 = Group(label='testgroupdescription1', description="g1").store()
         self.addCleanup(lambda: orm.Group.objects.delete(g1.id))
         g1.add_nodes(n)
 
-        g2 = Group(name='testgroupdescription2', description="g2")
+        g2 = Group(label='testgroupdescription2', description="g2")
         self.addCleanup(lambda: orm.Group.objects.delete(g2.id))
 
         # Preliminary checks
@@ -237,7 +237,7 @@ class TestGroups(AiidaTestCase):
         n7 = orm.Data().store()
         n8 = orm.Data().store()
 
-        g = orm.Group(name='test_adding_nodes').store()
+        g = orm.Group(label='test_adding_nodes').store()
         self.addCleanup(lambda: orm.Group.objects.delete(g.pk))
         g.store()
         # Single node
@@ -274,7 +274,7 @@ class TestGroups(AiidaTestCase):
         n8 = orm.Data().store()
         n_out = orm.Data().store()
 
-        g = Group(name='test_remove_nodes').store()
+        g = Group(label='test_remove_nodes').store()
         self.addCleanup(lambda: orm.Group.objects.delete(g.id))
 
         # Add initial nodes
@@ -309,13 +309,13 @@ class TestGroups(AiidaTestCase):
         self.assertEquals(set(), set([_.pk for _ in g.nodes]))
 
     def test_name_desc(self):
-        g = orm.Group(name='testgroup2', description='some desc')
-        self.assertEquals(g.name, 'testgroup2')
+        g = orm.Group(label='testgroup2', description='some desc')
+        self.assertEquals(g.label, 'testgroup2')
         self.assertEquals(g.description, 'some desc')
         self.assertTrue(g.is_user_defined)
         g.store()
         # Same checks after storing
-        self.assertEquals(g.name, 'testgroup2')
+        self.assertEquals(g.label, 'testgroup2')
         self.assertTrue(g.is_user_defined)
         self.assertEquals(g.description, 'some desc')
 
@@ -327,9 +327,9 @@ class TestGroups(AiidaTestCase):
 
         n = orm.Data().store()
 
-        g = orm.Group(name='testgroup3', description='some other desc').store()
+        g = orm.Group(label='testgroup3', description='some other desc').store()
 
-        gcopy = orm.Group.get(name='testgroup3')
+        gcopy = orm.Group.get(label='testgroup3')
         self.assertEquals(g.uuid, gcopy.uuid)
 
         g.add_nodes(n)
@@ -339,7 +339,7 @@ class TestGroups(AiidaTestCase):
 
         with self.assertRaises(NotExistent):
             # The group does not exist anymore
-            orm.Group.get(name='testgroup3')
+            orm.Group.get(label='testgroup3')
 
     def test_rename(self):
         """
@@ -347,24 +347,24 @@ class TestGroups(AiidaTestCase):
         """
         from aiida.orm.groups import Group
 
-        name_original = 'groupie'
-        name_changed = 'nogroupie'
+        label_original = 'groupie'
+        label_changed = 'nogroupie'
 
-        g = Group(name=name_original, description='I will be renamed')
+        g = Group(label=label_original, description='I will be renamed')
 
         # Check name changes work before storing
-        self.assertEquals(g.name, name_original)
-        g.name = name_changed
-        self.assertEquals(g.name, name_changed)
+        self.assertEquals(g.label, label_original)
+        g.label = label_changed
+        self.assertEquals(g.label, label_changed)
 
         # Revert the name to its original and store it
-        g.name = name_original
+        g.label = label_original
         g.store()
 
         # Check name changes work after storing
-        self.assertEquals(g.name, name_original)
-        g.name = name_changed
-        self.assertEquals(g.name, name_changed)
+        self.assertEquals(g.label, label_original)
+        g.label = label_changed
+        self.assertEquals(g.label, label_changed)
 
 
 class TestBool(AiidaTestCase):

--- a/aiida/backends/tests/orm/utils/loaders.py
+++ b/aiida/backends/tests/orm/utils/loaders.py
@@ -138,10 +138,10 @@ class TestOrmUtils(AiidaTestCase):
     def test_load_group(self):
         """Test the functionality of load_group."""
         name = 'groupie'
-        group = Group(name=name).store()
+        group = Group(label=name).store()
 
         # Load through label
-        loaded_group = load_group(group.name)
+        loaded_group = load_group(group.label)
         self.assertEquals(loaded_group.uuid, group.uuid)
 
         # Load through uuid
@@ -153,7 +153,7 @@ class TestOrmUtils(AiidaTestCase):
         self.assertEquals(loaded_group.uuid, group.uuid)
 
         # Load through label explicitly
-        loaded_group = load_group(label=group.name)
+        loaded_group = load_group(label=group.label)
         self.assertEquals(loaded_group.uuid, group.uuid)
 
         # Load through uuid explicitly

--- a/aiida/backends/tests/query.py
+++ b/aiida/backends/tests/query.py
@@ -460,7 +460,7 @@ class TestQueryHelp(AiidaTestCase):
         from aiida.orm.querybuilder import QueryBuilder
         from aiida.orm.groups import Group
         from aiida.orm.computers import Computer
-        g = Group(name='helloworld').store()
+        g = Group(label='helloworld').store()
         for cls in (StructureData, ParameterData, Data):
             obj = cls()
             obj._set_attr('foo-qh2', 'bar')
@@ -489,10 +489,10 @@ class TestQueryHelp(AiidaTestCase):
                 sorted([uuid for uuid, in qb.all()]),
                 sorted([uuid for uuid, in qb_new.all()]))
 
-        qb = QueryBuilder().append(Group, filters={'name': 'helloworld'})
+        qb = QueryBuilder().append(Group, filters={'label': 'helloworld'})
         self.assertEqual(qb.count(), 1)
 
-        qb = QueryBuilder().append((Group,), filters={'name': 'helloworld'})
+        qb = QueryBuilder().append((Group,), filters={'label': 'helloworld'})
         self.assertEqual(qb.count(), 1)
 
         qb = QueryBuilder().append(Computer, )
@@ -799,7 +799,7 @@ class QueryBuilderJoinsTests(AiidaTestCase):
 
         # Create a group that belongs to that user
         from aiida.orm.groups import Group
-        group = orm.Group(name="node_group")
+        group = orm.Group(label="node_group")
         group.user = user
         group.store()
 

--- a/aiida/backends/tests/utils/test_serialize.py
+++ b/aiida/backends/tests/utils/test_serialize.py
@@ -48,7 +48,7 @@ class TestSerialize(AiidaTestCase):
         Also make sure that the serialized data is json-serializable
         """
         group_name = 'groupie'
-        group_a = orm.Group(name=group_name).store()
+        group_a = orm.Group(label=group_name).store()
 
         data = {'group': group_a}
 
@@ -56,7 +56,7 @@ class TestSerialize(AiidaTestCase):
         deserialized_data = serialize.deserialize(serialized_data)
 
         self.assertEqual(data['group'].uuid, deserialized_data['group'].uuid)
-        self.assertEqual(data['group'].name, deserialized_data['group'].name)
+        self.assertEqual(data['group'].label, deserialized_data['group'].label)
 
     def test_serialize_node_round_trip(self):
         """Test you can serialize and deserialize a node"""
@@ -66,11 +66,11 @@ class TestSerialize(AiidaTestCase):
 
     def test_serialize_group_round_trip(self):
         """Test you can serialize and deserialize a group"""
-        group = orm.Group(name='test_serialize_group_round_trip').store()
+        group = orm.Group(label='test_serialize_group_round_trip').store()
         deserialized = serialize.deserialize(serialize.serialize(group))
 
         self.assertEqual(group.uuid, deserialized.uuid)
-        self.assertEqual(group.name, deserialized.name)
+        self.assertEqual(group.label, deserialized.label)
 
     def test_serialize_computer_round_trip(self):
         """Test you can serialize and deserialize a computer"""
@@ -90,7 +90,7 @@ class TestSerialize(AiidaTestCase):
 
     def test_serialize_unstored_group(self):
         """Test that you can't serialize an unstored group"""
-        group = orm.Group(name='test_serialize_unstored_group')
+        group = orm.Group(label='test_serialize_unstored_group')
 
         with self.assertRaises(ValueError):
             serialize.serialize(group)

--- a/aiida/backends/tests/work/process.py
+++ b/aiida/backends/tests/work/process.py
@@ -70,6 +70,7 @@ class TestProcessNamespace(AiidaTestCase):
 
 
 class ProcessStackTest(work.Process):
+
     _calc_class = WorkflowNode
 
     @override

--- a/aiida/cmdline/commands/cmd_data/cmd_upf.py
+++ b/aiida/cmdline/commands/cmd_data/cmd_upf.py
@@ -28,7 +28,7 @@ def upf():
 
 @upf.command('uploadfamily')
 @click.argument('folder', type=click.Path(exists=True, file_okay=False, resolve_path=True))
-@click.argument('group_name', type=click.STRING)
+@click.argument('group_label', type=click.STRING)
 @click.argument('group_description', type=click.STRING)
 @click.option(
     '--stop-if-existing',
@@ -36,7 +36,7 @@ def upf():
     default=False,
     help='Interrupt pseudos import if a pseudo was already present in the AiiDA database')
 @decorators.with_dbenv()
-def upf_uploadfamily(folder, group_name, group_description, stop_if_existing):
+def upf_uploadfamily(folder, group_label, group_description, stop_if_existing):
     """
     Upload a new pseudopotential family.
 
@@ -45,7 +45,7 @@ def upf_uploadfamily(folder, group_name, group_description, stop_if_existing):
     Call without parameters to get some help.
     """
     import aiida.orm.data.upf as upf_
-    files_found, files_uploaded = upf_.upload_upf_family(folder, group_name, group_description, stop_if_existing)
+    files_found, files_uploaded = upf_.upload_upf_family(folder, group_label, group_description, stop_if_existing)
     echo.echo_success("UPF files found: {}. New files uploaded: {}".format(files_found, files_uploaded))
 
 
@@ -75,18 +75,18 @@ def upf_listfamilies(elements, with_description):
         orm.Group,
         with_node='upfdata',
         tag='group',
-        project=["name", "description"],
-        filters={"type": {
+        project=["label", "description"],
+        filters={"type_string": {
             '==': UPFGROUP_TYPE
         }})
 
     query.distinct()
     if query.count() > 0:
         for res in query.dict():
-            group_name = res.get("group").get("name")
+            group_label = res.get("group").get("label")
             group_desc = res.get("group").get("description")
             query = orm.QueryBuilder()
-            query.append(orm.Group, tag='thisgroup', filters={"name": {'like': group_name}})
+            query.append(orm.Group, tag='thisgroup', filters={"label": {'like': group_label}})
             query.append(UpfData, project=["id"], with_group='thisgroup')
 
             if with_description:
@@ -94,7 +94,7 @@ def upf_listfamilies(elements, with_description):
             else:
                 description_string = ""
 
-            echo.echo_success("* {} [{} pseudos]{}".format(group_name, query.count(), description_string))
+            echo.echo_success("* {} [{} pseudos]{}".format(group_label, query.count(), description_string))
 
     else:
         echo.echo_warning("No valid UPF pseudopotential family found.")

--- a/aiida/cmdline/commands/cmd_data/cmd_upf.py
+++ b/aiida/cmdline/commands/cmd_data/cmd_upf.py
@@ -77,7 +77,7 @@ def upf_listfamilies(elements, with_description):
         tag='group',
         project=["label", "description"],
         filters={"type_string": {
-            '==': UPFGROUP_TYPE
+            '==': UPFGROUP_TYPE.value
         }})
 
     query.distinct()

--- a/aiida/cmdline/commands/cmd_export.py
+++ b/aiida/cmdline/commands/cmd_export.py
@@ -89,6 +89,7 @@ def inspect(archive, version, data, meta_data):
     default=False,
     show_default=True,
     help='Follow reverse CALL links (recursively) when calculating the node set to export.')
+@decorators.with_dbenv()
 def create(output_file, codes, computers, groups, nodes, input_forward, create_reversed, return_reversed, call_reversed,
            force, archive_format):
     """

--- a/aiida/cmdline/commands/cmd_group.py
+++ b/aiida/cmdline/commands/cmd_group.py
@@ -147,7 +147,7 @@ def group_show(group, raw, uuid):
 
         table = []
         table.append(["Group label", group.label])
-        table.append(["Group type_string", type_string if type_string else "<user-defined>"])
+        table.append(["Group type_string", type_string])
         table.append(["Group description", desc if desc else "<no description>"])
         echo.echo(tabulate(table))
 
@@ -313,7 +313,7 @@ def group_create(group_label):
     from aiida import orm
     from aiida.orm import GroupTypeString
 
-    group, created = orm.Group.objects.get_or_create(label=group_label, type_string=GroupTypeString.USER.value)
+    group, created = orm.Group.objects.get_or_create(label=group_label, type_string=GroupTypeString.USER)
 
     if created:
         echo.echo_success("Group created with PK = {} and name '{}'".format(group.id, group.label))
@@ -328,8 +328,10 @@ def group_create(group_label):
 def group_copy(source_group, destination_group):
     """Add all nodes that belong to source group to the destination group (which may or may not exist)."""
     from aiida import orm
+    from aiida.orm import GroupTypeString
 
-    dest_group = orm.Group.objects.get_or_create(label=destination_group, type_string=source_group.type_string)[0]
+    dest_group = orm.Group.objects.get_or_create(
+        label=destination_group, type_string=GroupTypeString(source_group.type_string))[0]
     try:
         dest_group.add_nodes(source_group.nodes)
         echo.echo_success("Nodes were succesfully copied from the group <{}> to the group "

--- a/aiida/cmdline/commands/cmd_group.py
+++ b/aiida/cmdline/commands/cmd_group.py
@@ -17,9 +17,9 @@ import click
 
 from aiida.common.exceptions import UniquenessError
 from aiida.cmdline.commands.cmd_verdi import verdi
+from aiida.cmdline.params import options, arguments, types
 from aiida.cmdline.utils import echo
 from aiida.cmdline.utils.decorators import with_dbenv
-from aiida.cmdline.params import options, arguments
 
 
 @verdi.group('group')
@@ -29,37 +29,34 @@ def verdi_group():
 
 
 @verdi_group.command("removenodes")
-@options.GROUP()
+@options.GROUP(required=True)
 @arguments.NODES()
 @options.FORCE(help="Force to remove the nodes from group.")
 @with_dbenv()
 def group_removenodes(group, nodes, force):
-    """
-    Remove NODES from a given AiiDA group.
-    """
+    """Remove NODES from a given AiiDA group."""
+
     if not force:
         click.confirm(
             "Are you sure to remove {} nodes from the group with PK = {} "
-            "({})?".format(len(nodes), group.pk, group.name),
+            "({})?".format(len(nodes), group.id, group.label),
             abort=True)
 
     group.remove_nodes(nodes)
 
 
 @verdi_group.command("addnodes")
-@options.GROUP()
+@options.GROUP(required=True)
 @options.FORCE(help="Force to add nodes in the group.")
 @arguments.NODES()
 @with_dbenv()
 def group_addnodes(group, force, nodes):
-    """
-    Add NODES to a given AiiDA group.
-    """
+    """Add NODES to a given AiiDA group."""
 
     if not force:
         click.confirm(
             "Are you sure to add {} nodes the group with PK = {} "
-            "({})?".format(len(nodes), group.pk, group.name),
+            "({})?".format(len(nodes), group.id, group.label),
             abort=True)
 
     group.add_nodes(nodes)
@@ -76,33 +73,30 @@ def group_delete(group, force):
     Pass the GROUP to delete an existing group.
     """
     from aiida import orm
-    group_pk = group.pk
-    group_name = group.name
+    group_id = group.id
+    group_label = group.label
 
     num_nodes = len(group.nodes)
     if num_nodes > 0 and not force:
         echo.echo_critical(("Group '{}' is not empty (it contains {} "
                             "nodes). Pass the -f option if you really want to delete "
-                            "it.".format(group_name, num_nodes)))
+                            "it.".format(group_label, num_nodes)))
 
     if not force:
-        click.confirm('Are you sure to kill the group with PK = {} ({})?'.format(group_pk, group_name), abort=True)
+        click.confirm('Are you sure to kill the group with PK = {} ({})?'.format(group_id, group_label), abort=True)
 
-    orm.Group.objects.delete(group_pk)
-    echo.echo_success("Group '{}' (PK={}) deleted.".format(group_name, group_pk))
+    orm.Group.objects.delete(group_id)
+    echo.echo_success("Group '{}' (PK={}) deleted.".format(group_label, group_id))
 
 
 @verdi_group.command("rename")
 @arguments.GROUP()
-@click.argument("name", nargs=1, type=click.STRING)
+@click.argument("label", nargs=1, type=click.STRING)
 @with_dbenv()
-def group_rename(group, name):
-    """
-    Rename an existing group. Pass the GROUP for which you want to rename and its
-    new NAME.
-    """
+def group_rename(group, label):
+    """Rename an existing group. Pass the GROUP which you want to rename and its new LABEL."""
     try:
-        group.name = name
+        group.label = label
     except UniquenessError as exception:
         echo.echo_critical("Error: {}.".format(exception))
     else:
@@ -134,9 +128,7 @@ def group_description(group, description):
 @arguments.GROUP()
 @with_dbenv()
 def group_show(group, raw, uuid):
-    """
-    Show information on a given group. Pass the GROUP as a parameter.
-    """
+    """Show information on a given group. Pass the GROUP as a parameter."""
 
     from aiida.common.utils import str_timedelta
     from aiida.utils import timezone
@@ -154,8 +146,8 @@ def group_show(group, raw, uuid):
         now = timezone.now()
 
         table = []
-        table.append(["Group name", group.name])
-        table.append(["Group type", type_string if type_string else "<user-defined>"])
+        table.append(["Group label", group.label])
+        table.append(["Group type_string", type_string if type_string else "<user-defined>"])
         table.append(["Group description", desc if desc else "<no description>"])
         echo.echo(tabulate(table))
 
@@ -176,6 +168,18 @@ def group_show(group, raw, uuid):
         echo.echo(tabulate(table, headers=header))
 
 
+@with_dbenv()
+def valid_group_type_strings():
+    from aiida.orm import GroupTypeString
+    return tuple(i.value for i in GroupTypeString)
+
+
+@with_dbenv()
+def user_defined_group():
+    from aiida.orm import GroupTypeString
+    return GroupTypeString.USER.value
+
+
 # pylint: disable=too-many-arguments, too-many-locals
 @verdi_group.command("list")
 @options.ALL_USERS(help="Show groups for all users, rather than only for the current user")
@@ -185,12 +189,15 @@ def group_show(group, raw, uuid):
     'user_email',
     type=click.STRING,
     help="Add a filter to show only groups belonging to a specific user")
+@click.option('-a', '--all-types', is_flag=True, default=False, help="Show groups of all types")
 @click.option(
     '-t',
     '--type',
     'group_type',
-    type=click.STRING,
-    help="Show groups of a specific type, instead of user-defined groups")
+    type=types.LazyChoice(valid_group_type_strings),
+    default=user_defined_group,
+    help="Show groups of a specific type, instead of user-defined groups. Start with semicolumn if you want to "
+    "specify aiida-internal type")
 @click.option(
     '-d', '--with-description', 'with_description', is_flag=True, default=False, help="Show also the group description")
 @click.option('-C', '--count', is_flag=True, default=False, help="Show also the number of nodes in the group")
@@ -215,62 +222,72 @@ def group_show(group, raw, uuid):
     help="add a filter to show only groups for which the name contains STRING")
 @options.NODE(help="Show only the groups that contain the node")
 @with_dbenv()
-def group_list(all_users, user_email, group_type, with_description, count, past_days, startswith, endswith, contains,
-               node):
-    """
-    List AiiDA user-defined groups.
-    """
+def group_list(all_users, user_email, all_types, group_type, with_description, count, past_days, startswith, endswith,
+               contains, node):
+    # pylint: disable=too-many-branches
+    """Show a list of groups."""
     import datetime
+    from aiida.common.utils import escape_for_sql_like
     from aiida.utils import timezone
-    from aiida.orm.groups import get_group_type_mapping
+    from aiida.orm import Group
+    from aiida.orm import QueryBuilder
+    from aiida.orm import User
     from aiida import orm
     from tabulate import tabulate
 
-    if all_users and user_email is not None:
-        echo.echo_critical("argument -A/--all-users: not allowed with argument -u/--user")
+    query = QueryBuilder()
+    filters = {}
 
-    if all_users:
-        user = None
-    else:
-        if user_email:
-            user = user_email
-        else:
-            # By default: only groups of this user
-            user = orm.User.objects.get_default()
+    # Specify group types
+    if not all_types:
+        filters = {'type_string': {'==': group_type}}
 
-    type_string = ""
-    if group_type is not None:
-        try:
-            type_string = get_group_type_mapping()[group_type]
-        except KeyError:
-            echo.echo_critical("Invalid group type. Valid group types are: {}".format(",".join(
-                sorted(get_group_type_mapping().keys()))))
-
-    n_days_ago = None
+    # Creation time
     if past_days:
-        n_days_ago = (timezone.now() - datetime.timedelta(days=past_days))
+        filters['time'] = {'>': timezone.now() - datetime.timedelta(days=past_days)}
 
-    name_filters = {'startswith': startswith, 'endswith': endswith, 'contains': contains}
+    # Query for specific group names
+    filters['or'] = []
+    if startswith:
+        filters['or'].append({'label': {'like': '{}%'.format(escape_for_sql_like(startswith))}})
+    if endswith:
+        filters['or'].append({'label': {'like': '%{}'.format(escape_for_sql_like(endswith))}})
+    if contains:
+        filters['or'].append({'label': {'like': '%{}%'.format(escape_for_sql_like(contains))}})
 
-    # Depending on --nodes option use or not key "nodes"
+    query.append(Group, filters=filters, tag='group', project='*')
 
-    if node:
-        result = orm.Group.query(
-            user=user, type_string=type_string, nodes=node, past_days=n_days_ago, name_filters=name_filters)
+    # Query groups that belong to specific user
+    if user_email:
+        user = user_email
     else:
-        result = orm.Group.query(user=user, type_string=type_string, past_days=n_days_ago, name_filters=name_filters)
+        # By default: only groups of this user
+        user = orm.User.objects.get_default().email
+
+    # Query groups that belong to all users
+    if not all_users:
+        query.append(User, filters={'email': {'==': user}}, with_group='group')
+
+    # Query groups that contain a particular node
+    if node:
+        from aiida.orm import Node
+        query.append(Node, filters={'id': {'==': node.id}}, with_group='group')
+
+    query.order_by({Group: {'id': 'asc'}})
+    result = query.all()
 
     projection_lambdas = {
         'pk': lambda group: str(group.pk),
-        'name': lambda group: group.name,
+        'label': lambda group: group.label,
+        'type_string': lambda group: group.type_string,
         'count': lambda group: len(group.nodes),
         'user': lambda group: group.user.email.strip(),
         'description': lambda group: group.description
     }
 
     table = []
-    projection_header = ['PK', 'Name', 'User']
-    projection_fields = ['pk', 'name', 'user']
+    projection_header = ['PK', 'Label', 'Type string', 'User']
+    projection_fields = ['pk', 'label', 'type_string', 'user']
 
     if with_description:
         projection_header.append('Description')
@@ -281,23 +298,41 @@ def group_list(all_users, user_email, group_type, with_description, count, past_
         projection_fields.append('count')
 
     for group in result:
-        table.append([projection_lambdas[field](group) for field in projection_fields])
+        table.append([projection_lambdas[field](group[0]) for field in projection_fields])
 
+    if not all_types:
+        echo.echo_info("If you want to see the groups of all types, please add -a/--all-types option")
     echo.echo(tabulate(table, headers=projection_header))
 
 
 @verdi_group.command("create")
-@click.argument('group_name', nargs=1, type=click.STRING)
+@click.argument('group_label', nargs=1, type=click.STRING)
 @with_dbenv()
-def group_create(group_name):
-    """
-    Create a new empty group with the name GROUP_NAME
-    """
+def group_create(group_label):
+    """Create a new empty group with the name GROUP_NAME."""
     from aiida import orm
+    from aiida.orm import GroupTypeString
 
-    group, created = orm.Group.objects.get_or_create(name=group_name)
+    group, created = orm.Group.objects.get_or_create(label=group_label, type_string=GroupTypeString.USER.value)
 
     if created:
-        echo.echo_success("Group created with PK = {} and name '{}'".format(group.pk, group.name))
+        echo.echo_success("Group created with PK = {} and name '{}'".format(group.id, group.label))
     else:
-        echo.echo_info("Group '{}' already exists, PK = {}".format(group.name, group.pk))
+        echo.echo_info("Group '{}' already exists, PK = {}".format(group.label, group.id))
+
+
+@verdi_group.command("copy")
+@arguments.GROUP('source_group')
+@click.argument('destination_group', nargs=1, type=click.STRING)
+@with_dbenv()
+def group_copy(source_group, destination_group):
+    """Add all nodes that belong to source group to the destination group (which may or may not exist)."""
+    from aiida import orm
+
+    dest_group = orm.Group.objects.get_or_create(label=destination_group, type_string=source_group.type_string)[0]
+    try:
+        dest_group.add_nodes(source_group.nodes)
+        echo.echo_success("Nodes were succesfully copied from the group <{}> to the group "
+                          "<{}>".format(source_group, destination_group))
+    except:
+        raise

--- a/aiida/cmdline/commands/cmd_import.py
+++ b/aiida/cmdline/commands/cmd_import.py
@@ -15,6 +15,7 @@ import click
 
 from aiida.cmdline.commands.cmd_verdi import verdi
 from aiida.cmdline.params.options import MultipleValueOption
+from aiida.cmdline.params.types import GroupParamType
 from aiida.cmdline.utils import decorators, echo
 from aiida.common import exceptions
 
@@ -28,8 +29,14 @@ from aiida.common import exceptions
     cls=MultipleValueOption,
     help="Discover all URL targets pointing to files with the .aiida extension for these HTTP addresses. "
     "Automatically discovered archive URLs will be downloadeded and added to ARCHIVES for importing")
+@click.option(
+    '-G',
+    '--group',
+    type=GroupParamType(create_if_not_exist=True),
+    help='Specify group to which all the import nodes will be added. If such a group does not exist, it will be'
+    ' created automatically.')
 @decorators.with_dbenv()
-def cmd_import(archives, webpages):
+def cmd_import(archives, webpages, group):
     """Import one or multiple exported AiiDA archives
 
     The ARCHIVES can be specified by their relative or absolute file path, or their HTTP URL.
@@ -71,7 +78,7 @@ def cmd_import(archives, webpages):
         echo.echo_info('importing archive {}'.format(archive))
 
         try:
-            import_data(archive)
+            import_data(archive, group)
         except exceptions.IncompatibleArchiveVersionError as exception:
             echo.echo_warning('{} cannot be imported: {}'.format(archive, exception))
             echo.echo_warning('run `verdi export migrate {}` to update it'.format(archive))
@@ -98,7 +105,7 @@ def cmd_import(archives, webpages):
             echo.echo_success('archive downloaded, proceeding with import')
 
             try:
-                import_data(temp_folder.get_abs_path(temp_file))
+                import_data(temp_folder.get_abs_path(temp_file), group)
             except exceptions.IncompatibleArchiveVersionError as exception:
                 echo.echo_warning('{} cannot be imported: {}'.format(archive, exception))
                 echo.echo_warning('download the archive file and run `verdi export migrate` to update it')

--- a/aiida/common/utils.py
+++ b/aiida/common/utils.py
@@ -1267,6 +1267,11 @@ SQL_TO_REGEX_TOKENS = [  # Remember in the strings below we have to escape backs
 ]
 
 
+def escape_for_sql_like(string):
+    """Function that escapes % or _ symbols provided by user"""
+    return string.replace('%', '\\%').replace('_', '\\_')
+
+
 def get_regex_pattern_from_sql(sql_pattern):
     r"""
     Convert a string providing a pattern to match in SQL

--- a/aiida/orm/autogroup.py
+++ b/aiida/orm/autogroup.py
@@ -20,7 +20,7 @@ from aiida.orm import GroupTypeString
 
 current_autogroup = None
 
-VERDIAUTOGROUP_TYPE = GroupTypeString.VERDIAUTOGROUP_TYPE.value
+VERDIAUTOGROUP_TYPE = GroupTypeString.VERDIAUTOGROUP_TYPE
 
 # TODO: make the Autogroup usable to the user, and not only to the verdi run
 

--- a/aiida/orm/autogroup.py
+++ b/aiida/orm/autogroup.py
@@ -15,11 +15,12 @@ import six
 
 from aiida.utils import timezone
 from aiida.common.exceptions import ValidationError, MissingPluginError
+from aiida.orm import GroupTypeString
 
 
 current_autogroup = None
 
-VERDIAUTOGROUP_TYPE = 'autogroup.run'
+VERDIAUTOGROUP_TYPE = GroupTypeString.VERDIAUTOGROUP_TYPE.value
 
 # TODO: make the Autogroup usable to the user, and not only to the verdi run
 
@@ -71,9 +72,7 @@ class Autogroup(object):
         return the_param
 
     def get_exclude(self):
-        """
-        Return the list of classes to exclude from autogrouping
-        """
+        """Return the list of classes to exclude from autogrouping."""
         try:
             return self.exclude
         except AttributeError:
@@ -90,29 +89,23 @@ class Autogroup(object):
             return []
 
     def get_include(self):
-        """
-        Return the list of classes to include in the autogrouping
-        """
+        """Return the list of classes to include in the autogrouping."""
         try:
             return self.include
         except AttributeError:
             return []
 
     def get_include_with_subclasses(self):
-        """
-        Return the list of classes to include in the autogrouping.
-        Will also include their derived subclasses
-        """
+        """Return the list of classes to include in the autogrouping.
+        Will also include their derived subclasses."""
         try:
             return self.include_with_subclasses
         except AttributeError:
             return []
 
     def get_group_name(self):
-        """
-        Get the name of the group.
-        If no group name was set, it will set a default one by itself.
-        """
+        """Get the name of the group.
+        If no group name was set, it will set a default one by itself."""
         try:
             return self.group_name
         except AttributeError:
@@ -122,9 +115,7 @@ class Autogroup(object):
             return self.group_name
 
     def set_exclude(self, exclude):
-        """
-        Return the list of classes to exclude from autogrouping.
-        """
+        """Return the list of classes to exclude from autogrouping."""
         the_exclude_classes = self._validate(exclude)
         if self.get_include() is not None:
             if 'all.' in self.get_include():

--- a/aiida/orm/data/upf.py
+++ b/aiida/orm/data/upf.py
@@ -24,7 +24,7 @@ from aiida.orm.data.singlefile import SinglefileData
 from aiida.orm import GroupTypeString
 
 
-UPFGROUP_TYPE = GroupTypeString.UPFGROUP_TYPE.value
+UPFGROUP_TYPE = GroupTypeString.UPFGROUP_TYPE
 
 _upfversion_regexp = re.compile(
     r"""

--- a/aiida/orm/groups.py
+++ b/aiida/orm/groups.py
@@ -12,43 +12,35 @@ from __future__ import division
 from __future__ import print_function
 from __future__ import absolute_import
 
+from enum import Enum
 from aiida.common import exceptions
 from aiida.common.utils import type_check
+from aiida.cmdline.utils import echo
 from aiida.manage import get_manager
 
 from . import convert
 from . import entities
 from . import users
 
-__all__ = ('Group',)
+__all__ = ('Group', 'GroupTypeString')
 
 
-def get_group_type_mapping():
-    """
-    Return a dictionary with ``{short_name: proper_long_name_in_DB}`` format,
-    where ``short_name`` is the name to use on the command line, while
-    ``proper_long_name_in_DB`` is the string stored in the ``type`` field of the
-    DbGroup table.
+class GroupTypeString(Enum):
+    """A simple enum of allowed group type strings."""
 
-    It is defined as a function so that the import statements are confined
-    inside here.
-    """
-    from aiida.orm.data.upf import UPFGROUP_TYPE
-    from aiida.orm.autogroup import VERDIAUTOGROUP_TYPE
-    from aiida.orm.importexport import IMPORTGROUP_TYPE
-
-    return {'data.upf': UPFGROUP_TYPE, 'import': IMPORTGROUP_TYPE, 'autogroup.run': VERDIAUTOGROUP_TYPE}
+    UPFGROUP_TYPE = 'data.upf'
+    IMPORTGROUP_TYPE = 'auto.import'
+    VERDIAUTOGROUP_TYPE = 'auto.run'
+    USER = 'user'
 
 
 class Group(entities.Entity):
-    """
-    An AiiDA ORM implementation of group of nodes.
-    """
+    """An AiiDA ORM implementation of group of nodes."""
 
     class Collection(entities.Collection):
         """Collection of Groups"""
 
-        def get_or_create(self, name, **kwargs):
+        def get_or_create(self, label=None, **kwargs):
             """
             Try to retrieve a group from the DB with the given arguments;
             create (and store) a new group if such a group was not present yet.
@@ -56,102 +48,39 @@ class Group(entities.Entity):
             :return: (group, created) where group is the group (new or existing,
               in any case already stored) and created is a boolean saying
             """
-            filters = {'name': name}
+            if 'name' in kwargs:
+                import warnings
+                # pylint: disable=redefined-builtin
+                from aiida.common.warnings import AiidaDeprecationWarning as DeprecationWarning
+                label = kwargs.pop('name')
+                warnings.warn('name is deprecated, use label instead', DeprecationWarning)  # pylint: disable=no-member
+            if 'type' in kwargs:
+                import warnings
+                # pylint: disable=redefined-builtin
+                from aiida.common.warnings import AiidaDeprecationWarning as DeprecationWarning
+                kwargs['type_string'] = kwargs.pop('type')
+                warnings.warn('type is deprecated, use type_string instead', DeprecationWarning)  # pylint: disable=no-member
+            if not label:
+                echo.echo_critical("Group label must be provided")
+
+            filters = {'label': label}
             if 'type_string' in kwargs:
                 filters['type_string'] = kwargs['type_string']
+                try:
+                    GroupTypeString(kwargs['type_string'])
+                except ValueError:
+                    echo.echo_critical("Group type_string <{}> is not allowed. Allowed type_strings are: "
+                                       "{}".format(kwargs['type_string'],
+                                                   ', '.join([i.value for i in GroupTypeString])))
+
             res = self.find(filters=filters)
 
             if not res:
-                return Group(name, backend=self.backend, **kwargs).store(), True
+                return Group(label, backend=self.backend, **kwargs).store(), True
             elif len(res) > 1:
                 raise exceptions.MultipleObjectsError("More than one groups found in the database")
             else:
                 return res[0], False
-
-        def group_query(self,
-                        name=None,
-                        type_string='',
-                        id=None,
-                        uuid=None,
-                        nodes=None,
-                        user=None,
-                        node_attributes=None,
-                        past_days=None,
-                        **kwargs):  # pylint: disable=too-many-arguments, redefined-builtin, invalid-name
-            """
-            Query for groups.
-
-            :note: By default, query for user-defined groups only (type_string=="").
-                If you want to query for all type of groups, pass type_string=None.
-                If you want to query for a specific type of groups, pass a specific
-                string as the type_string argument.
-
-            :param name: the name of the group
-            :param nodes: a node or list of nodes that belongs to the group (alternatively,
-                you can also pass a DbNode or list of DbNodes)
-            :param id: the pk of the group
-            :param uuid: the uuid of the group
-            :param type_string: the string for the type of node; by default, look
-                only for user-defined groups (see note above).
-            :param user: by default, query for groups of all users; if specified,
-                must be a DbUser object, or a string for the user email.
-            :param past_days: by default, query for all groups; if specified, query
-                the groups created in the last past_days. Must be a datetime object.
-            :param node_attributes: if not None, must be a dictionary with
-                format {k: v}. It will filter and return only groups where there
-                is at least a node with an attribute with key=k and value=v.
-                Different keys of the dictionary are joined with AND (that is, the
-                group should satisfy all requirements.
-                v can be a base data type (str, bool, int, float, ...)
-                If it is a list or iterable, that the condition is checked so that
-                there should be at least a node in the group with key=k and
-                value=each of the values of the iterable.
-            :param kwargs: any other filter to be passed to DbGroup.objects.filter
-
-                Example: if ``node_attributes = {'elements': ['Ba', 'Ti'], 'md5sum': 'xxx'}``,
-                    it will find groups that contain the node with md5sum = 'xxx', and moreover
-                    contain at least one node for element 'Ba' and one node for element 'Ti'.
-
-            """
-            # Put everything in the kwargs
-            # Two warninigs:
-            #   1. Make sure to change the key if the variable name gets changed!
-            #   2. These are assuming that if the default gets passed in then that means the user didn't
-            #      specify it.  This a) precludes actually checking for something _being_ the whatever the
-            #      default is, and, b) means that we need to make the right check e.g. 'is not None' or is 'is'
-            #      depending on the type  (usually strings vs objects)
-            if name:
-                kwargs['name'] = name
-            if type_string:
-                kwargs['type_string'] = type_string
-            if id is not None:
-                kwargs['id'] = id
-            if uuid is not None:
-                kwargs['uuid'] = uuid
-            if nodes:
-                kwargs['nodes'] = nodes
-            if user is not None:
-                type_check(user, users.User)
-                kwargs['user'] = user.backend_entity
-            if node_attributes is not None:
-                kwargs['node_attributes'] = node_attributes
-            if past_days is not None:
-                kwargs['past_days'] = past_days
-
-            return [Group.from_backend_entity(group) for group in self._backend.groups.query(**kwargs)]
-
-        def find(self, filters=None, order_by=None, limit=None):
-            """Custom find method for Group to correctly map to backend type_string"""
-            # We need to map type_string to type for now because the underlying ORM model
-            # for the current backends uses 'type' as the column name instead of type_string
-            # A better way to deal with this would be to implement a general way for the query builder
-            # to ask the backend class what the mapping between the attribute name and the column name
-            # should be.  Probably in the get_column() method...but this requires a bit more thought
-            if filters and 'type_string' in filters:
-                assert 'type' not in filters, "Can't supply type and type_string"
-                filters['type'] = filters.pop('type_string')
-
-            return super(Group.Collection, self).find(filters=filters, order_by=order_by, limit=limit)
 
         def delete(self, id):  # pylint: disable=invalid-name, redefined-builtin
             """
@@ -161,7 +90,15 @@ class Group(entities.Entity):
             """
             self._backend.groups.delete(id)
 
-    def __init__(self, name, user=None, description='', type_string='', backend=None):
+    # pylint: disable=too-many-arguments, redefined-builtin
+    def __init__(self,
+                 label=None,
+                 user=None,
+                 description='',
+                 type_string=GroupTypeString.USER.value,
+                 backend=None,
+                 name=None,
+                 type=None):
         """
         Create a new group. Either pass a dbgroup parameter, to reload
         ad group from the DB (and then, no further parameters are allowed),
@@ -169,18 +106,40 @@ class Group(entities.Entity):
 
         :param dbgroup: the dbgroup object, if you want to reload the group
             from the DB rather than creating a new one.
-        :param name: The group name, required on creation
+        :param label: The group label, required on creation
         :param description: The group description (by default, an empty string)
         :param user: The owner of the group (by default, the automatic user)
         :param type_string: a string identifying the type of group (by default,
             an empty string, indicating an user-defined group.
         """
+        if name:
+            import warnings
+            # pylint: disable=redefined-builtin
+            from aiida.common.warnings import AiidaDeprecationWarning as DeprecationWarning
+            label = name
+            warnings.warn('name is deprecated, use label instead', DeprecationWarning)  # pylint: disable=no-member
+        if type:
+            import warnings
+            # pylint: disable=redefined-builtin
+            from aiida.common.warnings import AiidaDeprecationWarning as DeprecationWarning
+            type_string = type
+            warnings.warn('type is deprecated, use type_string instead', DeprecationWarning)  # pylint: disable=no-member
+        if not label:
+            echo.echo_critical("Group label must be provided")
+
         backend = backend or get_manager().get_backend()
         user = user or users.User.objects(backend).get_default()
         type_check(user, users.User)
 
+        # Check that chosen type is allowed
+        try:
+            GroupTypeString(type_string)
+        except ValueError:
+            echo.echo_critical("Group type_string <{}> is not allowed. Allowed type_strings are: "
+                               "{}".format(type_string, ', '.join([i.value for i in GroupTypeString])))
+
         model = backend.groups.create(
-            name=name, user=user.backend_entity, description=description, type_string=type_string)
+            label=label, user=user.backend_entity, description=description, type_string=type_string)
         super(Group, self).__init__(model)
 
     def __repr__(self):
@@ -188,28 +147,55 @@ class Group(entities.Entity):
 
     def __str__(self):
         if self.type_string:
-            return '"{}" [type {}], of user {}'.format(self.name, self.type_string, self.user.email)
+            return '"{}" [type {}], of user {}'.format(self.label, self.type_string, self.user.email)
 
-        return '"{}" [user-defined], of user {}'.format(self.name, self.user.email)
+        return '"{}" [user-defined], of user {}'.format(self.label, self.user.email)
+
+    @property
+    def label(self):
+        """
+        :return: the label of the group as a string
+        """
+        return self._backend_entity.label
 
     @property
     def name(self):
         """
-        :return: the name of the group as a string
+        :return: the label of the group as a string
         """
-        return self._backend_entity.name
+        import warnings
+        # pylint: disable=redefined-builtin
+        from aiida.common.warnings import AiidaDeprecationWarning as DeprecationWarning
+        warnings.warn('name is deprecated, use label instead', DeprecationWarning)  # pylint: disable=no-member
+        return self._backend_entity.label
+
+    @label.setter
+    def label(self, label):
+        """
+        Attempt to change the label of the group instance. If the group is already stored
+        and the another group of the same type already exists with the desired label, a
+        UniquenessError will be raised
+
+        :param label: the new group label
+        :raises UniquenessError: if another group of same type and label already exists
+        """
+        self._backend_entity.label = label
 
     @name.setter
     def name(self, name):
         """
-        Attempt to change the name of the group instance. If the group is already stored
-        and the another group of the same type already exists with the desired name, a
+        Attempt to change the label of the group instance. If the group is already stored
+        and the another group of the same type already exists with the desired label, a
         UniquenessError will be raised
 
-        :param name: the new group name
-        :raises UniquenessError: if another group of same type and name already exists
+        :param label: the new group label
+        :raises UniquenessError: if another group of same type and label already exists
         """
-        self._backend_entity.name = name
+        import warnings
+        # pylint: disable=redefined-builtin
+        from aiida.common.warnings import AiidaDeprecationWarning as DeprecationWarning
+        warnings.warn('name is deprecated, use label instead', DeprecationWarning)  # pylint: disable=no-member
+        self._backend_entity.label = name
 
     @property
     def description(self):
@@ -224,6 +210,17 @@ class Group(entities.Entity):
         :return: the description of the group as a string
         """
         self._backend_entity.description = description
+
+    @property
+    def type(self):
+        """
+        :return: the string defining the type of the group
+        """
+        import warnings
+        # pylint: disable=redefined-builtin
+        from aiida.common.warnings import AiidaDeprecationWarning as DeprecationWarning
+        warnings.warn('type is deprecated, use type_string instead', DeprecationWarning)  # pylint: disable=no-member
+        return self._backend_entity.type_string
 
     @property
     def type_string(self):
@@ -295,12 +292,33 @@ class Group(entities.Entity):
         :return: the group
         :rtype: :class:`aiida.orm.Group`
         """
-        results = cls.query(**kwargs)
+        from aiida.orm import QueryBuilder
+
+        if 'name' in kwargs:
+            import warnings
+            # pylint: disable=redefined-builtin
+            from aiida.common.warnings import AiidaDeprecationWarning as DeprecationWarning
+            kwargs['label'] = kwargs.pop('name')
+            warnings.warn('name is deprecated, use label instead', DeprecationWarning)  # pylint: disable=no-member
+        if 'type' in kwargs:
+            import warnings
+            # pylint: disable=redefined-builtin
+            from aiida.common.warnings import AiidaDeprecationWarning as DeprecationWarning
+            kwargs['type_string'] = kwargs.pop('type')
+            warnings.warn('type is deprecated, use type_string instead', DeprecationWarning)  # pylint: disable=no-member
+
+        query = QueryBuilder()
+        filters = {}
+        for key, val in kwargs.items():
+            filters[key] = {'==': val}
+
+        query.append(cls, filters=filters)
+        results = query.all()
         if len(results) > 1:
             raise exceptions.MultipleObjectsError("Found {} groups matching criteria '{}'".format(len(results), kwargs))
         if not results:
             raise exceptions.NotExistent("No group found matching criteria '{}'".format(kwargs))
-        return results[0]
+        return results[0][0]
 
     @classmethod
     def get_or_create(cls, backend=None, **kwargs):
@@ -319,99 +337,42 @@ class Group(entities.Entity):
         return cls.objects(backend).get_or_create(**kwargs)
 
     @classmethod
-    def query(cls,
-              name=None,
-              type_string="",
-              id=None,
-              uuid=None,
-              nodes=None,
-              user=None,
-              node_attributes=None,
-              past_days=None,
-              backend=None,
-              **kwargs):  # pylint: disable=too-many-arguments, redefined-builtin, invalid-name
-        """
-        Query for groups.
-
-        :note: By default, query for user-defined groups only (type_string=="").
-            If you want to query for all type of groups, pass type_string=None.
-            If you want to query for a specific type of groups, pass a specific
-            string as the type_string argument.
-
-        :param name: the name of the group
-        :param nodes: a node or list of nodes that belongs to the group (alternatively,
-            you can also pass a DbNode or list of DbNodes)
-        :param id: the pk of the group
-        :param uuid: the uuid of the group
-        :param type_string: the string for the type of node; by default, look
-            only for user-defined groups (see note above).
-        :param user: by default, query for groups of all users; if specified,
-            must be a DbUser object, or a string for the user email.
-        :param past_days: by default, query for all groups; if specified, query
-            the groups created in the last past_days. Must be a datetime object.
-        :param node_attributes: if not None, must be a dictionary with
-            format {k: v}. It will filter and return only groups where there
-            is at least a node with an attribute with key=k and value=v.
-            Different keys of the dictionary are joined with AND (that is, the
-            group should satisfy all requirements.
-            v can be a base data type (str, bool, int, float, ...)
-            If it is a list or iterable, that the condition is checked so that
-            there should be at least a node in the group with key=k and
-            value=each of the values of the iterable.
-        :param backend: the backend to query
-        :param kwargs: any other filter to be passed to DbGroup.objects.filter
-
-            Example: if ``node_attributes = {'elements': ['Ba', 'Ti'], 'md5sum': 'xxx'}``,
-                it will find groups that contain the node with md5sum = 'xxx', and moreover
-                contain at least one node for element 'Ba' and one node for element 'Ti'.
-
-        """
-        return cls.objects(backend).group_query(
-            name=name,
-            type_string=type_string,
-            id=id,
-            uuid=uuid,
-            nodes=nodes,
-            user=user,
-            node_attributes=node_attributes,
-            past_days=past_days,
-            **kwargs)
-
-    @classmethod
     def get_from_string(cls, string):
         """
         Get a group from a string.
-        If only the name is provided, without colons,
+        If only the label is provided, without colons,
         only user-defined groups are searched;
-        add ':type_str' after the group name to choose also
+        add ':type_str' after the group label to choose also
         the type of the group equal to 'type_str'
         (e.g. 'data.upf', 'import', etc.)
 
         :raise ValueError: if the group type does not exist.
         :raise NotExistent: if the group is not found.
         """
-        name, sep, typestr = string.rpartition(':')
+        import warnings
+        # pylint: disable=redefined-builtin
+        from aiida.common.warnings import AiidaDeprecationWarning as DeprecationWarning
+        warnings.warn('get_from_string() is deprecated, use get() instead', DeprecationWarning)  # pylint: disable=no-member
+        label, sep, typestr = string.rpartition(':')
         if not sep:
-            name = typestr
-            typestr = ""
-        if typestr:
-            try:
-                internal_type_string = get_group_type_mapping()[typestr]
-            except KeyError:
-                msg = ("Invalid group type '{}'. Valid group types are: "
-                       "{}".format(typestr, ",".join(sorted(get_group_type_mapping().keys()))))
-                raise ValueError(msg)
-        else:
-            internal_type_string = ""
+            label = typestr
+            typestr = GroupTypeString.USER.value
 
         try:
-            group = cls.get(name=name, type_string=internal_type_string)
+            internal_type_string = GroupTypeString(typestr).value
+        except ValueError:
+            msg = ("Invalid group type '{}'. Valid group types are: "
+                   "{}".format(typestr, ', '.join([i.value for i in GroupTypeString])))
+            raise ValueError(msg)
+
+        try:
+            group = cls.get(label=label, type_string=internal_type_string)
             return group
         except exceptions.NotExistent:
             if typestr:
-                msg = ("No group of type '{}' with name '{}' " "found.".format(typestr, name))
+                msg = ("No group of type '{}' with label '{}' " "found.".format(typestr, label))
             else:
-                msg = ("No user-defined group with name '{}' " "found.".format(name))
+                msg = ("No user-defined group with label '{}' " "found.".format(label))
 
             raise exceptions.NotExistent(msg)
 
@@ -445,14 +406,14 @@ class Group(entities.Entity):
                 "is_foreign_key": False,
                 "type": "int"
             },
-            "name": {
-                "display_name": "Name",
+            "label": {
+                "display_name": "Label",
                 "help_text": "Name of the object",
                 "is_foreign_key": False,
                 "type": "str"
             },
-            "type": {
-                "display_name": "Type",
+            "type_string": {
+                "display_name": "Type_string",
                 "help_text": "Code type",
                 "is_foreign_key": False,
                 "type": "str"

--- a/aiida/orm/implementation/django/convert.py
+++ b/aiida/orm/implementation/django/convert.py
@@ -147,9 +147,9 @@ def _(dbmodel, backend):
     from . import groups
     djgroup_instance = models.DbGroup(
         id=dbmodel.id,
-        type=dbmodel.type,
+        type_string=dbmodel.type_string,
         uuid=dbmodel.uuid,
-        name=dbmodel.name,
+        label=dbmodel.label,
         time=dbmodel.time,
         description=dbmodel.description,
         user_id=dbmodel.user_id,

--- a/aiida/orm/implementation/django/dummy_model.py
+++ b/aiida/orm/implementation/django/dummy_model.py
@@ -132,9 +132,9 @@ class DbGroup(Base):
     id = Column(Integer, primary_key=True)
 
     uuid = Column(UUID(as_uuid=True), default=uuid_func)
-    name = Column(String(255), index=True)
+    label = Column(String(255), index=True)
 
-    type = Column(String(255), default="", index=True)
+    type_string = Column(String(255), default="", index=True)
 
     time = Column(DateTime(timezone=True), default=timezone.now)
     description = Column(Text, nullable=True)
@@ -144,13 +144,10 @@ class DbGroup(Base):
 
     dbnodes = relationship('DbNode', secondary=table_groups_nodes, backref="dbgroups", lazy='dynamic')
 
-    __table_args__ = (UniqueConstraint('name', 'type'),)
+    __table_args__ = (UniqueConstraint('label', 'type_string'),)
 
     def __str__(self):
-        if self.type:
-            return '<DbGroup [type: {}] "{}">'.format(self.type, self.name)
-
-        return '<DbGroup [user-defined] "{}">'.format(self.name)
+        return '<DbGroup [type: {}] "{}">'.format(self.type_string, self.label)
 
 
 class DbNode(Base):

--- a/aiida/orm/implementation/django/groups.py
+++ b/aiida/orm/implementation/django/groups.py
@@ -41,29 +41,29 @@ class DjangoGroup(entities.DjangoModelEntity[models.DbGroup], BackendGroup):  # 
     """The Django group object"""
     MODEL_CLASS = models.DbGroup
 
-    def __init__(self, backend, name, user, description='', type_string=''):
+    def __init__(self, backend, label, user, description='', type_string=''):
         """Construct a new Django group"""
         type_check(user, users.DjangoUser)
         super(DjangoGroup, self).__init__(backend)
 
         self._dbmodel = utils.ModelWrapper(
-            models.DbGroup(name=name, description=description, user=user.dbmodel, type=type_string))
+            models.DbGroup(label=label, description=description, user=user.dbmodel, type_string=type_string))
 
     @property
-    def name(self):
-        return self._dbmodel.name
+    def label(self):
+        return self._dbmodel.label
 
-    @name.setter
-    def name(self, name):
+    @label.setter
+    def label(self, label):
         """
-        Attempt to change the name of the group instance. If the group is already stored
-        and the another group of the same type already exists with the desired name, a
+        Attempt to change the label of the group instance. If the group is already stored
+        and the another group of the same type already exists with the desired label, a
         UniquenessError will be raised
 
-        :param name: the new group name
-        :raises UniquenessError: if another group of same type and name already exists
+        :param label : the new group label
+        :raises UniquenessError: if another group of same type and label already exists
         """
-        self._dbmodel.name = name
+        self._dbmodel.label = label
 
     @property
     def description(self):
@@ -75,7 +75,7 @@ class DjangoGroup(entities.DjangoModelEntity[models.DbGroup], BackendGroup):  # 
 
     @property
     def type_string(self):
-        return self._dbmodel.type
+        return self._dbmodel.type_string
 
     @property
     def user(self):
@@ -204,7 +204,7 @@ class DjangoGroupCollection(BackendGroupCollection):
     ENTITY_CLASS = DjangoGroup
 
     def query(self,
-              name=None,
+              label=None,
               type_string=None,
               pk=None,
               uuid=None,
@@ -212,16 +212,16 @@ class DjangoGroupCollection(BackendGroupCollection):
               user=None,
               node_attributes=None,
               past_days=None,
-              name_filters=None,
+              label_filters=None,
               **kwargs):  # pylint: disable=too-many-arguments
         # pylint: disable=too-many-branches,too-many-locals
         # Analyze args and kwargs to create the query
         queryobject = Q()
-        if name is not None:
-            queryobject &= Q(name=name)
+        if label is not None:
+            queryobject &= Q(label=label)
 
         if type_string is not None:
-            queryobject &= Q(type=type_string)
+            queryobject &= Q(type_string=type_string)
 
         if pk is not None:
             queryobject &= Q(pk=pk)
@@ -253,9 +253,9 @@ class DjangoGroupCollection(BackendGroupCollection):
             else:
                 queryobject &= Q(user=user.id)
 
-        if name_filters is not None:
-            name_filters_list = {"name__" + key: value for (key, value) in name_filters.items() if value}
-            queryobject &= Q(**name_filters_list)
+        if label_filters is not None:
+            label_filters_list = {"name__" + key: value for (key, value) in label_filters.items() if value}
+            queryobject &= Q(**label_filters_list)
 
         groups_pk = set(models.DbGroup.objects.filter(queryobject, **kwargs).values_list('pk', flat=True))
 

--- a/aiida/orm/implementation/general/node.py
+++ b/aiida/orm/implementation/general/node.py
@@ -1852,10 +1852,10 @@ class AbstractNode(object):
                         "current_autogroup is not an AiiDA Autogroup")
 
                 if current_autogroup.is_to_be_grouped(self):
-                    group_name = current_autogroup.get_group_name()
-                    if group_name is not None:
+                    group_label = current_autogroup.get_group_name()
+                    if group_label is not None:
                         g = Group.objects.get_or_create(
-                            name=group_name, type_string=VERDIAUTOGROUP_TYPE)[0]
+                            label=group_label, type_string=VERDIAUTOGROUP_TYPE)[0]
                         g.add_nodes(self)
 
         # This is useful because in this way I can do

--- a/aiida/orm/implementation/groups.py
+++ b/aiida/orm/implementation/groups.py
@@ -28,15 +28,15 @@ class BackendGroup(backends.BackendEntity):
     """
 
     @abc.abstractproperty
-    def name(self):
+    def label(self):
         """
         :return: the name of the group as a string
         """
         pass
 
     @abc.abstractproperty
-    @name.setter
-    def name(self, name):
+    @label.setter
+    def label(self, name):
         """
         Attempt to change the name of the group instance. If the group is already stored
         and the another group of the same type already exists with the desired name, a
@@ -185,9 +185,9 @@ class BackendGroup(backends.BackendEntity):
 
     def __str__(self):
         if self.type_string:
-            return '"{}" [type {}], of user {}'.format(self.name, self.type_string, self.user.email)
+            return '"{}" [type {}], of user {}'.format(self.label, self.type_string, self.user.email)
 
-        return '"{}" [user-defined], of user {}'.format(self.name, self.user.email)
+        return '"{}" [user-defined], of user {}'.format(self.label, self.user.email)
 
 
 @six.add_metaclass(abc.ABCMeta)
@@ -198,7 +198,7 @@ class BackendGroupCollection(backends.BackendCollection[BackendGroup]):
 
     @abc.abstractmethod
     def query(self,
-              name=None,
+              label=None,
               type_string=None,
               pk=None,
               uuid=None,
@@ -206,7 +206,7 @@ class BackendGroupCollection(backends.BackendCollection[BackendGroup]):
               user=None,
               node_attributes=None,
               past_days=None,
-              name_filters=None,
+              label_filters=None,
               **kwargs):  # pylint: disable=too-many-arguments
         """
         Query for groups.

--- a/aiida/orm/implementation/sqlalchemy/groups.py
+++ b/aiida/orm/implementation/sqlalchemy/groups.py
@@ -38,12 +38,12 @@ class SqlaGroup(entities.SqlaModelEntity[DbGroup], BackendGroup):  # pylint: dis
 
     MODEL_CLASS = DbGroup
 
-    def __init__(self, backend, name, user, description='', type_string=''):
+    def __init__(self, backend, label, user, description='', type_string=''):
         """
         Construct a new SQLA group
 
         :param backend: the backend to use
-        :param name: the group name
+        :param label: the group label
         :param user: the owner of the group
         :param description: an optional group description
         :param type_string: an optional type for the group to contain
@@ -51,30 +51,30 @@ class SqlaGroup(entities.SqlaModelEntity[DbGroup], BackendGroup):  # pylint: dis
         type_check(user, users.SqlaUser)
         super(SqlaGroup, self).__init__(backend)
 
-        dbgroup = DbGroup(name=name, description=description, user=user.dbmodel, type=type_string)
+        dbgroup = DbGroup(label=label, description=description, user=user.dbmodel, type_string=type_string)
         self._dbmodel = utils.ModelWrapper(dbgroup)
 
     @property
-    def name(self):
-        return self._dbmodel.name
+    def label(self):
+        return self._dbmodel.label
 
-    @name.setter
-    def name(self, name):
+    @label.setter
+    def label(self, label):
         """
-        Attempt to change the name of the group instance. If the group is already stored
-        and the another group of the same type already exists with the desired name, a
+        Attempt to change the label of the group instance. If the group is already stored
+        and the another group of the same type already exists with the desired label, a
         UniquenessError will be raised
 
-        :param name: the new group name
-        :raises UniquenessError: if another group of same type and name already exists
+        :param label: the new group label
+        :raises UniquenessError: if another group of same type and label already exists
         """
-        self._dbmodel.name = name
+        self._dbmodel.label = label
 
         if self.is_stored:
             try:
                 self._dbmodel.save()
             except Exception:
-                raise UniquenessError('a group of the same type with the name {} already exists'.format(name))
+                raise UniquenessError('a group of the same type with the label {} already exists'.format(label))
 
     @property
     def description(self):
@@ -90,7 +90,7 @@ class SqlaGroup(entities.SqlaModelEntity[DbGroup], BackendGroup):  # pylint: dis
 
     @property
     def type_string(self):
-        return self._dbmodel.type
+        return self._dbmodel.type_string
 
     @property
     def user(self):
@@ -251,7 +251,7 @@ class SqlaGroupCollection(BackendGroupCollection):
     ENTITY_CLASS = SqlaGroup
 
     def query(self,
-              name=None,
+              label=None,
               type_string=None,
               pk=None,
               uuid=None,
@@ -259,7 +259,7 @@ class SqlaGroupCollection(BackendGroupCollection):
               user=None,
               node_attributes=None,
               past_days=None,
-              name_filters=None,
+              label_filters=None,
               **kwargs):  # pylint: disable=too-many-arguments
         # pylint: disable=too-many-branches
         from aiida.orm.implementation.sqlalchemy.node import Node
@@ -268,10 +268,10 @@ class SqlaGroupCollection(BackendGroupCollection):
 
         filters = []
 
-        if name is not None:
-            filters.append(DbGroup.name == name)
+        if label is not None:
+            filters.append(DbGroup.label == label)
         if type_string is not None:
-            filters.append(DbGroup.type == type_string)
+            filters.append(DbGroup.type_string == type_string)
         if pk is not None:
             filters.append(DbGroup.id == pk)
         if uuid is not None:
@@ -301,16 +301,16 @@ class SqlaGroupCollection(BackendGroupCollection):
                 type_check(user, users.SqlaUser)
                 filters.append(DbGroup.user == user.dbmodel)
 
-        if name_filters:
-            for key, value in name_filters.items():
+        if label_filters:
+            for key, value in label_filters.items():
                 if not value:
                     continue
                 if key == "startswith":
-                    filters.append(DbGroup.name.like("{}%".format(value)))
+                    filters.append(DbGroup.label.like("{}%".format(value)))
                 elif key == "endswith":
-                    filters.append(DbGroup.name.like("%{}".format(value)))
+                    filters.append(DbGroup.label.like("%{}".format(value)))
                 elif key == "contains":
-                    filters.append(DbGroup.name.like("%{}%".format(value)))
+                    filters.append(DbGroup.label.like("%{}%".format(value)))
 
         if node_attributes:
             _LOGGER.warning("SQLA query doesn't support node attribute filters, ignoring '%s'", node_attributes)

--- a/aiida/orm/importexport.py
+++ b/aiida/orm/importexport.py
@@ -20,12 +20,12 @@ from aiida.common import exceptions
 from aiida.common.utils import (export_shard_uuid, get_class_string,
                                 get_object_from_string, grouper)
 from aiida.orm.computers import Computer
-from aiida.orm.groups import Group
+from aiida.orm.groups import Group, GroupTypeString
 from aiida.orm.node import Node
 from aiida.orm.querybuilder import QueryBuilder
 from aiida.orm.users import User
 
-IMPORTGROUP_TYPE = 'aiida.import'
+IMPORTGROUP_TYPE = GroupTypeString.IMPORTGROUP_TYPE.value
 DUPL_SUFFIX = ' (Imported #{})'
 
 # Giving names to the various entities. Attributes and links are not AiiDA
@@ -238,9 +238,9 @@ def get_all_fields_info():
         "time": {
             "convert_type": "date"
         },
-        "type": {},
+        "type_string": {},
         "uuid": {},
-        "name": {}
+        "label": {}
     }
     return all_fields_info, unique_identifiers
 
@@ -312,23 +312,23 @@ def deserialize_field(k, v, fields_info, import_unique_ids_mappings,
             return ("{}_id".format(k), None)
 
 
-def import_data(in_path, ignore_unknown_nodes=False,
+def import_data(in_path, group=None, ignore_unknown_nodes=False,
                 silent=False):
     from aiida.backends.settings import BACKEND
     from aiida.backends.profile import BACKEND_DJANGO, BACKEND_SQLA
 
     if BACKEND == BACKEND_SQLA:
-        return import_data_sqla(in_path, ignore_unknown_nodes=ignore_unknown_nodes,
+        return import_data_sqla(in_path, user_group=group, ignore_unknown_nodes=ignore_unknown_nodes,
                                 silent=silent)
     elif BACKEND == BACKEND_DJANGO:
-        return import_data_dj(in_path, ignore_unknown_nodes=ignore_unknown_nodes,
+        return import_data_dj(in_path, user_group=group, ignore_unknown_nodes=ignore_unknown_nodes,
                               silent=silent)
     else:
         raise Exception("Unknown settings.BACKEND: {}".format(
             BACKEND))
 
 
-def import_data_dj(in_path, ignore_unknown_nodes=False,
+def import_data_dj(in_path, user_group=None, ignore_unknown_nodes=False,
                    silent=False):
     """
     Import exported AiiDA environment to the AiiDA database.
@@ -582,13 +582,13 @@ def import_data_dj(in_path, ignore_unknown_nodes=False,
                     if Model is models.DbGroup:
                         # Check if there is already a group with the same name
                         dupl_counter = 0
-                        orig_name = import_data['name']
-                        while Model.objects.filter(name=import_data['name']):
-                            import_data['name'] = orig_name + DUPL_SUFFIX.format(dupl_counter)
+                        orig_label = import_data['label']
+                        while Model.objects.filter(label=import_data['label']):
+                            import_data['label'] = orig_label + DUPL_SUFFIX.format(dupl_counter)
                             dupl_counter += 1
                             if dupl_counter == 100:
-                                raise exceptions.UniquenessError("A group of that name ( {} ) already exists"
-                                    " and I could not create a new one".format(orig_name))
+                                raise exceptions.UniquenessError("A group of that label ( {} ) already exists"
+                                    " and I could not create a new one".format(orig_label))
 
                     elif Model is models.DbComputer:
                         # Check if there is already a computer with the same
@@ -808,30 +808,34 @@ def import_data_dj(in_path, ignore_unknown_nodes=False,
 
             # So that we do not create empty groups
             if pks_for_group:
-                # Get an unique name for the import group, based on the
-                # current (local) time
-                basename = timezone.localtime(timezone.now()).strftime(
-                    "%Y%m%d-%H%M%S")
-                counter = 0
-                created = False
-                while not created:
-                    if counter == 0:
-                        group_name = basename
-                    else:
-                        group_name = "{}_{}".format(basename, counter)
-                    try:
-                        group = Group(name=group_name, type_string=IMPORTGROUP_TYPE).store()
-                        created = True
-                    except (exceptions.UniquenessError, exceptions.IntegrityError):
-                        counter += 1
+                # If user specified a group, import all things in it
+                if user_group:
+                    group = user_group[0]
+                else:
+                    # Get an unique name for the import group, based on the
+                    # current (local) time
+                    basename = timezone.localtime(timezone.now()).strftime(
+                        "%Y%m%d-%H%M%S")
+                    counter = 0
+                    created = False
+                    while not created:
+                        if counter == 0:
+                            group_label = basename
+                        else:
+                            group_label = "{}_{}".format(basename, counter)
+                        try:
+                            group = Group(label=group_label, type_string=IMPORTGROUP_TYPE).store()
+                            created = True
+                        except (exceptions.UniquenessError, exceptions.IntegrityError):
+                            counter += 1
 
                 # Add all the nodes to the new group
-                # TODO: decide if we want to return the group name
+                # TODO: decide if we want to return the group label
                 group.add_nodes(models.DbNode.objects.filter(
                     pk__in=pks_for_group))
 
                 if not silent:
-                    print("IMPORTED NODES GROUPED IN IMPORT GROUP NAMED '{}'".format(group.name))
+                    print("IMPORTED NODES GROUPED IN IMPORT GROUP NAMED '{}'".format(group.label))
             else:
                 if not silent:
                     print("NO DBNODES TO IMPORT, SO NO GROUP CREATED")
@@ -860,7 +864,7 @@ def validate_uuid(given_uuid):
     return str(parsed_uuid) == given_uuid
 
 
-def import_data_sqla(in_path, ignore_unknown_nodes=False, silent=False):
+def import_data_sqla(in_path, user_group=None, ignore_unknown_nodes=False, silent=False):
     """
     Import exported AiiDA environment to the AiiDA database.
     If the 'in_path' is a folder, calls export_tree; otherwise, tries to
@@ -1093,17 +1097,17 @@ def import_data_sqla(in_path, ignore_unknown_nodes=False, silent=False):
                             if entity_name == GROUP_ENTITY_NAME:
                                 # Check if there is already a group with the same name,
                                 # and if so, recreate the name
-                                orig_name = v["name"]
+                                orig_label = v["label"]
                                 dupl_counter = 0
                                 while QueryBuilder().append(entity,
-                                            filters={'name': {"==": v["name"]}}).count():
+                                            filters={'label': {"==": v["label"]}}).count():
                                     # Rename the new group
-                                    v["name"] = orig_name + DUPL_SUFFIX.format(dupl_counter)
+                                    v["label"] = orig_label + DUPL_SUFFIX.format(dupl_counter)
                                     dupl_counter += 1
                                     if dupl_counter == 100:
-                                        raise exceptions.UniquenessError("A group of that name ( {} )"
+                                        raise exceptions.UniquenessError("A group of that label ( {} )"
                                                 "  already exists and I could not create a new one"
-                                                "".format(orig_name))
+                                                "".format(orig_label))
 
 
                             elif entity_name == COMPUTER_ENTITY_NAME:
@@ -1410,30 +1414,34 @@ def import_data_sqla(in_path, ignore_unknown_nodes=False, silent=False):
 
             # So that we do not create empty groups
             if pks_for_group:
-                # Get an unique name for the import group, based on the
-                # current (local) time
-                basename = timezone.localtime(timezone.now()).strftime(
-                    "%Y%m%d-%H%M%S")
-                counter = 0
-                created = False
-                while not created:
-                    if counter == 0:
-                        group_name = basename
-                    else:
-                        group_name = "{}_{}".format(basename, counter)
+                # If user specified a group, import all things in it
+                if user_group:
+                    group = user_group[0]
+                else:
+                    # Get an unique name for the import group, based on the
+                    # current (local) time
+                    basename = timezone.localtime(timezone.now()).strftime(
+                        "%Y%m%d-%H%M%S")
+                    counter = 0
+                    created = False
+                    while not created:
+                        if counter == 0:
+                            group_label = basename
+                        else:
+                            group_label = "{}_{}".format(basename, counter)
 
-                    group = Group(name=group_name,
-                                  type_string=IMPORTGROUP_TYPE)
-                    from aiida.backends.sqlalchemy.models.group import DbGroup
-                    if session.query(DbGroup).filter(
-                            DbGroup.name == group.backend_entity._dbmodel.name).count() == 0:
-                        session.add(group.backend_entity._dbmodel)
-                        created = True
-                    else:
-                        counter += 1
+                        group = Group(label=group_label,
+                                      type_string=IMPORTGROUP_TYPE)
+                        from aiida.backends.sqlalchemy.models.group import DbGroup
+                        if session.query(DbGroup).filter(
+                                DbGroup.label == group.backend_entity._dbmodel.label).count() == 0:
+                            session.add(group.backend_entity._dbmodel)
+                            created = True
+                        else:
+                            counter += 1
 
                 # Add all the nodes to the new group
-                # TODO: decide if we want to return the group name
+                # TODO: decide if we want to return the group label 
                 from aiida.backends.sqlalchemy.models.node import DbNode
                 group.add_nodes(session.query(DbNode).filter(
                     DbNode.id.in_(pks_for_group)).distinct().all())
@@ -1442,7 +1450,7 @@ def import_data_sqla(in_path, ignore_unknown_nodes=False, silent=False):
                 #     pk__in=pks_for_group))
 
                 if not silent:
-                    print("IMPORTED NODES GROUPED IN IMPORT GROUP NAMED '{}'".format(group.name))
+                    print("IMPORTED NODES GROUPED IN IMPORT GROUP NAMED '{}'".format(group.label))
             else:
                 if not silent:
                     print("NO DBNODES TO IMPORT, SO NO GROUP CREATED")

--- a/aiida/orm/importexport.py
+++ b/aiida/orm/importexport.py
@@ -25,7 +25,7 @@ from aiida.orm.node import Node
 from aiida.orm.querybuilder import QueryBuilder
 from aiida.orm.users import User
 
-IMPORTGROUP_TYPE = GroupTypeString.IMPORTGROUP_TYPE.value
+IMPORTGROUP_TYPE = GroupTypeString.IMPORTGROUP_TYPE
 DUPL_SUFFIX = ' (Imported #{})'
 
 # Giving names to the various entities. Attributes and links are not AiiDA

--- a/aiida/orm/utils/loaders.py
+++ b/aiida/orm/utils/loaders.py
@@ -516,7 +516,7 @@ class GroupEntityLoader(OrmEntityLoader):
         :raises NotExistent: if the orm base class does not support a LABEL like identifier
         """
         qb = QueryBuilder()
-        qb.append(cls=classes, tag='group', project=['*'], filters={'name': {'==': identifier}})
+        qb.append(cls=classes, tag='group', project=['*'], filters={'label': {'==': identifier}})
 
         return qb
 

--- a/aiida/restapi/translator/group.py
+++ b/aiida/restapi/translator/group.py
@@ -41,15 +41,15 @@ class GroupTranslator(BaseTranslator):
     # All the values from column_order must present in additional info dict
     # Note: final schema will contain details for only the fields present in column order
     _schema_projections = {
-        "column_order": ["id", "name", "type", "description", "user_id", "user_email", "uuid"],
+        "column_order": ["id", "label", "type_string", "description", "user_id", "user_email", "uuid"],
         "additional_info": {
             "id": {
                 "is_display": True
             },
-            "name": {
+            "label": {
                 "is_display": True
             },
-            "type": {
+            "type_string": {
                 "is_display": True
             },
             "description": {

--- a/docs/source/working_with_aiida/groups.rst
+++ b/docs/source/working_with_aiida/groups.rst
@@ -1,0 +1,117 @@
+Groups
+------
+
+Groups provide an additional level of data organization based on some common
+property(ies) shared between them. As by default AiiDA manages only casual
+relationships between calculations and data objecs -- it is often desired to
+organize them in Groups.
+
+Nodes of any types may be organized in Groups. Unlike Nodes, Groups can be
+modified at any time. Here we profide the list of typical operations that may
+be performed with Groups:
+
+.. note:: Any deletion operation like delition of a Group or nodes from a Group
+  will not delete the nodes themselfs. They will remain in you AiiDA database.
+
+
+1. **Create a new Group.**
+    From command line interface::
+
+      > verdi group create test_group
+
+    From python interface::
+      
+      In [1]: group = Group(label="test_group")
+
+      In [2]: group.store()
+      Out[2]: <Group: "test_group" [type user], of user xxx@xx.com>
+
+
+
+2. **List available Groups.**
+      > verdi group list
+
+    .. note:: By default ``verdi group list`` only shows groups of type *user*.
+      In case you want to show groups of other type use ``-t/--type`` options. If
+      you want to show groups of all types, use ``-a/--all-types`` option.
+
+    From python interface::
+
+      In [1]: query = QueryBuilder()
+
+      In [2]: query.append(Group, filters={'type_string':'user'})
+      Out[2]: <aiida.orm.querybuilder.QueryBuilder at 0x7f20db413ef0>
+
+      In [3]: query.all()
+      Out[3]: 
+      [[<Group: "another_group" [type user], of user ya@epfl.ch>],
+       [<Group: "old_group" [type user], of user ya@epfl.ch>],
+       [<Group: "new_group" [type user], of user ya@epfl.ch>]]
+
+
+3. **Add nodes to a Group.**
+    From command line interface::
+
+      > verdi group addnodes -G test_group 1
+
+    Here we are adding Node with pk number 1 to the group we just created
+
+    From python interface::
+
+      In [3]: from aiida.orm.data.parameter import ParameterData
+
+      In [4]: p = ParameterData().store()
+
+      In [5]: p
+      Out[5]: <ParameterData: uuid: 09b3d52a-d0c4-4e3c-823c-6157f84af920 (pk: 2)>
+
+      In [6]: group.add_nodes(p)
+
+4. **Show information about a Group.**
+    From command line interface::
+
+      > verdi group show test_group
+
+
+5. **Remove nodes from a Group.**
+
+    From command line interface::
+
+      > verdi group removenodes -G test_group 1
+
+
+6. **Rename Group.**
+    From command line interface::
+    
+      > verdi group rename test_group old_group
+
+    From python interface::
+      
+      In [1]: group = Group.get(label='test_group')
+
+      In [2]: group.label = "another_group"
+
+7. **Delete Group.**
+    From command line interface::
+    
+      > verdi group delete old_group
+
+8. **Copy one group into anohter.**
+    This operation will copy the content of source group into the destination
+    group. Moreover, if the destination group does not exist it will be created
+    automatically.
+
+    From command line interface::
+    
+      > verdi group copy source_group destination_group
+
+    From python interface::
+      
+      In [1]: src_group = Group.objects.get(label='source_group')
+
+      In [2]: dest_group = Group.get_or_create(label='destination_group')[0]
+
+      In [3]: dest_group.add_nodes(src_group.nodes)
+
+    
+

--- a/docs/source/working_with_aiida/index.rst
+++ b/docs/source/working_with_aiida/index.rst
@@ -48,6 +48,15 @@ Data types
     ../datatypes/kpoints
     ../datatypes/functionality
 
+======
+Groups
+======
+
+.. toctree::
+    :maxdepth: 4
+
+    groups
+
 ==========
 Schedulers
 ==========


### PR DESCRIPTION
Fixes #2075 and fixed #160 

* `aiida.orm.importexport`
  - While importing data from the export file allow to specify user-defined
    group and to put all the imported data in this group

* `aiida.common.utils`
  - Remove `get_group_type_mapping` function which was mapping
    machine-specific group names with the user-friendly ones
  - Add escape_for_sql_like that escapes `%` or `_` symbols provided by user

* `aiida.orm.groups`
   - Add `GroupTypeString` enum which contains all allowed group types:
      data.upf (was `data.upf.family`)
      auto.import (was `aiida.import`)
      auto.run (was `autogroup.run`)
      user (was empty string)
   -  Remove `Group.query` and `Group.group_query` methods, as they are redundant

* `aiida.orm.data.upf`:
  - Set `UPFGROUP_TYPE` to `GroupTypeString.UPFGROUP_TYPE`
  - Replace the usage of `Group.query` by `QueryBuilder` in `get_upf_groups`
    and `get_upf_family_names` methods

* `aiida.orm.autogroup`:
  - set `VERDIAUTOGROUP_TYPE` to `GroupTypeString.VERDIAUTOGROUP_TYPE`

* `aiida.cmdline.commands.cmd_group`
  - Add `verdi group copy`
  - Add option to show all available group types
  - Add defaulf for group_type option
  - Replace `Group.query` with `QueryBuilder` in `verdi group list`
  - Remove usage of the get_group_type_mapping() function

* `aiida.cmdline.commands.cmd_import`
  - Add the possibility to define a group that will contain all imported nodes.

* `aiida.cmdline.params.types.group`
  - Add the possibility to the `GroupParamType` to create groups if they don't exist

* `aiida.backend*`:
  - Rename `type` and `name` to `type_string` and `label` for the database models

* Improve documentation for django and sqla backends migration