### PR TITLE
add instructions when verdi import fails

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,7 +38,7 @@ install:
     - pip install -U pip wheel setuptools
     - pip install coveralls
     # Install AiiDA with some optional dependencies
-    - if [ "$TEST_TYPE" == "docs" ]; then pip install --no-use-pep517 . && pip install -r docs/requirements_for_rtd.txt; else pip install .[all]; fi
+    - if [ "$TEST_TYPE" == "docs" ]; then pip install --no-use-pep517 . && pip install -r docs/requirements_for_rtd.txt; else pip install --no-use-pep517 .[all]; fi
 
 env:
     ## Build matrix to test both backends, and the docs

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,6 +36,7 @@ before_install:
 install:
     # Upgrade pip setuptools and wheel to be able to run the next command
     - pip install -U pip==18.1 wheel setuptools coveralls
+    - pip uninstall numpy # try fixing problems with pre-existing numpy version
     # Install AiiDA with some optional dependencies
     - if [ "$TEST_TYPE" == "docs" ]; then pip install . && pip install -r docs/requirements_for_rtd.txt; else pip install .[all]; fi
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,7 +38,7 @@ install:
     - pip install -U pip wheel setuptools
     - pip install coveralls
     # Install AiiDA with some optional dependencies
-    - if [ "$TEST_TYPE" == "docs" ]; then pip install . && pip install -r docs/requirements_for_rtd.txt; else pip install .[all]; fi
+    - if [ "$TEST_TYPE" == "docs" ]; then pip install --no-use-pep517 . && pip install -r docs/requirements_for_rtd.txt; else pip install .[all]; fi
 
 env:
     ## Build matrix to test both backends, and the docs

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,10 +35,9 @@ before_install:
 
 install:
     # Upgrade pip setuptools and wheel to be able to run the next command
-    - pip install -U pip wheel setuptools
-    - pip install coveralls
+    - pip install -U pip==18.1 wheel setuptools coveralls
     # Install AiiDA with some optional dependencies
-    - if [ "$TEST_TYPE" == "docs" ]; then pip install --no-use-pep517 . && pip install -r docs/requirements_for_rtd.txt; else pip install --no-use-pep517 .[all]; fi
+    - if [ "$TEST_TYPE" == "docs" ]; then pip install . && pip install -r docs/requirements_for_rtd.txt; else pip install .[all]; fi
 
 env:
     ## Build matrix to test both backends, and the docs

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,11 +14,11 @@ services:
 
 addons:
     # make sure the path in .travis-data/test_script.sh matches the version requested here
-    postgresql: "9.5"
+    postgresql: "9.6"
 
     apt:
        packages:
-           - postgresql-server-dev-9.5
+           - postgresql-server-dev-9.6
            - texlive-base
            - texlive-generic-recommended
            - texlive-fonts-recommended
@@ -36,8 +36,9 @@ before_install:
 install:
     # Upgrade pip setuptools and wheel to be able to run the next command
     - pip install -U pip==18.1 wheel setuptools coveralls
-    - pip install numpy==1.15.4 # try fixing problems with pre-existing numpy version
-    - pip freeze
+    # Need numpy version that is compatible with pymatgen, see #2420
+    # Specifying it in pyproject.toml is not sufficient for travis (unknown reason)
+    - pip install numpy==1.15.4
     # Install AiiDA with some optional dependencies
     - if [ "$TEST_TYPE" == "docs" ]; then pip install . && pip install -r docs/requirements_for_rtd.txt; else pip install .[all]; fi
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,7 @@ before_install:
 install:
     # Upgrade pip setuptools and wheel to be able to run the next command
     - pip install -U pip==18.1 wheel setuptools coveralls
-    - pip uninstall numpy # try fixing problems with pre-existing numpy version
+    - pip uninstall --yes numpy # try fixing problems with pre-existing numpy version
     # Install AiiDA with some optional dependencies
     - if [ "$TEST_TYPE" == "docs" ]; then pip install . && pip install -r docs/requirements_for_rtd.txt; else pip install .[all]; fi
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,8 +37,9 @@ install:
     # Upgrade pip setuptools and wheel to be able to run the next command
     - pip install -U pip==18.1 wheel setuptools coveralls
     - pip uninstall --yes numpy # try fixing problems with pre-existing numpy version
+    - pip freeze
     # Install AiiDA with some optional dependencies
-    - if [ "$TEST_TYPE" == "docs" ]; then pip install . && pip install -r docs/requirements_for_rtd.txt; else pip install .[all]; fi
+    - if [ "$TEST_TYPE" == "docs" ]; then pip install . && pip install -r docs/requirements_for_rtd.txt; else pip install -vvv .[all]; fi
 
 env:
     ## Build matrix to test both backends, and the docs

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,7 @@ before_install:
 install:
     # Upgrade pip setuptools and wheel to be able to run the next command
     - pip install -U pip==18.1 wheel setuptools coveralls
-    #- pip uninstall --yes numpy # try fixing problems with pre-existing numpy version
+    - pip install numpy==1.15.4 # try fixing problems with pre-existing numpy version
     - pip freeze
     # Install AiiDA with some optional dependencies
     - if [ "$TEST_TYPE" == "docs" ]; then pip install . && pip install -r docs/requirements_for_rtd.txt; else pip install .[all]; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,10 +36,10 @@ before_install:
 install:
     # Upgrade pip setuptools and wheel to be able to run the next command
     - pip install -U pip==18.1 wheel setuptools coveralls
-    - pip uninstall --yes numpy # try fixing problems with pre-existing numpy version
+    #- pip uninstall --yes numpy # try fixing problems with pre-existing numpy version
     - pip freeze
     # Install AiiDA with some optional dependencies
-    - if [ "$TEST_TYPE" == "docs" ]; then pip install . && pip install -r docs/requirements_for_rtd.txt; else pip install -vvv .[all]; fi
+    - if [ "$TEST_TYPE" == "docs" ]; then pip install . && pip install -r docs/requirements_for_rtd.txt; else pip install .[all]; fi
 
 env:
     ## Build matrix to test both backends, and the docs

--- a/aiida/orm/importexport.py
+++ b/aiida/orm/importexport.py
@@ -939,6 +939,8 @@ def import_data_sqla(in_path, ignore_unknown_nodes=False, silent=False):
             else:
                 msg += "\nUpdate your AiiDA version in order to import this file."
 
+            raise ValueError(msg)
+
         ###################################################################
         #           CREATE UUID REVERSE TABLES AND CHECK IF               #
         #              I HAVE ALL NODES FOR THE LINKS                     #

--- a/aiida/orm/importexport.py
+++ b/aiida/orm/importexport.py
@@ -404,9 +404,14 @@ def import_data_dj(in_path,ignore_unknown_nodes=False,
         # PRELIMINARY CHECKS #
         ######################
         if metadata['export_version'] != expected_export_version:
-            raise ValueError("File export version is {}, but I can import only "
-                             "version {}".format(metadata['export_version'],
-                                                 expected_export_version))
+            msg = "Export file version is {}, can import only version {}"\
+                    .format(metadata['export_version'], expected_export_version)
+            if metadata['export_version'] < expected_export_version:
+                msg += "\nUse 'verdi export migrate' to update this export file."
+            else:
+                msg += "\nUpdate your AiiDA version in order to import this file."
+
+            raise ValueError(msg)
 
         ##########################################################################
         # CREATE UUID REVERSE TABLES AND CHECK IF I HAVE ALL NODES FOR THE LINKS #
@@ -927,10 +932,12 @@ def import_data_sqla(in_path, ignore_unknown_nodes=False, silent=False):
         # PRELIMINARY CHECKS #
         ######################
         if metadata['export_version'] != expected_export_version:
-            raise ValueError("File export version is {}, but I can "
-                             "import only version {}"
-                             .format(metadata['export_version'],
-                                     expected_export_version))
+            msg = "Export file version is {}, can import only version {}"\
+                    .format(metadata['export_version'], expected_export_version)
+            if metadata['export_version'] < expected_export_version:
+                msg += "\nUse 'verdi export migrate' to update this export file."
+            else:
+                msg += "\nUpdate your AiiDA version in order to import this file."
 
         ###################################################################
         #           CREATE UUID REVERSE TABLES AND CHECK IF               #

--- a/docs/requirements_for_rtd.txt
+++ b/docs/requirements_for_rtd.txt
@@ -48,7 +48,7 @@ pgtest==1.1.0
 plumpy==0.7.12
 portalocker==1.1.0
 psutil==5.4.5
-pymatgen==2019.1.24
+pymatgen==2018.12.12
 pyparsing==2.2.0
 python-dateutil==2.7.2
 python-memcached==1.59

--- a/docs/requirements_for_rtd.txt
+++ b/docs/requirements_for_rtd.txt
@@ -40,7 +40,7 @@ itsdangerous==0.24
 marshmallow-sqlalchemy==0.13.2
 meld3==1.0.2
 mock==2.0.0
-numpy==1.14.3
+numpy==1.15.4
 paramiko==2.4.2
 passlib==1.7.1
 pathlib2==2.3.0
@@ -48,7 +48,7 @@ pgtest==1.1.0
 plumpy==0.7.12
 portalocker==1.1.0
 psutil==5.4.5
-pymatgen==2018.4.20
+pymatgen==2018.12.12
 pyparsing==2.2.0
 python-dateutil==2.7.2
 python-memcached==1.59
@@ -56,6 +56,7 @@ python-mimeparse==1.6.0
 pytz==2018.4
 qe-tools==1.1.0
 reentry==1.2.2
+scipy==1.1.0
 seekpath==1.8.1
 singledispatch >= 3.4.0.3
 six==1.11.0

--- a/docs/requirements_for_rtd.txt
+++ b/docs/requirements_for_rtd.txt
@@ -40,7 +40,7 @@ itsdangerous==0.24
 marshmallow-sqlalchemy==0.13.2
 meld3==1.0.2
 mock==2.0.0
-numpy==1.16.0
+numpy==1.15.4
 paramiko==2.4.2
 passlib==1.7.1
 pathlib2==2.3.0

--- a/docs/requirements_for_rtd.txt
+++ b/docs/requirements_for_rtd.txt
@@ -56,7 +56,6 @@ python-mimeparse==1.6.0
 pytz==2018.4
 qe-tools==1.1.0
 reentry==1.2.2
-scipy==1.1.0
 seekpath==1.8.1
 singledispatch >= 3.4.0.3
 six==1.11.0

--- a/docs/requirements_for_rtd.txt
+++ b/docs/requirements_for_rtd.txt
@@ -48,7 +48,7 @@ pgtest==1.1.0
 plumpy==0.7.12
 portalocker==1.1.0
 psutil==5.4.5
-pymatgen==2018.4.20
+pymatgen==2019.1.24
 pyparsing==2.2.0
 python-dateutil==2.7.2
 python-memcached==1.59

--- a/docs/requirements_for_rtd.txt
+++ b/docs/requirements_for_rtd.txt
@@ -40,7 +40,7 @@ itsdangerous==0.24
 marshmallow-sqlalchemy==0.13.2
 meld3==1.0.2
 mock==2.0.0
-numpy==1.15.4
+numpy==1.14.3
 paramiko==2.4.2
 passlib==1.7.1
 pathlib2==2.3.0
@@ -48,7 +48,7 @@ pgtest==1.1.0
 plumpy==0.7.12
 portalocker==1.1.0
 psutil==5.4.5
-pymatgen==2018.12.12
+pymatgen==2018.4.20
 pyparsing==2.2.0
 python-dateutil==2.7.2
 python-memcached==1.59

--- a/docs/requirements_for_rtd.txt
+++ b/docs/requirements_for_rtd.txt
@@ -40,7 +40,7 @@ itsdangerous==0.24
 marshmallow-sqlalchemy==0.13.2
 meld3==1.0.2
 mock==2.0.0
-numpy==1.14.3
+numpy==1.16.0
 paramiko==2.4.2
 passlib==1.7.1
 pathlib2==2.3.0

--- a/environment.yml
+++ b/environment.yml
@@ -24,7 +24,7 @@ dependencies:
 - portalocker==1.1.0
 - psutil==5.4.5
 - meld3==1.0.2
-- numpy==1.14.3
+- numpy==1.15.4
 - SQLAlchemy==1.0.19
 - SQLAlchemy-Utils==0.33.0
 - alembic==0.9.9

--- a/environment.yml
+++ b/environment.yml
@@ -24,7 +24,7 @@ dependencies:
 - portalocker==1.1.0
 - psutil==5.4.5
 - meld3==1.0.2
-- numpy==1.15.4
+- numpy==1.14.3
 - SQLAlchemy==1.0.19
 - SQLAlchemy-Utils==0.33.0
 - alembic==0.9.9

--- a/environment.yml
+++ b/environment.yml
@@ -24,7 +24,7 @@ dependencies:
 - portalocker==1.1.0
 - psutil==5.4.5
 - meld3==1.0.2
-- numpy==1.14.3
+- numpy==1.16.0
 - SQLAlchemy==1.0.19
 - SQLAlchemy-Utils==0.33.0
 - alembic==0.9.9

--- a/environment.yml
+++ b/environment.yml
@@ -24,7 +24,7 @@ dependencies:
 - portalocker==1.1.0
 - psutil==5.4.5
 - meld3==1.0.2
-- numpy==1.16.0
+- numpy==1.15.4
 - SQLAlchemy==1.0.19
 - SQLAlchemy-Utils==0.33.0
 - alembic==0.9.9

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,3 @@
 [build-system]
 # Minimum requirements for the build system to execute.
-requires = ["setuptools", "wheel", "reentry==1.2.2"]
+requires = ["setuptools", "wheel", "reentry==1.2.2", "cython>=0.29"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,3 @@
 [build-system]
 # Minimum requirements for the build system to execute.
-requires = ["setuptools", "wheel", "reentry==1.2.2"]
+requires = ["setuptools", "wheel", "reentry==1.2.2", "fastentrypoints"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,3 @@
 [build-system]
 # Minimum requirements for the build system to execute.
-requires = ["setuptools", "wheel", "reentry==1.2.2", "fastentrypoints"]
+requires = ["setuptools", "wheel", "reentry==1.2.2"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,3 @@
 [build-system]
 # Minimum requirements for the build system to execute.
-requires = ["setuptools", "wheel", "reentry==1.2.2"]
+requires = ["setuptools", "wheel", "reentry==1.2.2", "numpy==1.15.4"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,3 @@
 [build-system]
 # Minimum requirements for the build system to execute.
-requires = ["setuptools", "wheel", "reentry==1.2.2", "cython>=0.29"]
+requires = ["setuptools", "wheel", "reentry==1.2.2"]

--- a/setup_requirements.py
+++ b/setup_requirements.py
@@ -39,7 +39,7 @@ install_requires = [
     'portalocker==1.1.0',
     'psutil==5.4.5',
     'meld3==1.0.2',
-    'numpy==1.14.3',
+    'numpy==1.16.0',
     'SQLAlchemy==1.0.19',  # Upgrade to SQLalchemy 1.1.5 does break tests, see #465
     'SQLAlchemy-Utils==0.33.0',
     'alembic==0.9.9',

--- a/setup_requirements.py
+++ b/setup_requirements.py
@@ -39,7 +39,7 @@ install_requires = [
     'portalocker==1.1.0',
     'psutil==5.4.5',
     'meld3==1.0.2',
-    'numpy==1.15.4',
+    'numpy==1.14.3',
     'SQLAlchemy==1.0.19',  # Upgrade to SQLalchemy 1.1.5 does break tests, see #465
     'SQLAlchemy-Utils==0.33.0',
     'alembic==0.9.9',
@@ -98,7 +98,7 @@ extras_require = {
     # Requirements for non-core functionalities that rely on external atomic manipulation/processing software
     'atomic_tools': [
         'spglib==1.10.3.65',
-        'pymatgen==2018.12.12',  # last version with py2 support
+        'pymatgen==2018.4.20',
         'ase==3.12.0',  # Updating breaks tests
         'PyMySQL==0.8.0',  # Required by ICSD tools
         'PyCifRW==4.2.1',  # Updating breaks tests

--- a/setup_requirements.py
+++ b/setup_requirements.py
@@ -98,7 +98,7 @@ extras_require = {
     # Requirements for non-core functionalities that rely on external atomic manipulation/processing software
     'atomic_tools': [
         'spglib==1.10.3.65',
-        'pymatgen==2019.1.24',
+        'pymatgen==2018.12.12',  # last version with py2 support
         'ase==3.12.0',  # Updating breaks tests
         'PyMySQL==0.8.0',  # Required by ICSD tools
         'PyCifRW==4.2.1',  # Updating breaks tests

--- a/setup_requirements.py
+++ b/setup_requirements.py
@@ -39,7 +39,7 @@ install_requires = [
     'portalocker==1.1.0',
     'psutil==5.4.5',
     'meld3==1.0.2',
-    'numpy==1.16.0',
+    'numpy==1.15.4',
     'SQLAlchemy==1.0.19',  # Upgrade to SQLalchemy 1.1.5 does break tests, see #465
     'SQLAlchemy-Utils==0.33.0',
     'alembic==0.9.9',

--- a/setup_requirements.py
+++ b/setup_requirements.py
@@ -39,7 +39,7 @@ install_requires = [
     'portalocker==1.1.0',
     'psutil==5.4.5',
     'meld3==1.0.2',
-    'numpy==1.14.3',
+    'numpy==1.15.4',
     'SQLAlchemy==1.0.19',  # Upgrade to SQLalchemy 1.1.5 does break tests, see #465
     'SQLAlchemy-Utils==0.33.0',
     'alembic==0.9.9',
@@ -98,7 +98,8 @@ extras_require = {
     # Requirements for non-core functionalities that rely on external atomic manipulation/processing software
     'atomic_tools': [
         'spglib==1.10.3.65',
-        'pymatgen==2018.4.20',
+        'pymatgen==2018.12.12',  # last version with py2 support
+        'scipy==1.1.0',  # required by pymatgen 2018.12.12
         'ase==3.12.0',  # Updating breaks tests
         'PyMySQL==0.8.0',  # Required by ICSD tools
         'PyCifRW==4.2.1',  # Updating breaks tests

--- a/setup_requirements.py
+++ b/setup_requirements.py
@@ -99,7 +99,6 @@ extras_require = {
     'atomic_tools': [
         'spglib==1.10.3.65',
         'pymatgen==2018.12.12',  # last version with py2 support
-        'scipy==1.1.0',  # required by pymatgen 2018.12.12
         'ase==3.12.0',  # Updating breaks tests
         'PyMySQL==0.8.0',  # Required by ICSD tools
         'PyCifRW==4.2.1',  # Updating breaks tests

--- a/setup_requirements.py
+++ b/setup_requirements.py
@@ -98,7 +98,7 @@ extras_require = {
     # Requirements for non-core functionalities that rely on external atomic manipulation/processing software
     'atomic_tools': [
         'spglib==1.10.3.65',
-        'pymatgen==2018.4.20',
+        'pymatgen==2019.1.24',
         'ase==3.12.0',  # Updating breaks tests
         'PyMySQL==0.8.0',  # Required by ICSD tools
         'PyCifRW==4.2.1',  # Updating breaks tests

--- a/setup_requirements.py
+++ b/setup_requirements.py
@@ -118,7 +118,7 @@ extras_require = {
         'codecov==2.0.15'
     ],
     'dev_precommit': [
-        'pre-commit==1.8.2',
+        'pre-commit==1.13.0',
         'yapf==0.21.0',
         'prospector==0.12.7',
         'pylint==1.8.4',


### PR DESCRIPTION
 * when verdi import fails because of an old/new export file version, add a hint on what to do
 * fix issue with pip 19.x
 * fix issue with prospector failing to install
 * fix nasty travis issue with build of pymatgen (built using incompatible numpy version provided by travis)