### PR TITLE
Fix import error of `md5_file` in `CifData` and `UpfData`

### DIFF
--- a/aiida/orm/node/data/cif.py
+++ b/aiida/orm/node/data/cif.py
@@ -492,12 +492,12 @@ class CifData(SinglefileData):
             True if the object was created, or False if the object was retrieved\
             from the DB.
         """
-        import aiida.common.utils
         import os
+        from aiida.common.files import md5_file
 
         if not os.path.abspath(filename):
             raise ValueError("filename must be an absolute path")
-        md5 = aiida.common.files.md5_file(filename)
+        md5 = md5_file(filename)
 
         cifs = cls.from_md5(md5)
         if not cifs:
@@ -866,14 +866,14 @@ class CifData(SinglefileData):
         """
         Computes and returns MD5 hash of the CIF file.
         """
-        import aiida.common.utils
         from aiida.common.exceptions import ValidationError
+        from aiida.common.files import md5_file
 
         abspath = self.get_file_abs_path()
         if not abspath:
             raise ValidationError("No valid CIF was passed!")
 
-        return aiida.common.files.md5_file(abspath)
+        return md5_file(abspath)
 
     def _get_aiida_structure(self, converter='pymatgen', store=False, **kwargs):
         """

--- a/aiida/orm/node/data/upf.py
+++ b/aiida/orm/node/data/upf.py
@@ -133,10 +133,11 @@ def upload_upf_family(folder, group_label, group_description,
     """
     import os
 
-    import aiida.common
-    from aiida.common import AIIDA_LOGGER
     from aiida import orm
-    from aiida.common.exceptions import UniquenessError, NotExistent
+    from aiida.common import AIIDA_LOGGER
+    from aiida.common.exceptions import UniquenessError
+    from aiida.common.files import md5_file
+
     if not os.path.isdir(folder):
         raise ValueError("folder must be a directory")
 
@@ -167,7 +168,7 @@ def upload_upf_family(folder, group_label, group_description,
     pseudo_and_created = []
 
     for f in files:
-        md5sum = aiida.common.files.md5_file(f)
+        md5sum = md5_file(f)
         qb = orm.QueryBuilder()
         qb.append(UpfData, filters={'attributes.md5': {'==': md5sum}})
         existing_upf = qb.first()
@@ -325,12 +326,12 @@ class UpfData(SinglefileData):
             True if the object was created, or False if the object was retrieved\
             from the DB.
         """
-        import aiida.common.utils
         import os
+        from aiida.common.files import md5_file
 
         if not os.path.isabs(filename):
             raise ValueError("filename must be an absolute path")
-        md5 = aiida.common.files.md5_file(filename)
+        md5 = md5_file(filename)
 
         pseudos = cls.from_md5(md5)
         if len(pseudos) == 0:
@@ -362,7 +363,7 @@ class UpfData(SinglefileData):
         are correctly reset.
         """
         from aiida.common.exceptions import ParsingError, ValidationError
-        import aiida.common.utils
+        from aiida.common.files import md5_file
 
         if self._to_be_stored is False:
             return self
@@ -372,7 +373,7 @@ class UpfData(SinglefileData):
             raise ValidationError("No valid UPF was passed!")
 
         parsed_data = parse_upf(upf_abspath)
-        md5sum = aiida.common.files.md5_file(upf_abspath)
+        md5sum = md5_file(upf_abspath)
 
         try:
             element = parsed_data['element']
@@ -403,10 +404,10 @@ class UpfData(SinglefileData):
         I pre-parse the file to store the attributes.
         """
         from aiida.common.exceptions import ParsingError
-        import aiida.common.utils
+        from aiida.common.files import md5_file
 
         parsed_data = parse_upf(filename)
-        md5sum = aiida.common.files.md5_file(filename)
+        md5sum = md5_file(filename)
 
         try:
             element = parsed_data['element']
@@ -439,7 +440,7 @@ class UpfData(SinglefileData):
 
     def _validate(self):
         from aiida.common.exceptions import ValidationError, ParsingError
-        import aiida.common.utils
+        from aiida.common.files import md5_file
 
         super(UpfData, self)._validate()
 
@@ -452,7 +453,7 @@ class UpfData(SinglefileData):
         except ParsingError:
             raise ValidationError("The file '{}' could not be "
                                   "parsed".format(upf_abspath))
-        md5 = aiida.common.files.md5_file(upf_abspath)
+        md5 = md5_file(upf_abspath)
 
         try:
             element = parsed_data['element']


### PR DESCRIPTION
Fixes #2437 

The recent move of `md5_file` from `aiida.common.utils` to
`aiida.common.files` was not caught in some of the methods of these
classes because it imported the whole module `aiida.common.utils` and
used the function as `aiida.common.utils.md5_file`.