### PR TITLE
Formalizing importable resources on second level modules

### DIFF
--- a/.ci/test_profile.py
+++ b/.ci/test_profile.py
@@ -152,7 +152,7 @@ class DeleteTestCase(unittest.TestCase):
         is not generated until the test function is entered, which calls the `with_temporary_config_instance`
         decorator.
         """
-        from aiida.manage import get_config
+        from aiida.manage.configuration import get_config
 
         config = get_config()
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -42,7 +42,6 @@
         aiida/backends/djsite/settings/__init__.py|
         aiida/backends/djsite/settings/settings_profile.py|
         aiida/backends/general/abstractqueries.py|
-        aiida/backends/__init__.py|
         aiida/backends/profile.py|
         aiida/backends/settings.py|
         aiida/backends/sqlalchemy/alembic_manage.py|
@@ -140,7 +139,6 @@
         aiida/orm/querybuilder.py|
         aiida/orm/implementation/django/utils.py|
         aiida/orm/implementation/sqlalchemy/utils.py|
-        aiida/orm/__init__.py|
         aiida/orm/importexport.py|
         aiida/orm/nodes/data/array/bands.py|
         aiida/orm/nodes/data/array/kpoints.py|
@@ -204,7 +202,6 @@
         aiida/tools/dbimporters/plugins/oqmd.py|
         aiida/tools/dbimporters/plugins/pcod.py|
         aiida/tools/dbimporters/plugins/tcod.py|
-        aiida/tools/__init__.py|
         aiida/transports/plugins/ssh.py|
         aiida/transports/plugins/test_all_plugins.py|
         aiida/transports/plugins/test_local.py|

--- a/aiida/__init__.py
+++ b/aiida/__init__.py
@@ -29,7 +29,7 @@ import six
 
 import aiida.common.warnings
 from aiida.common.log import configure_logging
-from aiida.manage import get_config_option
+from aiida.manage.configuration import get_config_option
 
 __copyright__ = (u'Copyright (c), This file is part of the AiiDA platform. '
                  u'For further information please visit http://www.aiida.net/. All rights reserved.')

--- a/aiida/backends/__init__.py
+++ b/aiida/backends/__init__.py
@@ -7,8 +7,3 @@
 # For further information on the license, see the LICENSE.txt file        #
 # For further information please visit http://www.aiida.net               #
 ###########################################################################
-from __future__ import division
-from __future__ import print_function
-from __future__ import absolute_import
-
-from . import settings

--- a/aiida/backends/djsite/db/migrations/__init__.py
+++ b/aiida/backends/djsite/db/migrations/__init__.py
@@ -66,7 +66,7 @@ class ModelModifierV0025(object):
         contain the separator symbol.).
 
         :return: None if the key is valid
-        :raise ValidationError: if the key is not valid
+        :raise aiida.common.ValidationError: if the key is not valid
         """
         from aiida.backends.utils import validate_attribute_key
         return validate_attribute_key(key)

--- a/aiida/backends/djsite/db/models.py
+++ b/aiida/backends/djsite/db/models.py
@@ -605,7 +605,7 @@ class DbMultipleValueAttributeBaseClass(m.Model):
         contain the separator symbol.).
 
         :return: None if the key is valid
-        :raise ValidationError: if the key is not valid
+        :raise aiida.common.ValidationError: if the key is not valid
         """
         from aiida.backends.utils import validate_attribute_key
         return validate_attribute_key(key)

--- a/aiida/backends/djsite/settings/settings.py
+++ b/aiida/backends/djsite/settings/settings.py
@@ -20,7 +20,7 @@ from aiida.common.exceptions import ConfigurationError, MissingConfigurationErro
 
 from aiida.backends import settings
 from aiida.common.setup import parse_repository_uri
-from aiida.manage import get_config
+from aiida.manage.configuration import get_config
 from aiida.common.timezone import get_current_timezone
 
 # Assumes that parent directory of aiida is root for

--- a/aiida/backends/djsite/utils.py
+++ b/aiida/backends/djsite/utils.py
@@ -72,7 +72,7 @@ def check_schema_version(profile_name=None):
       code. This is useful to have the code automatically set the DB version
       at the first code execution.
 
-    :raise ConfigurationError: if the two schema versions do not match.
+    :raise aiida.common.ConfigurationError: if the two schema versions do not match.
       Otherwise, just return.
     """
     # pylint: disable=duplicate-string-formatting-argument

--- a/aiida/backends/profile.py
+++ b/aiida/backends/profile.py
@@ -26,7 +26,7 @@ def load_profile(profile=None):
     be called by the user by hand.
     """
     from aiida.common.log import configure_logging
-    from aiida.manage import get_config
+    from aiida.manage.configuration import get_config
 
     if settings.LOAD_PROFILE_CALLED:
         raise InvalidOperation('You cannot call load_profile multiple times!')

--- a/aiida/backends/sqlalchemy/models/utils.py
+++ b/aiida/backends/sqlalchemy/models/utils.py
@@ -28,7 +28,7 @@ def validate_key(key):
     contain the separator symbol.).
 
     :return: None if the key is valid
-    :raise ValidationError: if the key is not valid
+    :raise aiida.common.ValidationError: if the key is not valid
     """
     if not isinstance(key, six.string_types):
         raise ValidationError("The key must be a string.")
@@ -50,7 +50,7 @@ def get_value_of_sub_field(key, original_get_value):
     :param original_get_value: The function that should be called to get the
     original value (which can be a dictionary too).
     :return: The value that correspond to the complex (or not) key.
-    :raise NotExistent: If the key doesn't correspond to a value
+    :raise aiida.common.NotExistent: If the key doesn't correspond to a value
     """
     keys = list()
     if _sep in key:

--- a/aiida/backends/sqlalchemy/tests/test_session.py
+++ b/aiida/backends/sqlalchemy/tests/test_session.py
@@ -18,7 +18,7 @@ from sqlalchemy.orm import sessionmaker
 
 import aiida.backends
 from aiida.backends.testbase import AiidaTestCase
-from aiida.manage import get_manager
+from aiida.manage.manager import get_manager
 
 
 class TestSessionSqla(AiidaTestCase):

--- a/aiida/backends/sqlalchemy/utils.py
+++ b/aiida/backends/sqlalchemy/utils.py
@@ -109,7 +109,7 @@ def _load_dbenv_noschemacheck(profile=None, connection=None):
     """
     Load the SQLAlchemy database.
     """
-    from aiida.manage import get_config
+    from aiida.manage.configuration import get_config
 
     config = get_config()
     profile = config.current_profile
@@ -388,7 +388,7 @@ def check_schema_version(profile_name=None):
     """
     Check if the version stored in the database is the same of the version of the code.
 
-    :raise ConfigurationError: if the two schema versions do not match
+    :raise aiida.common.ConfigurationError: if the two schema versions do not match
     """
     from aiida.backends import sqlalchemy as sa
     from aiida.backends.settings import IN_DOC_MODE

--- a/aiida/backends/testbase.py
+++ b/aiida/backends/testbase.py
@@ -22,7 +22,7 @@ from aiida.backends import settings
 from aiida.backends.tests import get_db_test_list
 from aiida.common.exceptions import ConfigurationError, TestsNotAllowedError, InternalError
 from aiida.common.lang import classproperty
-from aiida.manage import reset_manager
+from aiida.manage.manager import reset_manager
 
 
 def check_if_tests_can_run():

--- a/aiida/backends/testimplbase.py
+++ b/aiida/backends/testimplbase.py
@@ -76,7 +76,7 @@ class AiidaTestImplementation(object):
         """
         This method inserts default data into the database.
         """
-        from aiida.manage import get_config
+        from aiida.manage.configuration import get_config
 
         self.computer = orm.Computer(
             name='localhost',

--- a/aiida/backends/tests/cmdline/commands/test_config.py
+++ b/aiida/backends/tests/cmdline/commands/test_config.py
@@ -17,7 +17,7 @@ from click.testing import CliRunner
 from aiida.backends.testbase import AiidaTestCase
 from aiida.backends.tests.utils.configuration import with_temporary_config_instance
 from aiida.cmdline.commands import cmd_verdi
-from aiida.manage import get_config
+from aiida.manage.configuration import get_config
 
 
 class TestVerdiConfig(AiidaTestCase):

--- a/aiida/backends/tests/cmdline/commands/test_process.py
+++ b/aiida/backends/tests/cmdline/commands/test_process.py
@@ -28,7 +28,7 @@ from aiida.backends.tests.utils import processes as test_processes
 from aiida.cmdline.commands import cmd_process
 from aiida.common.links import LinkType
 from aiida.common.log import LOG_LEVEL_REPORT
-from aiida.manage import get_manager
+from aiida.manage.manager import get_manager
 from aiida.orm import WorkflowNode, WorkFunctionNode, WorkChainNode
 
 
@@ -43,7 +43,7 @@ class TestVerdiProcessDaemon(AiidaTestCase):
 
     def setUp(self):
         super(TestVerdiProcessDaemon, self).setUp()
-        from aiida.manage import get_config
+        from aiida.manage.configuration import get_config
         from aiida.engine.daemon.client import DaemonClient
 
         profile = get_config().current_profile

--- a/aiida/backends/tests/cmdline/commands/test_profile.py
+++ b/aiida/backends/tests/cmdline/commands/test_profile.py
@@ -17,7 +17,7 @@ from click.testing import CliRunner
 from aiida.backends.testbase import AiidaTestCase
 from aiida.cmdline.commands import cmd_profile
 from aiida.backends.tests.utils.configuration import create_mock_profile, with_temporary_config_instance
-from aiida.manage import get_config
+from aiida.manage.configuration import get_config
 
 
 class TestVerdiProfileSetup(AiidaTestCase):

--- a/aiida/backends/tests/cmdline/commands/test_setup.py
+++ b/aiida/backends/tests/cmdline/commands/test_setup.py
@@ -18,7 +18,7 @@ from aiida.backends import settings
 from aiida.backends.testbase import AiidaTestCase
 from aiida.backends.tests.utils.configuration import with_temporary_config_instance
 from aiida.cmdline.commands import cmd_setup
-from aiida.manage import get_config
+from aiida.manage.configuration import get_config
 
 
 class TestVerdiSetup(AiidaTestCase):

--- a/aiida/backends/tests/engine/test_futures.py
+++ b/aiida/backends/tests/engine/test_futures.py
@@ -18,7 +18,7 @@ from tornado import gen
 from aiida.backends.testbase import AiidaTestCase
 from aiida.backends.tests.utils import processes as test_processes
 from aiida.engine import processes, run
-from aiida.manage import get_manager
+from aiida.manage.manager import get_manager
 
 
 class TestWf(AiidaTestCase):

--- a/aiida/backends/tests/engine/test_rmq.py
+++ b/aiida/backends/tests/engine/test_rmq.py
@@ -19,7 +19,7 @@ from aiida.backends.testbase import AiidaTestCase
 from aiida.backends.tests.utils import processes as test_processes
 from aiida.engine import ProcessState, submit
 from aiida.orm.nodes.data.int import Int
-from aiida.manage import get_manager
+from aiida.manage.manager import get_manager
 
 
 class TestProcessControl(AiidaTestCase):

--- a/aiida/backends/tests/engine/test_runners.py
+++ b/aiida/backends/tests/engine/test_runners.py
@@ -15,7 +15,7 @@ import plumpy
 
 from aiida.backends.testbase import AiidaTestCase
 from aiida.engine import Process
-from aiida.manage import get_manager
+from aiida.manage.manager import get_manager
 from aiida.orm import WorkflowNode
 
 

--- a/aiida/backends/tests/engine/test_work_chain.py
+++ b/aiida/backends/tests/engine/test_work_chain.py
@@ -24,7 +24,7 @@ from aiida.common.links import LinkType
 from aiida.common.utils import Capturing
 from aiida.engine import ExitCode, Process, ToContext, WorkChain, if_, while_, return_, run, run_get_node
 from aiida.engine.persistence import ObjectLoader
-from aiida.manage import get_manager
+from aiida.manage.manager import get_manager
 from aiida.orm import load_node
 from aiida.orm.nodes.data.bool import Bool
 from aiida.orm.nodes.data.float import Float

--- a/aiida/backends/tests/manage/configuration/migrations/test_migrations.py
+++ b/aiida/backends/tests/manage/configuration/migrations/test_migrations.py
@@ -24,7 +24,7 @@ except ImportError:
 
 import aiida.common.json as json
 
-from aiida.manage import Config
+from aiida.manage.configuration import Config
 from aiida.manage.configuration.migrations.utils import check_and_migrate_config
 from aiida.manage.configuration.migrations.migrations import _MIGRATION_LOOKUP
 

--- a/aiida/backends/tests/manage/configuration/test_config.py
+++ b/aiida/backends/tests/manage/configuration/test_config.py
@@ -19,7 +19,7 @@ import tempfile
 from aiida.backends.testbase import AiidaTestCase
 from aiida.backends.tests.utils.configuration import create_mock_profile
 from aiida.common import exceptions
-from aiida.manage import Config, Profile
+from aiida.manage.configuration import Config, Profile
 from aiida.manage.configuration.migrations import CURRENT_CONFIG_VERSION, OLDEST_COMPATIBLE_CONFIG_VERSION
 from aiida.manage.configuration.options import get_option
 from aiida.common import json

--- a/aiida/backends/tests/manage/configuration/test_profile.py
+++ b/aiida/backends/tests/manage/configuration/test_profile.py
@@ -16,7 +16,7 @@ import uuid
 
 from aiida.backends.testbase import AiidaTestCase
 from aiida.backends.tests.utils.configuration import create_mock_profile
-from aiida.manage import Profile
+from aiida.manage.configuration import Profile
 
 
 class TestProfile(AiidaTestCase):

--- a/aiida/backends/tests/test_export_and_import.py
+++ b/aiida/backends/tests/test_export_and_import.py
@@ -391,7 +391,7 @@ class TestUsers(AiidaTestCase):
         from aiida.orm import CalcJobNode
         from aiida.orm.nodes.data.structure import StructureData
         from aiida.common.links import LinkType
-        from aiida.manage import get_manager
+        from aiida.manage.manager import get_manager
 
         manager = get_manager()
 
@@ -467,7 +467,7 @@ class TestUsers(AiidaTestCase):
         from aiida.orm import CalcJobNode
         from aiida.orm.nodes.data.structure import StructureData
         from aiida.common.links import LinkType
-        from aiida.manage import get_manager
+        from aiida.manage.manager import get_manager
 
         manager = get_manager()
 

--- a/aiida/backends/tests/utils/configuration.py
+++ b/aiida/backends/tests/utils/configuration.py
@@ -24,7 +24,7 @@ def create_mock_profile(name, repository_dirpath=None):
     :param name: name of the profile
     :param repository_dirpath: optional absolute path to use as the base for the repository path
     """
-    from aiida.manage import get_config, Profile
+    from aiida.manage.configuration import get_config, Profile
 
     if repository_dirpath is None:
         config = get_config()

--- a/aiida/backends/utils.py
+++ b/aiida/backends/utils.py
@@ -27,7 +27,7 @@ def validate_attribute_key(key):
     contain the separator symbol.).
 
     :return: None if the key is valid
-    :raise ValidationError: if the key is not valid
+    :raise aiida.common.ValidationError: if the key is not valid
     """
     from aiida.common.exceptions import ValidationError
 

--- a/aiida/cmdline/__init__.py
+++ b/aiida/cmdline/__init__.py
@@ -7,10 +7,17 @@
 # For further information on the license, see the LICENSE.txt file        #
 # For further information please visit http://www.aiida.net               #
 ###########################################################################
+# pylint: disable=wildcard-import,undefined-variable
 """The command line interface of AiiDA."""
 from __future__ import division
 from __future__ import print_function
 from __future__ import absolute_import
 
-# Default execname; can be substituted later in the call from exec_from_cmdline
-EXECNAME = 'verdi'
+from .params.arguments import *
+from .params.options import *
+from .params.types import *
+from .utils.decorators import *
+from .utils.echo import *
+
+__all__ = (params.arguments.__all__ + params.options.__all__ + params.types.__all__ + utils.decorators.__all__ +
+           utils.echo.__all__)

--- a/aiida/cmdline/commands/cmd_calculation.py
+++ b/aiida/cmdline/commands/cmd_calculation.py
@@ -21,7 +21,7 @@ from aiida.cmdline.commands.cmd_plugin import verdi_plugin
 from aiida.cmdline.commands.cmd_process import verdi_process
 from aiida.cmdline.params import arguments, options
 from aiida.cmdline.utils import decorators
-from aiida.manage import get_config_option
+from aiida.manage.configuration import get_config_option
 
 LIST_CMDLINE_PROJECT_DEFAULT = get_config_option('verdishell.calculation_list')
 LIST_CMDLINE_PROJECT_CHOICES = ('pk', 'ctime', 'process_state', 'job_state', 'scheduler_state', 'computer', 'type',

--- a/aiida/cmdline/commands/cmd_daemon.py
+++ b/aiida/cmdline/commands/cmd_daemon.py
@@ -23,7 +23,7 @@ from aiida.cmdline.commands.cmd_verdi import verdi
 from aiida.cmdline.utils import decorators, echo
 from aiida.cmdline.utils.common import get_env_with_venv_bin
 from aiida.cmdline.utils.daemon import get_daemon_status, print_client_response_status
-from aiida.manage import get_config
+from aiida.manage.configuration import get_config
 
 
 @verdi.group('daemon')

--- a/aiida/cmdline/commands/cmd_data/cmd_bands.py
+++ b/aiida/cmdline/commands/cmd_data/cmd_bands.py
@@ -45,7 +45,7 @@ def bands():
 @options.FORMULA_MODE()
 def bands_list(elements, elements_exclusive, raw, formula_mode, past_days, groups, all_users):
     """List BandsData objects."""
-    from aiida.manage import get_manager
+    from aiida.manage.manager import get_manager
     from tabulate import tabulate
     from argparse import Namespace
 

--- a/aiida/cmdline/commands/cmd_process.py
+++ b/aiida/cmdline/commands/cmd_process.py
@@ -22,7 +22,7 @@ from aiida.cmdline.params import arguments, options
 from aiida.cmdline.utils import decorators, echo
 from aiida.cmdline.utils.query.calculation import CalculationQueryBuilder
 from aiida.common.log import LOG_LEVELS
-from aiida.manage import get_manager
+from aiida.manage.manager import get_manager
 
 
 @verdi.group('process')

--- a/aiida/cmdline/commands/cmd_profile.py
+++ b/aiida/cmdline/commands/cmd_profile.py
@@ -19,7 +19,7 @@ from aiida.cmdline.commands.cmd_verdi import verdi
 from aiida.cmdline.params import arguments, options
 from aiida.cmdline.utils import defaults, echo
 from aiida.common import exceptions
-from aiida.manage import get_config
+from aiida.manage.configuration import get_config
 
 
 @verdi.group('profile')

--- a/aiida/cmdline/commands/cmd_status.py
+++ b/aiida/cmdline/commands/cmd_status.py
@@ -18,7 +18,7 @@ import click
 from aiida.cmdline.commands.cmd_verdi import verdi
 from aiida.cmdline.utils.daemon import get_daemon_status
 from aiida.common.utils import Capturing, get_repository_folder
-from aiida.manage import get_manager
+from aiida.manage.manager import get_manager
 
 
 class ServiceStatus(IntEnum):

--- a/aiida/cmdline/commands/cmd_user.py
+++ b/aiida/cmdline/commands/cmd_user.py
@@ -112,7 +112,7 @@ def user_list(color):
     List all the users.
     :param color: Show the list using colors
     """
-    from aiida.manage import get_manager
+    from aiida.manage.manager import get_manager
     from aiida import orm
 
     manager = get_manager()

--- a/aiida/cmdline/commands/cmd_verdi.py
+++ b/aiida/cmdline/commands/cmd_verdi.py
@@ -29,7 +29,7 @@ def verdi(ctx, profile, version):
     from aiida import get_version
     from aiida.backends import settings
     from aiida.cmdline.utils import echo
-    from aiida.manage import get_config
+    from aiida.manage.configuration import get_config
 
     if version:
         echo.echo('AiiDA version {}'.format(get_version()))

--- a/aiida/cmdline/params/arguments/__init__.py
+++ b/aiida/cmdline/params/arguments/__init__.py
@@ -8,17 +8,21 @@
 # For further information please visit http://www.aiida.net               #
 ###########################################################################
 # yapf: disable
-"""
-Module to make available commonly used click arguments.
-"""
+"""Module with pre-defined reusable commandline arguments that can be used as `click` decorators."""
 from __future__ import division
 from __future__ import print_function
 from __future__ import absolute_import
 
 import click
 
-from aiida.cmdline.params import types
-from aiida.cmdline.params.arguments.overridable import OverridableArgument
+from .. import types
+from .overridable import OverridableArgument
+
+__all__ = (
+    'PROFILE', 'PROFILES', 'CALCULATION', 'CALCULATIONS', 'CODE', 'CODES', 'COMPUTER', 'COMPUTERS', 'DATUM', 'DATA',
+    'GROUP', 'GROUPS', 'NODE', 'NODES', 'PROCESS', 'PROCESSES', 'WORKFLOW', 'WORKFLOWS', 'INPUT_FILE', 'OUTPUT_FILE',
+    'LABEL', 'USER', 'PROFILE_NAME', 'CONFIG_OPTION'
+)
 
 
 PROFILE = OverridableArgument('profile', type=types.ProfileParamType())

--- a/aiida/cmdline/params/options/__init__.py
+++ b/aiida/cmdline/params/options/__init__.py
@@ -8,18 +8,28 @@
 # For further information please visit http://www.aiida.net               #
 ###########################################################################
 # yapf: disable
-"""Provide reusable options, helping to keep interfaces consistent."""
-
-
+"""Module with pre-defined reusable commandline options that can be used as `click` decorators."""
 from __future__ import division
 from __future__ import print_function
 from __future__ import absolute_import
+
 import click
 
 from aiida.backends.profile import BACKEND_DJANGO, BACKEND_SQLA
-from aiida.cmdline.params import types
-from aiida.cmdline.params.options.multivalue import MultipleValueOption
-from aiida.cmdline.params.options.overridable import OverridableOption
+from .. import types
+from .multivalue import MultipleValueOption
+from .overridable import OverridableOption
+
+__all__ = (
+    'PROFILE', 'CALCULATION', 'CALCULATIONS', 'CODE', 'CODES', 'COMPUTER', 'COMPUTERS', 'DATUM', 'DATA', 'GROUP',
+    'GROUPS', 'NODE', 'NODES', 'FORCE', 'SILENT', 'VISUALIZATION_FORMAT', 'INPUT_FORMAT', 'EXPORT_FORMAT',
+    'ARCHIVE_FORMAT', 'NON_INTERACTIVE', 'USER_EMAIL', 'USER_FIRST_NAME', 'USER_LAST_NAME', 'USER_INSTITUTION',
+    'BACKEND', 'DB_HOST', 'DB_PORT', 'DB_USERNAME', 'DB_PASSWORD', 'DB_NAME', 'REPOSITORY_PATH', 'PROFILE_ONLY_CONFIG',
+    'PROFILE_SET_DEFAULT', 'PREPEND_TEXT', 'APPEND_TEXT', 'LABEL', 'DESCRIPTION', 'INPUT_PLUGIN', 'CALC_JOB_STATE',
+    'PROCESS_STATE', 'EXIT_STATUS', 'FAILED', 'LIMIT', 'PROJECT', 'ORDER_BY', 'PAST_DAYS', 'OLDER_THAN', 'ALL',
+    'ALL_STATES', 'ALL_USERS', 'RAW', 'HOSTNAME', 'TRANSPORT', 'SCHEDULER', 'USER', 'PORT', 'FREQUENCY', 'VERBOSE',
+    'TIMEOUT', 'FORMULA_MODE', 'TRAJECTORY_INDEX', 'WITH_ELEMENTS', 'WITH_ELEMENTS_EXCLUSIVE'
+)
 
 
 def valid_process_states():

--- a/aiida/cmdline/params/options/conditional.py
+++ b/aiida/cmdline/params/options/conditional.py
@@ -15,6 +15,7 @@
 from __future__ import division
 from __future__ import print_function
 from __future__ import absolute_import
+
 import click
 
 

--- a/aiida/cmdline/params/options/interactive.py
+++ b/aiida/cmdline/params/options/interactive.py
@@ -12,14 +12,14 @@
     :synopsis: Tools and an option class for interactive parameter entry with
     additional features such as help lookup.
 """
-
 from __future__ import division
 from __future__ import print_function
 from __future__ import absolute_import
+
 import click
 
-from aiida.cmdline.params.options.conditional import ConditionalOption
 from aiida.cmdline.utils import echo
+from .conditional import ConditionalOption
 
 
 def noninteractive(ctx):

--- a/aiida/cmdline/params/options/multivalue.py
+++ b/aiida/cmdline/params/options/multivalue.py
@@ -10,13 +10,13 @@
 """
 Module to define multi value options for click.
 """
-
 from __future__ import division
 from __future__ import print_function
 from __future__ import absolute_import
+
 import click
 
-from aiida.cmdline.params import types
+from .. import types
 
 
 class MultipleValueOption(click.Option):

--- a/aiida/cmdline/params/options/overridable.py
+++ b/aiida/cmdline/params/options/overridable.py
@@ -12,10 +12,10 @@
     :synopsis: Convenience class which can be used to defined a set of commonly used options that
         can be easily reused and which improves consistency across the command line interface
 """
-
 from __future__ import division
 from __future__ import print_function
 from __future__ import absolute_import
+
 import click
 
 

--- a/aiida/cmdline/params/options/test_conditional.py
+++ b/aiida/cmdline/params/options/test_conditional.py
@@ -11,12 +11,13 @@
 from __future__ import division
 from __future__ import print_function
 from __future__ import absolute_import
+
 import unittest
 
 import click
 from click.testing import CliRunner
 
-from aiida.cmdline.params.options.conditional import ConditionalOption
+from .conditional import ConditionalOption
 
 
 class ConditionalOptionTest(unittest.TestCase):

--- a/aiida/cmdline/params/options/test_interactive.py
+++ b/aiida/cmdline/params/options/test_interactive.py
@@ -17,8 +17,8 @@ import click
 from click.testing import CliRunner
 from click.types import IntParamType
 
-from aiida.cmdline.params.options.interactive import InteractiveOption
-from aiida.cmdline.params.options import NON_INTERACTIVE
+from . import NON_INTERACTIVE
+from .interactive import InteractiveOption
 
 
 class Only42IntParamType(IntParamType):

--- a/aiida/cmdline/params/types/__init__.py
+++ b/aiida/cmdline/params/types/__init__.py
@@ -31,9 +31,8 @@ from .user import UserParamType
 from .test_module import TestModuleParamType
 from .workflow import WorkflowParamType
 
-__all__ = [
-    'LazyChoice', 'IdentifierParamType', 'CalculationParamType', 'CodeParamType', 'ComputerParamType',
-    'ConfigOptionParamType', 'DataParamType', 'GroupParamType', 'NodeParamType', 'MpirunCommandParamType',
-    'MultipleValueParamType', 'NonEmptyStringParamType', 'PluginParamType', 'AbsolutePathParamType', 'ShebangParamType',
-    'UserParamType', 'TestModuleParamType', 'ProfileParamType', 'WorkflowParamType', 'ProcessParamType'
-]
+__all__ = ('LazyChoice', 'IdentifierParamType', 'CalculationParamType', 'CodeParamType', 'ComputerParamType',
+           'ConfigOptionParamType', 'DataParamType', 'GroupParamType', 'NodeParamType', 'MpirunCommandParamType',
+           'MultipleValueParamType', 'NonEmptyStringParamType', 'PluginParamType', 'AbsolutePathParamType',
+           'ShebangParamType', 'UserParamType', 'TestModuleParamType', 'ProfileParamType', 'WorkflowParamType',
+           'ProcessParamType')

--- a/aiida/cmdline/params/types/profile.py
+++ b/aiida/cmdline/params/types/profile.py
@@ -22,7 +22,7 @@ class ProfileParamType(click.ParamType):
     def convert(self, value, param, ctx):
         """Attempt to match the given value to a valid profile."""
         from aiida.common.exceptions import MissingConfigurationError, ProfileConfigurationError
-        from aiida.manage import get_config
+        from aiida.manage.configuration import get_config
 
         try:
             config = get_config()
@@ -39,7 +39,7 @@ class ProfileParamType(click.ParamType):
         :returns: list of tuples of valid entry points (matching incomplete) and a description
         """
         from aiida.common.exceptions import MissingConfigurationError
-        from aiida.manage import get_config
+        from aiida.manage.configuration import get_config
 
         try:
             config = get_config()

--- a/aiida/cmdline/utils/ascii_vis.py
+++ b/aiida/cmdline/utils/ascii_vis.py
@@ -16,7 +16,7 @@ from ete3 import Tree
 
 from aiida.common.links import LinkType
 
-__all__ = ['draw_children', 'draw_parents', 'format_call_graph']
+__all__ = ('draw_children', 'draw_parents', 'format_call_graph')
 
 TREE_LAST_ENTRY = u'\u2514\u2500\u2500 '
 TREE_MIDDLE_ENTRY = u'\u251C\u2500\u2500 '

--- a/aiida/cmdline/utils/common.py
+++ b/aiida/cmdline/utils/common.py
@@ -21,7 +21,7 @@ from tabulate import tabulate
 
 def get_env_with_venv_bin():
     """Create a clone of the current running environment with the AIIDA_PATH variable set directory of the config."""
-    from aiida.manage import get_config
+    from aiida.manage.configuration import get_config
 
     config = get_config()
 

--- a/aiida/cmdline/utils/decorators.py
+++ b/aiida/cmdline/utils/decorators.py
@@ -22,6 +22,7 @@ Provides:
 from __future__ import division
 from __future__ import print_function
 from __future__ import absolute_import
+
 from contextlib import contextmanager
 from functools import wraps
 
@@ -30,6 +31,8 @@ from click_spinner import spinner
 from . import echo
 
 DAEMON_NOT_RUNNING_DEFAULT_MESSAGE = 'daemon is not running'
+
+__all__ = ('with_dbenv', 'dbenv', 'only_if_daemon_running')
 
 
 def load_dbenv_if_not_loaded(**kwargs):
@@ -209,7 +212,7 @@ def deprecated_command(message):
         def decorated_function(*args, **kwargs):
             """Echo a deprecation warning before doing anything else."""
             from aiida.cmdline.utils import templates
-            from aiida.manage import get_config
+            from aiida.manage.configuration import get_config
             from textwrap import wrap
 
             profile = get_config().current_profile

--- a/aiida/cmdline/utils/defaults.py
+++ b/aiida/cmdline/utils/defaults.py
@@ -14,7 +14,7 @@ from __future__ import absolute_import
 
 from aiida.cmdline.utils import echo
 from aiida.common import exceptions
-from aiida.manage import get_config
+from aiida.manage.configuration import get_config
 
 
 def get_default_profile(ctx, param, value):  # pylint: disable=unused-argument

--- a/aiida/cmdline/utils/echo.py
+++ b/aiida/cmdline/utils/echo.py
@@ -11,10 +11,13 @@
 from __future__ import division
 from __future__ import print_function
 from __future__ import absolute_import
+
 import enum
 import sys
 
 import click
+
+__all__ = ('echo', 'echo_info', 'echo_success', 'echo_warning', 'echo_error', 'echo_critical', 'echo_dictionary')
 
 
 # pylint: disable=too-few-public-methods

--- a/aiida/cmdline/utils/shell.py
+++ b/aiida/cmdline/utils/shell.py
@@ -83,7 +83,7 @@ def run_shell(interface=None):
 
 def get_start_namespace():
     """Load all default and custom modules"""
-    from aiida.manage import get_config
+    from aiida.manage.configuration import get_config
 
     config = get_config()
 

--- a/aiida/common/__init__.py
+++ b/aiida/common/__init__.py
@@ -7,6 +7,7 @@
 # For further information on the license, see the LICENSE.txt file        #
 # For further information please visit http://www.aiida.net               #
 ###########################################################################
+# pylint: disable=wildcard-import,undefined-variable
 """
 Common data structures, utility classes and functions
 
@@ -17,4 +18,10 @@ from __future__ import division
 from __future__ import print_function
 from __future__ import absolute_import
 
-from aiida.common.log import AIIDA_LOGGER  # noqa: F401
+from .datastructures import *
+from .exceptions import *
+from .extendeddicts import *
+from .links import *
+from .log import *
+
+__all__ = (datastructures.__all__ + exceptions.__all__ + extendeddicts.__all__ + links.__all__ + log.__all__)

--- a/aiida/common/datastructures.py
+++ b/aiida/common/datastructures.py
@@ -14,7 +14,9 @@ from __future__ import absolute_import
 
 from enum import Enum, IntEnum
 
-from aiida.common.extendeddicts import DefaultFieldsAttributeDict
+from .extendeddicts import DefaultFieldsAttributeDict
+
+__all__ = ('CalcJobState', 'CalcInfo', 'CodeInfo', 'CodeRunMode')
 
 
 class CalcJobState(Enum):

--- a/aiida/common/exceptions.py
+++ b/aiida/common/exceptions.py
@@ -12,6 +12,15 @@ from __future__ import division
 from __future__ import print_function
 from __future__ import absolute_import
 
+__all__ = ('AiidaException', 'NotExistent', 'MultipleObjectsError', 'RemoteOperationError', 'ContentNotExistent',
+           'FailedError', 'StoringNotAllowed', 'ModificationNotAllowed', 'IntegrityError', 'UniquenessError',
+           'MissingEntryPointError', 'MultipleEntryPointError', 'LoadingEntryPointError', 'MissingPluginError',
+           'LoadingPluginFailed', 'InvalidOperation', 'ParsingError', 'InternalError', 'PluginInternalError',
+           'ValidationError', 'ConfigurationError', 'ProfileConfigurationError', 'MissingConfigurationError',
+           'ConfigurationVersionError', 'DbContentError', 'InputValidationError', 'FeatureNotAvailable',
+           'FeatureDisabled', 'LicensingException', 'TestsNotAllowedError', 'UnsupportedSpeciesError',
+           'DanglingLinkError', 'TransportTaskException', 'IncompatibleArchiveVersionError', 'OutputParsingError')
+
 
 class AiidaException(Exception):
     """

--- a/aiida/common/extendeddicts.py
+++ b/aiida/common/extendeddicts.py
@@ -12,7 +12,9 @@ from __future__ import division
 from __future__ import print_function
 from __future__ import absolute_import
 
-from aiida.common import exceptions
+from . import exceptions
+
+__all__ = ('AttributeDict', 'FixedFieldsAttributeDict', 'DefaultFieldsAttributeDict')
 
 
 class AttributeDict(dict):

--- a/aiida/common/links.py
+++ b/aiida/common/links.py
@@ -14,6 +14,8 @@ from __future__ import absolute_import
 
 from enum import Enum
 
+__all__ = ('LinkType',)
+
 
 class LinkType(Enum):
     """A simple enum of allowed link types."""

--- a/aiida/common/log.py
+++ b/aiida/common/log.py
@@ -16,7 +16,9 @@ import collections
 import logging
 import types
 
-from aiida.manage import get_config_option
+from aiida.manage.configuration import get_config_option
+
+__all__ = ('AIIDA_LOGGER',)
 
 # Custom logging level, intended specifically for informative log messages reported during WorkChains.
 # We want the level between INFO(20) and WARNING(30) such that it will be logged for the default loglevel, however

--- a/aiida/engine/__init__.py
+++ b/aiida/engine/__init__.py
@@ -1,11 +1,8 @@
 # -*- coding: utf-8 -*-
+# pylint: disable=wildcard-import,undefined-variable,redefined-builtin
 """Module with all the internals that make up the engine of `aiida-core`."""
 
-from .launch import run, run_get_node, run_get_pid, submit
-from .processes import Process, ProcessState, ExitCode, calcfunction, workfunction, assign_, append_, ToContext
-from .processes import WorkChain, if_, while_, return_, CalcJob
-from .runners import Runner
+from .launch import *
+from .processes import *
 
-__all__ = ('run', 'run_get_node', 'run_get_pid', 'submit', 'Process', 'ProcessState', 'ExitCode', 'calcfunction',
-           'workfunction', 'Process', 'ProcessState', 'assign_', 'append_', 'ToContext', 'WorkChain', 'if_', 'while_',
-           'return_', 'CalcJob', 'Runner')
+__all__ = (launch.__all__ + processes.__all__)

--- a/aiida/engine/daemon/client.py
+++ b/aiida/engine/daemon/client.py
@@ -24,7 +24,7 @@ import tempfile
 import six
 
 from aiida.common.files import which
-from aiida.manage import get_config
+from aiida.manage.configuration import get_config
 
 VERDI_BIN = which('verdi')
 # Recent versions of virtualenv create the environment variable VIRTUAL_ENV
@@ -47,8 +47,8 @@ def get_daemon_client(profile_name=None):
     :param profile_name: the profile name, will use the current profile if None
     :return: the daemon client
     :rtype: :class:`aiida.engine.daemon.client.DaemonClient`
-    :raises MissingConfigurationError: if the configuration file cannot be found
-    :raises ProfileConfigurationError: if the given profile does not exist
+    :raises aiida.common.MissingConfigurationError: if the configuration file cannot be found
+    :raises aiida.common.ProfileConfigurationError: if the given profile does not exist
     """
     config = get_config()
 

--- a/aiida/engine/daemon/runner.py
+++ b/aiida/engine/daemon/runner.py
@@ -17,7 +17,7 @@ import signal
 
 from aiida.common.log import configure_logging
 from aiida.engine.daemon.client import get_daemon_client
-from aiida.manage import get_manager
+from aiida.manage.manager import get_manager
 
 LOGGER = logging.getLogger(__name__)
 

--- a/aiida/engine/launch.py
+++ b/aiida/engine/launch.py
@@ -13,10 +13,10 @@ from __future__ import print_function
 from __future__ import absolute_import
 
 from aiida.manage import manager
-from . import processes
-from . import utils
+from .processes.process import Process, instantiate_process
+from .utils import is_process_function
 
-__all__ = 'run', 'run_get_pid', 'run_get_node', 'submit'
+__all__ = ('run', 'run_get_pid', 'run_get_node', 'submit')
 
 
 def run(process, *args, **inputs):
@@ -28,7 +28,7 @@ def run(process, *args, **inputs):
     :param inputs: the inputs to be passed to the process
     :return: the outputs of the process
     """
-    if isinstance(process, processes.Process):
+    if isinstance(process, Process):
         runner = process.runner
     else:
         runner = manager.get_manager().get_runner()
@@ -45,7 +45,7 @@ def run_get_node(process, *args, **inputs):
     :param inputs: the inputs to be passed to the process
     :return: tuple of the outputs of the process and the calculation node
     """
-    if isinstance(process, processes.Process):
+    if isinstance(process, Process):
         runner = process.runner
     else:
         runner = manager.get_manager().get_runner()
@@ -62,7 +62,7 @@ def run_get_pid(process, *args, **inputs):
     :param inputs: the inputs to be passed to the process
     :return: tuple of the outputs of the process and process pid
     """
-    if isinstance(process, processes.Process):
+    if isinstance(process, Process):
         runner = process.runner
     else:
         runner = manager.get_manager().get_runner()
@@ -79,12 +79,12 @@ def submit(process, **inputs):
     :param inputs: the inputs to be passed to the process
     :return: the calculation node of the process
     """
-    assert not utils.is_process_function(process), 'Cannot submit a process function'
+    assert not is_process_function(process), 'Cannot submit a process function'
 
     runner = manager.get_manager().get_runner()
     controller = manager.get_manager().get_process_controller()
 
-    process = processes.instantiate_process(runner, process, **inputs)
+    process = instantiate_process(runner, process, **inputs)
     runner.persister.save_checkpoint(process)
     process.close()
 

--- a/aiida/engine/persistence.py
+++ b/aiida/engine/persistence.py
@@ -19,7 +19,7 @@ import plumpy
 
 from aiida.orm.utils import serialize
 
-__all__ = 'AiiDAPersister', 'ObjectLoader', 'get_object_loader'
+__all__ = ('AiiDAPersister', 'ObjectLoader', 'get_object_loader')
 
 LOGGER = logging.getLogger(__name__)
 OBJECT_LOADER = None

--- a/aiida/engine/processes/__init__.py
+++ b/aiida/engine/processes/__init__.py
@@ -1,11 +1,11 @@
 # -*- coding: utf-8 -*-
+# pylint: disable=wildcard-import,undefined-variable,redefined-builtin
 """Module for processes and related utilities."""
 
-from .calcjobs import CalcJob
-from .exit_code import ExitCode
-from .functions import calcfunction, workfunction
-from .process import Process, ProcessState, instantiate_process
-from .workchains import assign_, append_, ToContext, WorkChain, if_, while_, return_
+from .calcjobs import *
+from .exit_code import *
+from .functions import *
+from .process import *
+from .workchains import *
 
-__all__ = ('CalcJob', 'ExitCode', 'calcfunction', 'workfunction', 'Process', 'ProcessState', 'instantiate_process',
-           'assign_', 'append_', 'ToContext', 'WorkChain', 'if_', 'while_', 'return_')
+__all__ = (calcjobs.__all__ + exit_code.__all__ + functions.__all__ + process.__all__ + workchains.__all__)

--- a/aiida/engine/processes/calcjobs/__init__.py
+++ b/aiida/engine/processes/calcjobs/__init__.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
+# pylint: disable=wildcard-import,undefined-variable
 """Module for the `CalcJob` process and related utilities."""
 
-from .calcjob import CalcJob
-from .manager import JobManager
+from .calcjob import *
 
-__all__ = ('CalcJob', 'JobManager')
+__all__ = (calcjob.__all__)

--- a/aiida/engine/processes/calcjobs/calcjob.py
+++ b/aiida/engine/processes/calcjobs/calcjob.py
@@ -18,6 +18,8 @@ from ..process import Process, ProcessState
 from ..process_spec import CalcJobProcessSpec
 from .tasks import Waiting, UPLOAD_COMMAND
 
+__all__ = ('CalcJob',)
+
 
 class CalcJob(Process):
     """Implementation of the CalcJob process."""

--- a/aiida/engine/processes/exit_code.py
+++ b/aiida/engine/processes/exit_code.py
@@ -16,7 +16,7 @@ from collections import namedtuple
 
 from aiida.common.extendeddicts import AttributeDict
 
-__all__ = 'ExitCode', 'ExitCodesNamespace'
+__all__ = ('ExitCode', 'ExitCodesNamespace')
 
 ExitCode = namedtuple('ExitCode', 'status message')
 ExitCode.__new__.__defaults__ = (0, None)

--- a/aiida/engine/processes/functions.py
+++ b/aiida/engine/processes/functions.py
@@ -11,7 +11,7 @@ import inspect
 from six.moves import zip  # pylint: disable=unused-import
 
 from aiida.common.lang import override
-from aiida.manage import get_manager
+from aiida.manage.manager import get_manager
 
 from .process import Process
 

--- a/aiida/engine/processes/process.py
+++ b/aiida/engine/processes/process.py
@@ -42,7 +42,7 @@ from .builder import ProcessBuilder
 from .ports import InputPort, PortNamespace
 from .process_spec import ProcessSpec
 
-__all__ = ('Process', 'ProcessState', 'instantiate_process')
+__all__ = ('Process', 'ProcessState')
 
 
 def instantiate_process(runner, process, *args, **inputs):

--- a/aiida/engine/processes/workchains/__init__.py
+++ b/aiida/engine/processes/workchains/__init__.py
@@ -1,7 +1,8 @@
 # -*- coding: utf-8 -*-
+# pylint: disable=wildcard-import,undefined-variable
 """Module for the `WorkChain` process and related utilities."""
 
-from .context import append_, assign_, ToContext
-from .workchain import WorkChain, if_, while_, return_
+from .context import *
+from .workchain import *
 
-__all__ = ('assign_', 'append_', 'ToContext', 'WorkChain', 'if_', 'while_', 'return_')
+__all__ = (context.__all__ + workchain.__all__)

--- a/aiida/engine/processes/workchains/awaitable.py
+++ b/aiida/engine/processes/workchains/awaitable.py
@@ -18,7 +18,7 @@ from enum import Enum
 from plumpy.utils import AttributesDict
 from aiida.orm import ProcessNode
 
-__all__ = ['Awaitable', 'AwaitableTarget', 'AwaitableAction', 'construct_awaitable']
+__all__ = ('Awaitable', 'AwaitableTarget', 'AwaitableAction', 'construct_awaitable')
 
 
 class Awaitable(AttributesDict):

--- a/aiida/engine/utils.py
+++ b/aiida/engine/utils.py
@@ -22,7 +22,7 @@ from tornado import concurrent, gen
 from aiida.common.links import LinkType
 from aiida.orm.nodes.data.frozendict import FrozenDict
 
-__all__ = 'RefObjectStore', 'interruptable_task', 'InterruptableFuture'
+__all__ = ('RefObjectStore', 'interruptable_task', 'InterruptableFuture')
 
 LOGGER = logging.getLogger(__name__)
 PROCESS_STATE_CHANGE_KEY = 'process|state_change|{}'

--- a/aiida/manage/__init__.py
+++ b/aiida/manage/__init__.py
@@ -7,7 +7,7 @@
 # For further information on the license, see the LICENSE.txt file        #
 # For further information please visit http://www.aiida.net               #
 ###########################################################################
-# pylint: disable=undefined-variable,wildcard-import,cyclic-import
+# pylint: disable=wildcard-import,undefined-variable
 """
 Managing an AiiDA instance:
 
@@ -20,11 +20,3 @@ Managing an AiiDA instance:
 .. note:: Modules in this sub package may require the database environment to be loaded
 
 """
-from __future__ import division
-from __future__ import print_function
-from __future__ import absolute_import
-
-from .configuration import *
-from .manager import *
-
-__all__ = (configuration.__all__ + manager.__all__)

--- a/aiida/manage/backup/backup_base.py
+++ b/aiida/manage/backup/backup_base.py
@@ -280,7 +280,7 @@ class AbstractBackup(object):
     def _get_repository_path(self):
         from aiida.common.setup import parse_repository_uri
         from aiida.common.exceptions import MissingConfigurationError
-        from aiida.manage import get_config
+        from aiida.manage.configuration import get_config
 
         try:
             config = get_config()

--- a/aiida/manage/caching.py
+++ b/aiida/manage/caching.py
@@ -26,7 +26,7 @@ from aiida.backends.utils import get_current_profile
 from aiida.common import exceptions
 from aiida.common.utils import get_object_from_string
 
-__all__ = ['get_use_cache', 'enable_caching', 'disable_caching']
+__all__ = ('get_use_cache', 'enable_caching', 'disable_caching')
 
 
 class ConfigKeys(Enum):
@@ -85,7 +85,7 @@ def configure(config_file=None):
     """
     # pylint: disable=global-statement
     if config_file is None:
-        from aiida.manage import get_config
+        from aiida.manage.configuration import get_config
 
         config = get_config()
         config_file = os.path.join(config.dirpath, 'cache_config.yml')

--- a/aiida/manage/configuration/__init__.py
+++ b/aiida/manage/configuration/__init__.py
@@ -23,7 +23,7 @@ def get_config():
 
     :return: the config
     :rtype: :class:`~aiida.manage.configuration.config.Config`
-    :raises ConfigurationError: if the configuration file could not be found, read or deserialized
+    :raises aiida.common.ConfigurationError: if the configuration file could not be found, read or deserialized
     """
     global CONFIG
 

--- a/aiida/manage/configuration/config.py
+++ b/aiida/manage/configuration/config.py
@@ -143,7 +143,7 @@ class Config(object):  # pylint: disable=useless-object-inheritance
         """Validate that a profile exists.
 
         :param name: name of the profile:
-        :raises ProfileConfigurationError: if the name is not found in the configuration file
+        :raises aiida.common.ProfileConfigurationError: if the name is not found in the configuration file
         """
         from aiida.common import exceptions
 
@@ -154,7 +154,7 @@ class Config(object):  # pylint: disable=useless-object-inheritance
         """Return the profile for the given name or the default one if not specified.
 
         :return: the profile instance or None if it does not exist
-        :raises ProfileConfigurationError: if the name is not found in the configuration file
+        :raises aiida.common.ProfileConfigurationError: if the name is not found in the configuration file
         """
         from aiida.common import exceptions
 
@@ -172,7 +172,7 @@ class Config(object):  # pylint: disable=useless-object-inheritance
         """Return the internal profile dictionary for the given name or the default one if not specified.
 
         :return: the profile instance or None if it does not exist
-        :raises ProfileConfigurationError: if the name is not found in the configuration file
+        :raises aiida.common.ProfileConfigurationError: if the name is not found in the configuration file
         """
         self.validate_profile(name)
         return self.dictionary[self.KEY_PROFILES][name]
@@ -200,7 +200,7 @@ class Config(object):  # pylint: disable=useless-object-inheritance
         """Remove a profile from the configuration.
 
         :param name: the name of the profile to remove
-        :raises ProfileConfigurationError: if the given profile does not exist
+        :raises aiida.common.ProfileConfigurationError: if the given profile does not exist
         :return: self
         """
         self.validate_profile(name)
@@ -212,7 +212,7 @@ class Config(object):  # pylint: disable=useless-object-inheritance
 
         :param name: name of the profile to set as new default
         :param overwrite: when True, set the profile as the new default even if a default profile is already defined
-        :raises ProfileConfigurationError: if the given profile does not exist
+        :raises aiida.common.ProfileConfigurationError: if the given profile does not exist
         :return: self
         """
         if self.default_profile_name and not overwrite:

--- a/aiida/manage/configuration/setup.py
+++ b/aiida/manage/configuration/setup.py
@@ -58,7 +58,8 @@ def setup_profile(profile_name, only_config, set_default=False, non_interactive=
     from aiida.cmdline.commands import cmd_user
     from aiida.common.exceptions import InvalidOperation
     from aiida.common.setup import create_profile, create_profile_noninteractive
-    from aiida.manage import get_config, get_manager
+    from aiida.manage.configuration import get_config
+    from aiida.manage.manager import get_manager
     from .settings import DEFAULT_AIIDA_USER
 
     config = get_config()
@@ -210,7 +211,7 @@ def delete_db(profile, non_interactive=True, verbose=False):
     :param verbose: if True, print parameters of DB connection
     :type verbose: bool
     """
-    from aiida.manage import get_config
+    from aiida.manage.configuration import get_config
     from aiida.manage.external.postgres import Postgres
     import aiida.common.json as json
 
@@ -254,7 +255,7 @@ def delete_from_config(profile, non_interactive=True):
     :param non_interactive: do not prompt for configuration values, fail if not all values are given as kwargs.
     :type non_interactive: bool
     """
-    from aiida.manage import get_config
+    from aiida.manage.configuration import get_config
 
     if non_interactive or click.confirm("Delete configuration for profile '{}'?\n"
                                         "WARNING: Permanently removes profile from the list of AiiDA profiles.".format(

--- a/aiida/manage/configuration/utils.py
+++ b/aiida/manage/configuration/utils.py
@@ -18,7 +18,7 @@ def load_config(create=False):
     :param create: when set to True, will create the configuration file if it does not already exist
     :return: the config
     :rtype: :class:`~aiida.manage.configuration.config.Config`
-    :raises MissingConfigurationError: if the configuration file could not be found and create=False
+    :raises aiida.common.MissingConfigurationError: if the configuration file could not be found and create=False
     """
     from .settings import AIIDA_CONFIG_FOLDER
     from aiida.backends.settings import IN_RT_DOC_MODE, DUMMY_CONF_FILE

--- a/aiida/manage/database/integrity/duplicate_uuid.py
+++ b/aiida/manage/database/integrity/duplicate_uuid.py
@@ -13,7 +13,7 @@ from __future__ import print_function
 from __future__ import absolute_import
 
 from aiida.common import exceptions
-from aiida.manage import get_manager
+from aiida.manage.manager import get_manager
 
 __all__ = ('verify_uuid_uniqueness', 'get_duplicate_uuids', 'deduplicate_uuids', 'TABLES_UUID_DEDUPLICATION')
 

--- a/aiida/manage/external/rmq.py
+++ b/aiida/manage/external/rmq.py
@@ -19,7 +19,7 @@ from tornado import gen
 from kiwipy import communications
 import plumpy
 
-__all__ = 'RemoteException', 'CommunicationTimeout', 'DeliveryFailed', 'ProcessLauncher'
+__all__ = ('RemoteException', 'CommunicationTimeout', 'DeliveryFailed', 'ProcessLauncher')
 
 LOGGER = logging.getLogger(__name__)
 

--- a/aiida/manage/fixtures.py
+++ b/aiida/manage/fixtures.py
@@ -45,7 +45,7 @@ from aiida import is_dbenv_loaded
 from aiida.backends import settings as backend_settings
 from aiida.backends.profile import BACKEND_DJANGO, BACKEND_SQLA
 from aiida.common import exceptions
-from aiida.manage import get_manager, reset_manager
+from aiida.manage.manager import get_manager, reset_manager
 from aiida.manage.configuration.setup import create_instance_directories
 from aiida.manage.configuration.utils import load_config
 from aiida.manage.external.postgres import Postgres

--- a/aiida/manage/manager.py
+++ b/aiida/manage/manager.py
@@ -16,7 +16,7 @@ import functools
 
 from .configuration import get_config
 
-__all__ = 'get_manager', 'reset_manager'
+__all__ = ('get_manager', 'reset_manager')
 
 MANAGER = None
 
@@ -175,8 +175,8 @@ class Manager(object):  # pylint: disable=useless-object-inheritance
 
         :return: the daemon client
         :rtype: :class:`aiida.daemon.client.DaemonClient`
-        :raises MissingConfigurationError: if the configuration file cannot be found
-        :raises ProfileConfigurationError: if the given profile does not exist
+        :raises aiida.common.MissingConfigurationError: if the configuration file cannot be found
+        :raises aiida.common.ProfileConfigurationError: if the given profile does not exist
         """
         from aiida.engine.daemon.client import DaemonClient
 

--- a/aiida/orm/__init__.py
+++ b/aiida/orm/__init__.py
@@ -7,8 +7,8 @@
 # For further information on the license, see the LICENSE.txt file        #
 # For further information please visit http://www.aiida.net               #
 ###########################################################################
+# pylint: disable=wildcard-import,undefined-variable,redefined-builtin
 """Main module to expose all orm classes and methods"""
-# pylint: disable=wildcard-import
 from __future__ import division
 from __future__ import print_function
 from __future__ import absolute_import
@@ -24,15 +24,5 @@ from .querybuilder import *
 from .users import *
 from .utils import *
 
-__all__ = (
-    authinfos.__all__ +
-    comments.__all__ +
-    computers.__all__ +
-    entities.__all__ +
-    groups.__all__ +
-    logs.__all__ +
-    nodes.__all__ +
-    querybuilder.__all__ +
-    users.__all__ +
-    utils.__all__
-)
+__all__ = (authinfos.__all__ + comments.__all__ + computers.__all__ + entities.__all__ + groups.__all__ + logs.__all__ +
+           nodes.__all__ + querybuilder.__all__ + users.__all__ + utils.__all__)

--- a/aiida/orm/authinfos.py
+++ b/aiida/orm/authinfos.py
@@ -14,7 +14,7 @@ from __future__ import absolute_import
 
 from aiida.common.exceptions import (ConfigurationError, MissingPluginError)
 from aiida.plugins import TransportFactory
-from aiida.manage import get_manager
+from aiida.manage.manager import get_manager
 from . import entities
 from . import users
 

--- a/aiida/orm/comments.py
+++ b/aiida/orm/comments.py
@@ -12,7 +12,7 @@ from __future__ import division
 from __future__ import print_function
 from __future__ import absolute_import
 
-from aiida.manage import get_manager
+from aiida.manage.manager import get_manager
 from . import entities
 from . import users
 

--- a/aiida/orm/computers.py
+++ b/aiida/orm/computers.py
@@ -18,7 +18,7 @@ import six
 
 from aiida import transports, schedulers
 from aiida.common import exceptions
-from aiida.manage import get_manager
+from aiida.manage.manager import get_manager
 from aiida.plugins import SchedulerFactory, TransportFactory
 
 from . import entities
@@ -572,7 +572,7 @@ class Computer(entities.Entity):
 
         :param user: a User instance.
         :return: a AuthInfo instance
-        :raise NotExistent: if the computer is not configured for the given
+        :raise aiida.common.NotExistent: if the computer is not configured for the given
             user.
         """
         from . import authinfos

--- a/aiida/orm/entities.py
+++ b/aiida/orm/entities.py
@@ -19,7 +19,7 @@ from plumpy.base.utils import super_check, call_with_super_check
 from aiida.common import exceptions
 from aiida.common import datastructures
 from aiida.common.lang import classproperty, type_check
-from aiida.manage import get_manager
+from aiida.manage.manager import get_manager
 
 __all__ = ('Entity', 'Collection')
 

--- a/aiida/orm/groups.py
+++ b/aiida/orm/groups.py
@@ -17,7 +17,7 @@ from enum import Enum
 from aiida.cmdline.utils import echo
 from aiida.common import exceptions
 from aiida.common.lang import type_check
-from aiida.manage import get_manager
+from aiida.manage.manager import get_manager
 
 from . import convert
 from . import entities
@@ -180,7 +180,7 @@ class Group(entities.Entity):
         UniquenessError will be raised
 
         :param label: the new group label
-        :raises UniquenessError: if another group of same type and label already exists
+        :raises aiida.common.UniquenessError: if another group of same type and label already exists
         """
         self._backend_entity.label = label
 
@@ -192,7 +192,7 @@ class Group(entities.Entity):
         UniquenessError will be raised
 
         :param label: the new group label
-        :raises UniquenessError: if another group of same type and label already exists
+        :raises aiida.common.UniquenessError: if another group of same type and label already exists
         """
         import warnings
         # pylint: disable=redefined-builtin
@@ -386,7 +386,7 @@ class Group(entities.Entity):
         (e.g. 'data.upf', 'import', etc.)
 
         :raise ValueError: if the group type does not exist.
-        :raise NotExistent: if the group is not found.
+        :raise aiida.common.NotExistent: if the group is not found.
         """
         import warnings
         # pylint: disable=redefined-builtin

--- a/aiida/orm/implementation/authinfos.py
+++ b/aiida/orm/implementation/authinfos.py
@@ -7,19 +7,17 @@
 # For further information on the license, see the LICENSE.txt file        #
 # For further information please visit http://www.aiida.net               #
 ###########################################################################
-"""
-Module for authinfo backend classes
-"""
-
+"""Module for authinfo backend classes."""
 from __future__ import division
 from __future__ import print_function
 from __future__ import absolute_import
+
 import abc
 import six
 
 from . import backends
 
-__all__ = 'BackendAuthInfo', 'BackendAuthInfoCollection'
+__all__ = ('BackendAuthInfo', 'BackendAuthInfoCollection')
 
 
 @six.add_metaclass(abc.ABCMeta)
@@ -150,7 +148,7 @@ class BackendAuthInfoCollection(backends.BackendCollection[BackendAuthInfo]):
         :param computer: a Computer instance
         :param user: a User instance
         :return: a AuthInfo object associated to the given computer and user
-        :raise NotExistent: if the user is not configured to use computer
+        :raise aiida.common.NotExistent: if the user is not configured to use computer
         :raise sqlalchemy.orm.exc.MultipleResultsFound: if the user is configured
             more than once to use the computer! Should never happen
         """

--- a/aiida/orm/implementation/comments.py
+++ b/aiida/orm/implementation/comments.py
@@ -17,7 +17,7 @@ import six
 
 from . import backends
 
-__all__ = 'BackendComment', 'BackendCommentCollection'
+__all__ = ('BackendComment', 'BackendCommentCollection')
 
 
 @six.add_metaclass(abc.ABCMeta)

--- a/aiida/orm/implementation/django/authinfos.py
+++ b/aiida/orm/implementation/django/authinfos.py
@@ -146,7 +146,7 @@ class DjangoAuthInfoCollection(BackendAuthInfoCollection):
         :param computer: a Computer instance
         :param user: a User instance
         :return: an AuthInfo object associated with the given computer and user
-        :raise NotExistent: if the user is not configured to use computer
+        :raise aiida.common.NotExistent: if the user is not configured to use computer
         :raise sqlalchemy.orm.exc.MultipleResultsFound: if the user is configured
             more than once to use the computer! Should never happen
         """

--- a/aiida/orm/implementation/django/groups.py
+++ b/aiida/orm/implementation/django/groups.py
@@ -32,7 +32,7 @@ from . import entities
 from . import users
 from . import utils
 
-__all__ = 'DjangoGroup', 'DjangoGroupCollection'
+__all__ = ('DjangoGroup', 'DjangoGroupCollection')
 
 
 class DjangoGroup(entities.DjangoModelEntity[models.DbGroup], BackendGroup):  # pylint: disable=abstract-method
@@ -59,7 +59,7 @@ class DjangoGroup(entities.DjangoModelEntity[models.DbGroup], BackendGroup):  # 
         UniquenessError will be raised
 
         :param label : the new group label
-        :raises UniquenessError: if another group of same type and label already exists
+        :raises aiida.common.UniquenessError: if another group of same type and label already exists
         """
         self._dbmodel.label = label
 

--- a/aiida/orm/implementation/django/nodes.py
+++ b/aiida/orm/implementation/django/nodes.py
@@ -322,7 +322,7 @@ class DjangoNode(entities.DjangoModelEntity[models.DbNode], BackendNode):
         :param link_type: the link type
         :param link_label: the link label
         :return: True if the proposed link is allowed, False otherwise
-        :raise ModificationNotAllowed: if either source or target node is not stored
+        :raise aiida.common.ModificationNotAllowed: if either source or target node is not stored
         """
         type_check(source, DjangoNode)
 

--- a/aiida/orm/implementation/groups.py
+++ b/aiida/orm/implementation/groups.py
@@ -20,7 +20,7 @@ from aiida.common import exceptions
 from . import backends
 from .nodes import BackendNode
 
-__all__ = 'BackendGroup', 'BackendGroupCollection'
+__all__ = ('BackendGroup', 'BackendGroupCollection')
 
 
 @six.add_metaclass(abc.ABCMeta)
@@ -44,7 +44,7 @@ class BackendGroup(backends.BackendEntity):
         UniquenessError will be raised
 
         :param name: the new group name
-        :raises UniquenessError: if another group of same type and name already exists
+        :raises aiida.common.UniquenessError: if another group of same type and name already exists
         """
 
     @abc.abstractproperty

--- a/aiida/orm/implementation/logs.py
+++ b/aiida/orm/implementation/logs.py
@@ -17,7 +17,7 @@ import six
 
 from . import backends
 
-__all__ = 'BackendLog', 'BackendLogCollection'
+__all__ = ('BackendLog', 'BackendLogCollection')
 
 
 @six.add_metaclass(abc.ABCMeta)

--- a/aiida/orm/implementation/sql/__init__.py
+++ b/aiida/orm/implementation/sql/__init__.py
@@ -17,4 +17,4 @@ All SQL backends with an ORM should subclass from the classes in this module
 
 from .backends import *
 
-__all__ = backends.__all__
+__all__ = (backends.__all__)

--- a/aiida/orm/implementation/sqlalchemy/authinfos.py
+++ b/aiida/orm/implementation/sqlalchemy/authinfos.py
@@ -121,7 +121,7 @@ class SqlaAuthInfoCollection(BackendAuthInfoCollection):
         :param computer: a Computer instance
         :param user: a User instance
         :return: an AuthInfo object associated with the given computer and user
-        :raise NotExistent: if the user is not configured to use computer
+        :raise aiida.common.NotExistent: if the user is not configured to use computer
         :raise sqlalchemy.orm.exc.MultipleResultsFound: if the user is configured
              more than once to use the computer! Should never happen
         """

--- a/aiida/orm/implementation/sqlalchemy/groups.py
+++ b/aiida/orm/implementation/sqlalchemy/groups.py
@@ -26,7 +26,7 @@ from . import entities
 from . import users
 from . import utils
 
-__all__ = 'SqlaGroup', 'SqlaGroupCollection'
+__all__ = ('SqlaGroup', 'SqlaGroupCollection')
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -66,7 +66,7 @@ class SqlaGroup(entities.SqlaModelEntity[DbGroup], BackendGroup):  # pylint: dis
         UniquenessError will be raised
 
         :param label: the new group label
-        :raises UniquenessError: if another group of same type and label already exists
+        :raises aiida.common.UniquenessError: if another group of same type and label already exists
         """
         self._dbmodel.label = label
 

--- a/aiida/orm/implementation/sqlalchemy/nodes.py
+++ b/aiida/orm/implementation/sqlalchemy/nodes.py
@@ -357,7 +357,7 @@ class SqlaNode(entities.SqlaModelEntity[models.DbNode], BackendNode):
         :param link_type: the link type
         :param link_label: the link label
         :return: True if the proposed link is allowed, False otherwise
-        :raise ModificationNotAllowed: if either source or target node is not stored
+        :raise aiida.common.ModificationNotAllowed: if either source or target node is not stored
         """
         session = get_scoped_session()
 

--- a/aiida/orm/implementation/sqlalchemy/utils.py
+++ b/aiida/orm/implementation/sqlalchemy/utils.py
@@ -22,7 +22,7 @@ import sqlalchemy.exc
 from aiida.common import exceptions
 from aiida.backends.sqlalchemy import get_scoped_session
 
-__all__ = ['django_filter', 'get_attr']
+__all__ = ('django_filter', 'get_attr')
 
 
 class ModelWrapper(object):

--- a/aiida/orm/implementation/users.py
+++ b/aiida/orm/implementation/users.py
@@ -14,7 +14,7 @@ import six
 
 from . import backends
 
-__all__ = 'BackendUser', 'BackendUserCollection'
+__all__ = ('BackendUser', 'BackendUserCollection')
 
 
 @six.add_metaclass(abc.ABCMeta)

--- a/aiida/orm/logs.py
+++ b/aiida/orm/logs.py
@@ -13,7 +13,7 @@ from __future__ import print_function
 from __future__ import absolute_import
 
 from aiida.common import timezone
-from aiida.manage import get_manager
+from aiida.manage.manager import get_manager
 from . import entities
 
 __all__ = ('Log', 'OrderSpecifier', 'ASCENDING', 'DESCENDING')

--- a/aiida/orm/nodes/__init__.py
+++ b/aiida/orm/nodes/__init__.py
@@ -7,20 +7,14 @@
 # For further information on the license, see the LICENSE.txt file        #
 # For further information please visit http://www.aiida.net               #
 ###########################################################################
+# pylint: disable=wildcard-import,undefined-variable
 """Module with `Node` sub classes for data and processes."""
 from __future__ import division
 from __future__ import print_function
 from __future__ import absolute_import
 
-from .data import Data, BaseType, ArrayData, BandsData, KpointsData, ProjectionData, TrajectoryData, XyData, Bool
-from .data import CifData, Code, Error, Float, FolderData, FrozenDict, Int, List, OrbitalData, ParameterData, RemoteData
-from .data import SinglefileData, Str, StructureData, UpfData
-from .process import ProcessNode
-from .process import CalculationNode, CalcFunctionNode, CalcJobNode, WorkflowNode, WorkChainNode, WorkFunctionNode
-from .node import Node
+from .data import *
+from .process import *
+from .node import *
 
-__all__ = ('Node', 'BaseType', 'Data', 'ArrayData', 'BandsData', 'KpointsData', 'ProjectionData', 'TrajectoryData',
-           'XyData', 'Bool', 'CifData', 'Code', 'Error', 'Float', 'FolderData', 'FrozenDict', 'Int', 'List',
-           'OrbitalData', 'ParameterData', 'RemoteData', 'SinglefileData', 'Str', 'StructureData', 'UpfData',
-           'ProcessNode', 'CalculationNode', 'CalcFunctionNode', 'CalcJobNode', 'WorkflowNode', 'WorkChainNode',
-           'WorkFunctionNode')
+__all__ = (data.__all__ + process.__all__ + node.__all__)

--- a/aiida/orm/nodes/data/code.py
+++ b/aiida/orm/nodes/data/code.py
@@ -158,8 +158,8 @@ class Code(Data):
         :param label: the code label identifying the code to load
         :param machinename: the machine name where code is setup
 
-        :raise NotExistent: if no code identified by the given string is found
-        :raise MultipleObjectsError: if the string cannot identify uniquely
+        :raise aiida.common.NotExistent: if no code identified by the given string is found
+        :raise aiida.common.MultipleObjectsError: if the string cannot identify uniquely
             a code
         """
         from aiida.common.exceptions import (NotExistent, MultipleObjectsError, InputValidationError)
@@ -192,10 +192,10 @@ class Code(Data):
         :param label: the code label identifying the code to load
         :param machinename: the machine name where code is setup
 
-        :raise NotExistent: if no code identified by the given string is found
-        :raise MultipleObjectsError: if the string cannot identify uniquely
+        :raise aiida.common.NotExistent: if no code identified by the given string is found
+        :raise aiida.common.MultipleObjectsError: if the string cannot identify uniquely
             a code
-        :raise InputValidationError: if neither a pk nor a label was passed in
+        :raise aiida.common.InputValidationError: if neither a pk nor a label was passed in
         """
         from aiida.common.exceptions import (NotExistent, MultipleObjectsError, InputValidationError)
         from aiida.orm.utils import load_code
@@ -231,10 +231,10 @@ class Code(Data):
 
         :param code_string: the code string identifying the code to load
 
-        :raise NotExistent: if no code identified by the given string is found
-        :raise MultipleObjectsError: if the string cannot identify uniquely
+        :raise aiida.common.NotExistent: if no code identified by the given string is found
+        :raise aiida.common.MultipleObjectsError: if the string cannot identify uniquely
             a code
-        :raise InputValidationError: if code_string is not of string type
+        :raise aiida.common.InputValidationError: if code_string is not of string type
 
         """
         from aiida.common.exceptions import NotExistent, MultipleObjectsError, InputValidationError
@@ -459,7 +459,7 @@ class Code(Data):
 
         :note: it also sets the ``builder.code`` value.
 
-        :raise MissingPluginError: if the specified plugin does not exist.
+        :raise aiida.common.MissingPluginError: if the specified plugin does not exist.
         :raise ValueError: if no default plugin was specified.
 
         :return:

--- a/aiida/orm/nodes/data/parameter.py
+++ b/aiida/orm/nodes/data/parameter.py
@@ -50,7 +50,7 @@ class ParameterData(Data):
             # Clear existing attributes and set the new dictionary
             self.clear_attributes()
             self.update_dict(dictionary)
-        except exceptions.ModificationNotAllowed:
+        except exceptions.ModificationNotAllowed:  # pylint: disable=try-except-raise
             # I reraise here to avoid to go in the generic 'except' below that would raise the same exception again
             raise
         except Exception:

--- a/aiida/orm/nodes/data/structure.py
+++ b/aiida/orm/nodes/data/structure.py
@@ -1600,7 +1600,7 @@ class StructureData(Data):
         :param conserve_particle: if True, allows the possibility of removing a site.
             currently not implemented.
 
-        :raises ModificationNotAllowed: if object is stored already
+        :raises aiida.common.ModificationNotAllowed: if object is stored already
         :raises ValueError: if positions are invalid
 
         .. note:: it is assumed that the order of the new_positions is

--- a/aiida/orm/nodes/data/upf.py
+++ b/aiida/orm/nodes/data/upf.py
@@ -56,9 +56,9 @@ def get_pseudos_from_structure(structure, family_name):
     structure, return a dictionary associating each kind name with its
     UpfData object.
 
-    :raise MultipleObjectsError: if more than one UPF for the same element is
+    :raise aiida.common.MultipleObjectsError: if more than one UPF for the same element is
        found in the group.
-    :raise NotExistent: if no UPF for an element in the group is
+    :raise aiida.common.NotExistent: if no UPF for an element in the group is
        found in the group.
     """
     from aiida.common.exceptions import NotExistent, MultipleObjectsError

--- a/aiida/orm/nodes/node.py
+++ b/aiida/orm/nodes/node.py
@@ -23,7 +23,7 @@ from aiida.common.escaping import sql_string_match
 from aiida.common.hashing import make_hash, _HASH_EXTRA_KEY
 from aiida.common.lang import classproperty, type_check
 from aiida.common.links import LinkType
-from aiida.manage import get_manager
+from aiida.manage.manager import get_manager
 from aiida.orm.utils.links import LinkManager, LinkTriple
 from aiida.orm.utils.repository import Repository
 from aiida.orm.utils.node import AbstractNodeMeta, clean_value
@@ -382,7 +382,7 @@ class Node(Entity):
         :param value: value of the attribute
         :param clean: boolean, when True will clean the value before passing it to the backend
         :param stored_check: boolean, if True skips the check whether the node is stored
-        :raise ModificationNotAllowed: if the node is stored and `stored_check=False`
+        :raise aiida.common.ModificationNotAllowed: if the node is stored and `stored_check=False`
         """
         if stored_check and self.is_stored:
             raise exceptions.ModificationNotAllowed('cannot set an attribute on a stored node')
@@ -431,7 +431,7 @@ class Node(Entity):
         :param key: name of the attribute
         :param stored_check: boolean, if True skips the check whether the node is stored
         :raises AttributeError: if the attribute does not exist
-        :raise ModificationNotAllowed: if the node is stored and `stored_check=False`
+        :raise aiida.common.ModificationNotAllowed: if the node is stored and `stored_check=False`
         """
         if stored_check and self.is_stored:
             raise exceptions.ModificationNotAllowed('cannot delete an attribute on a stored node')
@@ -536,7 +536,7 @@ class Node(Entity):
 
         :param key: name of the extra
         :param value: value of the extra
-        :raise ModificationNotAllowed: if the node is not stored
+        :raise aiida.common.ModificationNotAllowed: if the node is not stored
         """
         if not self.is_stored:
             raise exceptions.ModificationNotAllowed('cannot set extras on unstored nodes')
@@ -627,7 +627,7 @@ class Node(Entity):
         :param clean: whether to clean the value
             WARNING: when set to False, storing will throw errors
             for any data types not recognized by the db backend
-        :raise ValidationError: if the key is not valid, e.g. it contains the separator symbol
+        :raise aiida.common.ValidationError: if the key is not valid, e.g. it contains the separator symbol
         """
         if self.is_stored:
             raise exceptions.ModificationNotAllowed('can only call `append_to_attr` on unstored nodes')
@@ -693,7 +693,7 @@ class Node(Entity):
         :param key: fully qualified identifier for the object within the repository
         :param contents_only: boolean, if True, omit the top level directory of the path and only copy its contents.
         :param force: boolean, if True, will skip the mutability check
-        :raises ModificationNotAllowed: if repository is immutable and `force=False`
+        :raises aiida.common.ModificationNotAllowed: if repository is immutable and `force=False`
         """
         self._repository.put_object_from_tree(path, key, contents_only, force)
 
@@ -708,7 +708,7 @@ class Node(Entity):
         :param mode: the file mode with which the object will be written
         :param encoding: the file encoding with which the object will be written
         :param force: boolean, if True, will skip the mutability check
-        :raises ModificationNotAllowed: if repository is immutable and `force=False`
+        :raises aiida.common.ModificationNotAllowed: if repository is immutable and `force=False`
         """
         self._repository.put_object_from_file(path, key, mode, encoding, force)
 
@@ -723,7 +723,7 @@ class Node(Entity):
         :param mode: the file mode with which the object will be written
         :param encoding: the file encoding with which the object will be written
         :param force: boolean, if True, will skip the mutability check
-        :raises ModificationNotAllowed: if repository is immutable and `force=False`
+        :raises aiida.common.ModificationNotAllowed: if repository is immutable and `force=False`
         """
         self._repository.put_object_from_filelike(handle, key, mode, encoding, force)
 
@@ -735,7 +735,7 @@ class Node(Entity):
 
         :param key: fully qualified identifier for the object within the repository
         :param force: boolean, if True, will skip the mutability check
-        :raises ModificationNotAllowed: if repository is immutable and `force=False`
+        :raises aiida.common.ModificationNotAllowed: if repository is immutable and `force=False`
         """
         self._repository.delete_object(key, force)
 
@@ -753,8 +753,8 @@ class Node(Entity):
         """Return a comment corresponding to the given identifier.
 
         :param identifier: the comment pk
-        :raise NotExistent: if the comment with the given id does not exist
-        :raise MultipleObjectsError: if the id cannot be uniquely resolved to a comment
+        :raise aiida.common.NotExistent: if the comment with the given id does not exist
+        :raise aiida.common.MultipleObjectsError: if the id cannot be uniquely resolved to a comment
         :return: the comment
         """
         return Comment.objects.get(dbnode_id=self.pk, pk=identifier)
@@ -771,8 +771,8 @@ class Node(Entity):
 
         :param identifier: the comment pk
         :param content: the new comment content
-        :raise NotExistent: if the comment with the given id does not exist
-        :raise MultipleObjectsError: if the id cannot be uniquely resolved to a comment
+        :raise aiida.common.NotExistent: if the comment with the given id does not exist
+        :raise aiida.common.MultipleObjectsError: if the id cannot be uniquely resolved to a comment
         """
         comment = Comment.objects.get(dbnode_id=self.pk, pk=identifier)
         comment.set_content(content)
@@ -863,7 +863,7 @@ class Node(Entity):
         :param source: the node from which the link is coming
         :param link_type: the link type
         :param link_label: the link label
-        :raise UniquenessError: if the given link triple already exists in the cache
+        :raise aiida.common.UniquenessError: if the given link triple already exists in the cache
         """
         link_triple = LinkTriple(source, link_type, link_label)
 
@@ -1095,7 +1095,7 @@ class Node(Entity):
     def verify_are_parents_stored(self):
         """Verify that all `parent` nodes are already stored.
 
-        :raise ModificationNotAllowed: if one of the source nodes of incoming links is not stored.
+        :raise aiida.common.ModificationNotAllowed: if one of the source nodes of incoming links is not stored.
         """
         for link_triple in self._incoming_cache:
             if not link_triple.node.is_stored:

--- a/aiida/orm/nodes/process/__init__.py
+++ b/aiida/orm/nodes/process/__init__.py
@@ -7,14 +7,14 @@
 # For further information on the license, see the LICENSE.txt file        #
 # For further information please visit http://www.aiida.net               #
 ###########################################################################
+# pylint: disable=wildcard-import,undefined-variable
 """Module with `Node` sub classes for processes."""
 from __future__ import division
 from __future__ import print_function
 from __future__ import absolute_import
 
-from .calculation import CalculationNode, CalcFunctionNode, CalcJobNode
-from .process import ProcessNode
-from .workflow import WorkflowNode, WorkChainNode, WorkFunctionNode
+from .calculation import *
+from .process import *
+from .workflow import *
 
-__all__ = ('ProcessNode', 'CalculationNode', 'CalcFunctionNode', 'CalcJobNode', 'WorkflowNode', 'WorkChainNode',
-           'WorkFunctionNode')
+__all__ = (calculation.__all__ + process.__all__ + workflow.__all__)

--- a/aiida/orm/nodes/process/calculation/calcjob.py
+++ b/aiida/orm/nodes/process/calculation/calcjob.py
@@ -488,7 +488,7 @@ class CalcJobNode(CalculationNode):
         """Return the retrieved data folde.
 
         :return: the retrieved FolderData node
-        :raise MultipleObjectsError: if no or more than one retrieved node is found.
+        :raise aiida.common.MultipleObjectsError: if no or more than one retrieved node is found.
         """
         from aiida.orm.nodes.data.folder import FolderData
         return self.get_outgoing(node_class=FolderData, link_label_filter=self.link_label_retrieved).one().node

--- a/aiida/orm/querybuilder.py
+++ b/aiida/orm/querybuilder.py
@@ -37,7 +37,7 @@ from sqlalchemy.dialects.postgresql import array
 from aiida.common.exceptions import InputValidationError
 # The way I get column as a an attribute to the orm class
 from aiida.common.links import LinkType
-from aiida.manage import get_manager
+from aiida.manage.manager import get_manager
 from aiida.common.exceptions import ConfigurationError
 
 from . import authinfos
@@ -331,7 +331,7 @@ class QueryBuilder(object):
         When somebody hits: print(QueryBuilder) or print(str(QueryBuilder))
         I want to print the SQL-query. Because it looks cool...
         """
-        from aiida.manage import get_config
+        from aiida.manage.configuration import get_config
 
         config = get_config()
         engine = config.current_profile.dictionary['AIIDADB_ENGINE']

--- a/aiida/orm/users.py
+++ b/aiida/orm/users.py
@@ -14,7 +14,7 @@ from __future__ import absolute_import
 
 from aiida.common.hashing import is_password_usable
 from aiida.common import exceptions
-from aiida.manage import get_manager
+from aiida.manage.manager import get_manager
 
 from . import entities
 

--- a/aiida/orm/utils/__init__.py
+++ b/aiida/orm/utils/__init__.py
@@ -34,8 +34,8 @@ def load_entity(entity_loader=None, identifier=None, pk=None, uuid=None, label=N
     :returns: the Code instance
     :raise ValueError: if none or more than one of the identifiers are supplied
     :raise TypeError: if the provided identifier has the wrong type
-    :raise NotExistent: if no matching Code is found
-    :raise MultipleObjectsError: if more than one Code was found
+    :raise aiida.common.NotExistent: if no matching Code is found
+    :raise aiida.common.MultipleObjectsError: if more than one Code was found
     """
     from aiida.orm.utils.loaders import OrmEntityLoader, IdentifierType
 
@@ -97,8 +97,8 @@ def load_code(identifier=None, pk=None, uuid=None, label=None, sub_classes=None,
     :return: the Code instance
     :raise ValueError: if none or more than one of the identifiers are supplied
     :raise TypeError: if the provided identifier has the wrong type
-    :raise NotExistent: if no matching Code is found
-    :raise MultipleObjectsError: if more than one Code was found
+    :raise aiida.common.NotExistent: if no matching Code is found
+    :raise aiida.common.MultipleObjectsError: if more than one Code was found
     """
     from aiida.orm.utils.loaders import CodeEntityLoader
     return load_entity(CodeEntityLoader, identifier=identifier, pk=pk, uuid=uuid, label=label, sub_classes=sub_classes,
@@ -122,8 +122,8 @@ def load_computer(identifier=None, pk=None, uuid=None, label=None, sub_classes=N
     :return: the Computer instance
     :raise ValueError: if none or more than one of the identifiers are supplied
     :raise TypeError: if the provided identifier has the wrong type
-    :raise NotExistent: if no matching Computer is found
-    :raise MultipleObjectsError: if more than one Computer was found
+    :raise aiida.common.NotExistent: if no matching Computer is found
+    :raise aiida.common.MultipleObjectsError: if more than one Computer was found
     """
     from aiida.orm.utils.loaders import ComputerEntityLoader
     return load_entity(ComputerEntityLoader, identifier=identifier, pk=pk, uuid=uuid, label=label,
@@ -147,8 +147,8 @@ def load_group(identifier=None, pk=None, uuid=None, label=None, sub_classes=None
     :return: the Group instance
     :raise ValueError: if none or more than one of the identifiers are supplied
     :raise TypeError: if the provided identifier has the wrong type
-    :raise NotExistent: if no matching Group is found
-    :raise MultipleObjectsError: if more than one Group was found
+    :raise aiida.common.NotExistent: if no matching Group is found
+    :raise aiida.common.MultipleObjectsError: if more than one Group was found
     """
     from aiida.orm.utils.loaders import GroupEntityLoader
     return load_entity(GroupEntityLoader, identifier=identifier, pk=pk, uuid=uuid, label=label, sub_classes=sub_classes,
@@ -170,8 +170,8 @@ def load_node(identifier=None, pk=None, uuid=None, label=None, sub_classes=None,
     :returns: the node instance
     :raise ValueError: if none or more than one of the identifiers are supplied
     :raise TypeError: if the provided identifier has the wrong type
-    :raise NotExistent: if no matching Node is found
-    :raise MultipleObjectsError: if more than one Node was found
+    :raise aiida.common.NotExistent: if no matching Node is found
+    :raise aiida.common.MultipleObjectsError: if more than one Node was found
     """
     from aiida.orm.utils.loaders import NodeEntityLoader
     return load_entity(NodeEntityLoader, identifier=identifier, pk=pk, uuid=uuid, label=label, sub_classes=sub_classes,

--- a/aiida/orm/utils/links.py
+++ b/aiida/orm/utils/links.py
@@ -245,7 +245,7 @@ class LinkManager(object):  # pylint: disable=useless-object-inheritance
         """Return the node from list for given label.
 
         :return: node that corresponds to the given label
-        :raises NotExistent: if the label is not present among the link_triples
+        :raises aiida.common.NotExistent: if the label is not present among the link_triples
         """
         for entry in self.link_triples:
             if entry.link_label == label:

--- a/aiida/orm/utils/loaders.py
+++ b/aiida/orm/utils/loaders.py
@@ -19,10 +19,10 @@ from aiida.common.exceptions import MultipleObjectsError, NotExistent
 from aiida.common.lang import abstractclassmethod, classproperty
 from aiida.orm.querybuilder import QueryBuilder
 
-__all__ = [
+__all__ = (
     'get_loader', 'OrmEntityLoader', 'CalculationEntityLoader', 'CodeEntityLoader', 'ComputerEntityLoader',
     'GroupEntityLoader', 'NodeEntityLoader'
-]
+)
 
 
 def get_loader(orm_class):
@@ -85,7 +85,7 @@ class OrmEntityLoader(object):
         :param classes: a tuple of orm classes to which the identifier should be mapped
         :returns: the query builder instance
         :raises ValueError: if the identifier is invalid
-        :raises NotExistent: if the orm base class does not support a LABEL like identifier
+        :raises aiida.common.NotExistent: if the orm base class does not support a LABEL like identifier
         """
         raise NotImplementedError
 
@@ -179,8 +179,8 @@ class OrmEntityLoader(object):
         :param sub_classes: an optional tuple of orm classes, that should each be strict sub classes of the
             base orm class of the loader, that will narrow the queryset
         :returns: the loaded entity
-        :raises MultipleObjectsError: if the identifier maps onto multiple entities
-        :raises NotExistent: if the identifier maps onto not a single entity
+        :raises aiida.common.MultipleObjectsError: if the identifier maps onto multiple entities
+        :raises aiida.common.NotExistent: if the identifier maps onto not a single entity
         """
         qb, query_parameters = cls.get_query_builder(identifier, identifier_type, sub_classes, query_with_dashes)
         qb.limit(2)
@@ -311,7 +311,7 @@ class ProcessEntityLoader(OrmEntityLoader):
         :param classes: a tuple of orm classes to which the identifier should be mapped
         :returns: the query builder instance that should retrieve the entity corresponding to the identifier
         :raises ValueError: if the identifier is invalid
-        :raises NotExistent: if the orm base class does not support a LABEL like identifier
+        :raises aiida.common.NotExistent: if the orm base class does not support a LABEL like identifier
         """
         qb = QueryBuilder()
         qb.append(cls=classes, tag='process', project=['*'], filters={'label': {'==': identifier}})
@@ -343,7 +343,7 @@ class CalculationEntityLoader(OrmEntityLoader):
         :param classes: a tuple of orm classes to which the identifier should be mapped
         :returns: the query builder instance that should retrieve the entity corresponding to the identifier
         :raises ValueError: if the identifier is invalid
-        :raises NotExistent: if the orm base class does not support a LABEL like identifier
+        :raises aiida.common.NotExistent: if the orm base class does not support a LABEL like identifier
         """
         qb = QueryBuilder()
         qb.append(cls=classes, tag='calculation', project=['*'], filters={'label': {'==': identifier}})
@@ -375,7 +375,7 @@ class WorkflowEntityLoader(OrmEntityLoader):
         :param classes: a tuple of orm classes to which the identifier should be mapped
         :returns: the query builder instance that should retrieve the entity corresponding to the identifier
         :raises ValueError: if the identifier is invalid
-        :raises NotExistent: if the orm base class does not support a LABEL like identifier
+        :raises aiida.common.NotExistent: if the orm base class does not support a LABEL like identifier
         """
         qb = QueryBuilder()
         qb.append(cls=classes, tag='workflow', project=['*'], filters={'label': {'==': identifier}})
@@ -407,7 +407,7 @@ class CodeEntityLoader(OrmEntityLoader):
         :param classes: a tuple of orm classes to which the identifier should be mapped
         :returns: the query builder instance that should retrieve the entity corresponding to the identifier
         :raises ValueError: if the identifier is invalid
-        :raises NotExistent: if the orm base class does not support a LABEL like identifier
+        :raises aiida.common.NotExistent: if the orm base class does not support a LABEL like identifier
         """
         from aiida.orm.computers import Computer
 
@@ -449,7 +449,7 @@ class ComputerEntityLoader(OrmEntityLoader):
         :param classes: a tuple of orm classes to which the identifier should be mapped
         :returns: the query builder instance that should retrieve the entity corresponding to the identifier
         :raises ValueError: if the identifier is invalid
-        :raises NotExistent: if the orm base class does not support a LABEL like identifier
+        :raises aiida.common.NotExistent: if the orm base class does not support a LABEL like identifier
         """
         qb = QueryBuilder()
         qb.append(cls=classes, tag='computer', project=['*'], filters={'name': {'==': identifier}})
@@ -481,7 +481,7 @@ class DataEntityLoader(OrmEntityLoader):
         :param classes: a tuple of orm classes to which the identifier should be mapped
         :returns: the query builder instance that should retrieve the entity corresponding to the identifier
         :raises ValueError: if the identifier is invalid
-        :raises NotExistent: if the orm base class does not support a LABEL like identifier
+        :raises aiida.common.NotExistent: if the orm base class does not support a LABEL like identifier
         """
         qb = QueryBuilder()
         qb.append(cls=classes, tag='calculation', project=['*'], filters={'label': {'==': identifier}})
@@ -513,7 +513,7 @@ class GroupEntityLoader(OrmEntityLoader):
         :param classes: a tuple of orm classes to which the identifier should be mapped
         :returns: the query builder instance that should retrieve the entity corresponding to the identifier
         :raises ValueError: if the identifier is invalid
-        :raises NotExistent: if the orm base class does not support a LABEL like identifier
+        :raises aiida.common.NotExistent: if the orm base class does not support a LABEL like identifier
         """
         qb = QueryBuilder()
         qb.append(cls=classes, tag='group', project=['*'], filters={'label': {'==': identifier}})
@@ -545,7 +545,7 @@ class NodeEntityLoader(OrmEntityLoader):
         :param classes: a tuple of orm classes to which the identifier should be mapped
         :returns: the query builder instance that should retrieve the entity corresponding to the identifier
         :raises ValueError: if the identifier is invalid
-        :raises NotExistent: if the orm base class does not support a LABEL like identifier
+        :raises aiida.common.NotExistent: if the orm base class does not support a LABEL like identifier
         """
         qb = QueryBuilder()
         qb.append(cls=classes, tag='node', project=['*'], filters={'label': {'==': identifier}})

--- a/aiida/orm/utils/mixins.py
+++ b/aiida/orm/utils/mixins.py
@@ -151,7 +151,7 @@ class Sealable(object):  # pylint: disable=useless-object-inheritance
         :param source: the node from which the link is coming
         :param link_type: the link type
         :param link_label: the link label
-        :raise ModificationNotAllowed: if the target node (self) is sealed
+        :raise aiida.common.ModificationNotAllowed: if the target node (self) is sealed
         """
         if self.is_sealed:
             raise ModificationNotAllowed('Cannot add a link to a sealed node')
@@ -167,7 +167,7 @@ class Sealable(object):  # pylint: disable=useless-object-inheritance
         :param target: the node to which the link is going
         :param link_type: the link type
         :param link_label: the link label
-        :raise ModificationNotAllowed: if the source node (self) is sealed
+        :raise aiida.common.ModificationNotAllowed: if the source node (self) is sealed
         """
         if self.is_sealed:
             raise ModificationNotAllowed('Cannot add a link from a sealed node')
@@ -195,7 +195,7 @@ class Sealable(object):  # pylint: disable=useless-object-inheritance
 
         :param key: attribute name
         :param value: attribute value
-        :raise ModificationNotAllowed: if the node is already sealed or if the node is already stored
+        :raise aiida.common.ModificationNotAllowed: if the node is already sealed or if the node is already stored
             and the attribute is not updatable
         """
         if self.is_sealed:
@@ -213,7 +213,7 @@ class Sealable(object):  # pylint: disable=useless-object-inheritance
 
         :param key: attribute name
         :raise AttributeError: if key does not exist
-        :raise ModificationNotAllowed: if the node is already sealed or if the node is already stored
+        :raise aiida.common.ModificationNotAllowed: if the node is already sealed or if the node is already stored
             and the attribute is not updatable
         """
         if self.is_sealed:

--- a/aiida/orm/utils/repository.py
+++ b/aiida/orm/utils/repository.py
@@ -40,7 +40,8 @@ class Repository(object):  # pylint: disable=useless-object-inheritance
     def validate_mutability(self):
         """Raise if the repository is immutable.
 
-        :raises ModificationNotAllowed: if repository is marked as immutable because the corresponding node is stored
+        :raises aiida.common.ModificationNotAllowed: if repository is marked as immutable because the corresponding node
+            is stored
         """
         if self._is_stored:
             raise exceptions.ModificationNotAllowed('cannot modify the repository after the node has been stored')
@@ -133,7 +134,7 @@ class Repository(object):  # pylint: disable=useless-object-inheritance
         :param key: fully qualified identifier for the object within the repository
         :param contents_only: boolean, if True, omit the top level directory of the path and only copy its contents.
         :param force: boolean, if True, will skip the mutability check
-        :raises ModificationNotAllowed: if repository is immutable and `force=False`
+        :raises aiida.common.ModificationNotAllowed: if repository is immutable and `force=False`
         """
         if not force:
             self.validate_mutability()
@@ -165,7 +166,7 @@ class Repository(object):  # pylint: disable=useless-object-inheritance
         :param mode: the file mode with which the object will be written
         :param encoding: the file encoding with which the object will be written
         :param force: boolean, if True, will skip the mutability check
-        :raises ModificationNotAllowed: if repository is immutable and `force=False`
+        :raises aiida.common.ModificationNotAllowed: if repository is immutable and `force=False`
         """
         if not force:
             self.validate_mutability()
@@ -186,7 +187,7 @@ class Repository(object):  # pylint: disable=useless-object-inheritance
         :param mode: the file mode with which the object will be written
         :param encoding: the file encoding with which the object will be written
         :param force: boolean, if True, will skip the mutability check
-        :raises ModificationNotAllowed: if repository is immutable and `force=False`
+        :raises aiida.common.ModificationNotAllowed: if repository is immutable and `force=False`
         """
         if not force:
             self.validate_mutability()
@@ -209,7 +210,7 @@ class Repository(object):  # pylint: disable=useless-object-inheritance
 
         :param key: fully qualified identifier for the object within the repository
         :param force: boolean, if True, will skip the mutability check
-        :raises ModificationNotAllowed: if repository is immutable and `force=False`
+        :raises aiida.common.ModificationNotAllowed: if repository is immutable and `force=False`
         """
         if not force:
             self.validate_mutability()
@@ -225,7 +226,7 @@ class Repository(object):  # pylint: disable=useless-object-inheritance
             This check can be avoided by using the `force` flag, but this should be used with extreme caution!
 
         :param force: boolean, if True, will skip the mutability check
-        :raises ModificationNotAllowed: if repository is immutable and `force=False`
+        :raises aiida.common.ModificationNotAllowed: if repository is immutable and `force=False`
         """
         if not force:
             self.validate_mutability()

--- a/aiida/parsers/__init__.py
+++ b/aiida/parsers/__init__.py
@@ -7,8 +7,9 @@
 # For further information on the license, see the LICENSE.txt file        #
 # For further information please visit http://www.aiida.net               #
 ###########################################################################
+# pylint: disable=wildcard-import,undefined-variable
 """Module for classes and utilities to write parsers for calculation jobs."""
 
-from .parser import Parser
+from .parser import *
 
-__all__ = ('Parser',)
+__all__ = (parser.__all__)

--- a/aiida/parsers/parser.py
+++ b/aiida/parsers/parser.py
@@ -19,6 +19,8 @@ from aiida.common import exceptions
 from aiida.common import extendeddicts
 from aiida.engine import calcfunction
 
+__all__ = ('Parser',)
+
 
 class Parser(object):  # pylint: disable=useless-object-inheritance
     """Base class for a Parser that can parse the outputs produced by a CalcJob process."""
@@ -76,7 +78,7 @@ class Parser(object):  # pylint: disable=useless-object-inheritance
 
         :param link_label: the name of the link label
         :param node: the node to register as an output
-        :raises ModificationNotAllowed: if an output node was already registered with the same link label
+        :raises aiida.common.ModificationNotAllowed: if an output node was already registered with the same link label
         """
         if link_label in self._outputs:
             raise exceptions.ModificationNotAllowed('the output {} already exists'.format(link_label))

--- a/aiida/plugins/__init__.py
+++ b/aiida/plugins/__init__.py
@@ -7,10 +7,10 @@
 # For further information on the license, see the LICENSE.txt file        #
 # For further information please visit http://www.aiida.net               #
 ###########################################################################
+# pylint: disable=wildcard-import,undefined-variable
 """Classes and functions to load and interact with plugin classes accessible through defined entry points."""
 
-from .factories import CalculationFactory, DataFactory, DbImporterFactory, OrbitalFactory, ParserFactory
-from .factories import SchedulerFactory, TransportFactory, TcodExporterFactory, WorkflowFactory
+from .entry_point import *
+from .factories import *
 
-__all__ = ('CalculationFactory', 'DataFactory', 'DbImporterFactory', 'OrbitalFactory', 'ParserFactory',
-           'SchedulerFactory', 'TransportFactory', 'TcodExporterFactory', 'WorkflowFactory')
+__all__ = (entry_point.__all__ + factories.__all__)

--- a/aiida/plugins/entry_point.py
+++ b/aiida/plugins/entry_point.py
@@ -26,6 +26,8 @@ except ImportError:
 
 from aiida.common.exceptions import MissingEntryPointError, MultipleEntryPointError, LoadingEntryPointError
 
+__all__ = ('load_entry_point', 'load_entry_point_from_string')
+
 
 ENTRY_POINT_GROUP_PREFIX = 'aiida.'
 ENTRY_POINT_STRING_SEPARATOR = ':'
@@ -138,8 +140,8 @@ def get_entry_point_from_string(entry_point_string):
     :return: the entry point if it exists else None
     :raises TypeError: if the entry_point_string is not a string type
     :raises ValueError: if the entry_point_string cannot be split into two parts on the entry point string separator
-    :raises MissingEntryPointError: entry point was not registered
-    :raises MultipleEntryPointError: entry point could not be uniquely resolved
+    :raises aiida.common.MissingEntryPointError: entry point was not registered
+    :raises aiida.common.MultipleEntryPointError: entry point could not be uniquely resolved
     """
     group, name = parse_entry_point_string(entry_point_string)
     return get_entry_point(group, name)
@@ -153,9 +155,9 @@ def load_entry_point_from_string(entry_point_string):
     :return: class registered at the given entry point
     :raises TypeError: if the entry_point_string is not a string type
     :raises ValueError: if the entry_point_string cannot be split into two parts on the entry point string separator
-    :raises MissingEntryPointError: entry point was not registered
-    :raises MultipleEntryPointError: entry point could not be uniquely resolved
-    :raises LoadingEntryPointError: entry point could not be loaded
+    :raises aiida.common.MissingEntryPointError: entry point was not registered
+    :raises aiida.common.MultipleEntryPointError: entry point could not be uniquely resolved
+    :raises aiida.common.LoadingEntryPointError: entry point could not be loaded
     """
     group, name = parse_entry_point_string(entry_point_string)
     return load_entry_point(group, name)
@@ -170,9 +172,9 @@ def load_entry_point(group, name):
     :return: class registered at the given entry point
     :raises TypeError: if the entry_point_string is not a string type
     :raises ValueError: if the entry_point_string cannot be split into two parts on the entry point string separator
-    :raises MissingEntryPointError: entry point was not registered
-    :raises MultipleEntryPointError: entry point could not be uniquely resolved
-    :raises LoadingEntryPointError: entry point could not be loaded
+    :raises aiida.common.MissingEntryPointError: entry point was not registered
+    :raises aiida.common.MultipleEntryPointError: entry point could not be uniquely resolved
+    :raises aiida.common.LoadingEntryPointError: entry point could not be loaded
     """
     entry_point = get_entry_point(group, name)
 
@@ -226,8 +228,8 @@ def get_entry_point(group, name):
     :param group: the entry point group
     :param name: the name of the entry point
     :return: the entry point if it exists else None
-    :raises MissingEntryPointError: entry point was not registered
-    :raises MultipleEntryPointError: entry point could not be uniquely resolved
+    :raises aiida.common.MissingEntryPointError: entry point was not registered
+    :raises aiida.common.MultipleEntryPointError: entry point could not be uniquely resolved
     """
     entry_points = [ep for ep in get_entry_points(group) if ep.name == name]
 

--- a/aiida/plugins/factories.py
+++ b/aiida/plugins/factories.py
@@ -15,6 +15,9 @@ from __future__ import absolute_import
 
 from .entry_point import load_entry_point
 
+__all__ = ('BaseFactory', 'CalculationFactory', 'DataFactory', 'DbImporterFactory', 'OrbitalFactory', 'ParserFactory',
+           'SchedulerFactory', 'TransportFactory', 'TcodExporterFactory', 'WorkflowFactory')
+
 
 def BaseFactory(group, name):
     """Return the plugin class registered under a given entry point group and name.
@@ -22,9 +25,9 @@ def BaseFactory(group, name):
     :param group: entry point group
     :param name: entry point name
     :return: the plugin class
-    :raises MissingEntryPointError: entry point was not registered
-    :raises MultipleEntryPointError: entry point could not be uniquely resolved
-    :raises LoadingEntryPointError: entry point could not be loaded
+    :raises aiida.common.MissingEntryPointError: entry point was not registered
+    :raises aiida.common.MultipleEntryPointError: entry point could not be uniquely resolved
+    :raises aiida.common.LoadingEntryPointError: entry point could not be loaded
     """
     return load_entry_point(group, name)
 

--- a/aiida/plugins/utils.py
+++ b/aiida/plugins/utils.py
@@ -33,7 +33,7 @@ def registry_cache_folder_path():
     return the fully resolved path to the cache folder
     """
     from os import path as osp
-    from aiida.manage import get_config
+    from aiida.manage.configuration import get_config
     config = get_config()
     cache_dir = registry_cache_folder_name()
     return osp.join(config.dirpath, cache_dir)

--- a/aiida/restapi/translator/node.py
+++ b/aiida/restapi/translator/node.py
@@ -16,7 +16,7 @@ from aiida.common.exceptions import InputValidationError, ValidationError, \
     InvalidOperation
 from aiida.restapi.common.exceptions import RestValidationError
 from aiida.restapi.translator.base import BaseTranslator
-from aiida.manage import get_manager
+from aiida.manage.manager import get_manager
 from aiida import orm
 
 

--- a/aiida/schedulers/__init__.py
+++ b/aiida/schedulers/__init__.py
@@ -7,9 +7,10 @@
 # For further information on the license, see the LICENSE.txt file        #
 # For further information please visit http://www.aiida.net               #
 ###########################################################################
+# pylint: disable=wildcard-import,undefined-variable
 """Module for classes and utilities to interact with cluster schedulers."""
 
-from .datastructures import JobState, JobResource, JobTemplate, JobInfo
-from .scheduler import Scheduler, SchedulerError, SchedulerParsingError
+from .datastructures import *
+from .scheduler import *
 
-__all__ = ('JobState', 'JobResource', 'JobTemplate', 'JobInfo', 'Scheduler', 'SchedulerError', 'SchedulerParsingError')
+__all__ = (datastructures.__all__ + scheduler.__all__)

--- a/aiida/schedulers/datastructures.py
+++ b/aiida/schedulers/datastructures.py
@@ -26,6 +26,8 @@ from aiida.common.extendeddicts import DefaultFieldsAttributeDict
 
 SCHEDULER_LOGGER = AIIDA_LOGGER.getChild('scheduler')
 
+__all__ = ('JobState', 'JobResource', 'JobTemplate', 'JobInfo', 'NodeNumberJobResource', 'ParEnvJobResource', 'MachineInfo')
+
 
 class JobState(Enum):
     """Enumeration of possible scheduler states of a CalcJob.
@@ -245,7 +247,7 @@ class ParEnvJobResource(JobResource):
 
         :raise ValueError: on invalid parameters.
         :raise TypeError: on invalid parameters.
-        :raise ConfigurationError: if default_mpiprocs_per_machine was set for this
+        :raise aiida.common.ConfigurationError: if default_mpiprocs_per_machine was set for this
             computer, since ParEnvJobResource cannot accept this parameter.
         """
         from aiida.common.exceptions import ConfigurationError

--- a/aiida/schedulers/plugins/lsf.py
+++ b/aiida/schedulers/plugins/lsf.py
@@ -116,7 +116,7 @@ class LsfJobResource(JobResource):
 
         :raise ValueError: on invalid parameters.
         :raise TypeError: on invalid parameters.
-        :raise ConfigurationError: if default_mpiprocs_per_machine was set for this
+        :raise aiida.common.ConfigurationError: if default_mpiprocs_per_machine was set for this
             computer, since LsfJobResource cannot accept this parameter.
         """
         from aiida.common.exceptions import ConfigurationError

--- a/aiida/schedulers/scheduler.py
+++ b/aiida/schedulers/scheduler.py
@@ -21,6 +21,8 @@ from aiida.common.escaping import escape_for_bash
 from aiida.common.exceptions import AiidaException, FeatureNotAvailable
 from aiida.schedulers.datastructures import JobTemplate
 
+__all__ = ('Scheduler', 'SchedulerError', 'SchedulerParsingError')
+
 
 class SchedulerError(AiidaException):
     pass

--- a/aiida/settings.py
+++ b/aiida/settings.py
@@ -14,7 +14,7 @@ import os
 from aiida.backends import settings
 from aiida.common.exceptions import ConfigurationError, MissingConfigurationError
 from aiida.common.setup import parse_repository_uri
-from aiida.manage import get_config
+from aiida.manage.configuration import get_config
 
 
 TESTING_MODE = False

--- a/aiida/tools/__init__.py
+++ b/aiida/tools/__init__.py
@@ -7,6 +7,7 @@
 # For further information on the license, see the LICENSE.txt file        #
 # For further information please visit http://www.aiida.net               #
 ###########################################################################
+# pylint: disable=wildcard-import,undefined-variable,redefined-builtin
 """
 Tools to operate on AiiDA ORM class instances
 
@@ -20,7 +21,9 @@ What functionality should go directly in the ORM class in `aiida.orm` and what i
 
 """
 
-from .data.array.kpoints import get_explicit_kpoints_path, get_kpoints_path
-from .data.structure import structure_to_spglib_tuple, spglib_tuple_to_structure
+from .calculations import *
+from .data.array.kpoints import *
+from .data.structure import *
+from .dbimporters import *
 
-__all__ = ('get_explicit_kpoints_path', 'get_kpoints_path', 'structure_to_spglib_tuple', 'spglib_tuple_to_structure')
+__all__ = (calculations.__all__ + data.array.kpoints.__all__ + data.structure.__all__ + dbimporters.__all__)

--- a/aiida/tools/data/array/kpoints/__init__.py
+++ b/aiida/tools/data/array/kpoints/__init__.py
@@ -10,12 +10,13 @@
 from __future__ import division
 from __future__ import print_function
 from __future__ import absolute_import
+
 from aiida.orm.nodes.data.array.kpoints import KpointsData
 from aiida.orm.nodes.data.parameter import ParameterData
 from aiida.tools.data.array.kpoints import legacy
 from aiida.tools.data.array.kpoints import seekpath
 
-__all__ = ['get_kpoints_path', 'get_explicit_kpoints_path']
+__all__ = ('get_kpoints_path', 'get_explicit_kpoints_path')
 
 
 def get_kpoints_path(structure, method='seekpath', **kwargs):

--- a/aiida/tools/data/array/kpoints/seekpath.py
+++ b/aiida/tools/data/array/kpoints/seekpath.py
@@ -14,7 +14,7 @@ from __future__ import absolute_import
 from aiida.orm.nodes.data.array.kpoints import KpointsData
 from aiida.orm.nodes.data.parameter import ParameterData
 
-__all__ = ['check_seekpath_is_installed', 'get_explicit_kpoints_path', 'get_kpoints_path']
+__all__ = ('check_seekpath_is_installed', 'get_explicit_kpoints_path', 'get_kpoints_path')
 
 
 def check_seekpath_is_installed():

--- a/aiida/tools/data/structure/__init__.py
+++ b/aiida/tools/data/structure/__init__.py
@@ -22,7 +22,7 @@ from aiida.common.constants import elements
 from aiida.orm.nodes.data.structure import Kind, Site, StructureData
 from aiida.engine import calcfunction
 
-__all__ = ['structure_to_spglib_tuple', 'spglib_tuple_to_structure']
+__all__ = ('structure_to_spglib_tuple', 'spglib_tuple_to_structure')
 
 
 @calcfunction

--- a/aiida/tools/dbexporters/__init__.py
+++ b/aiida/tools/dbexporters/__init__.py
@@ -7,5 +7,3 @@
 # For further information on the license, see the LICENSE.txt file        #
 # For further information please visit http://www.aiida.net               #
 ###########################################################################
-
-

--- a/aiida/tools/dbexporters/tcod.py
+++ b/aiida/tools/dbexporters/tcod.py
@@ -353,7 +353,7 @@ def _get_calculation(node):
     :param node: an instance of subclass of :py:class:`aiida.orm.nodes.node.Node`
     :return: an instance of subclass of
         :py:class:`aiida.orm.nodes.process.process.ProcessNode`
-    :raises MultipleObjectsError: if the node has more than one calculation
+    :raises aiida.common.MultipleObjectsError: if the node has more than one calculation
         attached.
     """
     from aiida.common.exceptions import MultipleObjectsError
@@ -1081,7 +1081,7 @@ def deposit(what, type, author_name=None, author_email=None, url=None,
         instance.
     :raises ValueError: if any of the required parameters are not given.
     """
-    from aiida.manage import get_config
+    from aiida.manage.configuration import get_config
 
     config = get_config()
     parameters = {}

--- a/aiida/transports/__init__.py
+++ b/aiida/transports/__init__.py
@@ -7,8 +7,9 @@
 # For further information on the license, see the LICENSE.txt file        #
 # For further information please visit http://www.aiida.net               #
 ###########################################################################
+# pylint: disable=wildcard-import,undefined-variable
 """Module for classes and utilities to define transports to other machines."""
 
-from .transport import Transport
+from .transport import *
 
-__all__ = ('Transport',)
+__all__ = (transport.__all__)

--- a/aiida/transports/cli.py
+++ b/aiida/transports/cli.py
@@ -21,7 +21,7 @@ from aiida.cmdline.params.options.interactive import InteractiveOption
 from aiida.cmdline.utils.decorators import with_dbenv
 from aiida.cmdline.utils import echo
 from aiida.common.exceptions import NotExistent
-from aiida.manage import get_manager
+from aiida.manage.manager import get_manager
 
 TRANSPORT_PARAMS = []
 

--- a/aiida/transports/plugins/local.py
+++ b/aiida/transports/plugins/local.py
@@ -74,7 +74,7 @@ class LocalTransport(Transport):
         """
         Opens a local transport channel
 
-        :raise InvalidOperation: if the channel is already open
+        :raise aiida.common.InvalidOperation: if the channel is already open
         """
         from aiida.common.exceptions import InvalidOperation
 
@@ -89,7 +89,7 @@ class LocalTransport(Transport):
         """
         Closes the local transport channel
 
-        :raise InvalidOperation: if the channel is already open
+        :raise aiida.common.InvalidOperation: if the channel is already open
         """
         from aiida.common.exceptions import InvalidOperation
 

--- a/aiida/transports/transport.py
+++ b/aiida/transports/transport.py
@@ -11,6 +11,7 @@
 from __future__ import division
 from __future__ import print_function
 from __future__ import absolute_import
+
 from abc import ABCMeta
 import os
 import re
@@ -23,6 +24,8 @@ from aiida.common.exceptions import InternalError
 from aiida.common.lang import classproperty
 
 DEFAULT_TRANSPORT_INTERVAL = 30.
+
+__all__ = ('Transport',)
 
 
 @six.add_metaclass(ABCMeta)

--- a/docs/source/nitpick-exceptions
+++ b/docs/source/nitpick-exceptions
@@ -75,6 +75,7 @@ py:class  bool
 py:class  basestring
 py:class  None
 py:class  type
+py:class  typing.Final
 # this is required for metaclasses(?)
 py:class  __builtin__.bool
 py:class  __builtin__.float


### PR DESCRIPTION
Fixes #2521 

The convention for those resources, e.g. classes and functions, that
should be usable by users of `aiida-core`, is that they should be
importable directly from a second level module in the hierarchy. That is
to say, anything that can be imported directly from `aiida.orm` is
intended to be used by users and therefore these resources come with the
guarantee that if they will be changed or moved, this will be done with
a decent deprecation path.