### PR TITLE
Fix upper limit for dependency to `pg8000<1.13.0`

### DIFF
--- a/docs/requirements_for_rtd.txt
+++ b/docs/requirements_for_rtd.txt
@@ -43,6 +43,7 @@ numpy==1.14.3
 paramiko==2.4.2
 passlib==1.7.1
 pathlib2; python_version<'3.5'
+pg8000<1.13.0
 pgtest==1.1.0
 plumpy==0.12.1
 psutil==5.4.5

--- a/setup.json
+++ b/setup.json
@@ -103,6 +103,7 @@
     "testing": [
       "unittest2==1.1.0; python_version<'3.5'",
       "pgtest==1.1.0",
+      "pg8000<1.13.0",
       "sqlalchemy-diff==0.1.3",
       "coverage==4.5.1",
       "codecov==2.0.15",


### PR DESCRIPTION
Fixes #2449 

The library `pg8000` which is used by `pgtest` to interface with
Postgres and is used by us for testing purposed released a new minor
version `v1.13.0` on Feb 1 2019, in which it dropped `py2` support
causing our tests to fail miserably. For the time being, we put an upper
bound on that dependency.