### PR TITLE
Importing `metadata` for `Log`-entries properly and importing existing Logs and Comments properly

### DIFF
--- a/aiida/backends/sqlalchemy/models/comment.py
+++ b/aiida/backends/sqlalchemy/models/comment.py
@@ -56,3 +56,19 @@ class DbComment(Base):
             self.dbnode.get_simple_name(),
             self.dbnode.id, timezone.localtime(self.ctime).strftime("%Y-%m-%d")
         )
+
+    def __init__(self, *args, **kwargs):
+        super(DbComment, self).__init__(*args, **kwargs)
+        # The behavior of an unstored Comment instance should be that all its attributes should be initialized in
+        # accordance with the defaults specified on the collums, i.e. if a default is specified for the `uuid` column,
+        # then an unstored `DbComment` instance should have a default value for the `uuid` attribute. The exception here
+        # is the `mtime`, that we do not want to be set upon instantiation, but only upon storing. However, in
+        # SqlAlchemy a default *has* to be defined if one wants to get that value upon storing. But since defining a
+        # default on the column in combination with the hack in `aiida.backend.SqlAlchemy.models.__init__` to force all
+        # defaults to be populated upon instantiation, we have to unset the `mtime` attribute here manually.
+        #
+        # The only time that we allow mtime not to be null is when we explicitly pass mtime as a kwarg. This covers
+        # the case that a node is constructed based on some very predefined data like when we create nodes at the
+        # AiiDA import functions.
+        if 'mtime' not in kwargs:
+            self.mtime = None

--- a/aiida/backends/sqlalchemy/models/log.py
+++ b/aiida/backends/sqlalchemy/models/log.py
@@ -20,7 +20,6 @@ from sqlalchemy.types import Integer, DateTime, String, Text
 from aiida.backends.sqlalchemy.models.base import Base
 from aiida.common import timezone
 from aiida.common.utils import get_new_uuid
-from aiida.common.exceptions import ValidationError
 
 
 class DbLog(Base):

--- a/aiida/backends/sqlalchemy/models/node.py
+++ b/aiida/backends/sqlalchemy/models/node.py
@@ -96,7 +96,12 @@ class DbNode(Base):
         # SqlAlchemy a default *has* to be defined if one wants to get that value upon storing. But since defining a
         # default on the column in combination with the hack in `aiida.backend.SqlAlchemy.models.__init__` to force all
         # defaults to be populated upon instantiation, we have to unset the `mtime` attribute here manually.
-        self.mtime = None
+        #
+        # The only time that we allow mtime not to be null is when we explicitly pass mtime as a kwarg. This covers
+        # the case that a node is constructed based on some very predefined data like when we create nodes at the
+        # AiiDA import functions.
+        if 'mtime' not in kwargs:
+            self.mtime = None
 
         if self.attributes is None:
             self.attributes = dict()

--- a/aiida/backends/tests/__init__.py
+++ b/aiida/backends/tests/__init__.py
@@ -113,6 +113,7 @@ db_test_list = {
         'orm.groups': ['aiida.backends.tests.orm.test_groups'],
         'orm.implementation.backend': ['aiida.backends.tests.orm.implementation.test_backend'],
         'orm.implementation.nodes': ['aiida.backends.tests.orm.implementation.test_nodes'],
+        'orm.implementation.comments': ['aiida.backends.tests.orm.implementation.test_comments'],
         'orm.logs': ['aiida.backends.tests.orm.test_logs'],
         'orm.mixins': ['aiida.backends.tests.orm.test_mixins'],
         'orm.node': ['aiida.backends.tests.orm.node.test_node'],

--- a/aiida/backends/tests/cmdline/commands/test_calcjob.py
+++ b/aiida/backends/tests/cmdline/commands/test_calcjob.py
@@ -30,7 +30,7 @@ def get_result_lines(result):
 class TestVerdiCalculation(AiidaTestCase):
     """Tests for `verdi calcjob`."""
 
-    # Note remove this when reenabling the tests after solving issue #2342
+    # Note remove this when reenabling the tests after solving issue #2426
     # pylint: disable=no-member,unused-variable,unused-import
 
     @classmethod
@@ -97,7 +97,7 @@ class TestVerdiCalculation(AiidaTestCase):
         calc.set_process_state(ProcessState.FINISHED)
         cls.calcs.append(calc)
 
-        # Uncomment when issue 2342 is addressed
+        # Uncomment when issue 2426 is addressed
         # # Load the fixture containing a single ArithmeticAddCalculation node
         # import_archive_fixture('calcjob/arithmetic.add.aiida')
 
@@ -128,7 +128,7 @@ class TestVerdiCalculation(AiidaTestCase):
             self.assertNotIn(self.KEY_TWO, result.output)
             self.assertNotIn(self.VAL_TWO, result.output)
 
-    @unittest.skip('reenable when issue #2342 is addressed')
+    @unittest.skip("Reenable when issue #2426 has been solved (migrate exported files from 0.3 to 0.4)")
     def test_calcjob_inputls(self):
         """Test verdi calcjob inputls"""
         options = []
@@ -150,7 +150,7 @@ class TestVerdiCalculation(AiidaTestCase):
         self.assertIn('calcinfo.json', get_result_lines(result))
         self.assertIn('job_tmpl.json', get_result_lines(result))
 
-    @unittest.skip('reenable when issue #2342 is addressed')
+    @unittest.skip("Reenable when issue #2426 has been solved (migrate exported files from 0.3 to 0.4)")
     def test_calcjob_outputls(self):
         """Test verdi calcjob outputls"""
         options = []
@@ -171,7 +171,7 @@ class TestVerdiCalculation(AiidaTestCase):
         self.assertEqual(len(get_result_lines(result)), 1)
         self.assertIn('aiida.out', get_result_lines(result))
 
-    @unittest.skip('reenable when issue #2342 is addressed')
+    @unittest.skip("Reenable when issue #2426 has been solved (migrate exported files from 0.3 to 0.4)")
     def test_calcjob_inputcat(self):
         """Test verdi calcjob inputcat"""
         options = []
@@ -190,7 +190,7 @@ class TestVerdiCalculation(AiidaTestCase):
         self.assertEqual(len(get_result_lines(result)), 1)
         self.assertEqual(get_result_lines(result)[0], '2 3')
 
-    @unittest.skip('reenable when issue #2342 is addressed')
+    @unittest.skip("Reenable when issue #2426 has been solved (migrate exported files from 0.3 to 0.4)")
     def test_calcjob_outputcat(self):
         """Test verdi calcjob outputcat"""
         options = []

--- a/aiida/backends/tests/cmdline/commands/test_calculation.py
+++ b/aiida/backends/tests/cmdline/commands/test_calculation.py
@@ -30,6 +30,9 @@ def get_result_lines(result):
 class TestVerdiCalculation(AiidaTestCase):
     """Tests for `verdi calculation`."""
 
+    # Note remove this when reenabling the tests after solving issue #2426
+    # pylint: disable=no-member,unused-variable,unused-import
+
     @classmethod
     def setUpClass(cls, *args, **kwargs):
         super(TestVerdiCalculation, cls).setUpClass(*args, **kwargs)
@@ -97,7 +100,7 @@ class TestVerdiCalculation(AiidaTestCase):
         calc.set_process_state(ProcessState.FINISHED)
         cls.calcs.append(calc)
 
-        # Uncomment when issue 2342 is addressed
+        # Uncomment when issue 2426 is addressed
         # # Load the fixture containing a single ArithmeticAddCalculation node
         # import_archive_fixture('calcjob/arithmetic.add.aiida')
 
@@ -257,7 +260,7 @@ class TestVerdiCalculation(AiidaTestCase):
         self.assertClickResultNoException(result)
         self.assertTrue(len(get_result_lines(result)) > 0)
 
-    @unittest.skip('reenable when issue #2342 is addressed')
+    @unittest.skip("Reenable when issue #2426 has been solved (migrate exported files from 0.3 to 0.4)")
     def test_calculation_plugins(self):
         """Test verdi calculation plugins"""
         from aiida.plugins.entry_point import get_entry_points
@@ -275,7 +278,7 @@ class TestVerdiCalculation(AiidaTestCase):
         self.assertClickResultNoException(result)
         self.assertTrue(len(get_result_lines(result)) > len(calculation_plugins))
 
-    @unittest.skip('reenable when issue #2342 is addressed')
+    @unittest.skip("Reenable when issue #2426 has been solved (migrate exported files from 0.3 to 0.4)")
     def test_calculation_inputls(self):
         """Test verdi calculation inputls"""
         options = []
@@ -297,7 +300,7 @@ class TestVerdiCalculation(AiidaTestCase):
         self.assertIn('calcinfo.json', get_result_lines(result))
         self.assertIn('job_tmpl.json', get_result_lines(result))
 
-    @unittest.skip('reenable when issue #2342 is addressed')
+    @unittest.skip("Reenable when issue #2426 has been solved (migrate exported files from 0.3 to 0.4)")
     def test_calculation_outputls(self):
         """Test verdi calculation outputls"""
         options = []
@@ -318,7 +321,7 @@ class TestVerdiCalculation(AiidaTestCase):
         self.assertEqual(len(get_result_lines(result)), 1)
         self.assertIn('aiida.out', get_result_lines(result))
 
-    @unittest.skip('reenable when issue #2342 is addressed')
+    @unittest.skip("Reenable when issue #2426 has been solved (migrate exported files from 0.3 to 0.4)")
     def test_calculation_inputcat(self):
         """Test verdi calculation inputcat"""
         options = []
@@ -337,7 +340,7 @@ class TestVerdiCalculation(AiidaTestCase):
         self.assertEqual(len(get_result_lines(result)), 1)
         self.assertEqual(get_result_lines(result)[0], '2 3')
 
-    @unittest.skip('reenable when issue #2342 is addressed')
+    @unittest.skip("Reenable when issue #2426 has been solved (migrate exported files from 0.3 to 0.4)")
     def test_calculation_outputcat(self):
         """Test verdi calculation outputcat"""
         options = []

--- a/aiida/backends/tests/orm/implementation/test_comments.py
+++ b/aiida/backends/tests/orm/implementation/test_comments.py
@@ -1,0 +1,100 @@
+# -*- coding: utf-8 -*-
+###########################################################################
+# Copyright (c), The AiiDA team. All rights reserved.                     #
+# This file is part of the AiiDA code.                                    #
+#                                                                         #
+# The code is hosted on GitHub at https://github.com/aiidateam/aiida_core #
+# For further information on the license, see the LICENSE.txt file        #
+# For further information please visit http://www.aiida.net               #
+###########################################################################
+"""Unit tests for the BackendComment and BackendCommentCollection classes."""
+from __future__ import division
+from __future__ import print_function
+from __future__ import absolute_import
+
+from datetime import datetime
+from uuid import UUID
+
+from aiida.backends.testbase import AiidaTestCase
+from aiida.common import timezone
+
+
+class TestBackendComment(AiidaTestCase):
+    """Test BackendComment."""
+
+    @classmethod
+    def setUpClass(cls, *args, **kwargs):
+        super(TestBackendComment, cls).setUpClass(*args, **kwargs)
+        cls.computer = cls.computer.backend_entity  # Unwrap the `Computer` instance to `BackendComputer`
+        cls.user = cls.backend.users.create(email='tester@localhost').store()
+
+    def setUp(self):
+        super(TestBackendComment, self).setUp()
+        self.node = self.backend.nodes.create(
+            node_type='', user=self.user, computer=self.computer, label='label', description='description').store()
+        self.comment_content = 'comment content'
+
+    def test_creation(self):
+        """Test creation of a BackendComment and all its properties."""
+        comment = self.backend.comments.create(node=self.node, user=self.user, content=self.comment_content)
+
+        # Before storing
+        self.assertIsNone(comment.id)
+        self.assertIsNone(comment.pk)
+        self.assertTrue(isinstance(comment.uuid, str))
+        self.assertTrue(isinstance(comment.ctime, datetime))
+        self.assertIsNone(comment.mtime)
+        self.assertEqual(comment.content, self.comment_content)
+
+        # Store the comment.ctime before the store as a reference
+        now = timezone.now()
+        comment_ctime_before_store = comment.ctime
+        self.assertTrue(now > comment.ctime, '{} is not smaller than now {}'.format(comment.ctime, now))
+
+        comment.store()
+        comment_ctime = comment.ctime
+        comment_mtime = comment.mtime
+
+        # The comment.ctime should have been unchanged, but the comment.mtime should have changed
+        self.assertEqual(comment.ctime, comment_ctime_before_store)
+        self.assertIsNotNone(comment.mtime)
+        self.assertTrue(now < comment.mtime, '{} is not larger than now {}'.format(comment.mtime, now))
+
+        # After storing
+        self.assertTrue(isinstance(comment.id, int))
+        self.assertTrue(isinstance(comment.pk, int))
+        self.assertTrue(isinstance(comment.uuid, str))
+        self.assertTrue(isinstance(comment.ctime, datetime))
+        self.assertTrue(isinstance(comment.mtime, datetime))
+        self.assertEqual(comment.content, self.comment_content)
+
+        # Try to construct a UUID from the UUID value to prove that it has a valid UUID
+        UUID(comment.uuid)
+
+        # Change a column, which should trigger the save, update the mtime but leave the ctime untouched
+        comment.set_content('test')
+        self.assertEqual(comment.ctime, comment_ctime)
+        self.assertTrue(comment.mtime > comment_mtime)
+
+    def test_creation_with_time(self):
+        """
+        Test creation of a BackendComment when passing the mtime and the ctime. The passed ctime and mtime
+        should be respected since it is important for the correct import of nodes at the AiiDA import/export.
+        """
+        from aiida.orm.importexport import deserialize_attributes
+
+        ctime = deserialize_attributes('2019-02-27T16:20:12.245738', 'date')
+        mtime = deserialize_attributes('2019-02-27T16:27:14.798838', 'date')
+
+        comment = self.backend.comments.create(
+            node=self.node, user=self.user, content=self.comment_content, mtime=mtime, ctime=ctime)
+
+        # Check that the ctime and mtime are the given ones
+        self.assertEqual(comment.ctime, ctime)
+        self.assertEqual(comment.mtime, mtime)
+
+        comment.store()
+
+        # Check that the given values remain even after storing
+        self.assertEqual(comment.ctime, ctime)
+        self.assertEqual(comment.mtime, mtime)

--- a/aiida/cmdline/commands/cmd_import.py
+++ b/aiida/cmdline/commands/cmd_import.py
@@ -22,6 +22,7 @@ from aiida.common import exceptions
 
 EXTRAS_MODE_EXISTING = ['keep_existing', 'update_existing', 'mirror', 'none', 'ask']
 EXTRAS_MODE_NEW = ['import', 'none']
+COMMENT_MODE = ['newest', 'overwrite']
 
 
 # pylint: disable=too-few-public-methods
@@ -69,8 +70,15 @@ class ExtrasImportCode(Enum):
     help="Specify whether to import extras of new nodes: "
     "import: import extras. "
     "none: do not import extras.")
+@click.option(
+    '--comment-mode',
+    type=click.Choice(COMMENT_MODE),
+    default='newest',
+    help="Specify the way to import Comments with identical UUIDs: "
+    "newest: Only the newest Comments (based on mtime) (default)."
+    "overwrite: Replace existing Comments with those from the import file.")
 @decorators.with_dbenv()
-def cmd_import(archives, webpages, group, extras_mode_existing, extras_mode_new):
+def cmd_import(archives, webpages, group, extras_mode_existing, extras_mode_new, comment_mode):
     """Import one or multiple exported AiiDA archives
 
     The ARCHIVES can be specified by their relative or absolute file path, or their HTTP URL.
@@ -116,7 +124,8 @@ def cmd_import(archives, webpages, group, extras_mode_existing, extras_mode_new)
                 archive,
                 group,
                 extras_mode_existing=ExtrasImportCode[extras_mode_existing].value,
-                extras_mode_new=extras_mode_new)
+                extras_mode_new=extras_mode_new,
+                comment_mode=comment_mode)
         except exceptions.IncompatibleArchiveVersionError as exception:
             echo.echo_warning('{} cannot be imported: {}'.format(archive, exception))
             echo.echo_warning('run `verdi export migrate {}` to update it'.format(archive))
@@ -147,7 +156,8 @@ def cmd_import(archives, webpages, group, extras_mode_existing, extras_mode_new)
                     temp_folder.get_abs_path(temp_file),
                     group,
                     extras_mode_existing=ExtrasImportCode[extras_mode_existing].value,
-                    extras_mode_new=extras_mode_new)
+                    extras_mode_new=extras_mode_new,
+                    comment_mode=comment_mode)
             except exceptions.IncompatibleArchiveVersionError as exception:
                 echo.echo_warning('{} cannot be imported: {}'.format(archive, exception))
                 echo.echo_warning('download the archive file and run `verdi export migrate` to update it')

--- a/aiida/orm/implementation/comments.py
+++ b/aiida/orm/implementation/comments.py
@@ -24,9 +24,9 @@ __all__ = ('BackendComment', 'BackendCommentCollection')
 class BackendComment(backends.BackendEntity):
     """Base class for a node comment."""
 
-    @abc.abstractproperty
+    @property
     def uuid(self):
-        pass
+        return str(self._dbmodel.uuid)
 
     @abc.abstractproperty
     def ctime(self):
@@ -68,7 +68,7 @@ class BackendCommentCollection(backends.BackendCollection[BackendComment]):
     ENTITY_CLASS = BackendComment
 
     @abc.abstractmethod
-    def create(self, node, user, content=None):
+    def create(self, node, user, content=None, **kwargs):
         """
         Create a Comment for a given node and user
 

--- a/aiida/orm/implementation/sqlalchemy/comments.py
+++ b/aiida/orm/implementation/sqlalchemy/comments.py
@@ -12,8 +12,9 @@ from __future__ import division
 from __future__ import print_function
 from __future__ import absolute_import
 
-import six
-
+# pylint: disable=import-error,no-name-in-module,fixme
+from datetime import datetime
+from aiida.backends.sqlalchemy import get_scoped_session
 from aiida.backends.sqlalchemy.models import comment as models
 from aiida.common import exceptions
 from aiida.common import lang
@@ -29,18 +30,36 @@ class SqlaComment(entities.SqlaModelEntity[models.DbComment], BackendComment):
 
     MODEL_CLASS = models.DbComment
 
-    def __init__(self, backend, node, user, content=None):
+    # pylint: disable=too-many-arguments
+    def __init__(self, backend, node, user, content=None, ctime=None, mtime=None):
         """
         Construct a SqlaComment.
 
         :param node: a Node instance
         :param user: a User instance
         :param content: the comment content
+        :param ctime: The creation time as datetime object
+        :param mtime: The modification time as datetime object
         :return: a Comment object associated to the given node and user
         """
         super(SqlaComment, self).__init__(backend)
         lang.type_check(user, users.SqlaUser)  # pylint: disable=no-member
-        self._dbmodel = utils.ModelWrapper(models.DbComment(dbnode=node.dbmodel, user=user.dbmodel, content=content))
+
+        arguments = {
+            'dbnode': node.dbmodel,
+            'user': user.dbmodel,
+            'content': content,
+        }
+
+        if ctime:
+            lang.type_check(ctime, datetime, 'the given ctime is of type {}'.format(type(ctime)))
+            arguments['ctime'] = ctime
+
+        if mtime:
+            lang.type_check(mtime, datetime, 'the given mtime is of type {}'.format(type(mtime)))
+            arguments['mtime'] = mtime
+
+        self._dbmodel = utils.ModelWrapper(models.DbComment(**arguments))
 
     def store(self):
         """Can only store if both the node and user are stored as well."""
@@ -49,10 +68,6 @@ class SqlaComment(entities.SqlaModelEntity[models.DbComment], BackendComment):
             raise exceptions.ModificationNotAllowed('The corresponding node and/or user are not stored')
 
         super(SqlaComment, self).store()
-
-    @property
-    def uuid(self):
-        return six.text_type(self._dbmodel.uuid)
 
     @property
     def ctime(self):
@@ -90,7 +105,7 @@ class SqlaCommentCollection(BackendCommentCollection):
     def from_dbmodel(self, dbmodel):
         return SqlaComment.from_dbmodel(dbmodel, self.backend)
 
-    def create(self, node, user, content=None):
+    def create(self, node, user, content=None, **kwargs):
         """
         Create a Comment for a given node and user
 
@@ -99,7 +114,7 @@ class SqlaCommentCollection(BackendCommentCollection):
         :param content: the comment content
         :return: a Comment object associated to the given node and user
         """
-        return SqlaComment(self.backend, node, user, content)
+        return SqlaComment(self.backend, node, user, content, **kwargs)
 
     def delete(self, comment):
         """
@@ -109,7 +124,6 @@ class SqlaCommentCollection(BackendCommentCollection):
         """
         # pylint: disable=no-name-in-module,import-error
         from sqlalchemy.orm.exc import NoResultFound
-        from aiida.backends.sqlalchemy import get_scoped_session
         session = get_scoped_session()
 
         try:

--- a/aiida/orm/implementation/sqlalchemy/logs.py
+++ b/aiida/orm/implementation/sqlalchemy/logs.py
@@ -118,4 +118,4 @@ class SqlaLogCollection(BackendLogCollection):
                 entry.delete()
             get_scoped_session().commit()
         else:
-            raise NotImplementedError('Only deleting all by passing an empty filer dictionary is currently supported')
+            raise NotImplementedError('Only deleting all by passing an empty filter dictionary is currently supported')

--- a/aiida/orm/implementation/sqlalchemy/nodes.py
+++ b/aiida/orm/implementation/sqlalchemy/nodes.py
@@ -13,6 +13,7 @@ from __future__ import print_function
 from __future__ import absolute_import
 
 # pylint: disable=no-name-in-module,import-error
+from datetime import datetime
 from sqlalchemy.orm.exc import NoResultFound
 from sqlalchemy.exc import SQLAlchemyError
 
@@ -35,7 +36,16 @@ class SqlaNode(entities.SqlaModelEntity[models.DbNode], BackendNode):
 
     MODEL_CLASS = models.DbNode
 
-    def __init__(self, backend, node_type, user, computer=None, process_type=None, label='', description=''):
+    def __init__(self,
+                 backend,
+                 node_type,
+                 user,
+                 computer=None,
+                 process_type=None,
+                 label='',
+                 description='',
+                 ctime=None,
+                 mtime=None):
         """Construct a new `BackendNode` instance wrapping a new `DbNode` instance.
 
         :param backend: the backend
@@ -44,6 +54,8 @@ class SqlaNode(entities.SqlaModelEntity[models.DbNode], BackendNode):
         :param computer: associated `BackendComputer`
         :param label: string label
         :param description: string description
+        :param ctime: The creation time as datetime object
+        :param mtime: The modification time as datetime object
         """
         # pylint: disable=too-many-arguments
         super(SqlaNode, self).__init__(backend)
@@ -61,6 +73,14 @@ class SqlaNode(entities.SqlaModelEntity[models.DbNode], BackendNode):
         if computer:
             type_check(computer, SqlaComputer, 'computer is of type {}'.format(type(computer)))
             arguments['dbcomputer'] = computer.dbmodel
+
+        if ctime:
+            type_check(ctime, datetime, 'the given ctime is of type {}'.format(type(ctime)))
+            arguments['ctime'] = ctime
+
+        if mtime:
+            type_check(mtime, datetime, 'the given mtime is of type {}'.format(type(mtime)))
+            arguments['mtime'] = mtime
 
         self._dbmodel = utils.ModelWrapper(models.DbNode(**arguments))
 

--- a/aiida/orm/logs.py
+++ b/aiida/orm/logs.py
@@ -105,6 +105,9 @@ class Log(entities.Entity):
         """Construct a new log"""
         from aiida.common import exceptions
 
+        if metadata is not None and not isinstance(metadata, dict):
+            raise TypeError("metadata must be a dict")
+
         if not loggername or not levelname:
             raise exceptions.ValidationError('The loggername and levelname cannot be empty')
 


### PR DESCRIPTION
#### Fixes #2448 
**Short recap**: Check re-import of `Log`s is done properly.
**Wanted feature**: Import of `Log`s must not duplicate existing `Log`s, based on UUID.
**Example**: A node with 2 `Log`s exist in the database. I export the node and its `Log`s. Later, a new `Log` message is added to the same node in the database. I import my "old" export of the node (containing the 2 original `Log`s). I *must* end up with the node and its 3 `Log`s in my database, i.e. there should be no change in the content of the database concerning the existing node and its 3 `Log` entries.

Tests added:

- `test_export_and_import.py#TestLogs#`**`test_multiple_imports_for_single_node`**
- `test_export_and_import.py#TestLogs#`**`test_reimport_of_logs_for_single_node`**

#### Fixes #2484
**Short recap**: Fix import of `metadata` of `Log`s with django backend.

Changes made:

- Make a type-check of `metadata` in `orm/logs.py#__init__`
- Make sure a JSON-serializable string is produced for `metadata` when importing with a django backend.

Tests added or updated:

- `orm/test_logs.py#`**`test_raise_wrong_metadata_type_error`**
- `test_export_and_import.py#TestLogs#`**`test_export_import_of_critical_log_msg_and_metadata`** (updated)
- `test_export_and_import.py#TestLogs#`**`test_export_of_imported_logs`**

#### Fixes #2489
**Short recap**: Similar to issue #2448 and #2486, but for `Comment`s.
**Wanted feature**: Import of `Comment`s must not duplicate existing `Comment`s, based on UUID.
However, if a `Comment` has been edited, it should be possible to choose whether to keep/import the *newest* `Comment`, based on modification time, or *overwrite* existing `Comment`s with those being imported.

Changes made:

- When importing, a new kwarg can be passed: `comment_mode`. This is checked for what to do, when a `Comment` with the same UUID as an existing `Comment` is in the import-file. The following values are recognized:
  
  - `newest`: Keep/import the newest `Comment`, based on the modification time, `mtime`.
  - `overwrite`: Import the `Comment`, overwriting the existing `Comment`.
  
  In actuality, and for efficiency purposes, when importing, the existing `Comment` will always be updated with the values of the imported `Comment`, instead of having the existing `Comment` deleted before creating a new `Comment` in the database.

  - `orm/importexport.py#`**`_merge_comment`** handles the logic for `comment_mode`.

- `verdi import` understands `comment_mode`.
- Make sure a `str` is returned for the UUID when using the django backend.
- Several changes done by @szoupanos to do with making sure `mtime` is not changed upon ex-/import.
  These include:

  - a contextmanager: `backends/djsite/db/models.py#`**`suppress_auto_now`**,
  - an `__init__` for `backends/sqlaclhemy/models/comment.py`,
  - an `mtime` check for `Node`s in `backends/sqlalchemy/models/node.py`,
  - specifying `ctime` and `mtime` in `__init__` of `orm/implementation/django/comments.py` as well as in `../nodes.py` and similarly for the SQLAlchemy models.

Tests added:

- `test_export_and_import.py#TestComments#`**`test_multiple_imports_for_single_node`**
- `test_export_and_import.py#TestComments#`**`test_reimport_of_comments_for_single_node`**
- `test_export_and_import.py#TestComments#`**`test_mtime_of_imported_comments`**
- `test_export_and_import.py#TestComments#`**`test_import_arg_comment_mode`**
- `orm/implementation/`**`test_comments.py`**
- `orm/implementation/test_nodes#`**`test_creation_with_time`**

#### Minor fixes
Several minor fixes were done, especially in `importexport.py`.