### PR TITLE
Restore the import speed of main package to keep `verdi` snappy

### DIFF
--- a/aiida/backends/profile.py
+++ b/aiida/backends/profile.py
@@ -44,8 +44,9 @@ def load_profile(profile=None):
 
         settings.AIIDADB_PROFILE = profile
 
-    # Reconfigure the logging to make sure that profile specific logging configuration options are taken into account
-    configure_logging()
+    # Reconfigure the logging to make sure that profile specific logging configuration options are taken into account.
+    # Also set `with_orm=True` to make sure that the `DBLogHandler` is configured as well.
+    configure_logging(with_orm=True)
 
     profile = config.get_profile(profile)
 

--- a/aiida/common/lang.py
+++ b/aiida/common/lang.py
@@ -13,11 +13,90 @@ from __future__ import print_function
 from __future__ import absolute_import
 
 import functools
+import inspect
 
-import plumpy.lang
 
-override = plumpy.lang.override(check=False)  # pylint: disable=invalid-name
-protected = plumpy.lang.protected(check=False)  # pylint: disable=invalid-name
+def type_check(what, of_type, msg=None, allow_none=False):
+    """Verify that object 'what' is of type 'of_type' and if not the case, raise a TypeError.
+
+    :param what: the object to check
+    :param of_type: the type (or tuple of types) to compare to
+    :param msg: if specified, allows to customize the message that is passed within the TypeError exception
+    :param allow_none: boolean, if True will not raise if the passed `what` is `None`
+    """
+    if allow_none and what is None:
+        return
+
+    if not isinstance(what, of_type):
+        if msg is None:
+            msg = "Got object of type '{}', expecting '{}'".format(type(what), of_type)
+        raise TypeError(msg)
+
+
+def protected_decorator(check=False):
+    """Decorator to ensure that the decorated method is not called from outside the class hierarchy."""
+
+    def wrap(func):  # pylint: disable=missing-docstring
+        if isinstance(func, property):
+            raise RuntimeError("Protected must go after @property decorator")
+
+        args = inspect.getargspec(func)[0]  # pylint: disable=deprecated-method
+        if not args:
+            raise RuntimeError("Can only use the protected decorator on member functions")
+
+        # We can only perform checks if the interpreter is capable of giving
+        # us the stack i.e. currentframe() produces a valid object
+        if check and inspect.currentframe() is not None:
+
+            @functools.wraps(func)
+            def wrapped_fn(self, *args, **kwargs):  # pylint: disable=missing-docstring
+                try:
+                    calling_class = inspect.stack()[1][0].f_locals['self']
+                    assert self is calling_class
+                except (KeyError, AssertionError):
+                    raise RuntimeError("Cannot access protected function {} from outside"
+                                       " class hierarchy".format(func.__name__))
+
+                return func(self, *args, **kwargs)
+        else:
+            wrapped_fn = func
+
+        return wrapped_fn
+
+    return wrap
+
+
+def override_decorator(check=False):
+    """Decorator to signal that a method from a base class is being overridden completely."""
+
+    def wrap(func):  # pylint: disable=missing-docstring
+        if isinstance(func, property):
+            raise RuntimeError("Override must go after @property decorator")
+
+        args = inspect.getargspec(func)[0]  # pylint: disable=deprecated-method
+        if not args:
+            raise RuntimeError("Can only use the override decorator on member functions")
+
+        if check:
+
+            @functools.wraps(func)
+            def wrapped_fn(self, *args, **kwargs):  # pylint: disable=missing-docstring
+                try:
+                    getattr(super(self.__class__, self), func.__name__)
+                except AttributeError:
+                    raise RuntimeError("Function {} does not override a superclass method".format(func))
+
+                return func(self, *args, **kwargs)
+        else:
+            wrapped_fn = func
+
+        return wrapped_fn
+
+    return wrap
+
+
+protected = protected_decorator(check=False)  # pylint: disable=invalid-name
+override = override_decorator(check=False)  # pylint: disable=invalid-name
 
 
 class classproperty(object):  # pylint: disable=too-few-public-methods,invalid-name,useless-object-inheritance
@@ -116,23 +195,3 @@ class EmptyContextManager(object):  # pylint: disable=too-few-public-methods,use
 
     def __exit__(self, exc_type, exc_value, traceback):
         pass
-
-
-def type_check(what, of_type, msg=None, allow_none=False):
-    """
-    Check if object 'what' is of type 'of_type'.
-    If not, raise a TypeError.
-
-    :param what: the object to check
-    :param of_type: the type (or tuple of types) to compare to
-    :param msg: if specified, allows to customize the message that
-        is passed within the TypeError exception
-    :param allow_none: boolean, if True will not raise if the passed `what` is `None`
-    """
-    if allow_none and what is None:
-        return
-
-    if not isinstance(what, of_type):
-        if msg is None:
-            msg = "Got object of type '{}', expecting '{}'".format(type(what), of_type)
-        raise TypeError(msg)


### PR DESCRIPTION
Fixes #2508 

The logging needs to be configured upon loading the `aiida` package, but
we want to prevent the database environment or the `aiida.orm` module
from being loaded as this will slow down the initialization. This is
especially detrimental to the performance of `verdi` which everytime it
is loaded, i.e. also each time tab-completion is triggered, the whole
package needs to be loaded. To prevent this, the implementation of the
`DBLogHandler` was already moved from `aiida.common` to `aiida.orm.utils`
but since it is still being configured in `aiida.common.log`, the
logging module will import the `aiida.orm` module. To fix this, we
remove the handler from the default logging configuration and reinsert
it dynamically when the database environment is loaded, without which
the handler would be non-functional anyway.

The `aiida.common.lang` module will be imported when loading `verdi` and
importing the `protected` and `override` decorators from the `plumpy`
library were causing the whole library to be imported, slowing
everything down. By copying the implementation, the time for executing
`verdi` is roughly reduced by 25%.