### PR TITLE
Reenable the Travis linter pre-commit test

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -316,12 +316,12 @@
       )$
     pass_filenames: false
 
-  # - id: travis-linter
-  #   name: travis
-  #   entry: travis lint
-  #   files: .travis.yml
-  #   language: ruby
-  #   additional_dependencies: ['travis']
+  - id: travis-linter
+    name: travis
+    entry: travis lint
+    files: .travis.yml
+    language: ruby
+    additional_dependencies: ['travis']
 
   - id: version-number
     name: Check version numbers

--- a/setup.json
+++ b/setup.json
@@ -111,7 +111,7 @@
       "pytest-cov==2.5.1"
     ],
     "dev_precommit": [
-      "pre-commit==1.8.2",
+      "pre-commit==1.13.0",
       "yapf==0.23.0",
       "prospector==1.1.5",
       "pylint==1.9.3",


### PR DESCRIPTION
Fixes #2362 

The release of ruby `gem==3.0.0` in December 2018 broke the `pre-commit`
package because it used the `--no-ri / --no-rdoc` flags that were
deprecated in that gem release. These flags were replaced by the new
`--no-document` flag in `pre-commit==1.13.0`, which allows us to
reenable the Travis linter that had been temporarily disabled.