### PR TITLE
Add the `verdi data upf content` command

### DIFF
--- a/aiida/backends/tests/cmdline/commands/test_data.py
+++ b/aiida/backends/tests/cmdline/commands/test_data.py
@@ -752,6 +752,8 @@ class TestVerdiDataCif(AiidaTestCase, TestVerdiDataListable, TestVerdiDataExport
             g_e = Group(label='empty_group')
             g_e.store()
 
+        cls.cif = a
+
         return {
             TestVerdiDataListable.NODE_ID_STR: a.id,
             TestVerdiDataListable.NON_EMPTY_GROUP_ID_STR: g_ne.id,
@@ -814,6 +816,14 @@ class TestVerdiDataCif(AiidaTestCase, TestVerdiDataListable, TestVerdiDataExport
             res = self.cli_runner.invoke(cmd_cif.cif_import, options, catch_exceptions=False)
             self.assertIn(b'imported uuid', res.output_bytes, 'The string "imported uuid" was not found in the output'
                                                               ' of verdi data import.')
+
+    def test_content(self):
+        """Test that `verdi data cif content` returns the content of the file."""
+        options = [str(self.cif.uuid)]
+        result = self.cli_runner.invoke(cmd_cif.cif_content, options, catch_exceptions=False)
+
+        for line in result.output.split('\n'):
+            self.assertIn(line, self.valid_sample_cif_str)
 
     def test_export(self):
         """

--- a/aiida/cmdline/commands/cmd_data/cmd_cif.py
+++ b/aiida/cmdline/commands/cmd_data/cmd_cif.py
@@ -88,6 +88,19 @@ def cif_show(data, fmt):
     show_function(fmt, data)
 
 
+@cif.command('content')
+@arguments.DATA(type=types.DataParamType(sub_classes=('aiida.data:cif',)))
+@decorators.with_dbenv()
+def cif_content(data):
+    """Show the content of the file behind CifData objects."""
+    for node in data:
+        try:
+            with open(node.get_file_abs_path(), 'r') as handle:
+                echo.echo(handle.read())
+        except IOError as exception:
+            echo.echo_warning('could not read the content for CifData<{}>: {}'.format(node.pk, str(exception)))
+
+
 @cif.command('export')
 @arguments.DATUM(type=types.DataParamType(sub_classes=('aiida.data:cif',)))
 @options.EXPORT_FORMAT(type=click.Choice(EXPORT_FORMATS), default='cif')


### PR DESCRIPTION
Fixes #2467 

This will print the bare contents of the file behind `CifData` nodes