### PR TITLE
Reenable transport plugin tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,6 +32,9 @@ addons:
             - graphviz
 
 before_install:
+    # We need to replace `TRAVIS_HOME` with `HOME` because the former won't be set when SSH'ing to localhost on the
+    # the Travis machine, causing certain scripts sourced in the `.bashrc` to fail
+    - sed -i 's/TRAVIS_HOME/HOME/g' /home/travis/.travis/job_stages
     # This is needed for the SSH tests (being able to ssh to localhost)
     # And will also be used for the docker test
     - ssh-keygen -t rsa -N "" -f "${HOME}/.ssh/id_rsa"

--- a/aiida/transports/plugins/test_all_plugins.py
+++ b/aiida/transports/plugins/test_all_plugins.py
@@ -1263,7 +1263,6 @@ class TestExecuteCommandWait(unittest.TestCase):
     It also checks for escaping of the folder names.
     """
 
-    @unittest.skip('reenable when issue #2460 has been addressed')
     @run_for_all_plugins
     def test_exec_pwd(self, custom_transport):
         """
@@ -1306,7 +1305,6 @@ class TestExecuteCommandWait(unittest.TestCase):
                 t.chdir(location)
                 t.rmdir(subfolder)
 
-    @unittest.skip('reenable when issue #2460 has been addressed')
     @run_for_all_plugins
     def test_exec_with_stdin_string(self, custom_transport):
         test_string = str("some_test String")
@@ -1316,7 +1314,6 @@ class TestExecuteCommandWait(unittest.TestCase):
             self.assertEquals(stdout, test_string)
             self.assertEquals(stderr, "")
 
-    @unittest.skip('reenable when issue #2460 has been addressed')
     @run_for_all_plugins
     def test_exec_with_stdin_unicode(self, custom_transport):
         test_string = u"some_test String"
@@ -1326,7 +1323,6 @@ class TestExecuteCommandWait(unittest.TestCase):
             self.assertEquals(stdout, test_string)
             self.assertEquals(stderr, "")
 
-    @unittest.skip('reenable when issue #2460 has been addressed')
     @run_for_all_plugins
     def test_exec_with_stdin_filelike(self, custom_transport):
         from six.moves import cStringIO as StringIO


### PR DESCRIPTION
Fixes #2460 

A few transport plugin tests had been commented out because due to a
change on Travis they started failing. The reason was that Travis added
files to the `.bashrc` that depended on the `TRAVIS_HOME` environment
variable to be set, which was not the case if one SSH'ed to localhost.
This caused the sourcing of the `.bashrc` to fail during the SSH
transport tests in which we SSH to localhost where this environment
variable is not set. As a workaround we add a step in the before install
section of the `.travis.yml` where we use `sed` to replace the
`TRAVIS_HOME` variable for `HOME` which will in fact be set.