### PR TITLE
Fixed issue with wrong file mode for python3

### DIFF
--- a/aiida/manage/database/integrity/__init__.py
+++ b/aiida/manage/database/integrity/__init__.py
@@ -33,7 +33,7 @@ def write_database_integrity_violation(results, headers, reason_message, action_
     if action_message is None:
         action_message = 'nothing'
 
-    with NamedTemporaryFile(prefix='migration-', suffix='.log', dir='.', delete=False) as handle:
+    with NamedTemporaryFile(prefix='migration-', suffix='.log', dir='.', delete=False, mode='w+') as handle:
         echo.echo('')
         echo.echo_warning(
             '\n{}\nFound one or multiple records that violate the integrity of the database\nViolation reason: {}\n'


### PR DESCRIPTION
The log file to report an integrity violation was not correct and would
complain about expecting a bytes type instead of str.  Fixed by setting
the mode to w+.