### PR TITLE
Implement support for process functions in `verdi process report`

### DIFF
--- a/aiida/backends/tests/__init__.py
+++ b/aiida/backends/tests/__init__.py
@@ -74,6 +74,7 @@ db_test_list = {
         'cmdline.params.types.identifier': ['aiida.backends.tests.cmdline.params.types.test_identifier'],
         'cmdline.params.types.node': ['aiida.backends.tests.cmdline.params.types.test_node'],
         'cmdline.params.types.plugin': ['aiida.backends.tests.cmdline.params.types.test_plugin'],
+        'cmdline.utils.common': ['aiida.backends.tests.cmdline.utils.test_common'],
         'common.archive': ['aiida.backends.tests.common.test_archive'],
         'common.extendeddicts': ['aiida.backends.tests.common.test_extendeddicts'],
         'common.folders': ['aiida.backends.tests.common.test_folders'],

--- a/aiida/backends/tests/cmdline/utils/test_common.py
+++ b/aiida/backends/tests/cmdline/utils/test_common.py
@@ -1,0 +1,60 @@
+# -*- coding: utf-8 -*-
+###########################################################################
+# Copyright (c), The AiiDA team. All rights reserved.                     #
+# This file is part of the AiiDA code.                                    #
+#                                                                         #
+# The code is hosted on GitHub at https://github.com/aiidateam/aiida_core #
+# For further information on the license, see the LICENSE.txt file        #
+# For further information please visit http://www.aiida.net               #
+###########################################################################
+"""Tests for common command line utilities."""
+from __future__ import division
+from __future__ import print_function
+from __future__ import absolute_import
+
+from aiida.backends.testbase import AiidaTestCase
+from aiida.common.links import LinkType
+from aiida.orm import Code
+from aiida.orm.node import CalculationNode, CalcFunctionNode
+
+
+class TestCommonUtilities(AiidaTestCase):
+    """Tests for common command line utilities."""
+
+    def test_get_node_summary(self):
+        """Test the `get_node_summary` utility."""
+        from aiida.cmdline.utils.common import get_node_summary
+
+        computer_label = self.computer.name  # pylint: disable=no-member
+        code_label = 'test_code'
+
+        code = Code(
+            input_plugin_name='arithmetic.add',
+            remote_computer_exec=[self.computer, '/remote/abs/path'],
+        )
+        code.label = code_label
+        code.store()
+
+        node = CalculationNode()
+        node.set_computer(self.computer)
+        node.add_incoming(code, link_type=LinkType.INPUT_CALC, link_label='code')
+        node.store()
+
+        summary = get_node_summary(node)
+        self.assertIn(node.uuid, summary)
+        self.assertIn(code_label, summary)
+        self.assertIn(computer_label, summary)
+
+    def test_get_process_function_report(self):
+        """Test the `get_process_function_report` utility."""
+        from aiida.cmdline.utils.common import get_process_function_report
+
+        warning = 'You have been warned'
+
+        node = CalcFunctionNode()
+        node.store()
+
+        # Add a log message through the logger
+        node.logger.warning(warning)
+
+        self.assertIn(warning, get_process_function_report(node))

--- a/aiida/cmdline/commands/cmd_process.py
+++ b/aiida/cmdline/commands/cmd_process.py
@@ -94,14 +94,16 @@ def process_show(processes):
 @decorators.with_dbenv()
 def process_report(processes, levelname, indent_size, max_depth):
     """Show the log report for one or multiple processes."""
-    from aiida.cmdline.utils.common import get_calcjob_report, get_workchain_report
-    from aiida.orm.node import CalcJobNode, WorkChainNode
+    from aiida.cmdline.utils.common import get_calcjob_report, get_workchain_report, get_process_function_report
+    from aiida.orm.node import CalcJobNode, WorkChainNode, CalcFunctionNode, WorkFunctionNode
 
     for process in processes:
         if isinstance(process, CalcJobNode):
             echo.echo(get_calcjob_report(process))
         elif isinstance(process, WorkChainNode):
             echo.echo(get_workchain_report(process, levelname, indent_size, max_depth))
+        elif isinstance(process, (CalcFunctionNode, WorkFunctionNode)):
+            echo.echo(get_process_function_report(process))
         else:
             echo.echo('Nothing to show for node type {}'.format(process.__class__))
 

--- a/aiida/cmdline/utils/common.py
+++ b/aiida/cmdline/utils/common.py
@@ -128,7 +128,7 @@ def get_node_summary(node):
     except ValueError:
         pass
     else:
-        table.append(['code', code.label])
+        table.append(['code', code.node.label])
 
     return tabulate(table, headers=table_headers)
 
@@ -255,6 +255,23 @@ def get_calcjob_report(calcjob):
         report.append('+-> {} at {}'.format(log.levelname, log.time))
         for message in log.message.splitlines():
             report.append(' | {}'.format(message))
+
+    return '\n'.join(report)
+
+
+def get_process_function_report(node):
+    """
+    Return a multi line string representation of the log messages and output of a given process function node
+
+    :param node: the node
+    :return: a string representation of the log messages
+    """
+    from aiida import orm
+
+    report = []
+
+    for log in orm.Log.objects.get_logs_for(node):
+        report.append('{time:%Y-%m-%d %H:%M:%S} [{id}]: {msg}'.format(id=log.id, msg=log.message, time=log.time))
 
     return '\n'.join(report)
 

--- a/aiida/tools/dbimporters/plugins/mpds.py
+++ b/aiida/tools/dbimporters/plugins/mpds.py
@@ -296,7 +296,7 @@ class StructuresCollection(object):
 
         :param query: a dictionary with the query parameters
         """
-        for result in self.engine.find(query, filters=fmt):
+        for result in self.engine.find(query, fmt=fmt):
 
             if fmt != ApiFormat.CIF and ('object_type' not in result or result['object_type'] != 'S'):
                 continue
@@ -330,7 +330,7 @@ class MpdsCifEntry(CifEntry, MpdsEntry):
     def __init__(self, url, **kwargs):
         """
         The DbSearchResults base class instantiates a new DbEntry by explicitly passing the url
-        of the entry as an argument. In this case it is the same as the 'uri' value that is 
+        of the entry as an argument. In this case it is the same as the 'uri' value that is
         already contained in the source dictionary so we just copy it
         """
         cif = kwargs.pop('cif', None)


### PR DESCRIPTION
Fixes #2465 

The nodes used by process functions, i.e. `CalcFunctionNode` and
`WorkFunctionNode` also can have log messages attached that should be
displayable through `verdi process report`. This is implemented in a
helper function `get_process_function_report`.