### PR TITLE
Add deprecation warning for python 2 to `aiida/__init__.py`

### DIFF
--- a/aiida/__init__.py
+++ b/aiida/__init__.py
@@ -25,6 +25,7 @@ from __future__ import print_function
 from __future__ import absolute_import
 
 import warnings
+import six
 
 import aiida.common.warnings
 from aiida.common.log import configure_logging
@@ -52,6 +53,9 @@ if get_config_option('warnings.showdeprecations'):
     # This should default to 'once', i.e. once per different message
 else:
     warnings.simplefilter('ignore', aiida.common.warnings.AiidaDeprecationWarning)  # pylint: disable=no-member
+
+if six.PY2:
+    warnings.warn('python 2 will be deprecated in `aiida-core v2.0.0`', DeprecationWarning)  # pylint: disable=no-member
 
 
 def try_load_dbenv(*argc, **argv):


### PR DESCRIPTION
Fixes #2505 

Currently, it is being marked deprecated for `aiida-core>=2.0.0` even
though it is not yet known when that will be released. But it is very
likely that `aiida-core==v1.*` will be the last version to support
python 2.