### PR TITLE
Add functionality to delete individual Log entries to collection

### DIFF
--- a/aiida/backends/tests/orm/authinfo.py
+++ b/aiida/backends/tests/orm/authinfo.py
@@ -11,16 +11,18 @@
 from __future__ import division
 from __future__ import print_function
 from __future__ import absolute_import
+
 from aiida.backends.testbase import AiidaTestCase
+from aiida.common import exceptions
+from aiida.orm import authinfos
 
 
 class TestAuthinfo(AiidaTestCase):
     """Unit tests for the AuthInfo ORM class."""
 
-    @classmethod
-    def setUpClass(cls, *args, **kwargs):
-        super(TestAuthinfo, cls).setUpClass(*args, **kwargs)
-        cls.auth_info = cls.computer.configure()  # pylint: disable=no-member
+    def setUp(self):
+        super(TestAuthinfo, self).setUp()
+        self.auth_info = self.computer.configure()  # pylint: disable=no-member
 
     def test_set_auth_params(self):
         """Test the auth_params setter."""
@@ -28,3 +30,14 @@ class TestAuthinfo(AiidaTestCase):
 
         self.auth_info.set_auth_params(auth_params)
         self.assertEqual(self.auth_info.get_auth_params(), auth_params)
+
+    def test_delete(self):
+        """Test deleting a single AuthInfo."""
+        pk = self.auth_info.pk
+
+        self.assertEqual(len(authinfos.AuthInfo.objects.all()), 1)
+        authinfos.AuthInfo.objects.delete(pk)
+        self.assertEqual(len(authinfos.AuthInfo.objects.all()), 0)
+
+        with self.assertRaises(exceptions.NotExistent):
+            authinfos.AuthInfo.objects.delete(pk)

--- a/aiida/backends/tests/orm/comments.py
+++ b/aiida/backends/tests/orm/comments.py
@@ -68,6 +68,9 @@ class TestComment(AiidaTestCase):
         Comment.objects.delete(comment.pk)
 
         with self.assertRaises(exceptions.NotExistent):
+            Comment.objects.delete(comment_pk)
+
+        with self.assertRaises(exceptions.NotExistent):
             Comment.objects.get(id=comment_pk)
 
     def test_comment_querybuilder(self):

--- a/aiida/cmdline/utils/common.py
+++ b/aiida/cmdline/utils/common.py
@@ -251,8 +251,8 @@ def get_calcjob_report(calcjob):
         report.append('*** 0 LOG MESSAGES')
 
     for log in log_messages:
-        report.append('+-> {} at {}'.format(log['levelname'], log['time']))
-        for message in log['message'].splitlines():
+        report.append('+-> {} at {}'.format(log.levelname, log.time))
+        for message in log.message.splitlines():
             report.append(' | {}'.format(message))
 
     return '\n'.join(report)

--- a/aiida/orm/implementation/django/logs.py
+++ b/aiida/orm/implementation/django/logs.py
@@ -13,7 +13,9 @@ from __future__ import print_function
 from __future__ import absolute_import
 
 from aiida.backends.djsite.db import models
-import aiida.common.json as json
+from aiida.common import exceptions
+from aiida.common import json
+
 from . import entities
 from .. import BackendLog, BackendLogCollection
 
@@ -90,6 +92,20 @@ class DjangoLogCollection(BackendLogCollection):
 
     ENTITY_CLASS = DjangoLog
 
+    def delete(self, log_id):
+        """
+        Remove a Log entry from the collection with the given id
+
+        :param log_id: id of the log to delete
+        """
+        # pylint: disable=no-name-in-module,import-error
+        from django.core.exceptions import ObjectDoesNotExist
+        assert log_id is not None
+        try:
+            models.DbLog.objects.get(pk=log_id).delete()
+        except ObjectDoesNotExist:
+            raise exceptions.NotExistent("Log with id '{}' not found".format(log_id))
+
     def delete_many(self, filters):
         """
         Delete all log entries in the table
@@ -97,4 +113,4 @@ class DjangoLogCollection(BackendLogCollection):
         if not filters:
             models.DbLog.objects.all().delete()
         else:
-            raise NotImplementedError("Only deleting all by passing an empty filer dictionary is currently supported")
+            raise NotImplementedError('Only deleting all by passing an empty filer dictionary is currently supported')

--- a/aiida/orm/implementation/logs.py
+++ b/aiida/orm/implementation/logs.py
@@ -97,6 +97,14 @@ class BackendLogCollection(backends.BackendCollection[BackendLog]):
     ENTITY_CLASS = BackendLog
 
     @abc.abstractmethod
+    def delete(self, log_id):
+        """
+        Remove a Log entry from the collection with the given id
+
+        :param log_id: id of the log to delete
+        """
+
+    @abc.abstractmethod
     def delete_many(self, filters):
         """
         Delete multiple log entries in the table

--- a/aiida/orm/implementation/sqlalchemy/authinfo.py
+++ b/aiida/orm/implementation/sqlalchemy/authinfo.py
@@ -64,7 +64,7 @@ class SqlaAuthInfoCollection(BackendAuthInfoCollection):
 
         session = get_scoped_session()
         try:
-            session.query(DbAuthInfo).filter_by(id=authinfo_id).delete()
+            session.query(DbAuthInfo).filter_by(id=authinfo_id).one().delete()
             session.commit()
         except NoResultFound:
             raise exceptions.NotExistent("AuthInfo with id '{}' not found".format(authinfo_id))

--- a/aiida/orm/implementation/sqlalchemy/comments.py
+++ b/aiida/orm/implementation/sqlalchemy/comments.py
@@ -114,7 +114,7 @@ class SqlaCommentCollection(BackendCommentCollection):
         session = get_scoped_session()
 
         try:
-            session.query(models.DbComment).filter_by(id=comment).delete()
+            session.query(models.DbComment).filter_by(id=comment).one().delete()
             session.commit()
         except NoResultFound:
             raise exceptions.NotExistent("Comment with id '{}' not found".format(comment))

--- a/aiida/orm/logs.py
+++ b/aiida/orm/logs.py
@@ -90,6 +90,14 @@ class Log(entities.Entity):
             filters = {'objpk': objpk, 'objname': objname}
             return self.find(filters, order_by=order_by)
 
+        def delete(self, log_id):
+            """
+            Remove a Log entry from the collection with the given id
+
+            :param log_id: id of the log to delete
+            """
+            self._backend.logs.delete(log_id)
+
         def delete_many(self, filters):
             """
             Delete all the log entries matching the given filters


### PR DESCRIPTION
Fixes #2368 

Also fixed a bug in the `delete` method of the `AuthInfo` and `Comment`
collections that were not caught because there were no tests. If the
entry that was asked to be deleted did not exist, no exception was
raised, however, that was expected by the implementation.