### PR TITLE
Pin the version of dependency `pika==1.0.0b1`

### DIFF
--- a/docs/requirements_for_rtd.txt
+++ b/docs/requirements_for_rtd.txt
@@ -45,6 +45,7 @@ passlib==1.7.1
 pathlib2; python_version<'3.5'
 pg8000<1.13.0
 pgtest==1.1.0
+pika==1.0.0b1
 plumpy==0.12.1
 psutil==5.4.5
 pyblake2==1.1.2; python_version<'3.6'

--- a/setup.json
+++ b/setup.json
@@ -49,6 +49,7 @@
     "ipython>=4.0,<6.0",
     "plumpy==0.12.1",
     "kiwipy[rmq]==0.4.2",
+    "pika==1.0.0b1",
     "circus==0.14.0",
     "tornado==4.5.3",
     "pyblake2==1.1.2; python_version<'3.6'",


### PR DESCRIPTION
The second beta was just released which breaks our implementation. This
will have to be adapted later.