### PR TITLE
Prevent `verdi` from failing on empty profile list

### DIFF
--- a/aiida/backends/tests/cmdline/commands/test_verdi.py
+++ b/aiida/backends/tests/cmdline/commands/test_verdi.py
@@ -30,3 +30,17 @@ class TestVerdi(AiidaTestCase):
         result = self.cli_runner.invoke(cmd_verdi.verdi, ['--version'])
         self.assertIsNone(result.exception, result.output)
         self.assertIn(get_version(), result.output)
+
+    def test_verdi_with_empty_profile_list(self):
+        # pylint: disable=protected-access
+        """Test for #2424: verify that verdi remains operable even if profile list is empty"""
+        from aiida.manage.configuration import CONFIG
+
+        # Run verdi command with updated CONFIG featuring an empty profile list
+        config_dict = dict(CONFIG._dictionary)
+        CONFIG._dictionary[CONFIG.KEY_PROFILES] = {}
+        result = self.cli_runner.invoke(cmd_verdi.verdi, [])
+        self.assertIsNone(result.exception, result.output)
+
+        # Restore original CONFIG contents
+        CONFIG._dictionary = config_dict

--- a/aiida/cmdline/commands/cmd_profile.py
+++ b/aiida/cmdline/commands/cmd_profile.py
@@ -37,21 +37,29 @@ def profile_list():
 
     echo.echo_info('configuration folder: {}'.format(config.dirpath))
 
-    default_profile = config.default_profile_name
+    if not config.profiles:
+        echo.echo_info('no profiles configured')
+    else:
 
-    for profile in sorted(config.profiles, key=lambda p: p.name):
-        if profile.name == default_profile:
-            click.secho('{} {}'.format('*', profile.name), fg='green')
-        else:
-            click.secho('{} {}'.format(' ', profile.name))
+        default_profile = config.default_profile_name
+
+        for profile in sorted(config.profiles, key=lambda p: p.name):
+            if profile.name == default_profile:
+                click.secho('{} {}'.format('*', profile.name), fg='green')
+            else:
+                click.secho('{} {}'.format(' ', profile.name))
 
 
 @verdi_profile.command('show')
 @arguments.PROFILE(required=False, callback=defaults.get_default_profile)
 def profile_show(profile):
     """Show details for PROFILE or, when not specified, the default profile."""
+    if not profile:
+        echo.echo_critical('no profile to show')
+
+    echo.echo_info('Configuration for: {}'.format(profile.name))
     data = sorted([(k.lower(), v) for k, v in profile.dictionary.items()])
-    echo.echo(tabulate.tabulate(data, headers=('Attribute', 'Value')))
+    echo.echo(tabulate.tabulate(data))
 
 
 @verdi_profile.command('setdefault')

--- a/aiida/cmdline/commands/cmd_verdi.py
+++ b/aiida/cmdline/commands/cmd_verdi.py
@@ -43,9 +43,14 @@ def verdi(ctx, profile, version):
     except exceptions.ConfigurationError:
         config = None
     else:
-        if not profile:
-            profile = config.get_profile()
 
+        if not profile:
+            try:
+                profile = config.get_profile()
+            except exceptions.ProfileConfigurationError:
+                profile = None
+
+    if profile:
         settings.AIIDADB_PROFILE = profile.name
 
     ctx.obj.config = config

--- a/aiida/manage/configuration/config.py
+++ b/aiida/manage/configuration/config.py
@@ -156,6 +156,11 @@ class Config(object):  # pylint: disable=useless-object-inheritance
         :return: the profile instance or None if it does not exist
         :raises ProfileConfigurationError: if the name is not found in the configuration file
         """
+        from aiida.common import exceptions
+
+        if not name and not self.default_profile_name:
+            raise exceptions.ProfileConfigurationError('no default profile defined')
+
         if not name:
             name = self.default_profile_name
 


### PR DESCRIPTION
Resolves #2424 

Added a simple check for an empty profile list to the `verdi` base command, so that it only attempts to load a profile if the configs profile list is not empty (profile will be set to `None` otherwise, such as it is already done for the config if `get_config()` throws an exception).

I added a small testcase as well to check for this issue in the future.