### PR TITLE
Fix bug in `CalcJobNode.get_desc`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -98,7 +98,6 @@
         aiida/backends/tests/backup_script.py|
         aiida/backends/tests/backup_setup_script.py|
         aiida/backends/tests/base_dataclasses.py|
-        aiida/backends/tests/calculation_node.py|
         aiida/backends/tests/cmdline/commands/test_calculation.py|
         aiida/backends/tests/cmdline/commands/test_code.py|
         aiida/backends/tests/cmdline/commands/test_comment.py|

--- a/aiida/orm/node/process/calculation/calcjob.py
+++ b/aiida/orm/node/process/calculation/calcjob.py
@@ -1132,21 +1132,6 @@ class CalcJobNode(CalculationNode):
 
         return self.get_attr(self.JOB_STATE_KEY, None)
 
-    def _get_state_string(self):
-        """
-        Return a string, that is correct also when the state is imported
-        (in this case, the string will be in the format IMPORTED/ORIGSTATE
-        where ORIGSTATE is the original state from the node attributes).
-        """
-        state = self.get_state(from_attribute=False)
-        if state == calc_states.IMPORTED:
-            attribute_state = self.get_state(from_attribute=True)
-            if attribute_state is None:
-                attribute_state = "NOTFOUND"
-            return 'IMPORTED/{}'.format(attribute_state)
-        else:
-            return state
-
     def _is_new(self):
         """
         Get whether the calculation is in the NEW status.
@@ -2292,7 +2277,7 @@ class CalcJobNode(CalculationNode):
         Returns a string with infos retrieved from a CalcJobNode node's
         properties.
         """
-        return self.get_state(from_attribute=True)
+        return self.get_state()
 
 
 def _parse_single_arg(function_name, additional_parameter, args, kwargs):


### PR DESCRIPTION
Fixes #2352 

The function still called `CalcJobNode.get_state` with the argument
`from_attribute`, which has recently been removed. Originally, the
state was stored in a separate database table and had a proxy as an
attribute in the attribute table. The calc state table has been
removed, leaving the attribute as the only source of the state.