### PR TITLE
Update export schema version and temporarily disable export

### DIFF
--- a/aiida/backends/tests/cmdline/commands/test_calcjob.py
+++ b/aiida/backends/tests/cmdline/commands/test_calcjob.py
@@ -12,6 +12,9 @@
 from __future__ import division
 from __future__ import print_function
 from __future__ import absolute_import
+
+import unittest
+
 from click.testing import CliRunner
 
 from aiida.backends.testbase import AiidaTestCase
@@ -24,6 +27,7 @@ def get_result_lines(result):
     return [e for e in result.output.split('\n') if e]
 
 
+@unittest.skip('reenable when issue #2342 is addressed')
 class TestVerdiCalculation(AiidaTestCase):
     """Tests for `verdi calcjob`."""
 

--- a/aiida/backends/tests/cmdline/commands/test_calculation.py
+++ b/aiida/backends/tests/cmdline/commands/test_calculation.py
@@ -12,6 +12,9 @@
 from __future__ import division
 from __future__ import print_function
 from __future__ import absolute_import
+
+import unittest
+
 from click.testing import CliRunner
 
 from aiida.backends.testbase import AiidaTestCase
@@ -25,6 +28,7 @@ def get_result_lines(result):
     return [e for e in result.output.split('\n') if e]
 
 
+@unittest.skip('reenable when issue #2342 is addressed')
 class TestVerdiCalculation(AiidaTestCase):
     """Tests for `verdi calculation`."""
 

--- a/aiida/backends/tests/cmdline/commands/test_export.py
+++ b/aiida/backends/tests/cmdline/commands/test_export.py
@@ -16,6 +16,7 @@ import os
 import tempfile
 import tarfile
 import traceback
+import unittest
 import zipfile
 
 from click.testing import CliRunner
@@ -88,6 +89,7 @@ class TestVerdiExport(AiidaTestCase):
     def setUp(self):
         self.cli_runner = CliRunner()
 
+    @unittest.skip('reenable when issue #2342 is addressed')
     def test_create_file_already_exists(self):
         """Test that using a file that already exists, which is the case when using NamedTemporaryFile, will raise."""
         with tempfile.NamedTemporaryFile() as handle:
@@ -95,6 +97,7 @@ class TestVerdiExport(AiidaTestCase):
             result = self.cli_runner.invoke(cmd_export.create, options)
             self.assertIsNotNone(result.exception)
 
+    @unittest.skip('reenable when issue #2342 is addressed')
     def test_create_force(self):
         """
         Test that using a file that already exists, which is the case when using NamedTemporaryFile, will work
@@ -109,6 +112,7 @@ class TestVerdiExport(AiidaTestCase):
             result = self.cli_runner.invoke(cmd_export.create, options)
             self.assertIsNone(result.exception, result.output)
 
+    @unittest.skip('reenable when issue #2342 is addressed')
     def test_create_zip(self):
         """Test that creating an archive for a set of various ORM entities works with the zip format."""
         filename = next(tempfile._get_candidate_names())  # pylint: disable=protected-access
@@ -124,6 +128,7 @@ class TestVerdiExport(AiidaTestCase):
         finally:
             delete_temporary_file(filename)
 
+    @unittest.skip('reenable when issue #2342 is addressed')
     def test_create_zip_uncompressed(self):
         """Test that creating an archive for a set of various ORM entities works with the zip-uncompressed format."""
         filename = next(tempfile._get_candidate_names())  # pylint: disable=protected-access
@@ -139,6 +144,7 @@ class TestVerdiExport(AiidaTestCase):
         finally:
             delete_temporary_file(filename)
 
+    @unittest.skip('reenable when issue #2342 is addressed')
     def test_create_tar_gz(self):
         """Test that creating an archive for a set of various ORM entities works with the tar.gz format."""
         filename = next(tempfile._get_candidate_names())  # pylint: disable=protected-access

--- a/aiida/backends/tests/export_and_import.py
+++ b/aiida/backends/tests/export_and_import.py
@@ -17,6 +17,7 @@ from __future__ import absolute_import
 import io
 import six
 from six.moves import range, zip
+import unittest
 
 from aiida.backends.testbase import AiidaTestCase
 from aiida.orm.importexport import import_data
@@ -1557,6 +1558,7 @@ class TestComputer(AiidaTestCase):
             shutil.rmtree(export_file_tmp_folder, ignore_errors=True)
             shutil.rmtree(unpack_tmp_folder, ignore_errors=True)
 
+    @unittest.skip('reenable when issue #2342 is addressed')
     def test_import_of_django_sqla_export_file(self):
         """
         Check why sqla import manages to import the django export file correctly

--- a/aiida/cmdline/commands/cmd_export.py
+++ b/aiida/cmdline/commands/cmd_export.py
@@ -97,6 +97,8 @@ def create(output_file, codes, computers, groups, nodes, input_forward, create_r
     """
     from aiida.orm.importexport import export, export_zip
 
+    echo.echo_critical('the export functionality is currently disabled until issue #2342 is addressed')
+
     entities = []
 
     if codes:

--- a/aiida/orm/importexport.py
+++ b/aiida/orm/importexport.py
@@ -356,7 +356,7 @@ def import_data_dj(in_path, ignore_unknown_nodes=False,
     import aiida.utils.json as json
 
     # This is the export version expected by this function
-    expected_export_version = '0.3'
+    expected_export_version = '0.4'
 
     # The name of the subfolder in which the node files are stored
     nodes_export_subfolder = 'nodes'
@@ -885,7 +885,7 @@ def import_data_sqla(in_path, ignore_unknown_nodes=False, silent=False):
     import aiida.utils.json as json
 
     # This is the export version expected by this function
-    expected_export_version = '0.3'
+    expected_export_version = '0.4'
 
     # The name of the subfolder in which the node files are stored
     nodes_export_subfolder = 'nodes'
@@ -1727,7 +1727,7 @@ def export_tree(what, folder,allowed_licenses=None, forbidden_licenses=None,
     if not silent:
         print("STARTING EXPORT...")
 
-    EXPORT_VERSION = '0.3'
+    EXPORT_VERSION = '0.4'
 
     all_fields_info, unique_identifiers = get_all_fields_info()
 


### PR DESCRIPTION
Fixes #2340 

The migration after the provenance redesign has been merged into
`provenance_redesign`. To avoid people from importing "dirty" export
files into a cleanly migrated database, the export schema version is
upped. Additionally, creating new export archives with the latest
version is disabled, until the export procedure has been verified to
abide by the new rules in place after the provenance redesign.