### PR TITLE
Remove unserializable data from metadata in `Log` records

### DIFF
--- a/aiida/orm/logs.py
+++ b/aiida/orm/logs.py
@@ -58,8 +58,10 @@ class Log(entities.Entity):
 
             metadata = dict(record.__dict__)
 
-            # Get rid of the exc info because this is usually not serializable
-            metadata['exc_info'] = None
+            # Stringify the content of `exc_info` and `args` if they exist in the metadata to ensure serializability
+            for key in ['exc_info', 'args']:
+                if key in metadata:
+                    metadata[key] = str(metadata[key])
 
             return Log(
                 time=timezone.make_aware(datetime.fromtimestamp(record.created)),


### PR DESCRIPTION
Fixes #2363 

If unserializable data, often found in the `exc_info` or `args` keys, is
not removed from the metadata of a log record, a database exception will
be thrown.