### PR TITLE
Changes to `Data` class attributes and `TrajectoryData` data storage

### DIFF
--- a/aiida/backends/djsite/db/migrations/0026_trajectory_symbols_to_attribute.py
+++ b/aiida/backends/djsite/db/migrations/0026_trajectory_symbols_to_attribute.py
@@ -1,0 +1,77 @@
+# -*- coding: utf-8 -*-
+###########################################################################
+# Copyright (c), The AiiDA team. All rights reserved.                     #
+# This file is part of the AiiDA code.                                    #
+#                                                                         #
+# The code is hosted on GitHub at https://github.com/aiidateam/aiida_core #
+# For further information on the license, see the LICENSE.txt file        #
+# For further information please visit http://www.aiida.net               #
+###########################################################################
+# pylint: disable=invalid-name,too-few-public-methods
+"""Data migration for `TrajectoryData` nodes where symbol lists are moved from repository array to attribute.
+
+This process has to be done in two separate consecutive migrations to prevent data loss in between.
+"""
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+from __future__ import absolute_import
+
+# Remove when https://github.com/PyCQA/pylint/issues/1931 is fixed
+# pylint: disable=no-member,no-name-in-module,import-error
+from django.db import migrations
+
+from aiida.backends.djsite.db.migrations import upgrade_schema_version
+from . import ModelModifierV0025
+
+REVISION = '1.0.26'
+DOWN_REVISION = '1.0.25'
+
+
+def create_trajectory_symbols_attribute(apps, _):
+    """Create the symbols attribute from the repository array for all `TrajectoryData` nodes."""
+    from aiida.orm import load_node
+
+    DbAttribute = apps.get_model('db', 'DbAttribute')
+
+    modifier = ModelModifierV0025(DbAttribute)
+
+    DbNode = apps.get_model('db', 'DbNode')
+    trajectories_pk = DbNode.objects.filter(type='node.data.array.trajectory.TrajectoryData.').values_list(
+        'id', flat=True)
+    for t_pk in trajectories_pk:
+        trajectory = load_node(t_pk)
+        symbols = trajectory.get_array('symbols').tolist()
+        modifier.set_value_for_node(DbNode.objects.get(pk=trajectory.pk), 'symbols', symbols)
+
+
+def delete_trajectory_symbols_attribute(apps, _):
+    """Delete the symbols attribute for all `TrajectoryData` nodes."""
+    from aiida.orm import load_node
+
+    DbAttribute = apps.get_model('db', 'DbAttribute')
+
+    modifier = ModelModifierV0025(DbAttribute)
+
+    DbNode = apps.get_model('db', 'DbNode')
+    trajectories_pk = DbNode.objects.filter(type='node.data.array.trajectory.TrajectoryData.').values_list(
+        'id', flat=True)
+    for t_pk in trajectories_pk:
+        trajectory = load_node(t_pk)
+        modifier.del_value_for_node(DbNode.objects.get(pk=trajectory.pk), 'symbols')
+
+
+class Migration(migrations.Migration):
+    """Storing symbols in TrajectoryData nodes as attributes, while keeping numpy arrays.
+    TrajectoryData symbols arrays are deleted in the next migration.
+    We split the migration into two because every migration is wrapped in an atomic transaction and we want to avoid
+    to delete the data while it is written in the database"""
+
+    dependencies = [
+        ('db', '0025_move_data_within_node_module'),
+    ]
+
+    operations = [
+        migrations.RunPython(create_trajectory_symbols_attribute, reverse_code=delete_trajectory_symbols_attribute),
+        upgrade_schema_version(REVISION, DOWN_REVISION)
+    ]

--- a/aiida/backends/djsite/db/migrations/0027_delete_trajectory_symbols_array.py
+++ b/aiida/backends/djsite/db/migrations/0027_delete_trajectory_symbols_array.py
@@ -1,0 +1,83 @@
+# -*- coding: utf-8 -*-
+###########################################################################
+# Copyright (c), The AiiDA team. All rights reserved.                     #
+# This file is part of the AiiDA code.                                    #
+#                                                                         #
+# The code is hosted on GitHub at https://github.com/aiidateam/aiida_core #
+# For further information on the license, see the LICENSE.txt file        #
+# For further information please visit http://www.aiida.net               #
+###########################################################################
+# pylint: disable=invalid-name,too-few-public-methods
+"""Data migration for `TrajectoryData` nodes where symbol lists are moved from repository array to attribute.
+
+This process has to be done in two separate consecutive migrations to prevent data loss in between.
+"""
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+from __future__ import absolute_import
+
+# Remove when https://github.com/PyCQA/pylint/issues/1931 is fixed
+# pylint: disable=no-name-in-module,import-error
+from django.db import migrations
+
+from aiida.backends.djsite.db.migrations import upgrade_schema_version
+from . import ModelModifierV0025
+
+REVISION = '1.0.27'
+DOWN_REVISION = '1.0.26'
+
+
+def delete_trajectory_symbols_array(apps, _):
+    """Delete the symbols array from all `TrajectoryData` nodes."""
+    from aiida.orm import load_node
+
+    DbAttribute = apps.get_model('db', 'DbAttribute')
+
+    modifier = ModelModifierV0025(DbAttribute)
+
+    DbNode = apps.get_model('db', 'DbNode')
+    trajectories_pk = DbNode.objects.filter(type='node.data.array.trajectory.TrajectoryData.').values_list(
+        'id', flat=True)
+    for t_pk in trajectories_pk:
+        trajectory = load_node(t_pk)
+        modifier.del_value_for_node(DbNode.objects.get(pk=trajectory.pk), 'array|symbols')
+        # Remove the .npy file (using delete_array raises ModificationNotAllowed error)
+        trajectory._get_folder_pathsubfolder.remove_path('symbols.npy')  # pylint: disable=protected-access
+
+
+def create_trajectory_symbols_array(apps, _):
+    """Create the symbols array for all `TrajectoryData` nodes."""
+    import numpy
+    import tempfile
+    from aiida.orm import load_node
+
+    DbAttribute = apps.get_model('db', 'DbAttribute')
+
+    modifier = ModelModifierV0025(DbAttribute)
+
+    DbNode = apps.get_model('db', 'DbNode')
+    trajectories_pk = DbNode.objects.filter(type='node.data.array.trajectory.TrajectoryData.').values_list(
+        'id', flat=True)
+    for t_pk in trajectories_pk:
+        trajectory = load_node(t_pk)
+        symbols = numpy.array(trajectory.get_attr('symbols'))
+        # Save the .npy file (using set_array raises ModificationNotAllowed error)
+        with tempfile.NamedTemporaryFile() as _file:
+            numpy.save(_file, symbols)
+            _file.flush()
+            trajectory._get_folder_pathsubfolder.insert_path(_file.name, 'symbols.npy')  # pylint: disable=protected-access
+        modifier.set_value_for_node(DbNode.objects.get(pk=trajectory.pk), 'array|symbols', list(symbols.shape))
+
+
+class Migration(migrations.Migration):
+    """Deleting duplicated information stored in TrajectoryData symbols numpy arrays"""
+
+    dependencies = [
+        ('db', '0026_trajectory_symbols_to_attribute'),
+    ]
+
+    operations = [
+        migrations.RunPython(delete_trajectory_symbols_array, reverse_code=create_trajectory_symbols_array),
+        upgrade_schema_version(REVISION, DOWN_REVISION)
+    ]

--- a/aiida/backends/djsite/db/migrations/__init__.py
+++ b/aiida/backends/djsite/db/migrations/__init__.py
@@ -10,8 +10,11 @@
 from __future__ import division
 from __future__ import print_function
 from __future__ import absolute_import
+from django.apps import apps
 
-LATEST_MIGRATION = '0025_move_data_within_node_module'
+import six
+
+LATEST_MIGRATION = '0027_delete_trajectory_symbols_array'
 
 
 def _update_schema_version(version, apps, schema_editor):
@@ -36,3 +39,373 @@ def current_schema_version():
         fromlist=['REVISION']
     )
     return latest_migration.REVISION
+
+
+# Here I copied the class method definitions from aiida.backends.djsite.db.models
+# used to set and delete values for nodes.
+# This was done because:
+# 1) The DbAttribute object loaded with apps.get_model() does not provide the class methods
+# 2) When the django model changes the migration will continue to work
+# 3) If we defined in the migration a new class with these methodds as an extension of the DbAttribute class,
+# django detects a change in the model and creates a new migration
+
+
+class ModelModifierV0025(object):
+
+    from aiida.backends.utils import AIIDA_ATTRIBUTE_SEP
+
+    _subspecifier_field_name = 'dbnode'
+    _sep = AIIDA_ATTRIBUTE_SEP
+
+    def __init__(self, model_class):
+        self._model_class = model_class
+
+    def validate_key(self, key):
+        """
+        Validate the key string to check if it is valid (e.g., if it does not
+        contain the separator symbol.).
+
+        :return: None if the key is valid
+        :raise ValidationError: if the key is not valid
+        """
+        from aiida.backends.utils import validate_attribute_key
+        return validate_attribute_key(key)
+
+    def set_value_for_node(self, dbnode, key, value, with_transaction=False,
+                           stop_if_existing=False):
+        """
+        This is the raw-level method that accesses the DB. No checks are done
+        to prevent the user from (re)setting a valid key.
+        To be used only internally.
+
+        :todo: there may be some error on concurrent write;
+           not checked in this unlucky case!
+
+        :param dbnode: the dbnode for which the attribute should be stored;
+          in an integer is passed, this is used as the PK of the dbnode,
+          without any further check (for speed reasons)
+        :param key: the key of the attribute to store; must be a level-zero
+          attribute (i.e., no separators in the key)
+        :param value: the value of the attribute to store
+        :param with_transaction: if True (default), do this within a transaction,
+           so that nothing gets stored if a subitem cannot be created.
+           Otherwise, if this parameter is False, no transaction management
+           is performed.
+        :param stop_if_existing: if True, it will stop with an
+           UniquenessError exception if the key already exists
+           for the given node. Otherwise, it will
+           first delete the old value, if existent. The use with True is
+           useful if you want to use a given attribute as a "locking" value,
+           e.g. to avoid to perform an action twice on the same node.
+           Note that, if you are using transactions, you may get the error
+           only when the transaction is committed.
+
+        :raise ValueError: if the key contains the separator symbol used
+            internally to unpack dictionaries and lists (defined in cls._sep).
+        """
+        cls = self._model_class
+        DbNode = apps.get_model('db', 'DbNode')
+
+        if isinstance(dbnode, six.integer_types):
+            dbnode_node = DbNode(id=dbnode)
+        else:
+            dbnode_node = dbnode
+
+        self.set_value(key, value, with_transaction=with_transaction,
+                      subspecifier_value=dbnode_node,
+                      stop_if_existing=stop_if_existing)
+
+    def del_value_for_node(self, dbnode, key):
+        """
+        Delete an attribute from the database for the given dbnode.
+
+        :note: no exception is raised if no attribute with the given key is
+          found in the DB.
+
+        :param dbnode: the dbnode for which you want to delete the key.
+        :param key: the key to delete.
+        """
+        self.del_value(key, subspecifier_value=dbnode)
+
+    def del_value(self, key, only_children=False, subspecifier_value=None):
+        """
+        Delete a value associated with the given key (if existing).
+
+        :note: No exceptions are raised if no entry is found.
+
+        :param key: the key to delete. Can contain the separator self._sep if
+          you want to delete a subkey.
+        :param only_children: if True, delete only children and not the
+          entry itself.
+        :param subspecifier_value: must be None if this class has no
+          subspecifier set (e.g., the DbSetting class).
+          Must be the value of the subspecifier (e.g., the dbnode) for classes
+          that define it (e.g. DbAttribute and DbExtra)
+        """
+        cls = self._model_class
+        from django.db.models import Q
+
+        if self._subspecifier_field_name is None:
+            if subspecifier_value is not None:
+                raise ValueError("You cannot specify a subspecifier value for "
+                                 "class {} because it has no subspecifiers"
+                                 "".format(cls.__name__))
+            subspecifiers_dict = {}
+        else:
+            if subspecifier_value is None:
+                raise ValueError("You also have to specify a subspecifier value "
+                                 "for class {} (the {})".format(self.__name__,
+                                                                self._subspecifier_field_name))
+            subspecifiers_dict = {self._subspecifier_field_name:
+                                      subspecifier_value}
+
+        query = Q(key__startswith="{parentkey}{sep}".format(
+            parentkey=key, sep=self._sep),
+            **subspecifiers_dict)
+
+        if not only_children:
+            query.add(Q(key=key, **subspecifiers_dict), Q.OR)
+
+        cls.objects.filter(query).delete()
+
+    def set_value(self, key, value, with_transaction=False,
+                  subspecifier_value=None, other_attribs={},
+                  stop_if_existing=False):
+        """
+        Set a new value in the DB, possibly associated to the given subspecifier.
+
+        :note: This method also stored directly in the DB.
+
+        :param key: a string with the key to create (must be a level-0
+          attribute, that is it cannot contain the separator cls._sep).
+        :param value: the value to store (a basic data type or a list or a dict)
+        :param subspecifier_value: must be None if this class has no
+          subspecifier set (e.g., the DbSetting class).
+          Must be the value of the subspecifier (e.g., the dbnode) for classes
+          that define it (e.g. DbAttribute and DbExtra)
+        :param with_transaction: True if you want this function to be managed
+          with transactions. Set to False if you already have a manual
+          management of transactions in the block where you are calling this
+          function (useful for speed improvements to avoid recursive
+          transactions)
+        :param other_attribs: a dictionary of other parameters, to store
+          only on the level-zero attribute (e.g. for description in DbSetting).
+        :param stop_if_existing: if True, it will stop with an
+           UniquenessError exception if the new entry would violate an
+           uniqueness constraint in the DB (same key, or same key+node,
+           depending on the specific subclass). Otherwise, it will
+           first delete the old value, if existent. The use with True is
+           useful if you want to use a given attribute as a "locking" value,
+           e.g. to avoid to perform an action twice on the same node.
+           Note that, if you are using transactions, you may get the error
+           only when the transaction is committed.
+        """
+        cls = self._model_class
+        from django.db import transaction
+
+        self.validate_key(key)
+
+        try:
+            if with_transaction:
+                sid = transaction.savepoint()
+
+            # create_value returns a list of nodes to store
+            to_store = self.create_value(key, value,
+                                        subspecifier_value=subspecifier_value,
+                                        other_attribs=other_attribs)
+
+            if to_store:
+                if not stop_if_existing:
+                    # Delete the old values if stop_if_existing is False,
+                    # otherwise don't delete them and hope they don't
+                    # exist. If they exist, I'll get an UniquenessError
+
+                    # NOTE! Be careful in case the extra/attribute to
+                    # store is not a simple attribute but a list or dict:
+                    # like this, it should be ok because if we are
+                    # overwriting an entry it will stop anyway to avoid
+                    # to overwrite the main entry, but otherwise
+                    # there is the risk that trailing pieces remain
+                    # so in general it is good to recursively clean
+                    # all sub-items.
+                    self.del_value(key,
+                                  subspecifier_value=subspecifier_value)
+                cls.objects.bulk_create(to_store)
+
+            if with_transaction:
+                transaction.savepoint_commit(sid)
+        except BaseException as exc:  # All exceptions including CTRL+C, ...
+            from django.db.utils import IntegrityError
+            from aiida.common.exceptions import UniquenessError
+
+            if with_transaction:
+                transaction.savepoint_rollback(sid)
+            if isinstance(exc, IntegrityError) and stop_if_existing:
+                raise UniquenessError("Impossible to create the required "
+                                      "entry "
+                                      "in table '{}', "
+                                      "another entry already exists and the creation would "
+                                      "violate an uniqueness constraint.\nFurther details: "
+                                      "{}".format(cls.__name__, exc))
+            raise
+
+    def create_value(self, key, value, subspecifier_value=None,
+                     other_attribs={}):
+        """
+        Create a new list of attributes, without storing them, associated
+        with the current key/value pair (and to the given subspecifier,
+        e.g. the DbNode for DbAttributes and DbExtras).
+
+        :note: No hits are done on the DB, in particular no check is done
+          on the existence of the given nodes.
+
+        :param key: a string with the key to create (can contain the
+          separator self._sep if this is a sub-attribute: indeed, this
+          function calls itself recursively)
+        :param value: the value to store (a basic data type or a list or a dict)
+        :param subspecifier_value: must be None if this class has no
+          subspecifier set (e.g., the DbSetting class).
+          Must be the value of the subspecifier (e.g., the dbnode) for classes
+          that define it (e.g. DbAttribute and DbExtra)
+        :param other_attribs: a dictionary of other parameters, to store
+          only on the level-zero attribute (e.g. for description in DbSetting).
+
+        :return: always a list of class instances; it is the user
+          responsibility to store such entries (typically with a Django
+          bulk_create() call).
+        """
+        cls = self._model_class
+        import datetime
+
+        import aiida.common.json as json
+        from aiida.common.timezone import is_naive, make_aware, get_current_timezone
+
+        if self._subspecifier_field_name is None:
+            if subspecifier_value is not None:
+                raise ValueError("You cannot specify a subspecifier value for "
+                                 "class {} because it has no subspecifiers"
+                                 "".format(cls.__name__))
+            new_entry = cls(key=key, **other_attribs)
+        else:
+            if subspecifier_value is None:
+                raise ValueError("You also have to specify a subspecifier value "
+                                 "for class {} (the {})".format(cls.__name__,
+                                                                self._subspecifier_field_name))
+            further_params = other_attribs.copy()
+            further_params.update({self._subspecifier_field_name:
+                                       subspecifier_value})
+            new_entry = cls(key=key, **further_params)
+
+        list_to_return = [new_entry]
+
+        if value is None:
+            new_entry.datatype = 'none'
+            new_entry.bval = None
+            new_entry.tval = ''
+            new_entry.ival = None
+            new_entry.fval = None
+            new_entry.dval = None
+
+        elif isinstance(value, bool):
+            new_entry.datatype = 'bool'
+            new_entry.bval = value
+            new_entry.tval = ''
+            new_entry.ival = None
+            new_entry.fval = None
+            new_entry.dval = None
+
+        elif isinstance(value, six.integer_types):
+            new_entry.datatype = 'int'
+            new_entry.ival = value
+            new_entry.tval = ''
+            new_entry.bval = None
+            new_entry.fval = None
+            new_entry.dval = None
+
+        elif isinstance(value, float):
+            new_entry.datatype = 'float'
+            new_entry.fval = value
+            new_entry.tval = ''
+            new_entry.ival = None
+            new_entry.bval = None
+            new_entry.dval = None
+
+        elif isinstance(value, six.string_types):
+            new_entry.datatype = 'txt'
+            new_entry.tval = value
+            new_entry.bval = None
+            new_entry.ival = None
+            new_entry.fval = None
+            new_entry.dval = None
+
+        elif isinstance(value, datetime.datetime):
+
+            # current timezone is taken from the settings file of django
+            if is_naive(value):
+                value_to_set = make_aware(value, get_current_timezone())
+            else:
+                value_to_set = value
+
+            new_entry.datatype = 'date'
+            # TODO: time-aware and time-naive datetime objects, see
+            # https://docs.djangoproject.com/en/dev/topics/i18n/timezones/#naive-and-aware-datetime-objects
+            new_entry.dval = value_to_set
+            new_entry.tval = ''
+            new_entry.bval = None
+            new_entry.ival = None
+            new_entry.fval = None
+
+        elif isinstance(value, (list, tuple)):
+
+            new_entry.datatype = 'list'
+            new_entry.dval = None
+            new_entry.tval = ''
+            new_entry.bval = None
+            new_entry.ival = len(value)
+            new_entry.fval = None
+
+            for i, subv in enumerate(value):
+                # I do not need get_or_create here, because
+                # above I deleted all children (and I
+                # expect no concurrency)
+                # NOTE: I do not pass other_attribs
+                list_to_return.extend(self.create_value(
+                    key=("{}{}{:d}".format(key, self._sep, i)),
+                    value=subv,
+                    subspecifier_value=subspecifier_value))
+
+        elif isinstance(value, dict):
+
+            new_entry.datatype = 'dict'
+            new_entry.dval = None
+            new_entry.tval = ''
+            new_entry.bval = None
+            new_entry.ival = len(value)
+            new_entry.fval = None
+
+            for subk, subv in value.items():
+                self.validate_key(subk)
+
+                # I do not need get_or_create here, because
+                # above I deleted all children (and I
+                # expect no concurrency)
+                # NOTE: I do not pass other_attribs
+                list_to_return.extend(self.create_value(
+                    key="{}{}{}".format(key, self._sep, subk),
+                    value=subv,
+                    subspecifier_value=subspecifier_value))
+        else:
+            try:
+                jsondata = json.dumps(value)
+            except TypeError:
+                raise ValueError(
+                    "Unable to store the value: it must be either a basic datatype, or json-serializable: {}".format(
+                        value))
+
+            new_entry.datatype = 'json'
+            new_entry.tval = jsondata
+            new_entry.bval = None
+            new_entry.ival = None
+            new_entry.fval = None
+
+        return list_to_return

--- a/aiida/backends/djsite/manage.py
+++ b/aiida/backends/djsite/manage.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+###########################################################################
+# Copyright (c), The AiiDA team. All rights reserved.                     #
+# This file is part of the AiiDA code.                                    #
+#                                                                         #
+# The code is hosted on GitHub at https://github.com/aiidateam/aiida_core #
+# For further information on the license, see the LICENSE.txt file        #
+# For further information please visit http://www.aiida.net               #
+###########################################################################
+from __future__ import division
+from __future__ import print_function
+from __future__ import absolute_import
+import sys
+
+
+if __name__ == "__main__":
+    from django.core.management import execute_from_command_line
+
+    # Copy sys.argv
+    actual_argv = sys.argv[:]
+
+    # Check if there is also a cmdline option is --aiida-profile=PROFILENAME
+    try:
+        first_cmdline_option = sys.argv[1]
+    except IndexError:
+        first_cmdline_option = None
+
+    profile_name = None  # Use the default profile if not specified
+    if first_cmdline_option is not None:
+        cmdprefix = "--aiida-profile="
+        if first_cmdline_option.startswith(cmdprefix):
+            profile_name = first_cmdline_option[len(cmdprefix):]
+            # I remove the argument I just read
+            actual_argv = [actual_argv[0]] + actual_argv[2:]
+
+    if actual_argv[1] == 'migrate':
+        # Perform the same loading procedure as the normal load_dbenv does
+        from aiida.backends import settings
+        settings.LOAD_DBENV_CALLED = True
+        # We load the needed profile.
+        # This is going to set global variables in settings, including
+        # settings.BACKEND
+        from aiida.backends.profile import load_profile, BACKEND_DJANGO
+        load_profile(profile=profile_name)
+        if settings.BACKEND != BACKEND_DJANGO:
+            from aiida.common.exceptions import InvalidOperation
+            raise InvalidOperation("A Django migration procedure is initiated "
+                                   "but a different backend is used!")
+        # We load the Django specific _load_dbenv_noschemacheck
+        # When there will be a need for SQLAlchemy for a schema migration,
+        # we may abstract thw _load_dbenv_noschemacheck and make a common
+        # one for both backends
+        from aiida.backends.djsite.utils import _load_dbenv_noschemacheck
+        _load_dbenv_noschemacheck(profile=profile_name)
+    else:
+        # Load the general load_dbenv.
+        from aiida.backends.utils import load_dbenv
+        load_dbenv(profile=profile_name)
+
+    execute_from_command_line(actual_argv)

--- a/aiida/backends/sqlalchemy/migrations/versions/12536798d4d3_trajectory_symbols_to_attribute.py
+++ b/aiida/backends/sqlalchemy/migrations/versions/12536798d4d3_trajectory_symbols_to_attribute.py
@@ -1,0 +1,56 @@
+"""trajectory symbols to attribute
+
+Revision ID: 12536798d4d3
+Revises: 37f3d4882837
+Create Date: 2019-01-21 10:15:02.451308
+
+"""
+# pylint: disable=invalid-name
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+from __future__ import absolute_import
+
+# Remove when https://github.com/PyCQA/pylint/issues/1931 is fixed
+# pylint: disable=no-member,no-name-in-module,import-error
+
+from alembic import op
+from sqlalchemy.orm.session import Session
+
+from aiida.backends.sqlalchemy.utils import flag_modified
+from aiida.backends.sqlalchemy.models.node import DbNode
+from aiida.orm import load_node
+
+# revision identifiers, used by Alembic.
+revision = '12536798d4d3'
+down_revision = '37f3d4882837'
+branch_labels = None
+depends_on = None
+
+# Here we duplicate the data stored in a TrajectoryData symbols array, storing it as an attribute.
+# We delete the duplicates in the following migration (ce56d84bcc35) to avoid to delete data
+
+
+def upgrade():
+    """Migrations for the upgrade."""
+    session = Session(bind=op.get_bind())
+    trajectories = session.query(DbNode).filter_by(type='node.data.array.trajectory.TrajectoryData.').all()
+    for t in trajectories:
+        symbols = load_node(pk=t.id).get_array('symbols').tolist()
+        t.attributes['symbols'] = symbols
+        flag_modified(t, 'attributes')
+        session.add(t)
+    session.commit()
+    session.close()
+
+
+def downgrade():
+    """Migrations for the downgrade."""
+    session = Session(bind=op.get_bind())
+    trajectories = session.query(DbNode).filter_by(type='node.data.array.trajectory.TrajectoryData.').all()
+    for t in trajectories:
+        t.del_attr('symbols')
+        flag_modified(t, 'attributes')
+        session.add(t)
+    session.commit()
+    session.close()

--- a/aiida/backends/sqlalchemy/migrations/versions/6a5c2ea1439d_move_data_within_node_module.py
+++ b/aiida/backends/sqlalchemy/migrations/versions/6a5c2ea1439d_move_data_within_node_module.py
@@ -1,7 +1,7 @@
 """Data migration for `Data` nodes after it was moved in the `aiida.orm.node` module changing the type string.
 
 Revision ID: 6a5c2ea1439d
-Revises: 041a79fc615f
+Revises: 375c2db70663
 Create Date: 2019-01-18 19:44:32.156083
 
 """

--- a/aiida/backends/sqlalchemy/migrations/versions/ce56d84bcc35_delete_trajectory_symbols_array.py
+++ b/aiida/backends/sqlalchemy/migrations/versions/ce56d84bcc35_delete_trajectory_symbols_array.py
@@ -1,0 +1,63 @@
+"""delete trajectory symbols array
+
+Revision ID: ce56d84bcc35
+Revises: 12536798d4d3
+Create Date: 2019-01-21 15:35:07.280805
+
+"""
+# pylint: disable=invalid-name
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+from __future__ import absolute_import
+
+# Remove when https://github.com/PyCQA/pylint/issues/1931 is fixed
+# pylint: disable=no-member,no-name-in-module,import-error
+
+import numpy
+
+from alembic import op
+from sqlalchemy.orm.session import Session
+
+from aiida.backends.sqlalchemy.models.node import DbNode
+from aiida.backends.sqlalchemy.utils import flag_modified
+from aiida.orm import load_node
+
+# revision identifiers, used by Alembic.
+revision = 'ce56d84bcc35'
+down_revision = '12536798d4d3'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    """Migrations for the upgrade."""
+    session = Session(bind=op.get_bind())
+    trajectories = session.query(DbNode).filter_by(type='node.data.array.trajectory.TrajectoryData.').all()
+    for t in trajectories:
+        del t.attributes['array|symbols']
+        flag_modified(t, 'attributes')
+        # Remove the .npy file (using delete_array raises ModificationNotAllowed error)
+        load_node(pk=t.id)._get_folder_pathsubfolder.remove_path('symbols.npy')  # pylint: disable=protected-access
+        session.add(t)
+    session.commit()
+    session.close()
+
+
+def downgrade():
+    """Migrations for the downgrade."""
+    import tempfile
+    session = Session(bind=op.get_bind())
+    trajectories = session.query(DbNode).filter_by(type='node.data.array.trajectory.TrajectoryData.').all()
+    for t in trajectories:
+        symbols = numpy.array(t.get_attr('symbols'))
+        # Save the .npy file (using set_array raises ModificationNotAllowed error)
+        with tempfile.NamedTemporaryFile() as _file:
+            numpy.save(_file, symbols)
+            _file.flush()
+            load_node(pk=t.id)._get_folder_pathsubfolder.insert_path(_file.name, 'symbols.npy')  # pylint: disable=protected-access
+        t.attributes['array|symbols'] = list(symbols.shape)
+        flag_modified(t, 'attributes')
+        session.add(t)
+    session.commit()
+    session.close()

--- a/aiida/backends/tests/cmdline/commands/test_code.py
+++ b/aiida/backends/tests/cmdline/commands/test_code.py
@@ -146,13 +146,13 @@ class TestVerdiCodeCommands(AiidaTestCase):
         result = self.cli_runner.invoke(hide, [str(self.code.pk)])
         self.assertIsNone(result.exception, result.output)
 
-        self.assertTrue(self.code.is_hidden())
+        self.assertTrue(self.code.hidden)
 
     def test_reveal_one(self):
         result = self.cli_runner.invoke(reveal, [str(self.code.pk)])
         self.assertIsNone(result.exception, result.output)
 
-        self.assertFalse(self.code.is_hidden())
+        self.assertFalse(self.code.hidden)
 
     def test_relabel_code(self):
         result = self.cli_runner.invoke(relabel, [str(self.code.pk), 'new_code'])

--- a/aiida/backends/tests/cmdline/commands/test_data.py
+++ b/aiida/backends/tests/cmdline/commands/test_data.py
@@ -518,7 +518,7 @@ class TestVerdiDataTrajectory(AiidaTestCase, TestVerdiDataListable, TestVerdiDat
             0.,
             3.,
         ]]])
-        symbols = numpy.array(['H', 'O', 'C'])
+        symbols = ['H', 'O', 'C']
         positions = numpy.array([[[0., 0., 0.], [0.5, 0.5, 0.5], [1.5, 1.5, 1.5]], [[0., 0., 0.], [0.5, 0.5, 0.5],
                                                                                     [1.5, 1.5, 1.5]]])
         velocities = numpy.array([[[0., 0., 0.], [0., 0., 0.], [0., 0., 0.]], [[0.5, 0.5, 0.5], [0.5, 0.5, 0.5],

--- a/aiida/backends/tests/cmdline/commands/test_node.py
+++ b/aiida/backends/tests/cmdline/commands/test_node.py
@@ -518,7 +518,7 @@ class TestVerdiDataTrajectory(AiidaTestCase, TestVerdiDataListable, TestVerdiDat
             0.,
             3.,
         ]]])
-        symbols = numpy.array(['H', 'O', 'C'])
+        symbols = ['H', 'O', 'C']
         positions = numpy.array([[[0., 0., 0.], [0.5, 0.5, 0.5], [1.5, 1.5, 1.5]], [[0., 0., 0.], [0.5, 0.5, 0.5],
                                                                                     [1.5, 1.5, 1.5]]])
         velocities = numpy.array([[[0., 0., 0.], [0., 0., 0.], [0., 0., 0.]], [[0.5, 0.5, 0.5], [0.5, 0.5, 0.5],

--- a/aiida/backends/tests/dataclasses.py
+++ b/aiida/backends/tests/dataclasses.py
@@ -256,7 +256,7 @@ class TestCifData(AiidaTestCase):
 
     @unittest.skipIf(not has_ase(), "Unable to import ase")
     @unittest.skipIf(not has_pycifrw(), "Unable to import PyCifRW")
-    def test_get_aiida_structure(self):
+    def test_get_structure(self):
         import tempfile
 
         from aiida.orm.node.data.cif import CifData
@@ -286,9 +286,9 @@ O 0.5 0.5 0.5
             a = CifData(file=tmpf.name)
 
         with self.assertRaises(ValueError):
-            a._get_aiida_structure(converter='none')
+            a.get_structure(converter='none')
 
-        c = a._get_aiida_structure()
+        c = a.get_structure()
 
         self.assertEquals(c.get_kind_names(), ['C', 'O'])
 
@@ -330,13 +330,13 @@ O 0.5 0.5 0.5
             tmpf.flush()
             c = CifData(file=tmpf.name)
 
-        ase = c._get_aiida_structure(converter='ase', primitive_cell=False).get_ase()
+        ase = c.get_structure(converter='ase', primitive_cell=False).get_ase()
         self.assertEquals(ase.get_number_of_atoms(), 15)
 
-        ase = c._get_aiida_structure(converter='ase').get_ase()
+        ase = c.get_structure(converter='ase').get_ase()
         self.assertEquals(ase.get_number_of_atoms(), 15)
 
-        ase = c._get_aiida_structure(converter='ase', primitive_cell=True, subtrans_included=False).get_ase()
+        ase = c.get_structure(converter='ase', primitive_cell=True, subtrans_included=False).get_ase()
         self.assertEquals(ase.get_number_of_atoms(), 5)
 
     @unittest.skipIf(not has_ase(), "Unable to import ase")
@@ -389,13 +389,13 @@ Te2 0.00000 0.00000 0.79030 0.01912
             tmpf.flush()
             c = CifData(file=tmpf.name)
 
-        ase = c._get_aiida_structure(converter='pymatgen', primitive_cell=False).get_ase()
+        ase = c.get_structure(converter='pymatgen', primitive_cell=False).get_ase()
         self.assertEquals(ase.get_number_of_atoms(), 15)
 
-        ase = c._get_aiida_structure(converter='pymatgen').get_ase()
+        ase = c.get_structure(converter='pymatgen').get_ase()
         self.assertEquals(ase.get_number_of_atoms(), 15)
 
-        ase = c._get_aiida_structure(converter='pymatgen', primitive_cell=True).get_ase()
+        ase = c.get_structure(converter='pymatgen', primitive_cell=True).get_ase()
         self.assertEquals(ase.get_number_of_atoms(), 5)
 
     @unittest.skipIf(not has_pycifrw(), "Unable to import PyCifRW")
@@ -1899,7 +1899,7 @@ class TestStructureData(AiidaTestCase):
         a.append_atom(position=(0.5, 0.5, 0.5), symbols=['Ba'])
         a.append_atom(position=(1., 1., 1.), symbols=['Ti'])
 
-        c = a._get_cif()
+        c = a.get_cif()
         lines = c._prepare_cif()[0].decode('utf-8').split('\n')
         non_comments = []
         for line in lines:
@@ -2891,7 +2891,7 @@ class TestArrayData(AiidaTestCase):
 
     def test_iteration(self):
         """
-        Check the functionality of the iterarrays() iterator
+        Check the functionality of the get_iterarrays() iterator
         """
         from aiida.orm.node.data.array import ArrayData
         import numpy
@@ -2907,7 +2907,7 @@ class TestArrayData(AiidaTestCase):
         third = numpy.random.rand(6, 6)
         n.set_array('third', third)
 
-        for name, array in n.iterarrays():
+        for name, array in n.get_iterarrays():
             if name == 'first':
                 self.assertAlmostEquals(abs(first - array).max(), 0.)
             if name == 'second':
@@ -2959,7 +2959,7 @@ class TestTrajectoryData(AiidaTestCase):
             0.,
             3.,
         ]]])
-        symbols = numpy.array(['H', 'O', 'C'])
+        symbols = ['H', 'O', 'C']
         positions = numpy.array([[[0., 0., 0.], [0.5, 0.5, 0.5], [1.5, 1.5, 1.5]], [[0., 0., 0.], [0.5, 0.5, 0.5],
                                                                                     [1.5, 1.5, 1.5]]])
         velocities = numpy.array([[[0., 0., 0.], [0., 0., 0.], [0., 0., 0.]], [[0.5, 0.5, 0.5], [0.5, 0.5, 0.5],
@@ -2975,7 +2975,7 @@ class TestTrajectoryData(AiidaTestCase):
         self.assertAlmostEqual(abs(stepids - n.get_stepids()).sum(), 0.)
         self.assertAlmostEqual(abs(times - n.get_times()).sum(), 0.)
         self.assertAlmostEqual(abs(cells - n.get_cells()).sum(), 0.)
-        self.assertEqual(symbols.tolist(), n.get_symbols().tolist())
+        self.assertEqual(symbols, n.symbols)
         self.assertAlmostEqual(abs(positions - n.get_positions()).sum(), 0.)
         self.assertAlmostEqual(abs(velocities - n.get_velocities()).sum(), 0.)
 
@@ -2984,7 +2984,7 @@ class TestTrajectoryData(AiidaTestCase):
         self.assertEqual(data[0], stepids[1])
         self.assertAlmostEqual(data[1], times[1])
         self.assertAlmostEqual(abs(cells[1] - data[2]).sum(), 0.)
-        self.assertEqual(symbols.tolist(), data[3].tolist())
+        self.assertEqual(symbols, data[3])
         self.assertAlmostEqual(abs(data[4] - positions[1]).sum(), 0.)
         self.assertAlmostEqual(abs(data[5] - velocities[1]).sum(), 0.)
 
@@ -3003,7 +3003,7 @@ class TestTrajectoryData(AiidaTestCase):
         self.assertAlmostEqual(abs(stepids - n.get_stepids()).sum(), 0.)
         self.assertIsNone(n.get_times())
         self.assertAlmostEqual(abs(cells - n.get_cells()).sum(), 0.)
-        self.assertEqual(symbols.tolist(), n.get_symbols().tolist())
+        self.assertEqual(symbols, n.symbols)
         self.assertAlmostEqual(abs(positions - n.get_positions()).sum(), 0.)
         self.assertIsNone(n.get_velocities())
 
@@ -3016,7 +3016,7 @@ class TestTrajectoryData(AiidaTestCase):
         self.assertAlmostEqual(abs(stepids - n.get_stepids()).sum(), 0.)
         self.assertIsNone(n.get_times())
         self.assertAlmostEqual(abs(cells - n.get_cells()).sum(), 0.)
-        self.assertEqual(symbols.tolist(), n.get_symbols().tolist())
+        self.assertEqual(symbols, n.symbols)
         self.assertAlmostEqual(abs(positions - n.get_positions()).sum(), 0.)
         self.assertIsNone(n.get_velocities())
 
@@ -3029,7 +3029,7 @@ class TestTrajectoryData(AiidaTestCase):
         self.assertAlmostEqual(abs(stepids - n.get_stepids()).sum(), 0.)
         self.assertAlmostEqual(abs(times - n.get_times()).sum(), 0.)
         self.assertAlmostEqual(abs(cells - n.get_cells()).sum(), 0.)
-        self.assertEqual(symbols.tolist(), n.get_symbols().tolist())
+        self.assertEqual(symbols, n.symbols)
         self.assertAlmostEqual(abs(positions - n.get_positions()).sum(), 0.)
         self.assertIsNone(n.get_velocities())
 
@@ -3042,7 +3042,7 @@ class TestTrajectoryData(AiidaTestCase):
         self.assertAlmostEqual(abs(stepids - n.get_stepids()).sum(), 0.)
         self.assertAlmostEqual(abs(times - n.get_times()).sum(), 0.)
         self.assertAlmostEqual(abs(cells - n.get_cells()).sum(), 0.)
-        self.assertEqual(symbols.tolist(), n.get_symbols().tolist())
+        self.assertEqual(symbols, n.symbols)
         self.assertAlmostEqual(abs(positions - n.get_positions()).sum(), 0.)
         self.assertIsNone(n.get_velocities())
 
@@ -3055,7 +3055,7 @@ class TestTrajectoryData(AiidaTestCase):
         self.assertAlmostEqual(abs(stepids - n.get_stepids()).sum(), 0.)
         self.assertAlmostEqual(abs(times - n.get_times()).sum(), 0.)
         self.assertAlmostEqual(abs(cells - n.get_cells()).sum(), 0.)
-        self.assertEqual(symbols.tolist(), n.get_symbols().tolist())
+        self.assertEqual(symbols, n.symbols)
         self.assertAlmostEqual(abs(positions - n.get_positions()).sum(), 0.)
         self.assertIsNone(n.get_velocities())
 
@@ -3064,7 +3064,7 @@ class TestTrajectoryData(AiidaTestCase):
         self.assertEqual(data[0], stepids[1])
         self.assertAlmostEqual(data[1], times[1])
         self.assertAlmostEqual(abs(cells[1] - data[2]).sum(), 0.)
-        self.assertEqual(symbols.tolist(), data[3].tolist())
+        self.assertEqual(symbols, data[3])
         self.assertAlmostEqual(abs(data[4] - positions[1]).sum(), 0.)
         self.assertIsNone(data[5])
 
@@ -3083,7 +3083,7 @@ class TestTrajectoryData(AiidaTestCase):
         self.assertAlmostEqual(abs(stepids - n.get_stepids()).sum(), 0.)
         self.assertAlmostEqual(abs(times - n.get_times()).sum(), 0.)
         self.assertAlmostEqual(abs(cells - n.get_cells()).sum(), 0.)
-        self.assertEqual(symbols.tolist(), n.get_symbols().tolist())
+        self.assertEqual(symbols, n.symbols)
         self.assertAlmostEqual(abs(positions - n.get_positions()).sum(), 0.)
         self.assertIsNone(n.get_velocities())
 
@@ -3092,7 +3092,7 @@ class TestTrajectoryData(AiidaTestCase):
         self.assertEqual(data[0], stepids[1])
         self.assertAlmostEqual(data[1], times[1])
         self.assertAlmostEqual(abs(cells[1] - data[2]).sum(), 0.)
-        self.assertEqual(symbols.tolist(), data[3].tolist())
+        self.assertEqual(symbols, data[3])
         self.assertAlmostEqual(abs(data[4] - positions[1]).sum(), 0.)
         self.assertIsNone(data[5])
 
@@ -3141,7 +3141,7 @@ class TestTrajectoryData(AiidaTestCase):
             0.,
             3.,
         ]]])
-        symbols = numpy.array(['H', 'O', 'C'])
+        symbols = ['H', 'O', 'C']
         positions = numpy.array([[[0., 0., 0.], [0.5, 0.5, 0.5], [1.5, 1.5, 1.5]], [[0., 0., 0.], [0.5, 0.5, 0.5],
                                                                                     [1.5, 1.5, 1.5]]])
         velocities = numpy.array([[[0., 0., 0.], [0., 0., 0.], [0., 0., 0.]], [[0.5, 0.5, 0.5], [0.5, 0.5, 0.5],
@@ -3152,15 +3152,15 @@ class TestTrajectoryData(AiidaTestCase):
             stepids=stepids, cells=cells, symbols=symbols, positions=positions, times=times, velocities=velocities)
 
         from_step = n.get_step_structure(1)
-        from_get_aiida_structure = n._get_aiida_structure(index=1)
+        from_get_structure = n.get_structure(index=1)
 
-        for struc in [from_step, from_get_aiida_structure]:
+        for struc in [from_step, from_get_structure]:
             self.assertEqual(len(struc.sites), 3)  # 3 sites
             self.assertAlmostEqual(abs(numpy.array(struc.cell) - cells[1]).sum(), 0)
             newpos = numpy.array([s.position for s in struc.sites])
             self.assertAlmostEqual(abs(newpos - positions[1]).sum(), 0)
             newkinds = [s.kind_name for s in struc.sites]
-            self.assertEqual(newkinds, symbols.tolist())
+            self.assertEqual(newkinds, symbols)
 
             # Weird assignments (nobody should ever do this, but it is possible in
             # principle and we want to check
@@ -3195,7 +3195,7 @@ class TestTrajectoryData(AiidaTestCase):
             self.assertAlmostEqual(abs(newpos - positions[1]).sum(), 0)
             newkinds = [s.kind_name for s in struc.sites]
             # Kinds are in the same order as given in the custm_kinds list
-            self.assertEqual(newkinds, symbols.tolist())
+            self.assertEqual(newkinds, symbols)
             newatomtypes = [struc.get_kind(s.kind_name).symbols[0] for s in struc.sites]
             # Atoms remain in the same order as given in the positions list
             self.assertEqual(newatomtypes, ['He', 'Os', 'Cu'])
@@ -3247,7 +3247,7 @@ class TestTrajectoryData(AiidaTestCase):
 
         td = TrajectoryData(structurelist=structurelist)
         self.assertEqual(td.get_cells().tolist(), cells)
-        self.assertEqual(td.get_symbols().tolist(), symbols[0])
+        self.assertEqual(td.symbols, symbols[0])
         self.assertEqual(td.get_positions().tolist(), positions)
 
         symbols = [['H', 'O', 'C'], ['H', 'O', 'P']]
@@ -3301,7 +3301,7 @@ class TestTrajectoryData(AiidaTestCase):
             0.,
             3.,
         ]]])
-        symbols = numpy.array(['H', 'O', 'C'])
+        symbols = ['H', 'O', 'C']
         positions = numpy.array([[[0., 0., 0.], [0.5, 0.5, 0.5], [1.5, 1.5, 1.5]], [[0., 0., 0.], [0.5, 0.5, 0.5],
                                                                                     [1.5, 1.5, 1.5]]])
         velocities = numpy.array([[[0., 0., 0.], [0., 0., 0.], [0., 0., 0.]], [[0.5, 0.5, 0.5], [0.5, 0.5, 0.5],
@@ -3346,7 +3346,7 @@ class TestTrajectoryData(AiidaTestCase):
 
 class TestKpointsData(AiidaTestCase):
     """
-    Tests the TrajectoryData objects.
+    Tests the KpointsData objects.
     """
 
     def test_set_kpoints_path_legacy(self):

--- a/aiida/backends/tests/orm/data/remote.py
+++ b/aiida/backends/tests/orm/data/remote.py
@@ -58,6 +58,6 @@ class TestRemoteData(AiidaTestCase):
 
     def test_clean(self):
         """Try cleaning a RemoteData node."""
-        self.assertFalse(self.remote.is_empty())
+        self.assertFalse(self.remote.is_empty)
         self.remote._clean()
-        self.assertTrue(self.remote.is_empty())
+        self.assertTrue(self.remote.is_empty)

--- a/aiida/backends/tests/tcodexporter.py
+++ b/aiida/backends/tests/tcodexporter.py
@@ -156,7 +156,7 @@ class TestTcodDbExporter(AiidaTestCase):
             tmpf.flush()
             a = CifData(file=tmpf.name)
 
-        c = a._get_aiida_structure()
+        c = a.get_structure()
         c.store()
         pd = ParameterData()
 
@@ -249,7 +249,7 @@ class TestTcodDbExporter(AiidaTestCase):
             tmpf.flush()
             a = CifData(file=tmpf.name)
 
-        s = a._get_aiida_structure(store=True)
+        s = a.get_structure(store=True)
         val = export_values(s)
         script = val.first_block()['_tcod_file_contents'][1]
         function = '_get_aiida_structure_pymatgen_inline'

--- a/aiida/cmdline/commands/cmd_code.py
+++ b/aiida/cmdline/commands/cmd_code.py
@@ -165,7 +165,7 @@ def code_duplicate(ctx, code, non_interactive, **kwargs):
 @with_dbenv()
 def show(code, verbose):
     """Display detailed information for the given CODE."""
-    click.echo(tabulate.tabulate(code.full_text_info(verbose)))
+    click.echo(tabulate.tabulate(code.get_full_text_info(verbose)))
 
 
 @verdi_code.command()

--- a/aiida/orm/node/data/array/__init__.py
+++ b/aiida/orm/node/data/array/__init__.py
@@ -95,6 +95,20 @@ class ArrayData(Data):
         Iterator that returns tuples (name, array) for each array stored in the
         node.
         """
+        import warnings
+        from aiida.common.warnings import AiidaDeprecationWarning as DeprecationWarning  # pylint: disable=redefined-builtin
+        warnings.warn(  # pylint: disable=no-member
+            'This method has been deprecated and will be renamed to get_iterarrays() in AiiDA v1.0', DeprecationWarning)
+        return self.get_iterarrays()
+
+    def get_iterarrays(self):
+        """
+        Iterator that returns tuples (name, array) for each array stored in the
+        node.
+
+        .. versionadded:: 1.0
+           Renamed from iterarrays
+        """
         for name in self.get_arraynames():
             yield (name, self.get_array(name))
 

--- a/aiida/orm/node/data/array/trajectory.py
+++ b/aiida/orm/node/data/array/trajectory.py
@@ -499,7 +499,7 @@ class TrajectoryData(ArrayData):
 
     def get_structure(self, store=False, **kwargs):
         """
-        Creates :py:class:`aiida.orm.data.structure.StructureData`.
+        Creates :py:class:`aiida.orm.node.data.structure.StructureData`.
 
         .. versionadded:: 1.0
            Renamed from _get_aiida_structure
@@ -507,7 +507,7 @@ class TrajectoryData(ArrayData):
         :param converter: specify the converter. Default 'ase'.
         :param store: If True, intermediate calculation gets stored in the
             AiiDA database for record. Default False.
-        :return: :py:class:`aiida.orm.data.structure.StructureData` node.
+        :return: :py:class:`aiida.orm.node.data.structure.StructureData` node.
         """
         from aiida.orm.node.data.parameter import ParameterData
 
@@ -528,7 +528,7 @@ class TrajectoryData(ArrayData):
 
     def get_cif(self, index=None, **kwargs):
         """
-        Creates :py:class:`aiida.orm.data.cif.CifData`
+        Creates :py:class:`aiida.orm.node.data.cif.CifData`
 
         .. versionadded:: 1.0
            Renamed from _get_cif

--- a/aiida/orm/node/data/cif.py
+++ b/aiida/orm/node/data/cif.py
@@ -899,7 +899,7 @@ class CifData(SinglefileData):
 
     def get_structure(self, converter='pymatgen', store=False, **kwargs):
         """
-        Creates :py:class:`aiida.orm.data.structure.StructureData`.
+        Creates :py:class:`aiida.orm.node.data.structure.StructureData`.
 
         .. versionadded:: 1.0
            Renamed from _get_aiida_structure
@@ -913,7 +913,7 @@ class CifData(SinglefileData):
             the occupancies will be scaled down to 1. (pymatgen only)
         :param site_tolerance: This tolerance is used to determine if two sites are sitting in the same position,
             in which case they will be combined to a single disordered site. Defaults to 1e-4. (pymatgen only)
-        :return: :py:class:`aiida.orm.data.structure.StructureData` node.
+        :return: :py:class:`aiida.orm.node.data.structure.StructureData` node.
         """
         from . import cif  # pylint: disable=import-self
         from aiida.orm.node.data.parameter import ParameterData

--- a/aiida/orm/node/data/cif.py
+++ b/aiida/orm/node/data/cif.py
@@ -425,6 +425,7 @@ class CifData(SinglefileData):
         when setting ``ase`` or ``values``, a physical CIF file is generated
         first, the values are updated from the physical CIF file.
     """
+    # pylint: disable=abstract-method, too-many-public-methods
     _set_incompatibilities = [('ase', 'file'), ('ase', 'values'), ('file', 'values')]
     _scan_types = ['standard', 'flex']
     _parse_policies = ['eager', 'lazy']
@@ -889,6 +890,30 @@ class CifData(SinglefileData):
         :param site_tolerance: This tolerance is used to determine if two sites are sitting in the same position,
             in which case they will be combined to a single disordered site. Defaults to 1e-4. (pymatgen only)
         :return: :py:class:`aiida.orm.node.data.structure.StructureData` node.
+        """
+        import warnings
+        from aiida.common.warnings import AiidaDeprecationWarning as DeprecationWarning  # pylint: disable=redefined-builtin
+        warnings.warn(  # pylint: disable=no-member
+            'This method has been deprecated and will be renamed to get_structure() in AiiDA v1.0', DeprecationWarning)
+        return self.get_structure(converter=converter, store=store, **kwargs)
+
+    def get_structure(self, converter='pymatgen', store=False, **kwargs):
+        """
+        Creates :py:class:`aiida.orm.data.structure.StructureData`.
+
+        .. versionadded:: 1.0
+           Renamed from _get_aiida_structure
+
+        :param converter: specify the converter. Default 'pymatgen'.
+        :param store: if True, intermediate calculation gets stored in the
+            AiiDA database for record. Default False.
+        :param primitive_cell: if True, primitive cell is returned,
+            conventional cell if False. Default False.
+        :param occupancy_tolerance: If total occupancy of a site is between 1 and occupancy_tolerance,
+            the occupancies will be scaled down to 1. (pymatgen only)
+        :param site_tolerance: This tolerance is used to determine if two sites are sitting in the same position,
+            in which case they will be combined to a single disordered site. Defaults to 1e-4. (pymatgen only)
+        :return: :py:class:`aiida.orm.data.structure.StructureData` node.
         """
         from . import cif  # pylint: disable=import-self
         from aiida.orm.node.data.parameter import ParameterData

--- a/aiida/orm/node/data/code.py
+++ b/aiida/orm/node/data/code.py
@@ -59,7 +59,8 @@ class Code(Data):
         """
         self.set_extra(self.HIDDEN_KEY, False)
 
-    def is_hidden(self):
+    @property
+    def hidden(self):
         """
         Determines whether the Code is hidden or not
         """
@@ -471,6 +472,15 @@ class Code(Data):
         return builder
 
     def full_text_info(self, verbose=False):
+        """
+        Return a (multiline) string with a human-readable detailed information on this computer
+        """
+        import warnings
+        from aiida.common.warnings import AiidaDeprecationWarning as DeprecationWarning  # pylint: disable=redefined-builtin
+        warnings.warn('This method has been deprecated and will be renamed to get_full_text_info() in AiiDA v1.0', DeprecationWarning)
+        return self.get_full_text_info(verbose=verbose)
+
+    def get_full_text_info(self, verbose=False):
         """
         Return a (multiline) string with a human-readable detailed information on this computer
         """

--- a/aiida/orm/node/data/remote.py
+++ b/aiida/orm/node/data/remote.py
@@ -43,6 +43,7 @@ class RemoteData(Data):
 
         raise ModificationNotAllowed("Cannot add files or directories to a RemoteData object")
 
+    @property
     def is_empty(self):
         """
         Check if remote folder is empty

--- a/aiida/orm/node/data/structure.py
+++ b/aiida/orm/node/data/structure.py
@@ -957,7 +957,7 @@ class StructureData(Data):
         Write the given structure to a string of format XSF (for XCrySDen).
         """
         if self.is_alloy or self.has_vacancies:
-            raise NotImplementedError("XSF for alloys or systems with " "vacancies not implemented.")
+            raise NotImplementedError("XSF for alloys or systems with vacancies not implemented.")
 
         sites = self.sites
 
@@ -1061,7 +1061,7 @@ class StructureData(Data):
         Write the given structure to a string of format XYZ.
         """
         if self.is_alloy or self.has_vacancies:
-            raise NotImplementedError("XYZ for alloys or systems with " "vacancies not implemented.")
+            raise NotImplementedError("XYZ for alloys or systems with vacancies not implemented.")
 
         sites = self.sites
         cell = self.cell
@@ -1804,7 +1804,24 @@ class StructureData(Data):
             AiiDA database for record. Default False.
         :return: :py:class:`aiida.orm.node.data.cif.CifData` node.
         """
-        from aiida.orm.node.data.parameter import ParameterData
+        import warnings
+        from aiida.common.warnings import AiidaDeprecationWarning as DeprecationWarning  # pylint: disable=redefined-builtin
+        warnings.warn('This method has been deprecated and will be renamed to get_cif() in AiiDA v1.0', DeprecationWarning)
+        return self.get_cif(converter=converter, store=store, **kwargs)
+
+    def get_cif(self, converter='ase', store=False, **kwargs):
+        """
+        Creates :py:class:`aiida.orm.data.cif.CifData`.
+
+        .. versionadded:: 1.0
+           Renamed from _get_cif
+
+        :param converter: specify the converter. Default 'ase'.
+        :param store: If True, intermediate calculation gets stored in the
+            AiiDA database for record. Default False.
+        :return: :py:class:`aiida.orm.data.cif.CifData` node.
+        """
+        from .parameter import ParameterData
         from . import structure  # This same module
 
         param = ParameterData(dict=kwargs)

--- a/aiida/orm/node/data/structure.py
+++ b/aiida/orm/node/data/structure.py
@@ -1811,7 +1811,7 @@ class StructureData(Data):
 
     def get_cif(self, converter='ase', store=False, **kwargs):
         """
-        Creates :py:class:`aiida.orm.data.cif.CifData`.
+        Creates :py:class:`aiida.orm.node.data.cif.CifData`.
 
         .. versionadded:: 1.0
            Renamed from _get_cif
@@ -1819,7 +1819,7 @@ class StructureData(Data):
         :param converter: specify the converter. Default 'ase'.
         :param store: If True, intermediate calculation gets stored in the
             AiiDA database for record. Default False.
-        :return: :py:class:`aiida.orm.data.cif.CifData` node.
+        :return: :py:class:`aiida.orm.node.data.cif.CifData` node.
         """
         from .parameter import ParameterData
         from . import structure  # This same module

--- a/aiida/tools/dbexporters/tcod.py
+++ b/aiida/tools/dbexporters/tcod.py
@@ -981,7 +981,7 @@ def export_cifnode(what, parameters=None, trajectory_index=None,
     """
     The main exporter function. Exports given coordinate-containing \*Data
     node to :py:class:`aiida.orm.node.data.cif.CifData` node, ready to be
-    exported to TCOD. All \*Data types, having method ``_get_cif()``, are
+    exported to TCOD. All \*Data types, having method ``get_cif()``, are
     supported in addition to :py:class:`aiida.orm.node.data.cif.CifData`.
 
     :param what: data node to be exported.
@@ -1038,11 +1038,11 @@ def export_cifnode(what, parameters=None, trajectory_index=None,
 
     # Convert node to CifData (if required)
 
-    if not isinstance(node, CifData) and getattr(node, '_get_cif'):
+    if not isinstance(node, CifData) and getattr(node, 'get_cif'):
         function_args = {'store': store}
         if trajectory_index is not None:
             function_args['index'] = trajectory_index
-        node = node._get_cif(**function_args)
+        node = node.get_cif(**function_args)
 
     if not isinstance(node,CifData):
         raise NotImplementedError("Exporter does not know how to "

--- a/aiida/tools/dbimporters/baseclasses.py
+++ b/aiida/tools/dbimporters/baseclasses.py
@@ -319,7 +319,7 @@ class CifEntry(DbEntry):
         """
         cif = self.get_cif_node(store=store, parse_policy='lazy')
         
-        return cif._get_aiida_structure(converter=converter, store=store, **kwargs)
+        return cif.get_structure(converter=converter, store=store, **kwargs)
 
     def get_parsed_cif(self):
         """

--- a/docs/source/concepts/workflows.rst
+++ b/docs/source/concepts/workflows.rst
@@ -913,3 +913,15 @@ However, these workchains can be updated with just a few minor updates that we w
 * The import ``aiida.work.workfunction.workfunction`` has been moved to ``aiida.work.process_function.workfunction``.
 * The ``input_group`` has been deprecated and been replaced by namespaces. See the section on :ref:`port namespaces<ports_portnamespaces>` on how to use them.
 * The use of a ``.`` (period) in output keys is not supported in ``Process.out`` because that is now reserved to indicate namespaces.
+* The method ``ArrayData.iterarrayas()`` has been renamed to ``ArrayData.get_iterarrays()``.
+* The method ``TrajectoryData._get_cif()`` has been renamed to ``TrajectoryData.get_cif()``.
+* The method ``TrajectoryData._get_aiida_structure()`` has been renamed to ``TrajectoryData.get_structure()``.
+* The method ``StructureData._get_cif()`` has been renamed to ``StructureData.get_cif()``.
+* The method ``Code.full_text_info()`` has been renamed to ``Code.get_full_text_info()``.
+* The method ``Code.is_hidden()`` has been changed and is now accessed through the ``Code.hidden`` property.
+* The method ``RemoteData.is_empty()`` has been changes and is now accessed through the ``RemoteData.is_empty``.
+* The method ``.is_alloy()`` for classes ``StructureData`` and ``Kind`` is now accessed through the ``.is_alloy`` property.
+* The method ``.has_vacancies()`` for classes ``StructureData`` and ``Kind`` is now accessed through the ``.has_vacancies`` property.
+* The arguments ``stepids`` and ``cells`` of the :meth:`TrajectoryData.set_trajectory()<aiida.orm.data.array.trajectory.TrajectoryData.set_trajectory>` method are made optional
+  which has implications on the ordering of the arguments passed to this method. 
+* The list of atomic symbols for trajectories is no longer stored as array data but is now accessible through the ``TrajectoryData.symbols`` attribute.

--- a/docs/source/concepts/workflows.rst
+++ b/docs/source/concepts/workflows.rst
@@ -922,6 +922,6 @@ However, these workchains can be updated with just a few minor updates that we w
 * The method ``RemoteData.is_empty()`` has been changes and is now accessed through the ``RemoteData.is_empty``.
 * The method ``.is_alloy()`` for classes ``StructureData`` and ``Kind`` is now accessed through the ``.is_alloy`` property.
 * The method ``.has_vacancies()`` for classes ``StructureData`` and ``Kind`` is now accessed through the ``.has_vacancies`` property.
-* The arguments ``stepids`` and ``cells`` of the :meth:`TrajectoryData.set_trajectory()<aiida.orm.data.array.trajectory.TrajectoryData.set_trajectory>` method are made optional
+* The arguments ``stepids`` and ``cells`` of the :meth:`TrajectoryData.set_trajectory()<aiida.orm.node.data.array.trajectory.TrajectoryData.set_trajectory>` method are made optional
   which has implications on the ordering of the arguments passed to this method. 
 * The list of atomic symbols for trajectories is no longer stored as array data but is now accessible through the ``TrajectoryData.symbols`` attribute.

--- a/docs/source/developer_guide/core/modifying_the_schema.rst
+++ b/docs/source/developer_guide/core/modifying_the_schema.rst
@@ -1,4 +1,4 @@
-Mofidying the schema
+Modifying the schema
 ++++++++++++++++++++
 
 Django


### PR DESCRIPTION
Fixes #201 

Added migrations and tests for TrajectoryData symbols (from numpy array to attribute). 
In sqlalchemy migrations and test I used load_node; to discuss if we want to rewrite it to avoid using aiida functionality (e.g. to get and delete numpy arrays).