### PR TITLE
Ensure nested `calcfunctions` work as long `store_provenance=False`

### DIFF
--- a/aiida/backends/tests/work/test_calcfunctions.py
+++ b/aiida/backends/tests/work/test_calcfunctions.py
@@ -115,3 +115,19 @@ class TestCalcFunction(AiidaTestCase):
 
         with self.assertRaises(exceptions.InvalidOperation):
             test_calcfunction_caller(self.default_int)
+
+    def test_calculation_call_store_provenance_false(self):  # pylint: disable=invalid-name
+        """Verify that a `calcfunction` can call another calcfunction as long as `store_provenance` is False."""
+
+        @calcfunction
+        def test_calcfunction_caller(data):
+            return self.test_calcfunction(data, metadata={'store_provenance': False})  # pylint: disable=unexpected-keyword-arg
+
+        result, node = test_calcfunction_caller.run_get_node(self.default_int)
+
+        self.assertTrue(isinstance(result, Int))
+        self.assertTrue(isinstance(node, CalcFunctionNode))
+
+        # The node of the outermost `calcfunction` should have a single `CREATE` link and no `CALL_CALC` links
+        self.assertEqual(len(node.get_outgoing(link_type=LinkType.CREATE).all()), 1)
+        self.assertEqual(len(node.get_outgoing(link_type=LinkType.CALL_CALC).all()), 0)

--- a/aiida/work/processes.py
+++ b/aiida/work/processes.py
@@ -515,7 +515,7 @@ class Process(plumpy.Process):
 
         parent_calc = self.get_parent_calc()
 
-        if parent_calc:
+        if parent_calc and self.metadata.store_provenance:
 
             if isinstance(parent_calc, CalculationNode):
                 raise exceptions.InvalidOperation('calling processes from a calculation type process is forbidden.')


### PR DESCRIPTION
Fixes #2444 

In principle `calcfunctions` are not allowed to call other `calcfunctions`
because a calculation is not allowed to call other calculations.
However, `calcfunctions` can be called as normal functions by setting
the metadata variable `store_provenance` to `False`. Therefore, as long
as `store_provenance` is turned off for nested functions, a
`calcfunction` is allowed to call other `calcfunctions`.

To make this work, the `Process._setup_db_record` method had to be
adapted to only add a call link to the parent process, if and only if
`store_provenance` for the child node is enabled. Otherwise, the link
validation would fail since a `CALL` link outgoing of a
`CalculationNode` is forbidden.