### PR TITLE
Fixed 1714 expose_inputs deepcopy default value

### DIFF
--- a/aiida/backends/tests/work/process.py
+++ b/aiida/backends/tests/work/process.py
@@ -70,7 +70,6 @@ class TestProcessNamespace(AiidaTestCase):
 
 
 class ProcessStackTest(work.Process):
-
     _calc_class = WorkflowNode
 
     @override

--- a/aiida/backends/tests/work/work_chain.py
+++ b/aiida/backends/tests/work/work_chain.py
@@ -1265,6 +1265,33 @@ class TestWorkChainExpose(AiidaTestCase):
             }
         )
 
+    def test_issue_1741_expose_inputs(self):
+        """Test that expose inputs works correctly when copying a stored default value"""
+
+        stored_a = Int(5).store()
+
+        class Parent(work.WorkChain):
+            @classmethod
+            def define(cls, spec):
+                super(Parent, cls).define(spec)
+                spec.input('a', default=stored_a)
+                spec.outline(cls.step1)
+
+            def step1(self):
+                pass
+
+        class Child(work.WorkChain):
+            @classmethod
+            def define(cls, spec):
+                super(Child, cls).define(spec)
+                spec.expose_inputs(Parent)
+                spec.outline(cls.step1)
+
+            def step1(self):
+                pass
+
+        work.run(Child)
+
 
 class TestWorkChainReturnDict(AiidaTestCase):
     class PointlessWorkChain(WorkChain):

--- a/aiida/orm/data/__init__.py
+++ b/aiida/orm/data/__init__.py
@@ -75,9 +75,6 @@ class Data(Node):
 
         :returns: an unstored clone of this Data node
         """
-        if self.is_stored:
-            raise InvalidOperation('deep copying a stored Data node is not supported, use Data.clone() instead')
-
         return self.clone()
 
     def clone(self):


### PR DESCRIPTION
Allowing deepcopy of a stored node to support this use case.  See the
bug report https://github.com/aiidateam/aiida_core/issues/1741 for
default but simply put if you expose the inputs of a workchain with a
stored default plumpy will try to deepcopy that default value which was
expecting because of a ban on deepcopying stored nodes.