### PR TITLE
Ex-/import process_type column - Tests for correct export/import of v0.4 export-files

### DIFF
--- a/aiida/orm/importexport.py
+++ b/aiida/orm/importexport.py
@@ -252,7 +252,8 @@ def get_all_fields_info():
             "requires": COMPUTER_ENTITY_NAME,
             "related_name": "dbnodes"
         },
-        "description": {}
+        "description": {},
+        "process_type": {}
     }
     all_fields_info[ATTRIBUTE_ENTITY_NAME] = {
         "dbnode": {
@@ -1955,13 +1956,6 @@ def serialize_dict(datadict, remove_fields=[], rename_fields={},
         return (ret_dict, conversions)
     else:
         return ret_dict
-
-
-fields_to_export = {
-    'aiida.backends.djsite.db.models.DbNode':
-        ['description', 'public', 'nodeversion', 'uuid', 'mtime', 'user',
-         'ctime', 'dbcomputer', 'label', 'type'],
-}
 
 
 def fill_in_query(partial_query, originating_entity_str, current_entity_str,


### PR DESCRIPTION
Part of #2342.

**Crucial** addition of `process_type` column of `dbnode` table to be exported (added to `metadata.json`).

Mainly, this PR deals with the tests of export/import, in regards to checking exported files of v0.4 are compliant with the db migrations performed since v0.3.

Furthermore, the export/import tests file (`export_and_import.py`) has been mildly reordered. Dividing tests into more relevant and intuitive classes.
Redundant tests have been removed, while similar tests have been squashed, where the simplicity can be maintained.