### PR TITLE
Ensure that configuration options are considered for logging config

### DIFF
--- a/aiida/backends/profile.py
+++ b/aiida/backends/profile.py
@@ -25,6 +25,7 @@ def load_profile(profile=None):
     Load the profile. This function is called by load_dbenv and SHOULD NOT
     be called by the user by hand.
     """
+    from aiida.common.log import configure_logging
     from aiida.manage import get_config
 
     if settings.LOAD_PROFILE_CALLED:
@@ -42,6 +43,9 @@ def load_profile(profile=None):
             profile = config.default_profile_name
 
         settings.AIIDADB_PROFILE = profile
+
+    # Reconfigure the logging to make sure that profile specific logging configuration options are taken into account
+    configure_logging()
 
     profile = config.get_profile(profile)
 

--- a/aiida/manage/configuration/__init__.py
+++ b/aiida/manage/configuration/__init__.py
@@ -1,14 +1,16 @@
 # -*- coding: utf-8 -*-
 # pylint: disable=undefined-variable,wildcard-import,global-statement
 """Modules related to the configuration of an AiiDA instance."""
+from __future__ import absolute_import
 
 from .config import *
+from .options import *
 from .profile import *
 from .utils import *
 
 CONFIG = None
 
-__all__ = (config.__all__ + profile.__all__ + utils.__all__ + ('get_config',))
+__all__ = (config.__all__ + options.__all__ + profile.__all__ + utils.__all__ + ('get_config', 'get_config_option'))
 
 
 def get_config():
@@ -29,3 +31,36 @@ def get_config():
         CONFIG = load_config()
 
     return CONFIG
+
+
+def get_config_option(option_name):
+    """Return the value for the given configuration option.
+
+    This function will attempt to load the value of the option as defined for the current profile or otherwise as
+    defined configuration wide. If no configuration is yet loaded, this function will fall back on the default that may
+    be defined for the option itself. This is useful for options that need to be defined at loading time of AiiDA when
+    no configuration is yet loaded or may not even yet exist. In cases where one expects a profile to be loaded,
+    preference should be given to retrieving the option through the Config instance and its `option_get` method.
+
+    :param option_name: the name of the configuration option
+    :return: option value as specified for the profile/configuration if loaded, otherwise option default
+    """
+    from aiida.common import exceptions
+
+    option = options.get_option(option_name)
+
+    try:
+        config = get_config()
+    except exceptions.ConfigurationError:
+        value = option.default
+    else:
+        if config.current_profile:
+            # Try to get the option for the profile, but do not return the option default
+            value_profile = config.option_get(option_name, scope=config.current_profile.name, default=False)
+        else:
+            value_profile = None
+
+        # Value is the profile value if defined or otherwise the global value, which will be None if not set
+        value = value_profile if value_profile else config.option_get(option_name)
+
+    return value

--- a/aiida/manage/configuration/config.py
+++ b/aiida/manage/configuration/config.py
@@ -6,7 +6,6 @@ import io
 import os
 import shutil
 
-from aiida.common import exceptions
 from aiida.common import json
 
 from .migrations import CURRENT_CONFIG_VERSION, OLDEST_COMPATIBLE_CONFIG_VERSION
@@ -146,6 +145,8 @@ class Config(object):  # pylint: disable=useless-object-inheritance
         :param name: name of the profile:
         :raises ProfileConfigurationError: if the name is not found in the configuration file
         """
+        from aiida.common import exceptions
+
         if name not in self.profile_names:
             raise exceptions.ProfileConfigurationError('profile `{}` does not exist'.format(name))
 

--- a/aiida/manage/configuration/utils.py
+++ b/aiida/manage/configuration/utils.py
@@ -5,42 +5,11 @@ from __future__ import absolute_import
 import io
 import os
 
-from aiida.common import exceptions
-from aiida.common import json
-
 from .config import Config
 from .migrations import check_and_migrate_config
-from .options import get_option
 from .settings import DEFAULT_CONFIG_FILE_NAME
 
-__all__ = ('get_config_option', 'load_config')
-
-
-def get_config_option(option_name):
-    """Return the value for the given configuration option.
-
-    This function will attempt to load the value of the option as defined for the current profile or otherwise as
-    defined configuration wide. If no configuration is yet loaded, this function will fall back on the default that may
-    be defined for the option itself. This is useful for options that need to be defined at loading time of AiiDA when
-    no configuration is yet loaded or may not even yet exist. In cases where one expects a profile to be loaded,
-    preference should be given to retrieving the option through the Config instance and its `option_get` method.
-
-    :param option_name: the name of the configuration option
-    :return: option value as specified for the profile/configuration if loaded, otherwise option default
-    """
-    option = get_option(option_name)
-
-    try:
-        config = load_config()
-    except exceptions.ConfigurationError:
-        value = option.default
-    else:
-        if config.current_profile:
-            value = config.option_get(option_name, scope=config.current_profile.name)
-        else:
-            value = config.option_get(option_name)
-
-    return value
+__all__ = ('load_config',)
 
 
 def load_config(create=False):
@@ -53,6 +22,8 @@ def load_config(create=False):
     """
     from .settings import AIIDA_CONFIG_FOLDER
     from aiida.backends.settings import IN_RT_DOC_MODE, DUMMY_CONF_FILE
+    from aiida.common import exceptions
+    from aiida.common import json
 
     if IN_RT_DOC_MODE:
         return DUMMY_CONF_FILE


### PR DESCRIPTION
Fixes #2372 

The configuration knows various options to change the logging
configuration, however, these were not respected for two reasons:

 * Logging configuration was not lazily evaluated
 * Globally configured options were not agglomerated

The first problem was caused by the fact that the logging configuration
is evaluated upon loading the `aiida` module, at which point the profile
is not necessarily loaded yet, causing the `get_config_option` functions
to return the option defaults. The solution is to have the dictionary
lazily evaluated by using lambdas, which are resolved when
`configure_logging` is called. Finally, we make sure this function is
called each time the profile is set.

The second problem arose from the fact that if a profile is defined, the
`get_config_option` only returned the config value if explicitly set for
that profile and otherwise it would return the option default. This
means that if the option was defined globally for the configuration it
was ignored. This is now corrected where if the current profile does not
explicitly define a value for the option but it is globally defined, the
global value is returned.