### PR TITLE
Fix bug in the setup of a profile through `verdi setup/quicksetup`

### DIFF
--- a/aiida/common/setup.py
+++ b/aiida/common/setup.py
@@ -159,7 +159,7 @@ def create_profile(config, profile_name='default'):
             else:
                 print("{}: {}".format(key, value))
         # If the user doesn't want to change it, we abandon
-        if not click.prompt('Would you like to change it?'):
+        if not click.confirm('Would you like to change it?'):
             return profile
 
         # Otherwise, we continue.


### PR DESCRIPTION
Fixes #2394 

When setting up a profile that already exists, `verdi` is supposed
prompt the user whether they want to reuse the information of the
existing profile or if they want to change it. However, instead of
asking to confirm, the command was prompting, causing the user to always
have to reenter the information.