### PR TITLE
Use `ProfileParamType` in `verdi` and expose in `ctx.obj`

### DIFF
--- a/aiida/backends/profile.py
+++ b/aiida/backends/profile.py
@@ -7,18 +7,19 @@
 # For further information on the license, see the LICENSE.txt file        #
 # For further information please visit http://www.aiida.net               #
 ###########################################################################
-
 from __future__ import division
 from __future__ import print_function
 from __future__ import absolute_import
+
 from aiida.backends import settings
 from aiida.common.exceptions import InvalidOperation
-from aiida.common.setup import get_default_profile_name, get_profile_config
+from aiida.common.profile import get_default_profile_name
+from aiida.common.setup import get_profile_config
 
 
 # Possible choices for backend
-BACKEND_DJANGO = "django"
-BACKEND_SQLA = "sqlalchemy"
+BACKEND_DJANGO = 'django'
+BACKEND_SQLA = 'sqlalchemy'
 
 
 def load_profile(profile=None):

--- a/aiida/cmdline/commands/cmd_profile.py
+++ b/aiida/cmdline/commands/cmd_profile.py
@@ -17,9 +17,9 @@ import click
 
 from aiida.cmdline.commands.cmd_verdi import verdi
 from aiida.cmdline.utils import echo
-from aiida.cmdline.params import options, types
+from aiida.cmdline.params import arguments, options
 from aiida.control.postgres import Postgres
-from aiida.common.setup import get_default_profile_name
+from aiida.common.profile import get_default_profile_name
 
 
 @verdi.group('profile')
@@ -65,7 +65,7 @@ def profile_list():
 
 
 @verdi_profile.command('show')
-@click.argument('profile', nargs=1, type=types.ProfileParamType(), default=get_default_profile_name())
+@arguments.PROFILE(default=get_default_profile_name())
 def profile_show(profile):
     """Show details for PROFILE or, when not specified, the default profile."""
     import tabulate
@@ -76,7 +76,7 @@ def profile_show(profile):
 
 
 @verdi_profile.command('setdefault')
-@click.argument('profile', nargs=1, type=types.ProfileParamType())
+@arguments.PROFILE()
 def profile_setdefault(profile):
     """Set PROFILE as the default profile."""
     from aiida.common.setup import set_default_profile
@@ -86,7 +86,7 @@ def profile_setdefault(profile):
 
 @verdi_profile.command('delete')
 @options.FORCE(help='to skip any questions/warnings about loss of data')
-@click.argument('profiles', nargs=-1, type=types.ProfileParamType())
+@arguments.PROFILES()
 def profile_delete(force, profiles):
     """
     Delete PROFILES separated by space from aiida config file

--- a/aiida/cmdline/commands/cmd_verdi.py
+++ b/aiida/cmdline/commands/cmd_verdi.py
@@ -8,33 +8,37 @@
 # For further information please visit http://www.aiida.net               #
 ###########################################################################
 """The main `verdi` click group."""
-
 from __future__ import division
 from __future__ import print_function
 from __future__ import absolute_import
+
 import click
+
+from aiida.cmdline.params import options
+from aiida.common.extendeddicts import AttributeDict
+from aiida.common.profile import get_default_profile_name
 
 
 @click.group()
-@click.option(
-    '-p', '--profile', metavar='PROFILE', help='Execute the command for this profile instead of the default profile.')
+@options.PROFILE(default=get_default_profile_name())
 @click.option('--version', is_flag=True, default=False, help='Print the version of AiiDA that is currently installed.')
 @click.pass_context
 def verdi(ctx, profile, version):
     """The command line interface of AiiDA."""
     import sys
     import aiida
-    from aiida.cmdline.utils import echo
     from aiida.backends import settings
-    from aiida.common import setup
+    from aiida.cmdline.utils import echo
 
     if version:
         echo.echo('AiiDA version {}'.format(aiida.__version__))
         sys.exit(0)
 
-    if profile is None:
-        settings.AIIDADB_PROFILE = setup.get_default_profile_name()
-    else:
-        settings.AIIDADB_PROFILE = profile
+    if ctx.obj is None:
+        ctx.obj = AttributeDict()
+
+    if profile:
+        settings.AIIDADB_PROFILE = profile.name
+        ctx.obj.profile = profile
 
     ctx.help_option_names = ['-h', '--help']

--- a/aiida/cmdline/params/arguments/__init__.py
+++ b/aiida/cmdline/params/arguments/__init__.py
@@ -11,14 +11,19 @@
 """
 Module to make available commonly used click arguments.
 """
-
 from __future__ import division
 from __future__ import print_function
 from __future__ import absolute_import
+
 import click
 
 from aiida.cmdline.params import types
 from aiida.cmdline.params.arguments.overridable import OverridableArgument
+
+
+PROFILE = OverridableArgument('profile', type=types.ProfileParamType())
+
+PROFILES = OverridableArgument('profiles', type=types.ProfileParamType(), nargs=-1)
 
 CALCULATION = OverridableArgument('calculation', type=types.CalculationParamType())
 

--- a/aiida/cmdline/params/options/__init__.py
+++ b/aiida/cmdline/params/options/__init__.py
@@ -18,7 +18,6 @@ import click
 
 from aiida.backends.profile import BACKEND_DJANGO, BACKEND_SQLA
 from aiida.cmdline.params import types
-from aiida.cmdline.params.options.conditional import ConditionalOption
 from aiida.cmdline.params.options.multivalue import MultipleValueOption
 from aiida.cmdline.params.options.overridable import OverridableOption
 
@@ -44,6 +43,11 @@ def active_process_states():
         ProcessState.RUNNING.value,
     ])
 
+
+PROFILE = OverridableOption(
+    '-p', '--profile', 'profile',
+    type=types.ProfileParamType(),
+    help='Execute the command for this profile instead of the default profile.')
 
 CALCULATION = OverridableOption(
     '-C', '--calculation', 'calculation',

--- a/aiida/common/profile.py
+++ b/aiida/common/profile.py
@@ -36,11 +36,28 @@ CIRCUS_PUBSUB_SOCKET_TEMPLATE = 'circus.p.sock'
 CIRCUS_STATS_SOCKET_TEMPLATE = 'circus.s.sock'
 
 
+def get_default_profile_name():
+    """
+    Return the default profile name from the configuration.
+
+    :return: None if no default profile is found
+    """
+    from aiida.common.setup import get_config
+
+    try:
+        config = get_config()
+        default = config['default_profile']
+    except (exceptions.MissingConfigurationError, KeyError):
+        return None
+    else:
+        return default
+
+
 def get_current_profile_name():
     """
     Return the currently configured profile name or if not set, the default profile
     """
-    return settings.AIIDADB_PROFILE or setup.get_default_profile_name()
+    return settings.AIIDADB_PROFILE or get_default_profile_name()
 
 
 def get_profile_config(name=None):

--- a/aiida/common/setup.py
+++ b/aiida/common/setup.py
@@ -294,47 +294,6 @@ def set_default_profile(profile, force_rewrite=False):
         store_config(confs)
 
 
-def get_default_profile():
-    """
-    Return the default profile from the configuration
-
-    :return: None if no default profile is found
-    """
-    from aiida.common.exceptions import ProfileConfigurationError
-
-    config = get_config()
-    default_profile = get_default_profile_name()
-
-    if default_profile is None:
-        return None
-
-    try:
-        profile = config['profiles'][default_profile]
-    except KeyError:
-        raise ProfileConfigurationError('the defined default profile {} does not exist'.format(default_profile))
-
-    return profile
-
-
-def get_default_profile_name():
-    """
-    Return the default profile name from the configuration
-
-    :return: None if no default profile is found
-    """
-    from aiida.common.exceptions import MissingConfigurationError
-
-    try:
-        confs = get_config()
-    except MissingConfigurationError:
-        return None
-
-    try:
-        return confs['default_profile']
-    except KeyError:
-        return None
-
-
 def get_profiles_list():
     """
     Return the list of names of installed configurations


### PR DESCRIPTION
Fixes #2344 

The `verdi` entry point now uses the `ProfileParamType` for its `-p`
option, which enables tab-completion for the profile option.
In addition, we add the loaded profile to the `obj` attribute of the
click context `ctx`. This way, when a `verdi` sub commands needs the
active profile, one can simply use the `@click.pass_context` decorator
to access the profile through `ctx.obj.profile`.