### PR TITLE
Add more complicated blocking prompt for `verdi database migrate`

### DIFF
--- a/aiida/cmdline/commands/cmd_database.py
+++ b/aiida/cmdline/commands/cmd_database.py
@@ -35,14 +35,67 @@ def database_migrate(force):
     profile = manager.get_profile()
     backend = manager._load_backend(schema_check=False)  # pylint: disable=protected-access
 
-    if not force:
-        echo.echo_warning('Migrating your database might take a while.')
-        echo.echo_warning('Before continuing, make sure the daemon is stopped and you have a backup of your database.')
-        echo.echo_warning('', nl=False)
-        confirm_message = 'Are you really sure you want to migrate the database for profile "{}"?'.format(profile.name)
-        click.confirm(confirm_message, abort=True)
+    if force:
+        raise NotImplementedError('--force is disabled currently to prevent accidental migrations.')
 
-    backend.migrate()
+    echo.echo('\n' + '*' * 79 + '\n')
+    echo.echo_warning('Before continuing, make sure the daemon is stopped and you have a backup of your database.')
+    echo.echo_warning(
+        'It is ESSENTIAL to have a backup of your database - once you do this migration you can NEVER go back!')
+    echo.echo_warning('You will be committed to this new version of AiiDA.')
+    echo.echo_warning('Please be patient - migrating your database might take a while.')
+
+    echo.echo('\n' + '*' * 79 + '\n')
+
+    try:
+        # First prompt
+        backup_prompt = 'Have you got a back up of the database for profile "{}"?'.format(profile.name)
+        echo.echo_warning(backup_prompt)
+        echo.echo_warning('', nl=False)
+        confirm_message = 'Type "I DO HAVE A BACKUP"'
+        response = ''
+        while response != 'I DO HAVE A BACKUP':
+            response = click.prompt(confirm_message)
+
+        # Second prompt
+        echo.echo('')
+        echo.echo_warning('Have you stopped the daemon?')
+        echo.echo_warning('', nl=False)
+        confirm_message = 'Type "I HAVE STOPPED THE DAEMON"'
+        response = ''
+        while response != 'I HAVE STOPPED THE DAEMON':
+            response = click.prompt(confirm_message)
+
+        # Final prompt
+        echo.echo('')
+        message = 'Are you absolutely ready to migrate profile "{}"? This will be PERMANENT.'.format(profile.name)
+        echo.echo_warning(message)
+        echo.echo_warning('', nl=False)
+        confirm_message = 'Type "MAKE IT SO"'
+        response = ''
+        while response != 'MAKE IT SO':
+            response = click.prompt(confirm_message)
+
+        # Do the migration
+        echo.echo('\nRunning the migrations...\n')
+        backend.migrate()
+
+    except click.Abort:
+        echo.echo('\n')
+        echo.echo_critical('Cannot start the migration without a positive confirmation. '
+                           'Your data has not been affected.')
+
+    # Below is the `old` behaviour from the `provenance_redesign branch`. We may replace the above
+    # with this in the future, but for v1.0.0b release, we're using the above logic to emphasise
+    # the severity of choosing to execute this migration.
+    # if not force:
+    #    echo.echo_warning('Migrating your database might take a while.')
+    #    echo.echo_warning('Before continuing, make sure the daemon is stopped and you have a backup of your database.')
+    #    echo.echo_warning('', nl=False)
+    #    confirm_message = 'Are you really sure you want to migrate the database for profile "{}"?'.format(profile.name)
+    #    click.confirm(confirm_message, abort=True)
+
+    #backend.migrate()
 
 
 @verdi_database.group('integrity')


### PR DESCRIPTION
Fixes #2427 . 

- Adds a series of convoluted prompts to make the user aware that the migrations from `provenance redesign` are a serious business. Perhaps over the top, but I'll argue that they're effective.
- Disables the `--force' option, but retains it for the future. 

Automatic migrations are possible by not going through the click interface.