### PR TITLE
Add migration 7a6587e16f4c of release v0.12.3 to provenance_redesign branch

### DIFF
--- a/aiida/backends/sqlalchemy/migrations/versions/0aebbeab274d_base_data_plugin_type_string.py
+++ b/aiida/backends/sqlalchemy/migrations/versions/0aebbeab274d_base_data_plugin_type_string.py
@@ -10,7 +10,7 @@
 """Correct the type string for the base data types
 
 Revision ID: 0aebbeab274d
-Revises: 35d4ee9a1b0e
+Revises: 7a6587e16f4c
 Create Date: 2018-02-24 20:12:44.731358
 
 """
@@ -23,7 +23,7 @@ from sqlalchemy.sql import text
 
 # revision identifiers, used by Alembic.
 revision = '0aebbeab274d'
-down_revision = '35d4ee9a1b0e'
+down_revision = '7a6587e16f4c'
 branch_labels = None
 depends_on = None
 

--- a/aiida/backends/sqlalchemy/migrations/versions/59edaf8a8b79_adding_indexes_and_constraints_to_the_.py
+++ b/aiida/backends/sqlalchemy/migrations/versions/59edaf8a8b79_adding_indexes_and_constraints_to_the_.py
@@ -18,7 +18,7 @@ from __future__ import division
 from __future__ import print_function
 from __future__ import absolute_import
 from alembic import op
-
+from sqlalchemy.engine.reflection import Inspector
 
 # revision identifiers, used by Alembic.
 revision = '59edaf8a8b79'
@@ -28,6 +28,14 @@ depends_on = None
 
 
 def upgrade():
+    # Check if constraint uix_dbnode_id_dbgroup_id of migration 7a6587e16f4c
+    # is there and if yes, drop it
+    insp = Inspector.from_engine(op.get_bind())
+    for constr in insp.get_unique_constraints("db_dbgroup_dbnodes"):
+        if constr['name'] == 'uix_dbnode_id_dbgroup_id':
+            op.drop_constraint('uix_dbnode_id_dbgroup_id',
+                               'db_dbgroup_dbnodes')
+
     op.create_index('db_dbgroup_dbnodes_dbnode_id_idx', 'db_dbgroup_dbnodes',
                     ['dbnode_id'])
     op.create_index('db_dbgroup_dbnodes_dbgroup_id_idx', 'db_dbgroup_dbnodes',
@@ -42,3 +50,8 @@ def downgrade():
     op.drop_index('db_dbgroup_dbnodes_dbgroup_id_idx', 'db_dbgroup_dbnodes')
     op.drop_constraint('db_dbgroup_dbnodes_dbgroup_id_dbnode_id_key',
                        'db_dbgroup_dbnodes')
+    # Creating the constraint uix_dbnode_id_dbgroup_id that migration
+    # 7a6587e16f4c would add
+    op.create_unique_constraint(
+        'db_dbgroup_dbnodes_dbgroup_id_dbnode_id_key', 'db_dbgroup_dbnodes',
+        ['dbgroup_id', 'dbnode_id'])

--- a/aiida/backends/sqlalchemy/migrations/versions/7a6587e16f4c_unique_constraints_for_the_db_dbgroup_.py
+++ b/aiida/backends/sqlalchemy/migrations/versions/7a6587e16f4c_unique_constraints_for_the_db_dbgroup_.py
@@ -1,0 +1,39 @@
+# -*- coding: utf-8 -*-
+###########################################################################
+# Copyright (c), The AiiDA team. All rights reserved.                     #
+# This file is part of the AiiDA code.                                    #
+#                                                                         #
+# The code is hosted on GitHub at https://github.com/aiidateam/aiida_core #
+# For further information on the license, see the LICENSE.txt file        #
+# For further information please visit http://www.aiida.net               #
+###########################################################################
+# pylint: disable=invalid-name,no-member
+"""Unique constraints for the db_dbgroup_dbnodes table
+
+Revision ID: 7a6587e16f4c
+Revises: 35d4ee9a1b0e
+Create Date: 2019-02-11 19:25:11.744902
+
+"""
+from __future__ import absolute_import
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = '7a6587e16f4c'
+down_revision = '35d4ee9a1b0e'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    """
+    Add unique constraints to the db_dbgroup_dbnodes table.
+    """
+    op.create_unique_constraint('uix_dbnode_id_dbgroup_id', 'db_dbgroup_dbnodes', ['dbnode_id', 'dbgroup_id'])
+
+
+def downgrade():
+    """
+    Remove unique constraints from the db_dbgroup_dbnodes table.
+    """
+    op.drop_constraint('uix_dbnode_id_dbgroup_id', 'db_dbgroup_dbnodes')


### PR DESCRIPTION
This PR is the complementary PR of #2471
Please merge this before #2471 and please double-check that I did not miss anything.
Thanks a lot!

=======

This commit adds migration **7a6587e16f4c** of release v0.12.3 to provenance_redesign branch and to develop branch where provenance_redesign is going to be merged.

Migration **7a6587e16f4c** can not be automatically added to provenance_redesign/develop since
**59edaf8a8b79** (which already exists at provenance_redesign/develop) adds the same unique
constraint that **7a6587e16f4c** adds but with a different name.

Therefore **7a6587e16f4c** will be added just after **35d4ee9a1b0e** (the last common migration of v0.12.3
and provenance_redesign/develop) and **59edaf8a8b79** will stay at its place, a few migrations later in
develop/provenance redesign, and it will be modified a bit to also remove the constraint of
**7a6587e16f4c** (if it is there) before adding it with another name.

The migration history of provenance_redesign after the described changes:

```
ce56d84bcc35 -> 61fc0913fae9 (head), Final data migration for `Nodes` after `aiida.orm.nodes` reorganization was finalized to remove the `node.` prefix
12536798d4d3 -> ce56d84bcc35, delete trajectory symbols array
37f3d4882837 -> 12536798d4d3, trajectory symbols to attribute
6a5c2ea1439d -> 37f3d4882837, Make all uuid columns unique
375c2db70663 -> 6a5c2ea1439d, Data migration for `Data` nodes after it was moved in the `aiida.orm.node` module changing the type string.
ea2f50e7f615 -> 375c2db70663, This migration adds uniqueness constraint to the UUID column.
041a79fc615f -> ea2f50e7f615, This migration creates UUID column and populates it with distinct UUIDs
7ca08c391c49 -> 041a79fc615f, This migration cleans the log records from non-Node entity records.
It removes from the DbLog table the legacy workflow records and records
that correspond to an unknown entity and places them to corresponding files.
e72ad251bcdb -> 7ca08c391c49, Migration of CalcJobNode attributes for metadata options whose key changed.
b8b23ddefad4 -> e72ad251bcdb, DbGroup class: change type_string values
239cea6d2452 -> b8b23ddefad4, DbGroup class: Rename name with label and type with type_string
140c971ae0a3 -> 239cea6d2452, Migration after the provenance redesign
162b99bca4a2 -> 140c971ae0a3, Migration to reflect the name change of the built in calculation entry points in the database.
a603da2cc809 -> 162b99bca4a2, Drop the DbCalcState table
5d4d844852b6 -> a603da2cc809, Correct the type string for the code class
62fe0d36de90 -> 5d4d844852b6, Invalidating node hash - User should rehash nodes for caching
**59edaf8a8b79** -> 62fe0d36de90, Add a unique constraint on the UUID column of the Node model
a514d673c163 -> **59edaf8a8b79**, Adding indexes and constraints to the dbnode-dbgroup relationship table
f9a69de76a9a -> a514d673c163, Drop the DbLock model
6c629c886f84 -> f9a69de76a9a, Delete the kombu tables that were used by the old Celery based daemon and the obsolete related timestamps
0aebbeab274d -> 6c629c886f84, Add the process_type column to DbNode
**7a6587e16f4c** -> 0aebbeab274d, Correct the type string for the base data types
**35d4ee9a1b0e** -> **7a6587e16f4c**, Unique constraints for the db_dbgroup_dbnodes table
89176227b25 -> **35d4ee9a1b0e**, Migrating 'hidden' properties from DbAttribute to DbExtra for code.Code. nodes
a6048f0ffca8 -> 89176227b25, Add indexes to dbworkflowdata table
70c7d732f1b2 -> a6048f0ffca8, Updating link types - This is a copy of the Django migration script
e15ef2630a1b -> 70c7d732f1b2, Deleting dbpath table and triggers
<base> -> e15ef2630a1b, Initial schema
```

The migration history of v0.12.3
```
**35d4ee9a1b0e** -> **7a6587e16f4c** (head), Unique constraints for the db_dbgroup_dbnodes table
89176227b25 -> **35d4ee9a1b0e**, Migrating 'hidden' properties from DbAttribute to DbExtra for code.Code. nodes
a6048f0ffca8 -> 89176227b25, Add indexes to dbworkflowdata table
70c7d732f1b2 -> a6048f0ffca8, Updating link types - This is a copy of the Django migration script
e15ef2630a1b -> 70c7d732f1b2, Deleting dbpath table and triggers
<base> -> e15ef2630a1b, Initial schema
```