### PR TITLE
DOCS: Create placeholder for v1.0 breaking changes

### DIFF
--- a/docs/source/install/updating_installation.rst
+++ b/docs/source/install/updating_installation.rst
@@ -86,3 +86,13 @@ To find the update instructions for older versions of AiiDA follow the following
   SQLAlchemy backend. In case you were using SQLAlchemy before the introduction
   of Alembic, you may experience problems during your first migration. If it is
   the case, please see :ref:`this section <first_alembic_migration>`.
+
+
+
+.. _backward_incompatible_changes_beta_release:
+
+Backward incompatible changes in ``v1.0.0``
+===========================================
+ 
+The list of all backward-incompatible changes between the 0.x series and AiiDA 1.0 is 
+maintained `here <https://github.com/aiidateam/aiida_core/wiki/Backward-incompatible-changes-in-1.0.0>`_.


### PR DESCRIPTION
Resolves #2320

- Created a placeholder section in install/updating_installation
where the finalised prose describing all of the important behaviour changing and
backwards-incompatible change should be placed before the v1.0.0b release.
The content of this section is being drafted on the wiki at:
https://github.com/aiidateam/aiida_core/wiki/Backward-incompatible-changes-in-1.0.0
Before the beta release, the finalised content from the wiki page should be converted using
`pandoc` and then pasted in this section.

- Moved the section about converting workchains to the wiki. This section should be
included in the larger v1.0 changes text so that we don't have to maintain two seperate
versions of it.

Refer also to issue #2482.