### PR TITLE
Add a transaction context manager to backend

### DIFF
--- a/aiida/backends/tests/__init__.py
+++ b/aiida/backends/tests/__init__.py
@@ -97,6 +97,7 @@ db_test_list = {
         'orm.data.upf': ['aiida.backends.tests.orm.data.upf'],
         'orm.entities': ['aiida.backends.tests.orm.entities'],
         'orm.groups': ['aiida.backends.tests.orm.groups'],
+        'orm.implementation.backend': ['aiida.backends.tests.orm.implementation.test_backend'],
         'orm.logs': ['aiida.backends.tests.orm.logs'],
         'orm.mixins': ['aiida.backends.tests.orm.mixins'],
         'orm.node': ['aiida.backends.tests.orm.node.test_node'],

--- a/aiida/backends/tests/orm/implementation/test_backend.py
+++ b/aiida/backends/tests/orm/implementation/test_backend.py
@@ -1,0 +1,69 @@
+# -*- coding: utf-8 -*-
+###########################################################################
+# Copyright (c), The AiiDA team. All rights reserved.                     #
+# This file is part of the AiiDA code.                                    #
+#                                                                         #
+# The code is hosted on GitHub at https://github.com/aiidateam/aiida_core #
+# For further information on the license, see the LICENSE.txt file        #
+# For further information please visit http://www.aiida.net               #
+###########################################################################
+"""Unit tests for the ORM Backend class."""
+from __future__ import division
+from __future__ import print_function
+from __future__ import absolute_import
+from aiida.backends.testbase import AiidaTestCase
+from aiida import orm
+from aiida.common import exceptions
+
+
+class TestBackend(AiidaTestCase):
+    """Test backend."""
+
+    def test_transaction_nesting(self):
+        """Test that transaction nesting works."""
+        user = orm.User('initial@email.com').store()
+        with self.backend.transaction():
+            user.email = 'pre-failure@email.com'
+            try:
+                with self.backend.transaction():
+                    user.email = 'failure@email.com'
+                    self.assertEqual(user.email, 'failure@email.com')
+                    raise RuntimeError
+            except RuntimeError:
+                pass
+            self.assertEqual(user.email, 'pre-failure@email.com')
+        self.assertEqual(user.email, 'pre-failure@email.com')
+
+    def test_transaction(self):
+        """Test that transaction nesting works."""
+        user1 = orm.User('user1@email.com').store()
+        user2 = orm.User('user2@email.com').store()
+
+        try:
+            with self.backend.transaction():
+                user1.email = 'broken1@email.com'
+                user2.email = 'broken2@email.com'
+                raise RuntimeError
+        except RuntimeError:
+            pass
+        self.assertEqual(user1.email, 'user1@email.com')
+        self.assertEqual(user2.email, 'user2@email.com')
+
+    def test_store_in_transaction(self):
+        """Test that storing inside a transaction is correctly dealt with."""
+        user1 = orm.User('user_store@email.com')
+        with self.backend.transaction():
+            user1.store()
+        # the following shouldn't raise
+        orm.User.objects.get(email='user_store@email.com')
+
+        user2 = orm.User('user_store_fail@email.com')
+        try:
+            with self.backend.transaction():
+                user2.store()
+                raise RuntimeError
+        except RuntimeError:
+            pass
+
+        with self.assertRaises(exceptions.NotExistent):
+            orm.User.objects.get(email='user_store_fail@email.com')

--- a/aiida/orm/implementation/backends.py
+++ b/aiida/orm/implementation/backends.py
@@ -103,6 +103,16 @@ class Backend(object):
         :rtype: :class:`aiida.orm.implementation.BackendUserCollection`
         """
 
+    @abc.abstractmethod
+    def transaction(self):
+        """
+        Get a context manager that can be used as a transaction context for a series of backend operations.
+        If there is an exception within the context then the changes will be rolled back and the state will
+        be as before entering.  Transactions can be nested.
+
+        :return: a context manager to group database operations
+        """
+
 
 @six.add_metaclass(abc.ABCMeta)
 class BackendEntity(object):

--- a/aiida/orm/implementation/django/backend.py
+++ b/aiida/orm/implementation/django/backend.py
@@ -13,7 +13,7 @@ from __future__ import print_function
 
 from contextlib import contextmanager
 
-from django.db import models
+from django.db import models, transaction
 
 from aiida.backends.djsite.queries import DjangoQueryManager
 from aiida.orm.implementation.sql import SqlBackend
@@ -103,3 +103,6 @@ class DjangoBackend(SqlBackend[models.Model]):
             yield self.get_connection().cursor()
         finally:
             pass
+
+    def transaction(self):
+        return transaction.atomic()


### PR DESCRIPTION
This allows to group operations that will be rolled back if the
context is exited with an exception. This is laying the groundwork for
implementing `Node` as part of the new backend system as links, caches,
etc will have to be done in a transaction.