### PR TITLE
Solution for the fast node addition to group for v0.12

### DIFF
--- a/aiida/backends/sqlalchemy/migrations/versions/7a6587e16f4c_unique_constraints_for_the_db_dbgroup_.py
+++ b/aiida/backends/sqlalchemy/migrations/versions/7a6587e16f4c_unique_constraints_for_the_db_dbgroup_.py
@@ -1,0 +1,37 @@
+# -*- coding: utf-8 -*-
+###########################################################################
+# Copyright (c), The AiiDA team. All rights reserved.                     #
+# This file is part of the AiiDA code.                                    #
+#                                                                         #
+# The code is hosted on GitHub at https://github.com/aiidateam/aiida_core #
+# For further information on the license, see the LICENSE.txt file        #
+# For further information please visit http://www.aiida.net               #
+###########################################################################
+"""Unique constraints for the db_dbgroup_dbnodes table
+
+Revision ID: 7a6587e16f4c
+Revises: 35d4ee9a1b0e
+Create Date: 2019-02-11 19:25:11.744902
+
+"""
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = '7a6587e16f4c'
+down_revision = '35d4ee9a1b0e'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    """
+    Add unique constraints to the db_dbgroup_dbnodes table.
+    """
+    op.create_unique_constraint('uix_dbnode_id_dbgroup_id', 'db_dbgroup_dbnodes', ['dbnode_id', 'dbgroup_id'])
+
+
+def downgrade():
+    """
+    Remove unique constraints from the db_dbgroup_dbnodes table.
+    """
+    op.drop_constraint('uix_dbnode_id_dbgroup_id', 'db_dbgroup_dbnodes')

--- a/aiida/backends/sqlalchemy/models/group.py
+++ b/aiida/backends/sqlalchemy/models/group.py
@@ -26,7 +26,10 @@ table_groups_nodes = Table(
     Base.metadata,
     Column('id', Integer, primary_key=True),
     Column('dbnode_id', Integer, ForeignKey('db_dbnode.id', deferrable=True, initially="DEFERRED")),
-    Column('dbgroup_id', Integer, ForeignKey('db_dbgroup.id', deferrable=True, initially="DEFERRED"))
+    Column('dbgroup_id', Integer, ForeignKey('db_dbgroup.id', deferrable=True, initially="DEFERRED")),
+
+    # explicit/composite unique constraint.  'name' is optional.
+    UniqueConstraint('dbnode_id', 'dbgroup_id', name='uix_dbnode_id_dbgroup_id')
 )
 
 

--- a/aiida/orm/implementation/django/group.py
+++ b/aiida/orm/implementation/django/group.py
@@ -125,7 +125,7 @@ class Group(AbstractGroup):
         # To allow to do directly g = Group(...).store()
         return self
 
-    def add_nodes(self, nodes):
+    def add_nodes(self, nodes, **kargs):
         from aiida.backends.djsite.db.models import DbNode
         if not self.is_stored:
             raise ModificationNotAllowed("Cannot add nodes to a group before "

--- a/aiida/orm/implementation/general/group.py
+++ b/aiida/orm/implementation/general/group.py
@@ -232,7 +232,7 @@ class AbstractGroup(object):
         pass
 
     @abstractmethod
-    def add_nodes(self, nodes):
+    def add_nodes(self, nodes, **kargs):
         """
         Add a node or a set of nodes to the group.
 

--- a/aiida/orm/importexport.py
+++ b/aiida/orm/importexport.py
@@ -1402,7 +1402,8 @@ def import_data_sqla(in_path, ignore_unknown_nodes=False, silent=False):
                 qb_nodes = QueryBuilder().append(
                     Node, filters={'id': {'in': nodes_ids_to_add}})
                 nodes_to_add = [n[0] for n in qb_nodes.all()]
-                group.add_nodes(nodes_to_add)
+                # Adding nodes to group avoiding the SQLA ORM to increase speed
+                group.add_nodes(nodes_to_add, skip_orm=True)
 
             ######################################################
             # Put everything in a specific group
@@ -1442,12 +1443,9 @@ def import_data_sqla(in_path, ignore_unknown_nodes=False, silent=False):
                 # Add all the nodes to the new group
                 # TODO: decide if we want to return the group name
                 from aiida.backends.sqlalchemy.models.node import DbNode
+                # Adding nodes to group avoiding the SQLA ORM to increase speed
                 group.add_nodes(session.query(DbNode).filter(
-                    DbNode.id.in_(pks_for_group)).distinct().all())
-
-                # group.add_nodes(models.DbNode.objects.filter(
-                #     pk__in=pks_for_group))
-
+                    DbNode.id.in_(pks_for_group)).distinct().all(), skip_orm=True)
                 if not silent:
                     print "IMPORTED NODES GROUPED IN IMPORT GROUP NAMED '{}'".format(group.name)
             else:


### PR DESCRIPTION
This PR solves issue #1319 and provides a fast and non-ORM way to add nodes to a group. Import/export and more specifically import under SQLA should benefit from this.

@ltalirz Could you, please, verify that it works as expected at one of your databases (the corresponding tests pass)?

@giovannipizzi We should decide which version we will use at aiida/orm/implementation/sqlalchemy/group.py
I currently use the RAW SQLA query which is the fastest. I commented out the version that uses SQLA to construct the query since it needs SQLA 1.1+ and this is not supported at that version of AiiDA. Let's decide if it is worth it to make AiiDA compatible with SQLA 1.1+ or to keep the raw SQL version for 0.12

If we keep the raw SQL approach, maybe, we should do the group addition in batches and launch several SQL queries - I am not sure if I can add 1M of node ids in one INSERT SQL.