### PR TITLE
Add `CalculationTools` base and entry point `aiida.tools.calculations`

### DIFF
--- a/aiida/orm/node/process/process.py
+++ b/aiida/orm/node/process/process.py
@@ -44,6 +44,13 @@ class ProcessNode(Sealable, Node):
     # Specific sub classes should be marked as cacheable when appropriate
     _cacheable = False
 
+    def __str__(self):
+        base = super(ProcessNode, self).__str__()
+        if self.process_type:
+            return '{} ({})'.format(base, self.process_type)
+
+        return '{}'.format(base)
+
     @classproperty
     def _updatable_attributes(cls):
         return super(ProcessNode, cls)._updatable_attributes + (

--- a/aiida/tools/calculations/__init__.py
+++ b/aiida/tools/calculations/__init__.py
@@ -1,0 +1,7 @@
+# -*- coding: utf-8 -*-
+# pylint: disable=wildcard-import,undefined-variable
+"""Calculation tool plugins for Calculation classes."""
+
+from .base import *
+
+__all__ = (base.__all__)

--- a/aiida/tools/calculations/base.py
+++ b/aiida/tools/calculations/base.py
@@ -1,0 +1,17 @@
+# -*- coding: utf-8 -*-
+"""Base class for CalculationTools
+
+Sub-classes can be registered in the `aiida.tools.calculations` category to enable the `CalcJobNode` class from being
+able to find the tools plugin, load it and expose it through the `tools` property of the `CalcJobNode`.
+"""
+
+__all__ = ('CalculationTools',)
+
+
+class CalculationTools(object):
+    """Base class for CalculationTools."""
+
+    # pylint: disable=too-few-public-methods
+
+    def __init__(self, node):
+        self._node = node

--- a/setup.json
+++ b/setup.json
@@ -197,6 +197,8 @@
       "tcod = aiida.tools.dbexporters.tcod"
     ],
     "aiida.tests": [],
+    "aiida.tools.calculations": [
+    ],
     "aiida.tools.dbimporters": [
       "cod = aiida.tools.dbimporters.plugins.cod:CodDbImporter",
       "icsd = aiida.tools.dbimporters.plugins.icsd:IcsdDbImporter",


### PR DESCRIPTION
Fixes #2322 

With the migration to the new provenance design, the type string of
calculation nodes, no longer refer to the actual sub class of the
`JobCalculation` that was run, but just the base `CalcJobNode`. The
actual class of the calculation process was stored in the `process_type`
if it could be mapped onto a known entry point.

However, this change means that when a user now loads a node of a
completed calculation node, let's say `PwCalculation`, the loaded node
will be an instance of `CalcJobNode` and not `PwCalculation`, which means
that any utility methods defined on the `PwCalculation` class are
inaccessible.

We can return this functionality through the concept of calculation
tools, which will get exposed through the `CalcJobNode` class and will
load a specifically registered entry point.