### PR TITLE
remove broken verdi-plug entry point

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -60,7 +60,6 @@ if __name__ == '__main__':
         entry_points={
             'console_scripts': [
                 'verdi=aiida.cmdline.verdilib:run',
-                'verdi-plug = aiida.cmdline.verdi_plug:verdi_plug'
             ],
             # following are AiiDA plugin entry points:
             'aiida.calculations': [


### PR DESCRIPTION
verdi-plug entry point does not work (likely a leftover)

$ verdi-plug
Traceback (most recent call last):
  File "/Users/leopold/Applications/miniconda3/envs/aiida_master/bin/verdi-plug", line 5, in <module>
    from aiida.cmdline.verdi_plug import verdi_plug
ImportError: No module named verdi_plug