### PR TITLE
Export/import of extras:

### DIFF
--- a/aiida/backends/djsite/db/models.py
+++ b/aiida/backends/djsite/db/models.py
@@ -1072,7 +1072,11 @@ class DbAttributeBaseClass(DbMultipleValueAttributeBaseClass):
             stored in the Db table, correctly converted
             to the right type.
         """
-        return cls.get_all_values_for_nodepk(dbnode.pk)
+        if isinstance(dbnode, six.integer_types):
+            dbnode_node = DbNode(id=dbnode)
+        else:
+            dbnode_node = dbnode
+        return cls.get_all_values_for_nodepk(dbnode_node.pk)
 
     @classmethod
     def get_all_values_for_nodepk(cls, dbnodepk):

--- a/aiida/backends/djsite/db/models.py
+++ b/aiida/backends/djsite/db/models.py
@@ -1072,11 +1072,7 @@ class DbAttributeBaseClass(DbMultipleValueAttributeBaseClass):
             stored in the Db table, correctly converted
             to the right type.
         """
-        if isinstance(dbnode, six.integer_types):
-            dbnode_node = DbNode(id=dbnode)
-        else:
-            dbnode_node = dbnode
-        return cls.get_all_values_for_nodepk(dbnode_node.pk)
+        return cls.get_all_values_for_nodepk(dbnode.pk)
 
     @classmethod
     def get_all_values_for_nodepk(cls, dbnodepk):

--- a/aiida/backends/tests/export_and_import.py
+++ b/aiida/backends/tests/export_and_import.py
@@ -2599,9 +2599,13 @@ class TestExtras(AiidaTestCase):
         self.import_extras()
         with self.assertRaises(ValueError):
             import_data(self.export_file, silent=True, extras_mode_existing='xnd') # first letter is wrong
+        with self.assertRaises(ValueError):
             import_data(self.export_file, silent=True, extras_mode_existing='nxd') # second letter is wrong
+        with self.assertRaises(ValueError):
             import_data(self.export_file, silent=True, extras_mode_existing='nnx') # third letter is wrong
+        with self.assertRaises(ValueError):
             import_data(self.export_file, silent=True, extras_mode_existing='n') # too short
+        with self.assertRaises(ValueError):
             import_data(self.export_file, silent=True, extras_mode_existing='nndnn') # too long
         with self.assertRaises(TypeError):
             import_data(self.export_file, silent=True, extras_mode_existing=5) # wrong type

--- a/aiida/cmdline/commands/cmd_import.py
+++ b/aiida/cmdline/commands/cmd_import.py
@@ -11,6 +11,7 @@
 from __future__ import division
 from __future__ import print_function
 from __future__ import absolute_import
+from enum import Enum
 import click
 
 from aiida.cmdline.commands.cmd_verdi import verdi
@@ -18,6 +19,18 @@ from aiida.cmdline.params.options import MultipleValueOption
 from aiida.cmdline.params.types import GroupParamType
 from aiida.cmdline.utils import decorators, echo
 from aiida.common import exceptions
+
+EXTRAS_IMPORT_MODES = ['keep_existing', 'update_existing', 'mirror', 'none', 'ask']
+
+
+# pylint: disable=too-few-public-methods
+class ExtrasImportCode(Enum):
+    """Exit codes for the verdi command line."""
+    keep_existing = 'kcl'
+    update_existing = 'kcu'
+    mirror = 'ncu'
+    none = 'knl'
+    ask = 'kca'
 
 
 @verdi.command('import')
@@ -35,8 +48,18 @@ from aiida.common import exceptions
     type=GroupParamType(create_if_not_exist=True),
     help='Specify group to which all the import nodes will be added. If such a group does not exist, it will be'
     ' created automatically.')
+@click.option(
+    '-e',
+    '--extras_import_mode',
+    type=click.Choice(EXTRAS_IMPORT_MODES),
+    default='keep_existing',
+    help="keep_existing: in case of a name collision keep the original value. "
+    "update_existing: in case of a name collision take the updated value. "
+    "mirror: keep the imported extras only and remove the extras that are not present in the imported node. "
+    "none: do not import the new extras. "
+    "ask: ask what to do in case of a name collision. ")
 @decorators.with_dbenv()
-def cmd_import(archives, webpages, group):
+def cmd_import(archives, webpages, group, extras_import_mode):
     """Import one or multiple exported AiiDA archives
 
     The ARCHIVES can be specified by their relative or absolute file path, or their HTTP URL.
@@ -78,7 +101,7 @@ def cmd_import(archives, webpages, group):
         echo.echo_info('importing archive {}'.format(archive))
 
         try:
-            import_data(archive, group)
+            import_data(archive, group, extras_mode=ExtrasImportCode[extras_import_mode].value)
         except exceptions.IncompatibleArchiveVersionError as exception:
             echo.echo_warning('{} cannot be imported: {}'.format(archive, exception))
             echo.echo_warning('run `verdi export migrate {}` to update it'.format(archive))
@@ -105,7 +128,8 @@ def cmd_import(archives, webpages, group):
             echo.echo_success('archive downloaded, proceeding with import')
 
             try:
-                import_data(temp_folder.get_abs_path(temp_file), group)
+                import_data(
+                    temp_folder.get_abs_path(temp_file), group, extras_mode=ExtrasImportCode[extras_import_mode].value)
             except exceptions.IncompatibleArchiveVersionError as exception:
                 echo.echo_warning('{} cannot be imported: {}'.format(archive, exception))
                 echo.echo_warning('download the archive file and run `verdi export migrate` to update it')

--- a/aiida/orm/importexport.py
+++ b/aiida/orm/importexport.py
@@ -410,11 +410,12 @@ def import_data_dj(in_path, user_group=None, ignore_unknown_nodes=False,
 
     :param in_path: the path to a file or folder that can be imported in AiiDA
     :param extras_mode: 3 letter code that will identify what to do with the extras import. The first letter acts on
-    extras that are present in the original node and not present in the imported node. Can be either k (keep it) or n
-    (do not keep it). The second letter acts on the imported extras that are not present in the original node. Can be
-    either c (create it) or n (do not create it). The third letter says what to do in case of a name collision. Can be
-    l (leave the old value), u (update with a new value), d (delete the extra), a (ask what to do if the content is
-    different).
+                        extras that are present in the original node and not present in the imported node. Can be
+                        either k (keep it) or n (do not keep it). The second letter acts on the imported extras that
+                        are not present in the original node. Can be either c (create it) or n (do not create it). The
+                        third letter says what to do in case of a name collision. Can be l (leave the old value), u
+                        (update with a new value), d (delete the extra), a (ask what to do if the content is
+                        different).
     """
     import os
     import tarfile
@@ -1077,11 +1078,12 @@ def import_data_sqla(in_path, user_group=None, ignore_unknown_nodes=False,
 
     :param in_path: the path to a file or folder that can be imported in AiiDA
     :param extras_mode: 3 letter code that will identify what to do with the extras import. The first letter acts on
-    extras that are present in the original node and not present in the imported node. Can be either k (keep it) or n
-    (do not keep it). The second letter acts on the imported extras that are not present in the original node. Can be
-    either c (create it) or n (do not create it). The third letter says what to do in case of a name collision. Can be
-    l (leave the old value), u (update with a new value), d (delete the extra), a (ask what to do if the content is
-    different).
+                        extras that are present in the original node and not present in the imported node. Can be
+                        either k (keep it) or n (do not keep it). The second letter acts on the imported extras that
+                        are not present in the original node. Can be either c (create it) or n (do not create it). The
+                        third letter says what to do in case of a name collision. Can be l (leave the old value), u
+                        (update with a new value), d (delete the extra), a (ask what to do if the content is
+                        different).
     """
     import os
     import tarfile

--- a/aiida/orm/importexport.py
+++ b/aiida/orm/importexport.py
@@ -384,7 +384,23 @@ def deserialize_field(k, v, fields_info, import_unique_ids_mappings,
             return ("{}_id".format(k), None)
 
 def merge_extras(old_extras, new_extras, mode):
-    
+    """
+    :param old_extras: a dictionary containing the old extras of an already existing node
+    :param new_extras: a dictionary containing the new extras of an imported node
+    :param extras_mode_existing: 3 letter code that will identify what to do with the extras import. The first letter acts on
+                        extras that are present in the original node and not present in the imported node. Can be
+                        either k (keep it) or n (do not keep it). The second letter acts on the imported extras that
+                        are not present in the original node. Can be either c (create it) or n (do not create it). The
+                        third letter says what to do in case of a name collision. Can be l (leave the old value), u
+                        (update with a new value), d (delete the extra), a (ask what to do if the content is
+                        different).
+    """
+    from six import string_types
+    if not isinstance(mode, string_types):
+        raise TypeError("Parameter 'mode' should be of string type, you provided '{}' type".format(type(mode)))
+    elif not len(mode) == 3:
+        raise ValueError("Parameter 'mode' should be a 3-letter string, you provided: '{}'".format(mode))
+
     old_keys = set(old_extras.keys())
     new_keys = set(new_extras.keys())
     
@@ -431,13 +447,13 @@ def merge_extras(old_extras, new_extras, mode):
             for key in old_keys_only:
                 final_extras[key] = old_extras[key]
         elif mode[0] != 'n':
-            raise Exception("Unknown update extras mode: {}".format(mode))
+            raise ValueError("Unknown first letter of the update extras mode: '{}'. Should be either 'k' or 'n'".format(mode))
     
         if mode[1] == 'c':
             for key in new_keys_only:
                 final_extras[key] = new_extras[key]
         elif mode[1] != 'n':
-            raise Exception("Unknown update extras mode: {}".format(mode))
+            raise ValueError("Unknown second letter of the update extras mode: '{}'. Should be either 'c' or 'n'".format(mode))
     
         if mode[2] == 'u':
             for key in collided_keys:
@@ -455,7 +471,7 @@ def merge_extras(old_extras, new_extras, mode):
                     else:
                         final_extras[key] = old_extras[key]
         elif mode[2] != 'd':
-            raise Exception("Unknown update extras mode: {}".format(mode))
+            raise ValueError("Unknown third letter of the update extras mode: '{}'. Should be one of 'u'/'l'/'a'/'d'".format(mode))
 
     return final_extras
 


### PR DESCRIPTION
fixes #1761

1) Extras are now exported together with other data
2) Extras are now fully imported if the corresponding node did not exist
3) In case the imported node already exists in a database the following
logic may be chosen to import the extras:
   - keep_existing (default): keep extras with different names (old and imported
     ones), keep old value in case of name collision
   - update_existing: -/-/-, keep new value in case of name collision
   - ask: -/-/-, ask what to do in case of the name collision
   - mirror: completely overwrite the extras by the imported ones
   - none: keep old extras