### PR TITLE
Make the node repository API backend agnostic

### DIFF
--- a/.ci/test_daemon.py
+++ b/.ci/test_daemon.py
@@ -161,14 +161,22 @@ def validate_cached(cached_calcs):
             valid = False
 
         if isinstance(calc, CalcJobNode):
-            if 'raw_input' not in calc.repository._get_folder_pathsubfolder.get_content_list():
-                print("Cached calculation <{}> does not have a 'raw_input' folder".format(calc.pk))
+            original_calc = load_node(calc.get_extra('_aiida_cached_from'))
+            files_original = original_calc.list_object_names()
+            files_cached = calc.list_object_names()
+
+            if not files_cached:
+                print("Cached calculation <{}> does not have any raw inputs files".format(calc.pk))
                 print_report(calc.pk)
                 valid = False
-            original_calc = load_node(calc.get_extra('_aiida_cached_from'))
-            if 'raw_input' not in original_calc.repository._get_folder_pathsubfolder.get_content_list():
-                print("Original calculation <{}> does not have a 'raw_input' folder after being cached from."
+            if not files_original:
+                print("Original calculation <{}> does not have any raw inputs files after being cached from."
                       .format(original_calc.pk))
+                valid = False
+
+            if set(files_original) != set(files_cached):
+                print("different raw input files [{}] vs [{}] for original<{}> and cached<{}> calculation".format(
+                    set(files_original), set(files_cached), original_calc.pk, calc.pk))
                 valid = False
 
     return valid

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -146,21 +146,9 @@
         aiida/orm/nodes/data/array/kpoints.py|
         aiida/orm/nodes/data/array/projection.py|
         aiida/orm/nodes/data/array/xy.py|
-        aiida/orm/nodes/data/base.py|
-        aiida/orm/nodes/data/bool.py|
-        aiida/orm/nodes/data/error.py|
-        aiida/orm/nodes/data/float.py|
-        aiida/orm/nodes/data/folder.py|
-        aiida/orm/nodes/data/frozendict.py|
-        aiida/orm/nodes/data/int.py|
-        aiida/orm/nodes/data/list.py|
         aiida/orm/nodes/data/code.py|
-        aiida/orm/nodes/data/numeric.py|
         aiida/orm/nodes/data/orbital.py|
-        aiida/orm/nodes/data/parameter.py|
         aiida/orm/nodes/data/remote.py|
-        aiida/orm/nodes/data/singlefile.py|
-        aiida/orm/nodes/data/str.py|
         aiida/orm/nodes/data/structure.py|
         aiida/orm/nodes/data/upf.py|
         aiida/orm/nodes/process/calculation/calcjob.py|

--- a/aiida/backends/djsite/db/migrations/0027_delete_trajectory_symbols_array.py
+++ b/aiida/backends/djsite/db/migrations/0027_delete_trajectory_symbols_array.py
@@ -42,8 +42,7 @@ def delete_trajectory_symbols_array(apps, _):
     for t_pk in trajectories_pk:
         trajectory = load_node(t_pk)
         modifier.del_value_for_node(DbNode.objects.get(pk=trajectory.pk), 'array|symbols')
-        # Remove the .npy file (using delete_array raises ModificationNotAllowed error)
-        trajectory.repository._get_folder_pathsubfolder.remove_path('symbols.npy')  # pylint: disable=protected-access
+        trajectory.delete_object('symbols.npy', force=True)
 
 
 def create_trajectory_symbols_array(apps, _):
@@ -63,10 +62,11 @@ def create_trajectory_symbols_array(apps, _):
         trajectory = load_node(t_pk)
         symbols = numpy.array(trajectory.get_attribute('symbols'))
         # Save the .npy file (using set_array raises ModificationNotAllowed error)
-        with tempfile.NamedTemporaryFile() as _file:
-            numpy.save(_file, symbols)
-            _file.flush()
-            trajectory.repository._get_folder_pathsubfolder.insert_path(_file.name, 'symbols.npy')  # pylint: disable=protected-access
+        with tempfile.NamedTemporaryFile() as handle:
+            numpy.save(handle, symbols)
+            handle.flush()
+            handle.seek(0)
+            trajectory.put_object_from_filelike(handle, 'symbols.npy')
         modifier.set_value_for_node(DbNode.objects.get(pk=trajectory.pk), 'array|symbols', list(symbols.shape))
 
 

--- a/aiida/backends/djsite/db/subtests/test_migrations.py
+++ b/aiida/backends/djsite/db/subtests/test_migrations.py
@@ -112,11 +112,11 @@ class TestDuplicateNodeUuidMigration(TestMigrations):
             self.n_int_duplicates = 4
 
             node_bool = Bool(True)
-            node_bool.repository.add_path(handle.name, self.file_name)
+            node_bool.put_object_from_file(handle.name, self.file_name)
             node_bool.store()
 
             node_int = Int(1)
-            node_int.repository.add_path(handle.name, self.file_name)
+            node_int.put_object_from_file(handle.name, self.file_name)
             node_int.store()
 
             self.nodes_boolean.append(node_bool)
@@ -125,14 +125,14 @@ class TestDuplicateNodeUuidMigration(TestMigrations):
             for i in range(self.n_bool_duplicates):
                 node = Bool(True)
                 node.backend_entity.dbmodel.uuid = node_bool.uuid
-                node.repository.add_path(handle.name, self.file_name)
+                node.put_object_from_file(handle.name, self.file_name)
                 node.store()
                 self.nodes_boolean.append(node)
 
             for i in range(self.n_int_duplicates):
                 node = Int(1)
                 node.backend_entity.dbmodel.uuid = node_int.uuid
-                node.repository.add_path(handle.name, self.file_name)
+                node.put_object_from_file(handle.name, self.file_name)
                 node.store()
                 self.nodes_integer.append(node)
 
@@ -161,7 +161,7 @@ class TestDuplicateNodeUuidMigration(TestMigrations):
         self.assertEqual(len(set(uuids_integer)), len(nodes_integer))
 
         for node in nodes_boolean:
-            with node.repository._get_folder_pathsubfolder.open(self.file_name) as handle:
+            with node.open(self.file_name) as handle:
                 content = handle.read()
                 self.assertEqual(content, self.file_content)
 

--- a/aiida/backends/tests/__init__.py
+++ b/aiida/backends/tests/__init__.py
@@ -105,6 +105,7 @@ db_test_list = {
         'orm.utils.calcjob': ['aiida.backends.tests.orm.utils.test_calcjob'],
         'orm.utils.node': ['aiida.backends.tests.orm.utils.test_node'],
         'orm.utils.loaders': ['aiida.backends.tests.orm.utils.test_loaders'],
+        'orm.utils.repository': ['aiida.backends.tests.orm.utils.test_repository'],
         'work.calcfunctions': ['aiida.backends.tests.work.test_calcfunctions'],
         'work.class_loader': ['aiida.backends.tests.work.test_class_loader'],
         'work.daemon': ['aiida.backends.tests.work.test_daemon'],

--- a/aiida/backends/tests/cmdline/commands/test_data.py
+++ b/aiida/backends/tests/cmdline/commands/test_data.py
@@ -742,7 +742,7 @@ class TestVerdiDataCif(AiidaTestCase, TestVerdiDataListable, TestVerdiDataExport
             filename = fhandle.name
             fhandle.write(cls.valid_sample_cif_str)
             fhandle.flush()
-            a = CifData(file=filename, source={'version': '1234', 'db_name': 'COD', 'id': '0000001'})
+            a = CifData(filepath=filename, source={'version': '1234', 'db_name': 'COD', 'id': '0000001'})
             a.store()
 
             g_ne = Group(label='non_empty_group')

--- a/aiida/backends/tests/cmdline/commands/test_node.py
+++ b/aiida/backends/tests/cmdline/commands/test_node.py
@@ -745,7 +745,7 @@ class TestVerdiDataCif(AiidaTestCase, TestVerdiDataListable, TestVerdiDataExport
             filename = fhandle.name
             fhandle.write(cls.valid_sample_cif_str)
             fhandle.flush()
-            a = CifData(file=filename, source={'version': '1234', 'db_name': 'COD', 'id': '0000001'})
+            a = CifData(filepath=filename, source={'version': '1234', 'db_name': 'COD', 'id': '0000001'})
             a.store()
 
             g_ne = orm.Group(label='non_empty_group')

--- a/aiida/backends/tests/cmdline/commands/test_run.py
+++ b/aiida/backends/tests/cmdline/commands/test_run.py
@@ -66,4 +66,4 @@ if __name__ == '__main__':
             # Verify that the node has the correct function name and content
             self.assertTrue(isinstance(node, WorkFunctionNode))
             self.assertEqual(node.function_name, 'wf')
-            self.assertEqual(open(node.function_source_file, 'r').read(), script_content)
+            self.assertEqual(node.get_function_source_code(), script_content)

--- a/aiida/backends/tests/common/test_folders.py
+++ b/aiida/backends/tests/common/test_folders.py
@@ -13,9 +13,17 @@ Tests for the folder class
 from __future__ import division
 from __future__ import print_function
 from __future__ import absolute_import
-import sys
+
 import io
+import os
+import sys
+import shutil
+import tempfile
 import unittest
+
+import six
+
+from aiida.common.folders import Folder
 
 
 def fs_encoding_is_utf8():
@@ -39,10 +47,6 @@ class FoldersTest(unittest.TestCase):
         Check that there are no exceptions raised when
         using unicode folders.
         """
-        from aiida.common.folders import Folder
-        import os
-        import tempfile
-
         tmpsource = tempfile.mkdtemp()
         tmpdest = tempfile.mkdtemp()
         with io.open(os.path.join(tmpsource, "sąžininga"), 'w', encoding='utf8') as fhandle:
@@ -61,8 +65,53 @@ class FoldersTest(unittest.TestCase):
         """
         Check that the absolute path function can get an absolute path
         """
-        from aiida.common.folders import Folder
-
         folder = Folder('/tmp')
         # Should not raise any exception
         self.assertEqual(folder.get_abs_path('test_file.txt'), '/tmp/test_file.txt')
+
+    @staticmethod
+    @unittest.skipUnless(six.PY2, 'test is only for python2')
+    def test_create_file_from_filelike_py2():
+        """Test `aiida.common.folders.Folder.create_file_from_filelike` for python 2."""
+        unicode_string = u'unicode_string'
+        byte_string = 'byte_string'
+
+        try:
+            tempdir = tempfile.mkdtemp()
+            folder = Folder(tempdir)
+
+            # Passing a stream with matching file mode should work ofcourse
+            folder.create_file_from_filelike(six.StringIO(unicode_string), 'random.dat', mode='w', encoding='utf-8')
+            folder.create_file_from_filelike(six.StringIO(byte_string), 'random.dat', mode='wb', encoding=None)
+
+            # For python 2 the `create_file_from_filelike` should be able to deal with incoherent arguments, such as
+            # the examples below where a unicode string is passed with a binary mode, or a byte stream in unicode mode.
+            folder.create_file_from_filelike(six.StringIO(unicode_string), 'random.dat', mode='wb', encoding=None)
+            folder.create_file_from_filelike(six.StringIO(byte_string), 'random.dat', mode='w', encoding='utf-8')
+
+        finally:
+            shutil.rmtree(tempdir)
+
+    @unittest.skipUnless(six.PY3, 'test is only for python3')
+    def test_create_file_from_filelike_py3(self):
+        """Test `aiida.common.folders.Folder.create_file_from_filelike` for python 3."""
+        unicode_string = 'unicode_string'
+        byte_string = b'byte_string'
+
+        try:
+            tempdir = tempfile.mkdtemp()
+            folder = Folder(tempdir)
+
+            folder.create_file_from_filelike(six.StringIO(unicode_string), 'random.dat', mode='w', encoding='utf-8')
+            folder.create_file_from_filelike(six.BytesIO(byte_string), 'random.dat', mode='wb', encoding=None)
+
+            # For python three we make no exceptions, if you pass a unicode stream with binary mode, one should expect
+            # a TypeError. Same for the inverse case of wanting to write in unicode mode but passing a byte stream
+            with self.assertRaises(TypeError):
+                folder.create_file_from_filelike(six.StringIO(unicode_string), 'random.dat', mode='wb')
+
+            with self.assertRaises(TypeError):
+                folder.create_file_from_filelike(six.BytesIO(byte_string), 'random.dat', mode='w')
+
+        finally:
+            shutil.rmtree(tempdir)

--- a/aiida/backends/tests/orm/node/test_node.py
+++ b/aiida/backends/tests/orm/node/test_node.py
@@ -27,7 +27,7 @@ class TestNodeLinks(AiidaTestCase):
     def test_repository_garbage_collection(self):
         """Verify that the repository sandbox folder is cleaned after the node instance is garbage collected."""
         node = Data()
-        dirpath = node.repository.folder.abspath
+        dirpath = node._repository._get_temp_folder().abspath  # pylint: disable=protected-access
 
         self.assertTrue(os.path.isdir(dirpath))
         del node

--- a/aiida/backends/tests/orm/utils/test_repository.py
+++ b/aiida/backends/tests/orm/utils/test_repository.py
@@ -1,0 +1,116 @@
+# -*- coding: utf-8 -*-
+###########################################################################
+# Copyright (c), The AiiDA team. All rights reserved.                     #
+# This file is part of the AiiDA code.                                    #
+#                                                                         #
+# The code is hosted on GitHub at https://github.com/aiidateam/aiida_core #
+# For further information on the license, see the LICENSE.txt file        #
+# For further information please visit http://www.aiida.net               #
+###########################################################################
+"""Tests for the `Repository` utility class."""
+from __future__ import division
+from __future__ import print_function
+from __future__ import absolute_import
+
+import io
+import os
+import shutil
+import tempfile
+
+from aiida.backends.testbase import AiidaTestCase
+from aiida.orm import Node
+
+
+class TestRepository(AiidaTestCase):
+    """Tests for the node `Repository` utility class."""
+
+    def setUp(self):
+        """Create a dummy file tree."""
+        self.tempdir = tempfile.mkdtemp()
+        self.tree = {
+            'subdir': {
+                'a.txt': u'Content of file A\nWith some newlines',
+                'b.txt': u'Content of file B without newline',
+            },
+            'c.txt': u'Content of file C\n',
+        }
+
+        self.create_file_tree(self.tempdir, self.tree)
+
+    def tearDown(self):
+        shutil.rmtree(self.tempdir)
+
+    def create_file_tree(self, directory, tree):
+        """Create a file tree in the given directory.
+
+        :param directory: the absolute path of the directory into which to create the tree
+        :param tree: a dictionary representing the tree structure
+        """
+        for key, value in tree.items():
+            if isinstance(value, dict):
+                subdir = os.path.join(directory, key)
+                os.makedirs(subdir)
+                self.create_file_tree(subdir, value)
+            else:
+                with io.open(os.path.join(directory, key), 'w', encoding='utf8') as handle:
+                    handle.write(value)
+
+    def get_file_content(self, key):
+        """Get the content of a file for a given key.
+
+        :param key: the nested key of the file to retrieve
+        :return: the content of the file
+        """
+        parts = key.split(os.sep)
+        content = self.tree
+        for part in parts:
+            content = content[part]
+
+        return content
+
+    def test_put_object_from_filelike(self):
+        """Test the `put_object_from_filelike` method."""
+        key = os.path.join('subdir', 'a.txt')
+        filepath = os.path.join(self.tempdir, key)
+        content = self.get_file_content(key)
+
+        with io.open(filepath, 'r') as handle:
+            node = Node()
+            node.put_object_from_filelike(handle, key)
+            self.assertEqual(node.get_object_content(key), content)
+
+    def test_put_object_from_file(self):
+        """Test the `put_object_from_file` method."""
+        key = os.path.join('subdir', 'a.txt')
+        filepath = os.path.join(self.tempdir, key)
+        content = self.get_file_content(key)
+
+        node = Node()
+        node.put_object_from_file(filepath, key)
+        self.assertEqual(node.get_object_content(key), content)
+
+    def test_put_object_from_tree(self):
+        """Test the `put_object_from_tree` method."""
+        basepath = ''
+        node = Node()
+        node.put_object_from_tree(self.tempdir, basepath)
+
+        key = os.path.join('subdir', 'a.txt')
+        content = self.get_file_content(key)
+        self.assertEqual(node.get_object_content(key), content)
+
+        basepath = 'base'
+        node = Node()
+        node.put_object_from_tree(self.tempdir, basepath)
+
+        key = os.path.join(basepath, 'subdir', 'a.txt')
+        content = self.get_file_content(os.path.join('subdir', 'a.txt'))
+        self.assertEqual(node.get_object_content(key), content)
+
+        basepath = 'base/further/nested'
+        node = Node()
+        node.put_object_from_tree(self.tempdir, basepath)
+
+        key = os.path.join(basepath, 'subdir', 'a.txt')
+        content = self.get_file_content(os.path.join('subdir', 'a.txt'))
+        self.assertEqual(node.get_object_content(key), content)

--- a/aiida/backends/tests/test_generic.py
+++ b/aiida/backends/tests/test_generic.py
@@ -35,7 +35,7 @@ class TestCode(AiidaTestCase):
         with tempfile.NamedTemporaryFile(mode='w+') as fhandle:
             fhandle.write("#/bin/bash\n\necho test run\n")
             fhandle.flush()
-            code.repository.add_path(fhandle.name, 'test.sh')
+            code.put_object_from_filelike(fhandle, 'test.sh')
 
         code.store()
         self.assertTrue(code.can_run_on(self.computer))
@@ -68,14 +68,14 @@ class TestCode(AiidaTestCase):
         with tempfile.NamedTemporaryFile(mode='w+') as fhandle:
             fhandle.write("#/bin/bash\n\necho test run\n")
             fhandle.flush()
-            code.repository.add_path(fhandle.name, 'test.sh')
+            code.put_object_from_filelike(fhandle, 'test.sh')
 
         with self.assertRaises(ValidationError):
             # There are files inside
             code.store()
 
         # If there are no files, I can store
-        code.repository.remove_path('test.sh')
+        code.delete_object('test.sh')
         code.store()
 
         self.assertEquals(code.get_remote_computer().pk, self.computer.pk)

--- a/aiida/backends/tests/work/test_process_function.py
+++ b/aiida/backends/tests/work/test_process_function.py
@@ -12,8 +12,6 @@ from __future__ import division
 from __future__ import print_function
 from __future__ import absolute_import
 
-import io
-
 from aiida.backends.testbase import AiidaTestCase
 from aiida.orm.nodes.data.bool import get_true_node
 from aiida.orm.nodes.data.int import Int
@@ -135,27 +133,17 @@ class TestProcessFunction(AiidaTestCase):
         _, node = test_process_function.run_get_node(data=Int(5))
 
         # Read the source file of the calculation function that should be stored in the repository
-        # into memory, which should be exactly this test file
-        function_source_file = node.function_source_file
-
-        self.assertIsNotNone(function_source_file)
-
-        with io.open(function_source_file, encoding='utf8') as handle:
-            function_source_code = handle.readlines()
-
-        # Get the attributes that should be stored in the node
-        function_name = node.function_name
-        function_starting_line_number = node.function_starting_line_number
+        function_source_code = node.get_function_source_code().split('\n')
 
         # Verify that the function name is correct and the first source code linenumber is stored
-        self.assertEqual(function_name, function_name)
-        self.assertIsInstance(function_starting_line_number, int)
+        self.assertEqual(node.function_name, function_name)
+        self.assertIsInstance(node.function_starting_line_number, int)
 
         # Check that first line number is correct. Note that the first line should correspond
         # to the `@workfunction` directive, but since the list is zero-indexed we actually get the
         # following line, which should correspond to the function name i.e. `def test_process_function(data)`
-        function_name_from_source = function_source_code[function_starting_line_number]
-        self.assertTrue(function_name in function_name_from_source)
+        function_name_from_source = function_source_code[node.function_starting_line_number]
+        self.assertTrue(node.function_name in function_name_from_source)
 
     def test_function_varargs(self):
         """Variadic arguments are not supported and should raise."""

--- a/aiida/calculations/plugins/templatereplacer.py
+++ b/aiida/calculations/plugins/templatereplacer.py
@@ -156,9 +156,9 @@ class TemplatereplacerCalculation(CalcJob):
             raise exceptions.InputValidationError(
                 "If you ask for input_through_stdin you have to specify a input_file_name")
 
-        input_file = StringIO(input_file_template.format(**parameters))
+        input_content = input_file_template.format(**parameters)
         if input_file_name:
-            folder.create_file_from_filelike(input_file, input_file_name)
+            folder.create_file_from_filelike(StringIO(input_content), input_file_name, 'w', encoding='utf8')
         else:
             if input_file_template:
                 self.logger.warning("No input file name passed, but a input file template is present")

--- a/aiida/cmdline/commands/cmd_data/cmd_cif.py
+++ b/aiida/cmdline/commands/cmd_data/cmd_cif.py
@@ -95,8 +95,7 @@ def cif_content(data):
     """Show the content of the file behind CifData objects."""
     for node in data:
         try:
-            with open(node.get_file_abs_path(), 'r') as handle:
-                echo.echo(handle.read())
+            echo.echo(node.get_content())
         except IOError as exception:
             echo.echo_warning('could not read the content for CifData<{}>: {}'.format(node.pk, str(exception)))
 

--- a/aiida/cmdline/commands/cmd_data/cmd_upf.py
+++ b/aiida/cmdline/commands/cmd_data/cmd_upf.py
@@ -116,9 +116,8 @@ def upf_exportfamily(folder, group):
     for node in group.nodes:
         dest_path = os.path.join(folder, node.filename)
         if not os.path.isfile(dest_path):
-            with io.open(dest_path, 'w', encoding='utf8') as dest:
-                with node.repository._get_folder_pathsubfolder.open(node.filename) as source:  # pylint: disable=protected-access
-                    dest.write(source.read())
+            with io.open(dest_path, 'w', encoding='utf8') as handle:
+                handle.write(node.get_content())
         else:
             echo.echo_warning('File {} is already present in the destination folder'.format(node.filename))
 

--- a/aiida/cmdline/commands/cmd_node.py
+++ b/aiida/cmdline/commands/cmd_node.py
@@ -36,19 +36,12 @@ def verdi_node_repo():
 @with_dbenv()
 def repo_cat(node, relative_path):
     """Output the content of a file in the repository folder."""
-    from aiida.cmdline.utils.repository import cat_repo_files
-
     try:
-        cat_repo_files(node, relative_path)
-    except ValueError as exc:
-        echo.echo_critical(str(exc))
-    except IOError as exc:
-        import errno
-        # Ignore Broken pipe errors, re-raise everything else
-        if exc.errno == errno.EPIPE:
-            pass
-        else:
-            echo.echo_critical(str(exc))
+        content = node.get_object_content(relative_path)
+    except Exception as exception:  # pylint: disable=broad-except
+        echo.echo_critical('failed to get the content of file `{}`: {}'.format(relative_path, exception))
+    else:
+        echo.echo(content)
 
 
 @verdi_node_repo.command('ls')
@@ -58,12 +51,12 @@ def repo_cat(node, relative_path):
 @with_dbenv()
 def repo_ls(node, relative_path, color):
     """List files in the repository folder."""
-    from aiida.cmdline.utils.repository import list_repo_files
+    from aiida.cmdline.utils.repository import list_repository_contents
 
     try:
-        list_repo_files(node, relative_path, color)
-    except ValueError as exc:
-        echo.echo_critical(str(exc))
+        list_repository_contents(node, relative_path, color)
+    except ValueError as exception:
+        echo.echo_critical(exception)
 
 
 @verdi_node.command('label')
@@ -144,7 +137,7 @@ def show(nodes, print_groups):
 
     for node in nodes:
         # pylint: disable=fixme
-        #TODO: Add a check here on the node type, otherwise it might try to access
+        # TODO: Add a check here on the node type, otherwise it might try to access
         # attributes such as code which are not necessarily there
         echo.echo(get_node_info(node))
 

--- a/aiida/common/folders.py
+++ b/aiida/common/folders.py
@@ -235,51 +235,38 @@ class Folder(object):  # pylint: disable=useless-object-inheritance
 
         return dest_abs_path
 
-    def create_file_from_filelike(self, src_filelike, dest_name):
+    def create_file_from_filelike(self, filelike, filename, mode='wb', encoding=None):
+        """Create a file with the given filename from a filelike object.
+
+        :param filelike: a filelike object whose contents to copy
+        :param filename: the filename for the file that is to be created
+        :param mode: the mode with which the target file will be written
+        :param encoding: the encoding with which the target file will be written
+        :return: the absolute filepath of the created file
         """
-        Create a file from a file-like object.
+        filename = six.text_type(filename)
+        filepath = self.get_abs_path(filename)
 
-        :note: if the current file position in src_filelike is not 0,
-          only the contents from the current file position to the end of the
-          file will be copied in the new file.
+        with io.open(filepath, mode=mode, encoding=encoding) as handle:
 
-        :param src_filelike: the file-like object (e.g., if you have
-            a string called s, you can pass ``io.StringIO(s)``)
-        :param dest_name: the destination filename will have this file name.
-        """
-        filename = six.text_type(dest_name)
+            # In python 2 a string literal can either be of unicode or string (bytes) type. Since we do not know what
+            # will be coming in, if the requested mode is not binary, in the case of incoming bytes, the content will
+            # have to be encoded. Therefore in the case of a non-binary mode for python2, we attempt to encode the
+            # incoming filelike object and in case of failure do nothing.
+            if six.PY2 and 'b' not in mode:
+                import codecs
+                utf8reader = codecs.getreader('utf8')
 
-        # I get the full path of the filename, checking also that I don't
-        # go beyond the folder limits
-        dest_abs_path = self.get_abs_path(filename)
-
-        # If Py2, the incoming filelike may contain a unicode or string type.
-        # We want to write explicity with UTF8 encoding, so io.open requires
-        # a unicode type.
-        # First we try and use a UTF8 stream reader wrapper to decode the characters
-        # from the incoming filelike object as if they are UFT8 encoded.
-        # If a unicode type is encountered, Python will attempt to convert to a str
-        # type using the ASCII codec which will fail if any non ASCII chars are
-        # present, raising a UnicodeEncodeError exception. In this case, as we already
-        # have unicode type text, we can catch this and call shutil.copyfileobj without
-        # the wrapper.
-        # In Py3, all str types are unicode, so we can avoid using the wrapper.
-        import codecs
-        utf8wrapper = codecs.getreader('utf8')
-
-        with io.open(dest_abs_path, 'w', encoding='utf8') as dest_fhandle:
-            if six.PY2:
                 try:
-                    shutil.copyfileobj(utf8wrapper(src_filelike), dest_fhandle)
-                except UnicodeEncodeError:
-                    shutil.copyfileobj(src_filelike, dest_fhandle)
+                    shutil.copyfileobj(utf8reader(filelike), handle)
+                except (UnicodeDecodeError, UnicodeEncodeError):
+                    shutil.copyfileobj(filelike, handle)
             else:
-                shutil.copyfileobj(src_filelike, dest_fhandle)
+                shutil.copyfileobj(filelike, handle)
 
-        # Set the mode
-        os.chmod(dest_abs_path, self.mode_file)
+        os.chmod(filepath, self.mode_file)
 
-        return dest_abs_path
+        return filepath
 
     def remove_path(self, filename):
         """

--- a/aiida/daemon/execmanager.py
+++ b/aiida/daemon/execmanager.py
@@ -274,7 +274,7 @@ def retrieve_calculation(calculation, transport, retrieved_temporary_folder):
         with SandboxFolder() as folder:
             retrieve_files_from_list(calculation, transport, folder.abspath, retrieve_list)
             # Here I retrieved everything; now I store them inside the calculation
-            retrieved_files.replace_with_folder(folder.abspath, overwrite=True)
+            retrieved_files.put_object_from_tree(folder.abspath)
 
         # Second, retrieve the singlefiles
         with SandboxFolder() as folder:
@@ -408,7 +408,7 @@ def _retrieve_singlefiles(job, transport, folder, retrieve_file_list, logger_ext
     for (linkname, subclassname, filename) in singlefile_list:
         SinglefileSubclass = DataFactory(subclassname)
         singlefile = SinglefileSubclass()
-        singlefile.set_file(filename)
+        singlefile.put_object_from_file(filename)
         singlefile.add_incoming(job, link_type=LinkType.CREATE, link_label=linkname)
         singlefiles.append(singlefile)
 

--- a/aiida/manage/database/delete/nodes.py
+++ b/aiida/manage/database/delete/nodes.py
@@ -191,7 +191,7 @@ def delete_nodes(pks,
 
     # Recover the list of folders to delete before actually deleting the nodes. I will delete the folders only later,
     # so that if there is a problem during the deletion of the nodes in the DB, I don't delete the folders
-    folders = [load_node(pk).repository.folder for pk in pks_set_to_delete]
+    repositories = [load_node(pk)._repository for pk in pks_set_to_delete]  # pylint: disable=protected-access
 
     delete_nodes_and_connections(pks_set_to_delete)
 
@@ -213,5 +213,5 @@ def delete_nodes(pks,
 
     # If we are here, we managed to delete the entries from the DB.
     # I can now delete the folders
-    for folder in folders:
-        folder.erase()
+    for repository in repositories:
+        repository.erase(force=True)

--- a/aiida/orm/importexport.py
+++ b/aiida/orm/importexport.py
@@ -2622,7 +2622,6 @@ def export_tree(what, folder, allowed_licenses=None, forbidden_licenses=None,
         'groups_uuid': groups_uuid,
     }
 
-
     # N.B. We're really calling zipfolder.open
     with folder.open('data.json', mode='w') as fhandle:
         # fhandle.write(json.dumps(data, cls=UUIDEncoder))
@@ -2660,13 +2659,8 @@ def export_tree(what, folder, allowed_licenses=None, forbidden_licenses=None,
             thisnodefolder = nodesubfolder.get_subfolder(
                 sharded_uuid, create=False,
                 reset_limit=True)
-            # In this way, I copy the content of the folder, and not the folder
-            # itself
+            # In this way, I copy the content of the folder, and not the folder itself
             src = RepositoryFolder(section=Repository._section_name, uuid=uuid).abspath
-            if not os.path.exists(os.path.join(src, Repository._path_subfolder_name)):
-                raise ContentNotExistent("The exported repository folder '{}' for node<{}> does not contain the '{}' "
-                        "sub folder, probably it was deleted manually before exporting. Try to recreate it and export "
-                        "again.".format(src, uuid, Repository._path_subfolder_name))
             thisnodefolder.insert_path(src=src, dest_name='.')
 
 

--- a/aiida/orm/nodes/data/base.py
+++ b/aiida/orm/nodes/data/base.py
@@ -7,6 +7,7 @@
 # For further information on the license, see the LICENSE.txt file        #
 # For further information please visit http://www.aiida.net               #
 ###########################################################################
+"""`Data` sub class to be used as a base for data containers that represent base python data types."""
 from __future__ import division
 from __future__ import print_function
 from __future__ import absolute_import
@@ -34,24 +35,20 @@ def to_aiida_type(value):
 
 @six.add_metaclass(abc.ABCMeta)
 class BaseType(Data):
-    """
-    Store a base python type as a AiiDA node in the DB.
-
-    Provide the .value property to get the actual value.
-    """
+    """`Data` sub class to be used as a base for data containers that represent base python data types."""
 
     def __init__(self, *args, **kwargs):
         try:
             getattr(self, '_type')
         except AttributeError:
-            raise RuntimeError('Derived class must define the _type class member')
+            raise RuntimeError('Derived class must define the `_type` class member')
 
         super(BaseType, self).__init__(**kwargs)
 
         try:
             value = args[0]
         except IndexError:
-            value = self._type()
+            value = self._type()  # pylint: disable=no-member
 
         self.value = value
 
@@ -61,7 +58,7 @@ class BaseType(Data):
 
     @value.setter
     def value(self, value):
-        self.set_attribute('value', self._type(value))
+        self.set_attribute('value', self._type(value))  # pylint: disable=no-member
 
     def __str__(self):
         return super(BaseType, self).__str__() + ' value: {}'.format(self.value)
@@ -69,14 +66,12 @@ class BaseType(Data):
     def __eq__(self, other):
         if isinstance(other, BaseType):
             return self.value == other.value
-        else:
-            return self.value == other
+        return self.value == other
 
     def __ne__(self, other):
         if isinstance(other, BaseType):
             return self.value != other.value
-        else:
-            return self.value != other
+        return self.value != other
 
     def new(self, value=None):
         return self.__class__(value)

--- a/aiida/orm/nodes/data/bool.py
+++ b/aiida/orm/nodes/data/bool.py
@@ -7,6 +7,7 @@
 # For further information on the license, see the LICENSE.txt file        #
 # For further information please visit http://www.aiida.net               #
 ###########################################################################
+"""`Data` sub class to represent a boolean value."""
 from __future__ import division
 from __future__ import print_function
 from __future__ import absolute_import
@@ -19,9 +20,8 @@ __all__ = ('Bool',)
 
 
 class Bool(BaseType):
-    """
-    Class to store booleans as AiiDA nodes
-    """
+    """`Data` sub class to represent a boolean value."""
+
     _type = bool
 
     def __int__(self):
@@ -43,26 +43,22 @@ def _(value):
 
 
 def get_true_node():
-    """
-    Return a Bool Data node, with value True
+    """Return a `Bool` node with value `True`
 
-    Cannot be done as a singleton in the module, because it would be generated
-    at import time, with the risk that (e.g. in the tests, or at the very first use
-    of AiiDA) a user is not yet defined in the DB (but a user is mandatory in the
-    DB before you can create new Nodes in AiiDA).
+    .. note:: this function serves as a substitute for defining the node as a module singleton, because that would be
+        instantiated at import time, at which time not all required database resources may be defined.
+
+    :return: a `Bool` instance with the value `True`
     """
-    TRUE = Bool(True)
-    return TRUE
+    return Bool(True)
 
 
 def get_false_node():
-    """
-    Return a Bool Data node, with value False
+    """Return a `Bool` node with value `False`
 
-    Cannot be done as a singleton in the module, because it would be generated
-    at import time, with the risk that (e.g. in the tests, or at the very first use
-    of AiiDA) a user is not yet defined in the DB (but a user is mandatory in the
-    DB before you can create new Nodes in AiiDA).
+    .. note:: this function serves as a substitute for defining the node as a module singleton, because that would be
+        instantiated at import time, at which time not all required database resources may be defined.
+
+    :return: a `Bool` instance with the value `False`
     """
-    FALSE = Bool(False)
-    return FALSE
+    return Bool(False)

--- a/aiida/orm/nodes/data/cif.py
+++ b/aiida/orm/nodes/data/cif.py
@@ -225,13 +225,13 @@ class CifData(SinglefileData):
     """
     Wrapper for Crystallographic Interchange File (CIF)
 
-    .. note:: the file (physical) is held as the authoritative source of
+    .. note:: the filepath (physical) is held as the authoritative source of
         information, so all conversions are done through the physical file:
         when setting ``ase`` or ``values``, a physical CIF file is generated
         first, the values are updated from the physical CIF file.
     """
     # pylint: disable=abstract-method, too-many-public-methods
-    _set_incompatibilities = [('ase', 'file'), ('ase', 'values'), ('file', 'values')]
+    _set_incompatibilities = [('ase', 'filepath'), ('ase', 'values'), ('filepath', 'values')]
     _scan_types = ('standard', 'flex')
     _parse_policies = ('eager', 'lazy')
     _values = None
@@ -239,7 +239,7 @@ class CifData(SinglefileData):
 
     def __init__(self,
                  ase=None,
-                 file=None,
+                 filepath=None,
                  values=None,
                  source=None,
                  scan_type='standard',
@@ -249,7 +249,7 @@ class CifData(SinglefileData):
 
         args = {
             'ase': ase,
-            'file': file,
+            'filepath': filepath,
             'values': values,
         }
 
@@ -257,7 +257,7 @@ class CifData(SinglefileData):
             if args[left] is not None and args[right] is not None:
                 raise ValueError('cannot pass {} and {} at the same time'.format(left, right))
 
-        super(CifData, self).__init__(file, **kwargs)
+        super(CifData, self).__init__(filepath, **kwargs)
         self.set_scan_type(scan_type)
         self.set_parse_policy(parse_policy)
 
@@ -270,7 +270,7 @@ class CifData(SinglefileData):
         if values is not None:
             self.set_values(values)
 
-        if not self.is_stored and file is not None and self.get_attribute('parse_policy') == 'eager':
+        if not self.is_stored and filepath is not None and self.get_attribute('parse_policy') == 'eager':
             self.parse()
 
     @staticmethod
@@ -332,9 +332,9 @@ class CifData(SinglefileData):
         cifs = cls.from_md5(md5)
         if not cifs:
             if store_cif:
-                instance = cls(file=filename).store()
+                instance = cls(filepath=filename).store()
                 return (instance, True)
-            instance = cls(file=filename)
+            instance = cls(filepath=filename)
             return (instance, True)
 
         if len(cifs) > 1:
@@ -369,7 +369,7 @@ class CifData(SinglefileData):
         """
         if not kwargs and self._ase:
             return self.ase
-        return CifData.read_cif(self.repository._get_folder_pathsubfolder.open(self.filename), **kwargs)  # pylint: disable=protected-access
+        return CifData.read_cif(self.open(), **kwargs)
 
     def set_ase(self, aseatoms):
         """
@@ -383,7 +383,7 @@ class CifData(SinglefileData):
             with Capturing():
                 tmpf.write(pycifrw_from_cif(cif, loops=ase_loops).WriteOut())
             tmpf.flush()
-            self.set_file(tmpf.name)
+            self.put_object_from_file(tmpf.name)
 
     @ase.setter
     def ase(self, aseatoms):
@@ -400,7 +400,8 @@ class CifData(SinglefileData):
             import CifFile
             from CifFile import CifBlock  # pylint: disable=no-name-in-module
 
-            c = CifFile.ReadCif(self.get_file_abs_path(), scantype=self.get_attribute('scan_type'))  # pylint: disable=no-member
+            with self.open() as handle:
+                c = CifFile.ReadCif(handle, scantype=self.get_attribute('scan_type'))  # pylint: disable=no-member
             for k, v in c.items():
                 c.dictionary[k] = CifBlock(v)
             self._values = c
@@ -421,7 +422,7 @@ class CifData(SinglefileData):
             with Capturing():
                 tmpf.write(values.WriteOut())
             tmpf.flush()
-            self.set_file(tmpf.name)
+            self.put_object_from_file(tmpf.name)
 
         self._values = values
 
@@ -453,14 +454,14 @@ class CifData(SinglefileData):
         return super(CifData, self).store(*args, **kwargs)
 
     # pylint: disable=attribute-defined-outside-init
-    def set_file(self, filename):
+    def put_object_from_file(self, path, key=None, mode='w', encoding='utf8', force=False):
         """
         Set the file.
 
         If the source is set and the MD5 checksum of new file
         is different from the source, the source has to be deleted.
         """
-        super(CifData, self).set_file(filename)
+        super(CifData, self).put_object_from_file(path, key, mode, encoding, force)
         md5sum = self.generate_md5()
         if isinstance(self.source, dict) and \
                 self.source.get('source_md5', None) is not None and \
@@ -683,14 +684,11 @@ class CifData(SinglefileData):
         """
         Computes and returns MD5 hash of the CIF file.
         """
-        from aiida.common.exceptions import ValidationError
-        from aiida.common.files import md5_file
+        from aiida.common.files import md5_from_filelike
 
-        abspath = self.get_file_abs_path()
-        if not abspath:
-            raise ValidationError("No valid CIF was passed!")
-
-        return md5_file(abspath)
+        # Open in binary mode which is required for generating the md5 checksum
+        with self.open(mode='rb') as handle:
+            return md5_from_filelike(handle)
 
     def _get_aiida_structure(self, converter='pymatgen', store=False, **kwargs):
         """
@@ -759,8 +757,8 @@ class CifData(SinglefileData):
             # Note: this overwrites the CIF file!
             self.set_values(self._values)
 
-        with self.repository._get_folder_pathsubfolder.open(self.filename) as f:  # pylint: disable=protected-access
-            return f.read().encode('utf-8'), {}
+        with self.open() as handle:
+            return handle.read().encode('utf-8'), {}
 
     # pylint: disable=unused-argument
     def _prepare_tcod(self, main_file_name="", **kwargs):

--- a/aiida/orm/nodes/data/data.py
+++ b/aiida/orm/nodes/data/data.py
@@ -80,9 +80,7 @@ class Data(Node):
         clone = self.__class__.from_backend_entity(backend_clone)
 
         clone.set_attributes(copy.deepcopy(self.attributes))
-
-        for path in self.repository.get_folder_list():
-            clone.repository.add_path(self.repository.get_abs_path(path), path)
+        clone.put_object_from_tree(self._repository._get_base_folder().abspath)  # pylint: disable=protected-access
 
         return clone
 

--- a/aiida/orm/nodes/data/error.py
+++ b/aiida/orm/nodes/data/error.py
@@ -7,6 +7,7 @@
 # For further information on the license, see the LICENSE.txt file        #
 # For further information please visit http://www.aiida.net               #
 ###########################################################################
+"""`Data` sub class to represent an error."""
 from __future__ import division
 from __future__ import print_function
 from __future__ import absolute_import
@@ -17,4 +18,4 @@ __all__ = ('Error',)
 
 
 class Error(Data):
-    pass
+    """`Data` sub class to represent an error."""

--- a/aiida/orm/nodes/data/float.py
+++ b/aiida/orm/nodes/data/float.py
@@ -7,6 +7,7 @@
 # For further information on the license, see the LICENSE.txt file        #
 # For further information please visit http://www.aiida.net               #
 ###########################################################################
+"""`Data` sub class to represent a float value."""
 from __future__ import division
 from __future__ import print_function
 from __future__ import absolute_import
@@ -20,9 +21,8 @@ __all__ = ('Float',)
 
 
 class Float(NumericType):
-    """
-    Class to store float numbers as AiiDA nodes
-    """
+    """`Data` sub class to represent a float value."""
+
     _type = float
 
 

--- a/aiida/orm/nodes/data/folder.py
+++ b/aiida/orm/nodes/data/folder.py
@@ -7,13 +7,10 @@
 # For further information on the license, see the LICENSE.txt file        #
 # For further information please visit http://www.aiida.net               #
 ###########################################################################
+"""`Data` sub class to represent a folder on a file system."""
 from __future__ import division
 from __future__ import print_function
 from __future__ import absolute_import
-
-import os
-
-from aiida.common.exceptions import ModificationNotAllowed
 
 from .data import Data
 
@@ -21,47 +18,4 @@ __all__ = ('FolderData',)
 
 
 class FolderData(Data):
-    """
-    Stores a folder with subfolders and files.
-
-    No special attributes are set.
-    """
-
-    def replace_with_folder(self, folder, overwrite=True):
-        """
-        Replace the data with another folder, always copying and not moving the
-        original files.
-
-        Args:
-            folder: the folder to copy from
-            overwrite: if to overwrite the current content or not
-        """
-
-        if not os.path.isabs(folder):
-            raise ValueError("folder must be an absolute path")
-
-        # TODO: implement the logic on the folder? Or set a 'locked' flag on folders?
-
-        if not self.is_stored:
-            self.repository._get_folder_pathsubfolder.replace_with_folder(folder, move=False, overwrite=overwrite)
-        else:
-            raise ModificationNotAllowed("You cannot change the files after the node has been stored")
-
-    def get_file_content(self, path):
-        """
-        Return the content of a path stored inside the folder as a string.
-
-        :raise NotExistent: if the path does not exist.
-        """
-        from aiida.common.exceptions import NotExistent
-
-        try:
-            with self.open(path, check_existence=True) as handle:
-                return handle.read()
-        except (OSError, IOError):
-            raise NotExistent("Error reading the file '{}' inside node with "
-                              "pk= {}, it probably does not exist?".format(path, self.pk))
-
-    def open(self, path, check_existence=False):
-        """Docs."""
-        return self.repository._get_folder_pathsubfolder.open(path, check_existence=check_existence)
+    """`Data` sub class to represent a folder on a file system."""

--- a/aiida/orm/nodes/data/int.py
+++ b/aiida/orm/nodes/data/int.py
@@ -7,6 +7,7 @@
 # For further information on the license, see the LICENSE.txt file        #
 # For further information please visit http://www.aiida.net               #
 ###########################################################################
+"""`Data` sub class to represent an integer value."""
 from __future__ import division
 from __future__ import print_function
 from __future__ import absolute_import
@@ -20,9 +21,8 @@ __all__ = ('Int',)
 
 
 class Int(NumericType):
-    """
-    Class to store integer numbers as AiiDA nodes
-    """
+    """`Data` sub class to represent an integer value."""
+
     _type = int
 
 

--- a/aiida/orm/nodes/data/list.py
+++ b/aiida/orm/nodes/data/list.py
@@ -7,6 +7,7 @@
 # For further information on the license, see the LICENSE.txt file        #
 # For further information please visit http://www.aiida.net               #
 ###########################################################################
+"""`Data` sub class to represent a list."""
 from __future__ import division
 from __future__ import print_function
 from __future__ import absolute_import
@@ -19,9 +20,7 @@ __all__ = ('List',)
 
 
 class List(Data, MutableSequence):
-    """
-    Class to store python lists as AiiDA nodes
-    """
+    """`Data` sub class to represent a list."""
 
     _LIST_KEY = 'list'
 
@@ -34,16 +33,16 @@ class List(Data, MutableSequence):
         return self.get_list()[item]
 
     def __setitem__(self, key, value):
-        l = self.get_list()
-        l[key] = value
+        data = self.get_list()
+        data[key] = value
         if not self._using_list_reference():
-            self.set_list(l)
+            self.set_list(data)
 
     def __delitem__(self, key):
-        l = self.get_list()
-        del l[key]
+        data = self.get_list()
+        del data[key]
         if not self._using_list_reference():
-            self.set_list(l)
+            self.set_list(data)
 
     def __len__(self):
         return len(self.get_list())
@@ -61,61 +60,69 @@ class List(Data, MutableSequence):
         return not self == other
 
     def append(self, value):
-        l = self.get_list()
-        l.append(value)
+        data = self.get_list()
+        data.append(value)
         if not self._using_list_reference():
-            self.set_list(l)
+            self.set_list(data)
 
-    def extend(self, L):
-        l = self.get_list()
-        l.extend(L)
+    def extend(self, value):  # pylint: disable=arguments-differ
+        data = self.get_list()
+        data.extend(value)
         if not self._using_list_reference():
-            self.set_list(l)
+            self.set_list(data)
 
-    def insert(self, i, value):
-        l = self.get_list()
-        l.insert(i, value)
+    def insert(self, i, value):  # pylint: disable=arguments-differ
+        data = self.get_list()
+        data.insert(i, value)
         if not self._using_list_reference():
-            self.set_list(l)
+            self.set_list(data)
 
     def remove(self, value):
         del self[value]
 
-    def pop(self, **kwargs):
-        l = self.get_list()
-        l.pop(**kwargs)
+    def pop(self, **kwargs):  # pylint: disable=arguments-differ
+        data = self.get_list()
+        data.pop(**kwargs)
         if not self._using_list_reference():
-            self.set_list(l)
+            self.set_list(data)
 
-    def index(self, value):
+    def index(self, value):  # pylint: disable=arguments-differ
         return self.get_list().index(value)
 
     def count(self, value):
         return self.get_list().count(value)
 
     def sort(self, key=None, reverse=False):
-        l = self.get_list()
-        l.sort(key=key, reverse=reverse)
+        data = self.get_list()
+        data.sort(key=key, reverse=reverse)
         if not self._using_list_reference():
-            self.set_list(l)
+            self.set_list(data)
 
     def reverse(self):
-        l = self.get_list()
-        l.reverse()
+        data = self.get_list()
+        data.reverse()
         if not self._using_list_reference():
-            self.set_list(l)
+            self.set_list(data)
 
     def get_list(self):
+        """Return the contents of this node.
+
+        :return: a list
+        """
         try:
             return self.get_attribute(self._LIST_KEY)
         except AttributeError:
             self.set_list(list())
             return self.get_attribute(self._LIST_KEY)
 
-    def set_list(self, list_):
-        if not isinstance(list_, list):
+    def set_list(self, data):
+        """Set the contents of this node.
+
+        :param data: the list to set
+        """
+        if not isinstance(data, list):
             raise TypeError('Must supply list type')
-        self.set_attribute(self._LIST_KEY, list_)
+        self.set_attribute(self._LIST_KEY, data)
 
     def _using_list_reference(self):
         """

--- a/aiida/orm/nodes/data/parameter.py
+++ b/aiida/orm/nodes/data/parameter.py
@@ -7,10 +7,14 @@
 # For further information on the license, see the LICENSE.txt file        #
 # For further information please visit http://www.aiida.net               #
 ###########################################################################
+"""`Data` sub class to represent a dictionary."""
 from __future__ import division
 from __future__ import print_function
 from __future__ import absolute_import
 
+import copy
+
+from aiida.common import exceptions
 from .data import Data
 from .base import to_aiida_type
 
@@ -18,82 +22,75 @@ __all__ = ('ParameterData',)
 
 
 class ParameterData(Data):
-    """
-    Pass as input in the init a dictionary, and it will get stored as internal attributes.
-
-    Usual rules for attribute names apply (in particular, keys cannot start with
-    an underscore). If this is the case, a ValueError will be raised.
-
-    You can then change/delete/add more attributes before storing with the
-    usual methods of aiida.orm.Node
-    """
+    """`Data` sub class to represent a dictionary."""
 
     def __init__(self, **kwargs):
+        """Store a dictionary as a `Node` instance.
+
+        Usual rules for attribute names apply, in particular, keys cannot start with an underscore, or a `ValueError`
+        will be raised.
+
+        Initial attributes can be changed, deleted or added as long as the node is not stored.
+
+        :param dict: the dictionary to set
+        """
         dictionary = kwargs.pop('dict', None)
         super(ParameterData, self).__init__(**kwargs)
         if dictionary:
             self.set_dict(dictionary)
 
-    def set_dict(self, dict):
-        """
-        Replace the current dictionary with another one.
+    def set_dict(self, dictionary):
+        """ Replace the current dictionary with another one.
 
-        :param dict: The dictionary to set.
+        :param dictionary: dictionary to set
         """
-        import copy
-        from aiida.common.exceptions import ModificationNotAllowed
-
-        old_dict = copy.deepcopy(self.get_dict())
+        dictionary_backup = copy.deepcopy(self.get_dict())
 
         try:
-            # Delete existing attributes
+            # Clear existing attributes and set the new dictionary
             self.clear_attributes()
-            # I set the keys
-            self.update_dict(dict)
-        except ModificationNotAllowed:
-            # I reraise here to avoid to go in the generic 'except' below,
-            # that would raise again the same exception
+            self.update_dict(dictionary)
+        except exceptions.ModificationNotAllowed:
+            # I reraise here to avoid to go in the generic 'except' below that would raise the same exception again
             raise
         except Exception:
             # Try to restore the old data
             self.clear_attributes()
-            self.update_dict(old_dict)
+            self.update_dict(dictionary_backup)
             raise
 
-    def update_dict(self, dict):
-        """
-        Update the current dictionary with the keys provided in the dictionary.
+    def update_dict(self, dictionary):
+        """Update the current dictionary with the keys provided in the dictionary.
 
-        :param dict: a dictionary with the keys to substitute. It works like
-          dict.update(), adding new keys and overwriting existing keys.
+        .. note:: works exactly as `dict.update()` where new keys are simply added and existing keys are overwritten.
+
+        :param dictionary: a dictionary with the keys to substitute
         """
-        for key, value in dict.items():
+        for key, value in dictionary.items():
             self.set_attribute(key, value)
 
     def get_dict(self):
-        """
-        Return a dict with the parameters
+        """Return a dictionary with the parameters currently set.
+
+        :return: dictionary
         """
         return dict(self.attributes)
 
     def keys(self):
-        """
-        Iterator of valid keys stored in the ParameterData object
+        """Iterator of valid keys stored in the ParameterData object.
+
+        :return: iterator over the keys of the current dictionary
         """
         for key in self.attributes.keys():
             yield key
 
-    def add_path(self, *args, **kwargs):
-        from aiida.common.exceptions import ModificationNotAllowed
-        raise ModificationNotAllowed('Cannot add files or directories to a ParameterData object')
-
     @property
     def dict(self):
-        """
-        To be used to get direct access to the underlying dictionary with the
-        syntax node.dict.key or node.dict['key'].
+        """Return an instance of `AttributeManager` that transforms the dictionary into an attribute dict.
 
-        :return: an instance of the AttributeResultManager.
+        .. note:: this will allow one to do `node.dict.key` as well as `node.dict[key]`.
+
+        :return: an instance of the `AttributeResultManager`.
         """
         from aiida.orm.utils.managers import AttributeManager
         return AttributeManager(self)
@@ -101,4 +98,4 @@ class ParameterData(Data):
 
 @to_aiida_type.register(dict)
 def _(value):
-    return ParameterData(dict=value)
+    return ParameterData(dictionary=value)

--- a/aiida/orm/nodes/data/remote.py
+++ b/aiida/orm/nodes/data/remote.py
@@ -30,9 +30,6 @@ class RemoteData(Data):
         if remote_path is not None:
             self.set_remote_path(remote_path)
 
-    def get_dbcomputer(self):
-        return self.dbnode.dbmodel
-
     def get_computer_name(self):
         return self.computer.name
 
@@ -41,14 +38,6 @@ class RemoteData(Data):
 
     def set_remote_path(self, val):
         self.set_attribute('remote_path', val)
-
-    def add_path(self, src_abs, dst_filename=None):
-        """
-        Disable adding files or directories to a RemoteData
-        """
-        from aiida.common.exceptions import ModificationNotAllowed
-
-        raise ModificationNotAllowed("Cannot add files or directories to a RemoteData object")
 
     @property
     def is_empty(self):

--- a/aiida/orm/nodes/data/str.py
+++ b/aiida/orm/nodes/data/str.py
@@ -7,6 +7,7 @@
 # For further information on the license, see the LICENSE.txt file        #
 # For further information please visit http://www.aiida.net               #
 ###########################################################################
+"""`Data` sub class to represent a string value."""
 from __future__ import division
 from __future__ import print_function
 from __future__ import absolute_import
@@ -19,9 +20,8 @@ __all__ = ('Str',)
 
 
 class Str(BaseType):
-    """
-    Class to store strings as AiiDA nodes
-    """
+    """`Data` sub class to represent a string value."""
+
     _type = str
 
 

--- a/aiida/orm/utils/mixins.py
+++ b/aiida/orm/utils/mixins.py
@@ -59,7 +59,7 @@ class FunctionCalculationMixin(object):  # pylint: disable=useless-object-inheri
 
         try:
             source_file_path = inspect.getsourcefile(func)
-            with io.open(source_file_path, encoding='utf8') as handle:
+            with io.open(source_file_path, 'r', encoding='utf8') as handle:
                 self._set_source_file(handle)
         except (IOError, OSError):
             pass
@@ -115,17 +115,13 @@ class FunctionCalculationMixin(object):  # pylint: disable=useless-object-inheri
         """
         self.set_attribute(self.FUNCTION_STARTING_LINE_KEY, function_starting_line_number)
 
-    @property
-    def function_source_file(self):
+    def get_function_source_code(self):
         """
         Return the absolute path to the source file in the repository
 
         :returns: the absolute path of the source file in the repository, or None if it does not exist
         """
-        try:
-            return self.repository.get_abs_path(self.FUNCTION_SOURCE_FILE_PATH, check_existence=True)
-        except OSError:
-            return None
+        return self.get_object_content(self.FUNCTION_SOURCE_FILE_PATH)
 
     def _set_source_file(self, source_file_handle):
         """
@@ -133,7 +129,7 @@ class FunctionCalculationMixin(object):  # pylint: disable=useless-object-inheri
 
         :param source_file_handle: a file like object with the source file
         """
-        self.repository.create_file_from_filelike(source_file_handle, self.FUNCTION_SOURCE_FILE_PATH)
+        self.put_object_from_filelike(source_file_handle, self.FUNCTION_SOURCE_FILE_PATH)
 
 
 class Sealable(object):  # pylint: disable=useless-object-inheritance

--- a/aiida/orm/utils/repository.py
+++ b/aiida/orm/utils/repository.py
@@ -2,34 +2,33 @@
 """Class that represents the repository of a `Node` instance."""
 from __future__ import absolute_import
 
+import collections
+import enum
+import io
 import os
 
 from aiida.common import exceptions
 from aiida.common.folders import RepositoryFolder, SandboxFolder
 
 
+class FileType(enum.Enum):
+
+    DIRECTORY = 0
+    FILE = 1
+
+
+File = collections.namedtuple('File', ['name', 'type'])
+
+
 class Repository(object):  # pylint: disable=useless-object-inheritance
-    """
-    A mixin class that knows about file repositories, to mix in
-    with the BackendNode class
-    """
+    """Class that represents the repository of a `Node` instance."""
 
     # Name to be used for the Repository section
     _section_name = 'node'
 
-    # The name of the subfolder in which to put the files/directories
-    # added with add_path
-    _path_subfolder_name = 'path'
-
-    # Flag that says if the node is storable or not.
-    # By default, bare nodes (and also ProcessNodes) are not storable,
-    # all subclasses (WorkflowNode, CalculationNode, Data and their subclasses)
-    # are storable. This flag is checked in store()
-    _storable = False
-    _unstorable_message = 'only Data, WorkflowNode, CalculationNode or their subclasses can be stored'
-
-    def __init__(self, uuid, is_stored):
+    def __init__(self, uuid, is_stored, base_path=None):
         self._is_stored = is_stored
+        self._base_path = base_path
         self._temp_folder = None
         self._repo_folder = RepositoryFolder(section=self._section_name, uuid=uuid)
 
@@ -38,111 +37,239 @@ class Repository(object):  # pylint: disable=useless-object-inheritance
         if getattr(self, '_temp_folder', None) is not None:
             self._temp_folder.erase()
 
-    @property
-    def folder(self):
-        """
-        Get the folder associated with the node,
-        whether it is in the temporary or the permanent repository.
+    def validate_mutability(self):
+        """Raise if the repository is immutable.
 
-        :return: the RepositoryFolder object.
+        :raises ModificationNotAllowed: if repository is marked as immutable because the corresponding node is stored
         """
         if self._is_stored:
-            return self._repo_folder
+            raise exceptions.ModificationNotAllowed('cannot modify the repository after the node has been stored')
 
-        return self._get_temp_folder()
+    @staticmethod
+    def validate_object_key(key):
+        """Validate the key of an object.
+
+        :param key: an object key in the repository
+        :raises ValueError: if the key is not a valid object key
+        """
+        if key and os.path.isabs(key):
+            raise ValueError('the key must be a relative path')
+
+    def list_objects(self, key=None):
+        """Return a list of the objects contained in this repository, optionally in the given sub directory.
+
+        :param key: fully qualified identifier for the object within the repository
+        :return: a list of `File` named tuples representing the objects present in directory with the given key
+        """
+        folder = self._get_base_folder()
+
+        if key:
+            folder = folder.get_subfolder(key)
+
+        objects = []
+
+        for filename in folder.get_content_list():
+            if os.path.isdir(os.path.join(folder.abspath, filename)):
+                objects.append(File(filename, FileType.DIRECTORY))
+            else:
+                objects.append(File(filename, FileType.FILE))
+
+        return sorted(objects, key=lambda x: x.name)
+
+    def list_object_names(self, key=None):
+        """Return a list of the object names contained in this repository, optionally in the given sub directory.
+
+        :param key: fully qualified identifier for the object within the repository
+        :return: a list of `File` named tuples representing the objects present in directory with the given key
+        """
+        return [entry.name for entry in self.list_objects(key)]
+
+    def open(self, key, mode='r'):
+        """Open a file handle to an object stored under the given key.
+
+        :param key: fully qualified identifier for the object within the repository
+        :param mode: the mode under which to open the handle
+        """
+        return io.open(self._get_base_folder().get_abs_path(key), mode=mode)
+
+    def get_object(self, key):
+        """Return the object identified by key.
+
+        :param key: fully qualified identifier for the object within the repository
+        :return: a `File` named tuple representing the object located at key
+        """
+        self.validate_object_key(key)
+
+        try:
+            directory, filename = key.rsplit(os.sep, 1)
+        except ValueError:
+            directory, filename = None, key
+
+        folder = self._get_base_folder()
+
+        if directory:
+            folder = folder.get_subfolder(directory)
+
+        if os.path.isdir(os.path.join(folder.abspath, filename)):
+            return File(filename, FileType.DIRECTORY)
+
+        return File(filename, FileType.FILE)
+
+    def get_object_content(self, key):
+        """Return the content of a object identified by key.
+
+        :param key: fully qualified identifier for the object within the repository
+        """
+        with self.open(key) as handle:
+            return handle.read()
+
+    def put_object_from_tree(self, path, key=None, contents_only=True, force=False):
+        """Store a new object under `key` with the contents of the directory located at `path` on this file system.
+
+        .. warning:: If the repository belongs to a stored node, a `ModificationNotAllowed` exception will be raised.
+            This check can be avoided by using the `force` flag, but this should be used with extreme caution!
+
+        :param path: absolute path of directory whose contents to copy to the repository
+        :param key: fully qualified identifier for the object within the repository
+        :param contents_only: boolean, if True, omit the top level directory of the path and only copy its contents.
+        :param force: boolean, if True, will skip the mutability check
+        :raises ModificationNotAllowed: if repository is immutable and `force=False`
+        """
+        if not force:
+            self.validate_mutability()
+
+        self.validate_object_key(key)
+
+        if not os.path.isabs(path):
+            raise ValueError('the `path` must be an absolute path')
+
+        folder = self._get_base_folder()
+
+        if key:
+            folder = folder.get_subfolder(key, create=True)
+
+        if contents_only:
+            for entry in os.listdir(path):
+                folder.insert_path(os.path.join(path, entry))
+        else:
+            folder.insert_path(path)
+
+    def put_object_from_file(self, path, key, mode='w', encoding='utf8', force=False):
+        """Store a new object under `key` with contents of the file located at `path` on this file system.
+
+        .. warning:: If the repository belongs to a stored node, a `ModificationNotAllowed` exception will be raised.
+            This check can be avoided by using the `force` flag, but this should be used with extreme caution!
+
+        :param path: absolute path of file whose contents to copy to the repository
+        :param key: fully qualified identifier for the object within the repository
+        :param mode: the file mode with which the object will be written
+        :param encoding: the file encoding with which the object will be written
+        :param force: boolean, if True, will skip the mutability check
+        :raises ModificationNotAllowed: if repository is immutable and `force=False`
+        """
+        if not force:
+            self.validate_mutability()
+
+        self.validate_object_key(key)
+
+        with io.open(path) as handle:
+            self.put_object_from_filelike(handle, key, mode=mode, encoding=encoding)
+
+    def put_object_from_filelike(self, handle, key, mode='w', encoding='utf8', force=False):
+        """Store a new object under `key` with contents of filelike object `handle`.
+
+        .. warning:: If the repository belongs to a stored node, a `ModificationNotAllowed` exception will be raised.
+            This check can be avoided by using the `force` flag, but this should be used with extreme caution!
+
+        :param handle: filelike object with the content to be stored
+        :param key: fully qualified identifier for the object within the repository
+        :param mode: the file mode with which the object will be written
+        :param encoding: the file encoding with which the object will be written
+        :param force: boolean, if True, will skip the mutability check
+        :raises ModificationNotAllowed: if repository is immutable and `force=False`
+        """
+        if not force:
+            self.validate_mutability()
+
+        self.validate_object_key(key)
+
+        folder = self._get_base_folder()
+
+        if os.sep in key:
+            basepath, key = key.split(os.sep, 1)
+            folder = folder.get_subfolder(basepath, create=True)
+
+        folder.create_file_from_filelike(handle, key, mode=mode, encoding=encoding)
+
+    def delete_object(self, key, force=False):
+        """Delete the object from the repository.
+
+        .. warning:: If the repository belongs to a stored node, a `ModificationNotAllowed` exception will be raised.
+            This check can be avoided by using the `force` flag, but this should be used with extreme caution!
+
+        :param key: fully qualified identifier for the object within the repository
+        :param force: boolean, if True, will skip the mutability check
+        :raises ModificationNotAllowed: if repository is immutable and `force=False`
+        """
+        if not force:
+            self.validate_mutability()
+
+        self.validate_object_key(key)
+
+        self._get_base_folder().remove_path(key)
+
+    def erase(self, force=False):
+        """Delete the repository folder.
+
+        .. warning:: If the repository belongs to a stored node, a `ModificationNotAllowed` exception will be raised.
+            This check can be avoided by using the `force` flag, but this should be used with extreme caution!
+
+        :param force: boolean, if True, will skip the mutability check
+        :raises ModificationNotAllowed: if repository is immutable and `force=False`
+        """
+        if not force:
+            self.validate_mutability()
+
+        self._repo_folder.erase()
 
     def store(self):
         """Store the contents of the sandbox folder into the repository folder."""
+        if self._is_stored:
+            raise exceptions.ModificationNotAllowed('repository is already stored')
+
         self._repo_folder.replace_with_folder(self._get_temp_folder().abspath, move=True, overwrite=True)
         self._is_stored = True
 
     def restore(self):
         """Move the contents from the repository folder back into the sandbox folder."""
+        if not self._is_stored:
+            raise exceptions.ModificationNotAllowed('repository is not yet stored')
+
         self._temp_folder.replace_with_folder(self._repo_folder.abspath, move=True, overwrite=True)
         self._is_stored = False
 
-    @property
-    def _get_folder_pathsubfolder(self):
-        """
-        Get the subfolder in the repository.
+    def _get_base_folder(self):
+        """Return the base sub folder in the repository.
 
         :return: a Folder object.
         """
-        return self.folder.get_subfolder(self._path_subfolder_name, reset_limit=True)
+        if self._is_stored:
+            folder = self._repo_folder
+        else:
+            folder = self._get_temp_folder()
 
-    def get_abs_path(self, relpath, check_existence=False):
-        """
-        Return an absolute path for a file or folder in this folder.
+        if self._base_path is not None:
+            folder = folder.get_subfolder(self._base_path, reset_limit=True)
+            folder.create()
 
-        The advantage of using this method is that it checks that filename
-        is a valid filename within this folder,
-        and not something e.g. containing slashes.
-
-        :param filename: The file or directory.
-        :param check_existence: if False, just return the file path.
-            Otherwise, also check if the file or directory actually exists.
-            Raise OSError if it does not.
-        """
-        return self._get_folder_pathsubfolder.get_abs_path(relpath, check_existence)
-
-    def get_folder_list(self, subfolder='.'):
-        """
-        Get the the list of files/directory in the repository of the object.
-
-        :param subfolder: get the list of a subfolder
-        :return: a list of strings.
-        """
-        return self._get_folder_pathsubfolder.get_subfolder(subfolder).get_content_list()
+        return folder
 
     def _get_temp_folder(self):
-        """
-        Get the folder of the Node in the temporary repository.
+        """Return the temporary sandbox folder.
 
         :return: a SandboxFolder object mapping the node in the repository.
         """
-        # I create the temp folder only at is first usage
         if self._temp_folder is None:
-            self._temp_folder = SandboxFolder()  # This is also created
-            # Create the 'path' subfolder in the Sandbox
-            self._get_folder_pathsubfolder.create()
+            self._temp_folder = SandboxFolder()
+
         return self._temp_folder
-
-    def remove_path(self, path):
-        """
-        Remove a file or directory from the repository directory.
-        Can be called only before storing.
-
-        :param str path: relative path to file/directory.
-        """
-        if self._is_stored:
-            raise exceptions.ModificationNotAllowed("Cannot delete a path after storing the node")
-
-        if os.path.isabs(path):
-            raise ValueError("The destination path in remove_path " "must be a relative path")
-        self._get_folder_pathsubfolder.remove_path(path)
-
-    def add_path(self, src_abs, dst_path=None):
-        """
-        Copy a file or folder from a local file inside the repository directory.
-        If there is a subpath, folders will be created.
-
-        Copy to a cache directory if the entry has not been saved yet.
-
-        :param str src_abs: the absolute path of the file to copy.
-        :param str dst_filename: the (relative) path on which to copy.
-
-        :todo: in the future, add an add_attachment() that has the same
-            meaning of a extras file. Decide also how to store. If in two
-            separate subfolders, remember to reset the limit.
-        """
-        if self._is_stored:
-            raise exceptions.ModificationNotAllowed("Cannot insert a path after storing the node")
-
-        if not os.path.isabs(src_abs):
-            raise ValueError("The source path in add_path must be absolute")
-        if os.path.isabs(dst_path):
-            raise ValueError("The destination path in add_path must be a filename without any subfolder")
-        self._get_folder_pathsubfolder.insert_path(src_abs, dst_path)
-
-    def create_file_from_filelike(self, src_filelike, dest_name):
-        self._get_folder_pathsubfolder.create_file_from_filelike(src_filelike, dest_name)

--- a/aiida/restapi/translator/data/upf.py
+++ b/aiida/restapi/translator/data/upf.py
@@ -67,7 +67,7 @@ class UpfDataTranslator(DataTranslator):
         response = {}
 
         if node.folder.exists():
-            folder_node = node.repository._get_folder_pathsubfolder  # pylint: disable=protected-access
+            folder_node = node._repository._get_folder_pathsubfolder  # pylint: disable=protected-access
             filename = node.filename
 
             try:

--- a/aiida/tools/data/cif.py
+++ b/aiida/tools/data/cif.py
@@ -117,7 +117,8 @@ def _get_aiida_structure_pymatgen_inline(cif, **kwargs):
         if argument in parameters:
             constructor_kwargs[argument] = parameters.pop(argument)
 
-    parser = CifParser(cif.get_file_abs_path(), **constructor_kwargs)
+    with cif.open() as handle:
+        parser = CifParser(handle, **constructor_kwargs)
 
     try:
         structures = parser.get_structures(**parameters)
@@ -126,7 +127,8 @@ def _get_aiida_structure_pymatgen_inline(cif, **kwargs):
         # Verify whether the failure was due to wrong occupancy numbers
         try:
             constructor_kwargs['occupancy_tolerance'] = 1E10
-            parser = CifParser(cif.get_file_abs_path(), **constructor_kwargs)
+            with cif.open() as handle:
+                parser = CifParser(handle, **constructor_kwargs)
             structures = parser.get_structures(**parameters)
         except ValueError:
             # If it still fails, the occupancies were not the reason for failure

--- a/aiida/tools/dbexporters/tcod.py
+++ b/aiida/tools/dbexporters/tcod.py
@@ -419,7 +419,6 @@ def _inline_to_standalone_script(calc):
 
     function_name = calc.function_name
     function_namespace = calc.function_namespace
-    function_source_file = calc.function_source_file
 
     if function_name is None:
         function_name = 'f'
@@ -427,8 +426,7 @@ def _inline_to_standalone_script(calc):
     if function_namespace is None:
         function_namespace = '__main__'
 
-    with open(function_source_file) as handle:
-        code_string = handle.read().encode('utf-8')
+    code_string = calc.get_function_source_code()
 
     if function_namespace.startswith('aiida.'):
         code_string = "from {} import {}".format(function_namespace, function_name)
@@ -467,9 +465,9 @@ def _collect_calculation_data(calc):
     }
 
     if isinstance(calc, CalcJobNode):
-        retrieved_abspath = calc.get_retrieved_node().repository.folder.abspath
+        retrieved_abspath = calc.get_retrieved_node()._repository._get_base_folder().abspath
         files_in  = _collect_files(calc._raw_input_folder.abspath)
-        files_out = _collect_files(os.path.join(retrieved_abspath, 'path'))
+        files_out = _collect_files(retrieved_abspath)
         this_calc['env'] = calc.get_option('environment_variables')
         stdout_name = '{}.out'.format(aiida_executable_name)
         while stdout_name in [files_in,files_out]:

--- a/aiida/tools/dbimporters/baseclasses.py
+++ b/aiida/tools/dbimporters/baseclasses.py
@@ -302,7 +302,7 @@ class CifEntry(DbEntry):
         with tempfile.NamedTemporaryFile(mode='w+') as f:
             f.write(self.cif)
             f.flush()
-            cifnode = CifData(file=f.name, source=self.source, parse_policy=parse_policy)
+            cifnode = CifData(filepath=f.name, source=self.source, parse_policy=parse_policy)
 
         # Maintaining backwards-compatibility. Parameter 'store' should
         # be removed in the future, as the new node can be stored later.
@@ -351,7 +351,7 @@ class UpfEntry(DbEntry):
         with tempfile.NamedTemporaryFile(mode='w+', prefix=self.source['id']) as f:
             f.write(self.contents)
             f.flush()
-            upfnode = UpfData(file=f.name, source=self.source)
+            upfnode = UpfData(filepath=f.name, source=self.source)
 
         # Maintaining backwards-compatibility. Parameter 'store' should
         # be removed in the future, as the new node can be stored later.

--- a/aiida/work/calcjob.py
+++ b/aiida/work/calcjob.py
@@ -133,7 +133,7 @@ class CalcJob(Process):
                             code.pk, self.node.pk, computer.name))
 
             # After this call, no modifications to the folder should be done
-            self.node._store_raw_input_folder(folder.abspath)  # pylint: disable=protected-access
+            self.node.put_object_from_tree(folder.abspath, force=True)
 
         # Launch the upload operation
         return plumpy.Wait(msg='Waiting to upload', data=(UPLOAD_COMMAND, calc_info, script_filename))
@@ -180,8 +180,6 @@ class CalcJob(Process):
         # pylint: disable=too-many-locals,too-many-statements,too-many-branches
         import os
 
-        from six.moves import StringIO
-
         from aiida.common.exceptions import PluginInternalError, ValidationError
         from aiida.schedulers.datastructures import JobTemplate
         from aiida.common.utils import validate_list_of_string_tuples
@@ -190,7 +188,7 @@ class CalcJob(Process):
         from aiida.orm.computers import Computer
         from aiida.orm.utils import load_node
         from aiida.plugins import DataFactory
-        import aiida.common.json as json
+        from aiida.common import json
 
         computer = self.node.computer
         inputs = self.node.get_incoming(link_type=LinkType.INPUT_CALC)
@@ -357,11 +355,11 @@ class CalcJob(Process):
 
         script_filename = '_aiidasubmit.sh'
         script_content = scheduler.get_submit_script(job_tmpl)
-        folder.create_file_from_filelike(StringIO(script_content), script_filename)
+        folder.create_file_from_filelike(six.StringIO(script_content), script_filename, 'w', encoding='utf8')
 
         subfolder = folder.get_subfolder('.aiida', create=True)
-        subfolder.create_file_from_filelike(StringIO(json.dumps(job_tmpl)), 'job_tmpl.json')
-        subfolder.create_file_from_filelike(StringIO(json.dumps(calcinfo)), 'calcinfo.json')
+        subfolder.create_file_from_filelike(six.StringIO(json.dumps(job_tmpl)), 'job_tmpl.json', 'w', encoding='utf8')
+        subfolder.create_file_from_filelike(six.StringIO(json.dumps(calcinfo)), 'calcinfo.json', 'w', encoding='utf8')
 
         if calcinfo.local_copy_list is None:
             calcinfo.local_copy_list = []

--- a/docs/source/developer_guide/core/internals.rst
+++ b/docs/source/developer_guide/core/internals.rst
@@ -244,8 +244,6 @@ Folder management
 =================
 ``Folder`` objects represent directories on the disk (virtual or not) where extra information for the node are stored. These folders can be temporary or permanent.
 
-- :py:meth:`~aiida.orm.nodes.Node.repository` returns the repository instance associated to the ``node``.
-
 
 Store & deletion
 ================


### PR DESCRIPTION
Fixes #2504 

Initially, the only backend supported for the file repository of nodes
was the local file system. In the near future, additional backends such
as an object store or a remote file system will be implemented. For this
to work the API of the node repository will have to be adapted because
now it is geared to work with a local file system. To prevent too many
changes after the release of the beta, we already define the API here
that should be able to support the different repository backends that
will be implemented in the future.