### PR TITLE
Simplify imports from the `aiida.orm`

### DIFF
--- a/.ci/polish/cli.py
+++ b/.ci/polish/cli.py
@@ -96,9 +96,7 @@ def launch(expression, code, use_calculations, use_calcfunctions, sleep, timeout
     import sys
     import time
     import uuid
-    from aiida.orm import Code
-    from aiida.orm.nodes.data.int import Int
-    from aiida.orm.nodes.data.str import Str
+    from aiida.orm import Code, Int, Str
     from aiida.engine import run_get_node, submit
     from lib.expression import generate, validate, evaluate
     from lib.workchain import generate_outlines, format_outlines, write_workchain

--- a/.ci/polish/lib/template/base.tpl
+++ b/.ci/polish/lib/template/base.tpl
@@ -2,10 +2,7 @@
 from numpy import prod
 from copy import deepcopy
 from aiida.engine import submit, WorkChain, if_, while_, append_, ToContext, calcfunction
-from aiida.orm import Code
-from aiida.orm.nodes.data.int import Int
-from aiida.orm.nodes.data.str import Str
-from aiida.orm.nodes.data.dict import Dict
+from aiida.orm import Code, Int, Str, Dict
 from aiida.plugins import CalculationFactory
 
 

--- a/.ci/test_daemon.py
+++ b/.ci/test_daemon.py
@@ -18,15 +18,11 @@ import time
 from six.moves import range
 
 from aiida.common import exceptions
-from aiida.manage.caching import enable_caching
-from aiida.engine.daemon.client import get_daemon_client
 from aiida.engine import run_get_node, submit
+from aiida.engine.daemon.client import get_daemon_client
 from aiida.engine.persistence import ObjectLoader
-from aiida.orm import Code, load_node
-from aiida.orm.nodes.data.int import Int
-from aiida.orm.nodes.data.str import Str
-from aiida.orm.nodes.data.list import List
-from aiida.orm import CalcJobNode
+from aiida.manage.caching import enable_caching
+from aiida.orm import CalcJobNode, Code, load_node, Int, Str, List
 from aiida.plugins import CalculationFactory, DataFactory
 from workchains import (
     NestedWorkChain, DynamicNonDbInput, DynamicDbInput, DynamicMixedInput, ListEcho, CalcFunctionRunnerWorkChain,

--- a/.ci/workchains.py
+++ b/.ci/workchains.py
@@ -13,9 +13,7 @@ from __future__ import absolute_import
 
 from aiida.engine import calcfunction, workfunction, WorkChain, ToContext, append_
 from aiida.engine.persistence import ObjectLoader
-from aiida.orm.nodes.data.int import Int
-from aiida.orm.nodes.data.list import List
-from aiida.orm.nodes.data.str import Str
+from aiida.orm import Int, List, Str
 
 
 class NestedWorkChain(WorkChain):

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -118,11 +118,9 @@
         aiida/backends/tests/engine/test_daemon.py|
         aiida/backends/tests/engine/test_persistence.py|
         aiida/backends/tests/engine/test_process.py|
-        aiida/backends/tests/engine/test_run.py|
         aiida/backends/tests/engine/test_futures.py|
         aiida/backends/tests/engine/test_launch.py|
         aiida/backends/tests/engine/test_process_builder.py|
-        aiida/backends/tests/engine/test_process_spec.py|
         aiida/backends/tests/engine/test_rmq.py|
         aiida/backends/tests/engine/test_runners.py|
         aiida/backends/tests/engine/test_transport.py|

--- a/aiida/backends/djsite/db/migrations/__init__.py
+++ b/aiida/backends/djsite/db/migrations/__init__.py
@@ -277,7 +277,7 @@ class ModelModifierV0025(object):
         cls = self._model_class
         import datetime
 
-        import aiida.common.json as json
+        from aiida.common import json
         from aiida.common.timezone import is_naive, make_aware, get_current_timezone
 
         if self._subspecifier_field_name is None:

--- a/aiida/backends/djsite/db/models.py
+++ b/aiida/backends/djsite/db/models.py
@@ -323,7 +323,7 @@ def _deserialize_attribute(mainitem, subitems, sep, original_class=None,
     :return: the deserialized value
     :raise aiida.backends.djsite.db.models.DeserializationException: if an error occurs
     """
-    import aiida.common.json as json
+    from aiida.common import json
     from aiida.common.timezone import (
         is_naive, make_aware, get_current_timezone)
 
@@ -719,7 +719,7 @@ class DbMultipleValueAttributeBaseClass(m.Model):
         """
         import datetime
 
-        import aiida.common.json as json
+        from aiida.common import json
         from aiida.common.timezone import is_naive, make_aware, get_current_timezone
 
         if cls._subspecifier_field_name is None:
@@ -1362,7 +1362,7 @@ class DbComputer(m.Model):
         return dbcomputer
 
     def _get_val_from_metadata(self, key):
-        import aiida.common.json as json
+        from aiida.common import json
 
         try:
             metadata = json.loads(self.metadata)

--- a/aiida/backends/djsite/db/subtests/test_migrations.py
+++ b/aiida/backends/djsite/db/subtests/test_migrations.py
@@ -96,8 +96,7 @@ class TestDuplicateNodeUuidMigration(TestMigrations):
     migrate_to = '0014_add_node_uuid_unique_constraint'
 
     def setUpBeforeMigration(self):
-        from aiida.orm.nodes.data.bool import Bool
-        from aiida.orm.nodes.data.int import Int
+        from aiida.orm import Bool, Int
 
         self.file_name = 'test.temp'
         self.file_content = '#!/bin/bash\n\necho test run\n'
@@ -681,7 +680,7 @@ class TestTrajectoryDataMigration(TestMigrations):
     ]]])
 
     def setUpBeforeMigration(self):
-        from aiida.orm.nodes.data.array.trajectory import TrajectoryData
+        from aiida.orm import TrajectoryData
 
         # Create a TrajectoryData node
         node = TrajectoryData()

--- a/aiida/backends/djsite/db/subtests/test_query.py
+++ b/aiida/backends/djsite/db/subtests/test_query.py
@@ -23,10 +23,8 @@ class TestQueryBuilderDjango(AiidaTestCase):
             DbNode, DbUser, DbComputer,
             DbGroup,
         )
-        from aiida.orm.querybuilder import QueryBuilder
-        from aiida.orm.nodes.data.structure import StructureData
-        from aiida.orm import Group, Node, Computer, Data
         from aiida.common.exceptions import DbContentError
+        from aiida.orm import QueryBuilder, Group, Node, Computer, Data, StructureData
         qb = QueryBuilder()
 
         with self.assertRaises(DbContentError):

--- a/aiida/backends/djsite/queries.py
+++ b/aiida/backends/djsite/queries.py
@@ -113,14 +113,14 @@ class DjangoQueryManager(AbstractQueryManager):
 
     def get_bands_and_parents_structure(self, args):
         """
-        Returns bands and closest parent structure     
+        Returns bands and closest parent structure
         """
         from collections import defaultdict
         from django.db.models import Q
-        from aiida.common.utils import grouper
         from aiida.backends.djsite.db import models
+        from aiida.common.utils import grouper
         from aiida.orm.nodes.data.structure import (get_formula, get_symbols_string)
-        from aiida.orm.nodes.data.array.bands import BandsData
+        from aiida.orm import BandsData
         from aiida import orm
 
         user = orm.User.objects.get_default()
@@ -238,9 +238,8 @@ def get_closest_parents(pks, *args, **kwargs):
         For now a work around is to use chunk_size=1.
 
     """
-    from aiida.orm import Node
-    from aiida.backends.djsite.db import models
     from copy import deepcopy
+    from aiida.backends.djsite.db import models
     from aiida.common.utils import grouper
     try:
         the_pks = list(pks)

--- a/aiida/backends/general/abstractqueries.py
+++ b/aiida/backends/general/abstractqueries.py
@@ -64,10 +64,9 @@ class AbstractQueryManager(object):
             where in `ctime_by_day` the key is a string in the format 'YYYY-MM-DD' and the value is
             an integer with the number of nodes created that day.
         """
-        from aiida.orm.querybuilder import QueryBuilder as QB
-        from aiida.orm import User, Node
-        from collections import Counter
         import datetime
+        from collections import Counter
+        from aiida.orm import User, Node, QueryBuilder
 
         def count_statistics(dataset):
 
@@ -108,7 +107,7 @@ class AbstractQueryManager(object):
 
         statistics = {}
 
-        q = QB()
+        q = QueryBuilder()
         q.append(Node, project=['id', 'ctime', 'type'], tag='node')
 
         if user_pk is not None:
@@ -133,13 +132,10 @@ class AbstractQueryManager(object):
 
         import datetime
         from aiida.common import timezone
-        from aiida.orm.querybuilder import QueryBuilder
         from aiida.orm.nodes.data.structure import (get_formula, get_symbols_string)
-        from aiida.orm.nodes.data.array.bands import BandsData
-        from aiida.orm.nodes.data.structure import StructureData
         from aiida import orm
 
-        qb = QueryBuilder()
+        qb = orm.QueryBuilder()
         if args.all_users is False:
             user = orm.User.objects.get_default()
             qb.append(orm.User, tag="creator", filters={"email": user.email})
@@ -152,7 +148,7 @@ class AbstractQueryManager(object):
             n_days_ago = now - datetime.timedelta(days=args.past_days)
             bdata_filters.update({"ctime": {'>=': n_days_ago}})
 
-        qb.append(BandsData, tag="bdata", with_user="creator",
+        qb.append(orm.BandsData, tag="bdata", with_user="creator",
                   filters=bdata_filters,
                   project=["id", "label", "ctime"]
                   )
@@ -167,11 +163,11 @@ class AbstractQueryManager(object):
             qb.append(orm.Group, tag="group", filters=group_filters,
                       group_of="bdata")
 
-        qb.append(StructureData, tag="sdata", with_descendants="bdata",
+        qb.append(orm.StructureData, tag="sdata", with_descendants="bdata",
                   # We don't care about the creator of StructureData
                   project=["id", "attributes.kinds", "attributes.sites"])
 
-        qb.order_by({StructureData: {'ctime': 'desc'}})
+        qb.order_by({orm.StructureData: {'ctime': 'desc'}})
 
         list_data = qb.distinct()
 
@@ -236,8 +232,8 @@ class AbstractQueryManager(object):
         :param node_pks: one node pk or an iterable of node pks
         :return: a list of aiida objects with all the parents of the nodes
         """
-        from aiida.orm.querybuilder import QueryBuilder
-        from aiida.orm import Node
+        from aiida.orm import Node, QueryBuilder
+
         qb = QueryBuilder()
         qb.append(Node, tag='low_node',
                   filters={'id': {'in': node_pks}})

--- a/aiida/backends/sqlalchemy/utils.py
+++ b/aiida/backends/sqlalchemy/utils.py
@@ -19,7 +19,7 @@ try:
     json_dumps = partial(json.dumps, double_precision=15)
     json_loads = partial(json.loads, precise_float=True)
 except ImportError:
-    import aiida.common.json as json
+    from aiida.common import json
 
     json_dumps = json.dumps
     json_loads = json.loads

--- a/aiida/backends/tests/cmdline/commands/test_calcjob.py
+++ b/aiida/backends/tests/cmdline/commands/test_calcjob.py
@@ -39,9 +39,7 @@ class TestVerdiCalculation(AiidaTestCase):
         from aiida.backends.tests.utils.fixtures import import_archive_fixture
         from aiida.common.links import LinkType
         from aiida.engine import ProcessState
-        from aiida.orm import Data
-        from aiida.orm import CalcJobNode
-        from aiida.orm.nodes.data.dict import Dict
+        from aiida.orm import Data, CalcJobNode, Dict
         from aiida.plugins import CalculationFactory
         from aiida import orm
 

--- a/aiida/backends/tests/cmdline/commands/test_calculation.py
+++ b/aiida/backends/tests/cmdline/commands/test_calculation.py
@@ -36,9 +36,7 @@ class TestVerdiCalculation(AiidaTestCase):
         from aiida.backends.tests.utils.fixtures import import_archive_fixture
         from aiida.common.links import LinkType
         from aiida.engine import ProcessState
-        from aiida.orm import Data
-        from aiida.orm import CalcJobNode
-        from aiida.orm.nodes.data.dict import Dict
+        from aiida.orm import Data, CalcJobNode, Dict
         from aiida.plugins import CalculationFactory
         from aiida import orm
 

--- a/aiida/backends/tests/cmdline/commands/test_data.py
+++ b/aiida/backends/tests/cmdline/commands/test_data.py
@@ -25,16 +25,6 @@ from contextlib import contextmanager
 from click.testing import CliRunner
 
 from aiida import orm
-from aiida.orm.groups import Group
-from aiida.orm.nodes.data.array import ArrayData
-from aiida.orm.nodes.data.array.bands import BandsData
-from aiida.orm.nodes.data.array.kpoints import KpointsData
-from aiida.orm.nodes.data.cif import CifData, has_pycifrw
-from aiida.orm.nodes.data.dict import Dict
-from aiida.orm.nodes.data.remote import RemoteData
-from aiida.orm.nodes.data.structure import StructureData
-from aiida.orm.nodes.data.array.trajectory import TrajectoryData
-
 from aiida.backends.testbase import AiidaTestCase
 from aiida.cmdline.commands.cmd_data import cmd_array
 from aiida.cmdline.commands.cmd_data import cmd_bands
@@ -45,6 +35,8 @@ from aiida.cmdline.commands.cmd_data import cmd_structure
 from aiida.cmdline.commands.cmd_data import cmd_trajectory
 from aiida.cmdline.commands.cmd_data import cmd_upf
 from aiida.engine import calcfunction
+from aiida.orm.nodes.data.cif import has_pycifrw
+from aiida.orm import Group, ArrayData, BandsData, KpointsData, CifData, Dict, RemoteData, StructureData, TrajectoryData
 
 
 @contextmanager
@@ -373,7 +365,7 @@ class TestVerdiDataBands(AiidaTestCase, TestVerdiDataListable):
         self.assertIn(b'Usage:', output, "Sub-command verdi data bands show --help failed.")
 
     def test_bandslist(self):
-        from aiida.orm.nodes.data.array.bands import BandsData
+        from aiida.orm import BandsData
 
         self.data_listing_test(BandsData, 'FeO', self.ids)
 
@@ -483,8 +475,6 @@ class TestVerdiDataTrajectory(AiidaTestCase, TestVerdiDataListable, TestVerdiDat
 
     @staticmethod
     def create_trajectory_data():
-        from aiida.orm.nodes.data.array.trajectory import TrajectoryData
-        from aiida.orm.groups import Group
         import numpy
 
         # Create a node with two arrays
@@ -596,9 +586,6 @@ class TestVerdiDataStructure(AiidaTestCase, TestVerdiDataListable, TestVerdiData
 
     @staticmethod
     def create_structure_data():
-        from aiida.orm.nodes.data.structure import StructureData, Site, Kind
-        from aiida.orm.groups import Group
-
         alat = 4.  # angstrom
         cell = [
             [
@@ -786,8 +773,6 @@ class TestVerdiDataCif(AiidaTestCase, TestVerdiDataListable, TestVerdiDataExport
         This method tests that the Cif listing works as expected with all
         possible flags and arguments.
         """
-        from aiida.orm.nodes.data.cif import CifData
-
         self.data_listing_test(CifData, 'C O2', self.ids)
 
     def test_showhelp(self):

--- a/aiida/backends/tests/cmdline/commands/test_database.py
+++ b/aiida/backends/tests/cmdline/commands/test_database.py
@@ -20,9 +20,7 @@ from click.testing import CliRunner
 from aiida.backends.testbase import AiidaTestCase
 from aiida.cmdline.commands import cmd_database
 from aiida.common.links import LinkType
-from aiida.orm.nodes.data import Data
-from aiida.orm import Node
-from aiida.orm import CalculationNode, WorkflowNode
+from aiida.orm import Data, Node, CalculationNode, WorkflowNode
 
 
 class TestVerdiDatabasaIntegrity(AiidaTestCase):

--- a/aiida/backends/tests/cmdline/commands/test_node.py
+++ b/aiida/backends/tests/cmdline/commands/test_node.py
@@ -24,15 +24,6 @@ from six.moves import cStringIO as StringIO
 from click.testing import CliRunner
 
 from aiida import orm
-from aiida.orm.nodes.data.array import ArrayData
-from aiida.orm.nodes.data.array.bands import BandsData
-from aiida.orm.nodes.data.array.kpoints import KpointsData
-from aiida.orm.nodes.data.cif import CifData, has_pycifrw
-from aiida.orm.nodes.data.dict import Dict
-from aiida.orm.nodes.data.remote import RemoteData
-from aiida.orm.nodes.data.structure import StructureData
-from aiida.orm.nodes.data.array.trajectory import TrajectoryData
-
 from aiida.backends.testbase import AiidaTestCase
 from aiida.cmdline.commands.cmd_data import cmd_array
 from aiida.cmdline.commands.cmd_data import cmd_bands
@@ -41,9 +32,9 @@ from aiida.cmdline.commands.cmd_data import cmd_parameter
 from aiida.cmdline.commands.cmd_data import cmd_remote
 from aiida.cmdline.commands.cmd_data import cmd_structure
 from aiida.cmdline.commands.cmd_data import cmd_trajectory
-from aiida.cmdline.commands.cmd_data import cmd_upf
-
 from aiida.engine import calcfunction
+from aiida.orm.nodes.data.cif import has_pycifrw
+from aiida.orm import ArrayData, BandsData, CifData, KpointsData, Dict, RemoteData, StructureData, TrajectoryData
 
 
 @contextmanager
@@ -372,8 +363,6 @@ class TestVerdiDataBands(AiidaTestCase, TestVerdiDataListable):
         self.assertIn(b'Usage:', output, "Sub-command verdi data bands show --help failed.")
 
     def test_bandslist(self):
-        from aiida.orm.nodes.data.array.bands import BandsData
-
         self.data_listing_test(BandsData, 'FeO', self.ids)
 
     def test_bandexporthelp(self):
@@ -484,7 +473,6 @@ class TestVerdiDataTrajectory(AiidaTestCase, TestVerdiDataListable, TestVerdiDat
 
     @staticmethod
     def create_trajectory_data():
-        from aiida.orm.nodes.data.array.trajectory import TrajectoryData
         import numpy
 
         # Create a node with two arrays
@@ -597,8 +585,6 @@ class TestVerdiDataStructure(AiidaTestCase, TestVerdiDataListable, TestVerdiData
 
     @staticmethod
     def create_structure_data():
-        from aiida.orm.nodes.data.structure import StructureData, Site, Kind
-
         alat = 4.  # angstrom
         cell = [
             [
@@ -787,8 +773,6 @@ class TestVerdiDataCif(AiidaTestCase, TestVerdiDataListable, TestVerdiDataExport
         This method tests that the Cif listing works as expected with all
         possible flags and arguments.
         """
-        from aiida.orm.nodes.data.cif import CifData
-
         self.data_listing_test(CifData, 'C O2', self.ids)
 
     def test_showhelp(self):

--- a/aiida/backends/tests/cmdline/commands/test_rehash.py
+++ b/aiida/backends/tests/cmdline/commands/test_rehash.py
@@ -11,6 +11,7 @@
 from __future__ import division
 from __future__ import print_function
 from __future__ import absolute_import
+
 from click.testing import CliRunner
 
 from aiida.backends.testbase import AiidaTestCase
@@ -23,10 +24,7 @@ class TestVerdiRehash(AiidaTestCase):
     @classmethod
     def setUpClass(cls, *args, **kwargs):
         super(TestVerdiRehash, cls).setUpClass(*args, **kwargs)
-        from aiida.orm import Data
-        from aiida.orm.nodes.data.bool import Bool
-        from aiida.orm.nodes.data.float import Float
-        from aiida.orm.nodes.data.int import Int
+        from aiida.orm import Data, Bool, Float, Int
 
         cls.node_base = Data().store()
         cls.node_bool_true = Bool(True).store()

--- a/aiida/backends/tests/cmdline/params/types/test_data.py
+++ b/aiida/backends/tests/cmdline/params/types/test_data.py
@@ -11,9 +11,10 @@
 from __future__ import division
 from __future__ import print_function
 from __future__ import absolute_import
+
 from aiida.backends.testbase import AiidaTestCase
 from aiida.cmdline.params.types import DataParamType
-from aiida.orm.nodes.data import Data
+from aiida.orm import Data
 from aiida.orm.utils.loaders import OrmEntityLoader
 
 

--- a/aiida/backends/tests/engine/test_calcfunctions.py
+++ b/aiida/backends/tests/engine/test_calcfunctions.py
@@ -17,8 +17,7 @@ from aiida.common import exceptions
 from aiida.common.links import LinkType
 from aiida.engine import calcfunction, Process
 from aiida.manage.caching import enable_caching
-from aiida.orm.nodes.data.int import Int
-from aiida.orm import CalcFunctionNode
+from aiida.orm import Int, CalcFunctionNode
 
 
 class TestCalcFunction(AiidaTestCase):

--- a/aiida/backends/tests/engine/test_launch.py
+++ b/aiida/backends/tests/engine/test_launch.py
@@ -13,8 +13,7 @@ from __future__ import absolute_import
 
 from aiida.backends.testbase import AiidaTestCase
 from aiida.engine import run, run_get_node, run_get_pid, Process, WorkChain, calcfunction
-from aiida.orm.nodes.data.int import Int
-from aiida.orm import WorkChainNode, CalcFunctionNode
+from aiida.orm import Int, WorkChainNode, CalcFunctionNode
 
 
 @calcfunction

--- a/aiida/backends/tests/engine/test_process.py
+++ b/aiida/backends/tests/engine/test_process.py
@@ -19,11 +19,7 @@ from aiida.backends.testbase import AiidaTestCase
 from aiida.backends.tests.utils import processes as test_processes
 from aiida.common.lang import override
 from aiida.engine import Process, run, run_get_pid
-from aiida.orm import load_node
-from aiida.orm.nodes.data.dict import Dict
-from aiida.orm.nodes.data.int import Int
-from aiida.orm.nodes.data.str import Str
-from aiida.orm import WorkflowNode
+from aiida.orm import load_node, Dict, Int, Str, WorkflowNode
 
 
 class NameSpacedProcess(Process):

--- a/aiida/backends/tests/engine/test_process_builder.py
+++ b/aiida/backends/tests/engine/test_process_builder.py
@@ -13,10 +13,7 @@ from __future__ import absolute_import
 
 from aiida.backends.testbase import AiidaTestCase
 from aiida.engine import WorkChain, Process
-from aiida.orm.nodes.data.dict import Dict
-from aiida.orm.nodes.data.bool import Bool
-from aiida.orm.nodes.data.float import Float
-from aiida.orm.nodes.data.int import Int
+from aiida.orm import Dict, Bool, Float, Int
 from aiida.plugins import CalculationFactory
 
 DEFAULT_INT = 256

--- a/aiida/backends/tests/engine/test_process_function.py
+++ b/aiida/backends/tests/engine/test_process_function.py
@@ -14,11 +14,8 @@ from __future__ import absolute_import
 
 from aiida.backends.testbase import AiidaTestCase
 from aiida.engine import run, run_get_node, submit, calcfunction, workfunction, Process, ExitCode
+from aiida.orm import Int, Str, WorkFunctionNode, CalcFunctionNode
 from aiida.orm.nodes.data.bool import get_true_node
-from aiida.orm.nodes.data.int import Int
-from aiida.orm.nodes.data.str import Str
-from aiida.orm import WorkFunctionNode
-from aiida.orm import CalcFunctionNode
 
 DEFAULT_INT = 256
 DEFAULT_LABEL = 'Default label'

--- a/aiida/backends/tests/engine/test_process_spec.py
+++ b/aiida/backends/tests/engine/test_process_spec.py
@@ -7,15 +7,18 @@
 # For further information on the license, see the LICENSE.txt file        #
 # For further information please visit http://www.aiida.net               #
 ###########################################################################
+"""Tests for the `ProcessSpec` class."""
 from __future__ import division
 from __future__ import print_function
 from __future__ import absolute_import
 
 from aiida.backends.testbase import AiidaTestCase
 from aiida.engine import Process
+from aiida.orm import Node, Data
 
 
 class TestProcessSpec(AiidaTestCase):
+    """Tests for the `ProcessSpec` class."""
 
     def setUp(self):
         super(TestProcessSpec, self).setUp()
@@ -27,50 +30,42 @@ class TestProcessSpec(AiidaTestCase):
         self.assertIsNone(Process.current())
 
     def test_dynamic_input(self):
-        from aiida.orm import Node
-        from aiida.orm.nodes.data import Data
-
-        n = Node()
-        d = Data()
+        """Test a process spec with dynamic input enabled."""
+        node = Node()
+        data = Data()
         self.assertIsNotNone(self.spec.validate_inputs({'key': 'foo'}))
         self.assertIsNotNone(self.spec.validate_inputs({'key': 5}))
-        self.assertIsNotNone(self.spec.validate_inputs({'key': n}))
-        self.assertIsNone(self.spec.validate_inputs({'key': d}))
+        self.assertIsNotNone(self.spec.validate_inputs({'key': node}))
+        self.assertIsNone(self.spec.validate_inputs({'key': data}))
 
     def test_dynamic_output(self):
-        from aiida.orm import Node
-        from aiida.orm.nodes.data import Data
-
-        n = Node()
-        d = Data()
+        """Test a process spec with dynamic output enabled."""
+        node = Node()
+        data = Data()
         self.assertIsNotNone(self.spec.validate_outputs({'key': 'foo'}))
         self.assertIsNotNone(self.spec.validate_outputs({'key': 5}))
-        self.assertIsNotNone(self.spec.validate_outputs({'key': n}))
-        self.assertIsNone(self.spec.validate_outputs({'key': d}))
+        self.assertIsNotNone(self.spec.validate_outputs({'key': node}))
+        self.assertIsNone(self.spec.validate_outputs({'key': data}))
 
     def test_exit_code(self):
-        """
-        Test the definition of error codes through the ProcessSpec
-        """
+        """Test the definition of error codes through the ProcessSpec."""
         label = 'SOME_EXIT_CODE'
         status = 418
         message = 'I am a teapot'
 
         self.spec.exit_code(status, label, message)
 
-        self.assertEquals(self.spec.exit_codes.SOME_EXIT_CODE.status, status)
-        self.assertEquals(self.spec.exit_codes.SOME_EXIT_CODE.message, message)
+        self.assertEqual(self.spec.exit_codes.SOME_EXIT_CODE.status, status)
+        self.assertEqual(self.spec.exit_codes.SOME_EXIT_CODE.message, message)
 
-        self.assertEquals(self.spec.exit_codes['SOME_EXIT_CODE'].status, status)
-        self.assertEquals(self.spec.exit_codes['SOME_EXIT_CODE'].message, message)
+        self.assertEqual(self.spec.exit_codes['SOME_EXIT_CODE'].status, status)
+        self.assertEqual(self.spec.exit_codes['SOME_EXIT_CODE'].message, message)
 
-        self.assertEquals(self.spec.exit_codes[label].status, status)
-        self.assertEquals(self.spec.exit_codes[label].message, message)
+        self.assertEqual(self.spec.exit_codes[label].status, status)
+        self.assertEqual(self.spec.exit_codes[label].message, message)
 
     def test_exit_code_invalid(self):
-        """
-        Test type validation for registering new error codes
-        """
+        """Test type validation for registering new error codes."""
         status = 418
         label = 'SOME_EXIT_CODE'
         message = 'I am a teapot'

--- a/aiida/backends/tests/engine/test_rmq.py
+++ b/aiida/backends/tests/engine/test_rmq.py
@@ -18,8 +18,8 @@ from tornado import gen
 from aiida.backends.testbase import AiidaTestCase
 from aiida.backends.tests.utils import processes as test_processes
 from aiida.engine import ProcessState, submit
-from aiida.orm.nodes.data.int import Int
 from aiida.manage.manager import get_manager
+from aiida.orm import Int
 
 
 class TestProcessControl(AiidaTestCase):

--- a/aiida/backends/tests/engine/test_run.py
+++ b/aiida/backends/tests/engine/test_run.py
@@ -7,6 +7,7 @@
 # For further information on the license, see the LICENSE.txt file        #
 # For further information please visit http://www.aiida.net               #
 ###########################################################################
+"""Tests for the `run` functions."""
 from __future__ import division
 from __future__ import print_function
 from __future__ import absolute_import
@@ -14,24 +15,20 @@ from __future__ import absolute_import
 from aiida.backends.testbase import AiidaTestCase
 from aiida.backends.tests.utils.processes import DummyProcess
 from aiida.engine import run, run_get_node
-from aiida.orm.nodes.data.int import Int
-from aiida.orm.nodes.data.str import Str
-from aiida.orm import ProcessNode
+from aiida.orm import Int, Str, ProcessNode
 
 
 class TestRun(AiidaTestCase):
+    """Tests for the `run` functions."""
 
-    def setUp(self):
-        super(TestRun, self).setUp()
-
-    def tearDown(self):
-        super(TestRun, self).tearDown()
-
-    def test_run(self):
+    @staticmethod
+    def test_run():
+        """Test the `run` function."""
         inputs = {'a': Int(2), 'b': Str('test')}
         run(DummyProcess, **inputs)
 
     def test_run_get_node(self):
+        """Test the `run_get_node` function."""
         inputs = {'a': Int(2), 'b': Str('test')}
-        result, node = run_get_node(DummyProcess, **inputs)
+        result, node = run_get_node(DummyProcess, **inputs)  # pylint: disable=unused-variable
         self.assertIsInstance(node, ProcessNode)

--- a/aiida/backends/tests/engine/test_work_chain.py
+++ b/aiida/backends/tests/engine/test_work_chain.py
@@ -25,11 +25,7 @@ from aiida.common.utils import Capturing
 from aiida.engine import ExitCode, Process, ToContext, WorkChain, if_, while_, return_, run, run_get_node
 from aiida.engine.persistence import ObjectLoader
 from aiida.manage.manager import get_manager
-from aiida.orm import load_node
-from aiida.orm.nodes.data.bool import Bool
-from aiida.orm.nodes.data.float import Float
-from aiida.orm.nodes.data.int import Int
-from aiida.orm.nodes.data.str import Str
+from aiida.orm import load_node, Bool, Float, Int, Str
 
 
 def run_until_paused(proc):

--- a/aiida/backends/tests/engine/test_workfunctions.py
+++ b/aiida/backends/tests/engine/test_workfunctions.py
@@ -16,8 +16,7 @@ from aiida.backends.testbase import AiidaTestCase
 from aiida.manage.caching import enable_caching
 from aiida.common.links import LinkType
 from aiida.engine import workfunction, Process
-from aiida.orm.nodes.data.int import Int
-from aiida.orm import WorkFunctionNode
+from aiida.orm import Int, WorkFunctionNode
 
 
 class TestWorkFunction(AiidaTestCase):

--- a/aiida/backends/tests/manage/configuration/migrations/test_migrations.py
+++ b/aiida/backends/tests/manage/configuration/migrations/test_migrations.py
@@ -22,7 +22,7 @@ try:
 except ImportError:
     import mock
 
-import aiida.common.json as json
+from aiida.common import json
 
 from aiida.manage.configuration import Config
 from aiida.manage.configuration.migrations.utils import check_and_migrate_config

--- a/aiida/backends/tests/orm/data/test_data.py
+++ b/aiida/backends/tests/orm/data/test_data.py
@@ -6,8 +6,7 @@ from __future__ import absolute_import
 
 from aiida.backends.testbase import AiidaTestCase
 from aiida.common.links import LinkType
-from aiida.orm import CalculationNode
-from aiida.orm.nodes.data import Data
+from aiida.orm import CalculationNode, Data
 
 
 class TestDataNodeLinks(AiidaTestCase):

--- a/aiida/backends/tests/orm/data/test_remote.py
+++ b/aiida/backends/tests/orm/data/test_remote.py
@@ -10,6 +10,7 @@
 from __future__ import division
 from __future__ import print_function
 from __future__ import absolute_import
+
 import errno
 import io
 import os
@@ -17,9 +18,7 @@ import shutil
 import tempfile
 
 from aiida.backends.testbase import AiidaTestCase
-from aiida.orm.nodes.data.remote import RemoteData
-
-from aiida.orm import User, AuthInfo
+from aiida.orm import RemoteData, User, AuthInfo
 
 
 class TestRemoteData(AiidaTestCase):

--- a/aiida/backends/tests/orm/data/test_upf.py
+++ b/aiida/backends/tests/orm/data/test_upf.py
@@ -20,8 +20,8 @@ import shutil
 import os
 
 from aiida.backends.testbase import AiidaTestCase
-from aiida.orm.nodes.data.upf import parse_upf
 from aiida.common.exceptions import ParsingError
+from aiida.orm.nodes.data.upf import parse_upf
 
 
 class TestUpfParser(AiidaTestCase):

--- a/aiida/backends/tests/orm/node/test_node.py
+++ b/aiida/backends/tests/orm/node/test_node.py
@@ -7,11 +7,8 @@ from __future__ import absolute_import
 import os
 
 from aiida.backends.testbase import AiidaTestCase
-from aiida.common import exceptions
-from aiida.common.links import LinkType
-from aiida.orm.nodes.data import Data
-from aiida.orm import Node, User
-from aiida.orm import CalculationNode, WorkflowNode
+from aiida.common import exceptions, LinkType
+from aiida.orm import Data, Node, User, CalculationNode, WorkflowNode
 from aiida.orm.utils.links import LinkTriple
 
 

--- a/aiida/backends/tests/orm/test_mixins.py
+++ b/aiida/backends/tests/orm/test_mixins.py
@@ -15,8 +15,7 @@ from __future__ import absolute_import
 from aiida.backends.testbase import AiidaTestCase
 from aiida.common import exceptions
 from aiida.common.links import LinkType
-from aiida.orm.nodes.data.int import Int
-from aiida.orm import CalculationNode
+from aiida.orm import Int, CalculationNode
 from aiida.orm.utils.mixins import Sealable
 
 

--- a/aiida/backends/tests/orm/utils/test_calcjob.py
+++ b/aiida/backends/tests/orm/utils/test_calcjob.py
@@ -14,8 +14,7 @@ from __future__ import absolute_import
 
 from aiida.backends.testbase import AiidaTestCase
 from aiida.common.links import LinkType
-from aiida.orm.nodes.data.dict import Dict
-from aiida.orm import CalcJobNode
+from aiida.orm import Dict, CalcJobNode
 from aiida.orm.utils.calcjob import CalcJobResultManager
 from aiida.plugins import CalculationFactory
 from aiida.plugins.entry_point import get_entry_point_string_from_class

--- a/aiida/backends/tests/orm/utils/test_node.py
+++ b/aiida/backends/tests/orm/utils/test_node.py
@@ -13,7 +13,7 @@ from __future__ import print_function
 from __future__ import absolute_import
 
 from aiida.backends.testbase import AiidaTestCase
-from aiida.orm.nodes.data import Data
+from aiida.orm import Data
 from aiida.orm.utils.node import load_node_class
 
 

--- a/aiida/backends/tests/test_backup_script.py
+++ b/aiida/backends/tests/test_backup_script.py
@@ -25,7 +25,7 @@ from aiida.common import utils
 from aiida.manage.backup import backup_setup
 from aiida.manage.backup import backup_utils
 from aiida.orm import Data
-import aiida.common.json as json
+from aiida.common import json
 
 
 if not is_dbenv_loaded():

--- a/aiida/backends/tests/test_base_dataclasses.py
+++ b/aiida/backends/tests/test_base_dataclasses.py
@@ -17,13 +17,8 @@ from six.moves import range, zip
 
 from aiida.backends.testbase import AiidaTestCase
 from aiida.common.exceptions import ModificationNotAllowed
-from aiida.orm import load_node
-from aiida.orm.nodes.data.numeric import NumericType
-from aiida.orm.nodes.data.list import List
-from aiida.orm.nodes.data.bool import Bool, get_true_node, get_false_node
-from aiida.orm.nodes.data.float import Float
-from aiida.orm.nodes.data.int import Int
-from aiida.orm.nodes.data.str import Str
+from aiida.orm import load_node, List, Bool, Float, Int, Str, NumericType
+from aiida.orm.nodes.data.bool import get_true_node, get_false_node
 
 
 class TestList(AiidaTestCase):

--- a/aiida/backends/tests/test_caching_config.py
+++ b/aiida/backends/tests/test_caching_config.py
@@ -10,32 +10,27 @@
 from __future__ import division
 from __future__ import print_function
 from __future__ import absolute_import
-import io
-import unittest
-import tempfile
 
+import tempfile
+import unittest
 import yaml
 
 from aiida.backends.utils import get_current_profile
-from aiida.manage.caching import configure, get_use_cache, enable_caching, disable_caching
-from aiida.orm.nodes.data.bool import Bool
-from aiida.orm.nodes.data.float import Float
-from aiida.orm.nodes.data.int import Int
 from aiida.calculations.plugins.templatereplacer import TemplatereplacerCalculation
+from aiida.manage.caching import configure, get_use_cache, enable_caching, disable_caching
+from aiida.orm import Bool, Float, Int
+
 
 class CacheConfigTest(unittest.TestCase):
-    """
-    Tests the caching configuration.
-    """
+    """Tests the caching configuration."""
+
     def setUp(self):
-        """
-        Write a temporary config file, and load the configuration.
-        """
+        """Write a temporary config file, and load the configuration."""
         self.config_reference = {
             get_current_profile(): {
                 'default': True,
-                'enabled': ['aiida.orm.nodes.data.bool.Bool', 'aiida.orm.nodes.data.float.Float'],
-                'disabled': ['aiida.calculations.plugins.templatereplacer.TemplatereplacerCalculation', 'aiida.orm.nodes.data.bool.Bool']
+                'enabled': ['aiida.orm.Bool', 'aiida.orm.Float'],
+                'disabled': ['aiida.calculations.plugins.templatereplacer.TemplatereplacerCalculation', 'aiida.orm.Bool']
             }
         }
         with tempfile.NamedTemporaryFile() as tmpf:
@@ -60,11 +55,10 @@ class CacheConfigTest(unittest.TestCase):
 
     def test_contextmanager_disable_global(self):
         with disable_caching():
-            self.assertTrue(get_use_cache(Float)) # explicitly set, hence not overwritten
+            self.assertTrue(get_use_cache(Float))  # explicitly set, hence not overwritten
             self.assertFalse(get_use_cache(Int))
 
     def test_disable_caching(self):
-        from aiida.orm.nodes.data.float import Float
         with disable_caching(Float):
             self.assertFalse(get_use_cache(Float))
         self.assertTrue(get_use_cache(Float))

--- a/aiida/backends/tests/test_dataclasses.py
+++ b/aiida/backends/tests/test_dataclasses.py
@@ -13,15 +13,20 @@ Tests for specific subclasses of Data
 from __future__ import print_function
 from __future__ import absolute_import
 from __future__ import division
+
 import io
+import os
+import tempfile
 import unittest
 
 from six.moves import range
 
-from aiida.orm import load_node
-from aiida.common.exceptions import ModificationNotAllowed
 from aiida.backends.testbase import AiidaTestCase
+from aiida.common.exceptions import ModificationNotAllowed
 from aiida.common.utils import Capturing
+from aiida.orm import load_node
+from aiida.orm import CifData, SinglefileData, StructureData, KpointsData, BandsData, ArrayData, TrajectoryData, Dict
+from aiida.orm.nodes.data.structure import Kind, Site
 
 
 def has_seekpath():
@@ -64,11 +69,6 @@ class TestSinglefileData(AiidaTestCase):
     """
 
     def test_reload_singlefiledata(self):
-        import os
-        import tempfile
-
-        from aiida.orm.nodes.data.singlefile import SinglefileData
-
         file_content = 'some text ABCDE'
         with tempfile.NamedTemporaryFile(mode='w+') as tmpf:
             filename = tmpf.name
@@ -103,11 +103,9 @@ class TestCifData(AiidaTestCase):
     """
     Tests for CifData class.
     """
-    from aiida.orm.nodes.data.cif import has_pycifrw
-    from aiida.orm.nodes.data.structure import has_ase, has_pymatgen, has_spglib, \
-        get_pymatgen_version
-    
     from distutils.version import StrictVersion
+    from aiida.orm.nodes.data.cif import has_pycifrw
+    from aiida.orm.nodes.data.structure import has_ase, has_pymatgen, has_spglib, get_pymatgen_version
 
     valid_sample_cif_str = '''
         data_test
@@ -150,11 +148,6 @@ class TestCifData(AiidaTestCase):
 
     @unittest.skipIf(not has_pycifrw(), "Unable to import PyCifRW")
     def test_reload_cifdata(self):
-        import os
-        import tempfile
-
-        from aiida.orm.nodes.data.cif import CifData
-
         file_content = "data_test _cell_length_a 10(1)"
         with tempfile.NamedTemporaryFile(mode='w+') as tmpf:
             filename = tmpf.name
@@ -216,10 +209,6 @@ class TestCifData(AiidaTestCase):
 
     @unittest.skipIf(not has_pycifrw(), "Unable to import PyCifRW")
     def test_parse_cifdata(self):
-        import tempfile
-
-        from aiida.orm.nodes.data.cif import CifData
-
         file_content = "data_test _cell_length_a 10(1)"
         with tempfile.NamedTemporaryFile(mode='w+') as tmpf:
             tmpf.write(file_content)
@@ -230,10 +219,6 @@ class TestCifData(AiidaTestCase):
 
     @unittest.skipIf(not has_pycifrw(), "Unable to import PyCifRW")
     def test_change_cifdata_file(self):
-        import tempfile
-
-        from aiida.orm.nodes.data.cif import CifData
-
         file_content_1 = "data_test _cell_length_a 10(1)"
         file_content_2 = "data_test _cell_length_a 11(1)"
         with tempfile.NamedTemporaryFile(mode='w+') as tmpf:
@@ -253,10 +238,6 @@ class TestCifData(AiidaTestCase):
     @unittest.skipIf(not has_ase(), "Unable to import ase")
     @unittest.skipIf(not has_pycifrw(), "Unable to import PyCifRW")
     def test_get_structure(self):
-        import tempfile
-
-        from aiida.orm.nodes.data.cif import CifData
-
         with tempfile.NamedTemporaryFile(mode='w+') as tmpf:
             tmpf.write('''
 data_test
@@ -296,10 +277,7 @@ O 0.5 0.5 0.5
         returned by ASE ase.io.read() method. Test input is
         adapted from http://www.crystallography.net/cod/9012064.cif@120115
         """
-        import tempfile
         import ase
-
-        from aiida.orm.nodes.data.cif import CifData
 
         with tempfile.NamedTemporaryFile(mode='w+') as tmpf:
             tmpf.write('''
@@ -344,10 +322,6 @@ O 0.5 0.5 0.5
         returned by ASE ase.io.read() method. Test input is
         adapted from http://www.crystallography.net/cod/9012064.cif@120115
         """
-        import tempfile
-
-        from aiida.orm.nodes.data.cif import CifData
-
         with tempfile.NamedTemporaryFile(mode='w+') as tmpf:
             tmpf.write('''
 data_9012064
@@ -483,9 +457,6 @@ _tag                                    '[value]'
         are supported.
         Should not raise any error.
         """
-        import tempfile
-        from aiida.orm.nodes.data.cif import CifData
-
         with tempfile.NamedTemporaryFile(mode='w+') as tmpf:
             tmpf.write('''
 data_0
@@ -497,9 +468,6 @@ _tag   {}
     @unittest.skipIf(not has_ase(), "Unable to import ase")
     @unittest.skipIf(not has_pycifrw(), "Unable to import PyCifRW")
     def test_cif_roundtrip(self):
-        import tempfile
-        from aiida.orm.nodes.data.cif import CifData
-
         with tempfile.NamedTemporaryFile(mode='w+') as tmpf:
             tmpf.write('''
                 data_test
@@ -543,9 +511,6 @@ _tag   {}
     @unittest.skipIf(not has_ase(), "Unable to import ase")
     @unittest.skipIf(not has_pycifrw(), "Unable to import PyCifRW")
     def test_attached_hydrogens(self):
-        import tempfile
-        from aiida.orm.nodes.data.cif import CifData
-
         with tempfile.NamedTemporaryFile(mode='w+') as tmpf:
             tmpf.write('''
                 data_test
@@ -602,9 +567,7 @@ _tag   {}
         Test case for refinement (space group determination) for a
         CifData object.
         """
-        from aiida.orm.nodes.data.cif import CifData
         from aiida.tools.data.cif import refine_inline
-        import tempfile
 
         with tempfile.NamedTemporaryFile(mode='w+') as tmpf:
             tmpf.write('''
@@ -670,9 +633,6 @@ _tag   {}
         """
         Check that different scan_types of PyCifRW produce the same result.
         """
-        import tempfile
-        from aiida.orm.nodes.data.cif import CifData
-
         with tempfile.NamedTemporaryFile(mode='w+') as tmpf:
             tmpf.write(self.valid_sample_cif_str)
             tmpf.flush()
@@ -691,9 +651,6 @@ _tag   {}
 
         Note: This test does not need PyCifRW.
         """
-        import tempfile
-        from aiida.orm.nodes.data.cif import CifData
-
         with tempfile.NamedTemporaryFile(mode='w+') as tmpf:
             tmpf.write(self.valid_sample_cif_str)
             tmpf.flush()
@@ -716,9 +673,6 @@ _tag   {}
         """
         Test that loading of CIF file occurs as defined by parse_policy.
         """
-        import tempfile
-        from aiida.orm.nodes.data.cif import CifData
-
         with tempfile.NamedTemporaryFile(mode='w+') as tmpf:
             tmpf.write(self.valid_sample_cif_str)
             tmpf.flush()
@@ -743,9 +697,6 @@ _tag   {}
         """
         Test that setting a new file clears formulae and spacegroups.
         """
-        import tempfile
-        from aiida.orm.nodes.data.cif import CifData
-
         with tempfile.NamedTemporaryFile(mode='w+') as tmpf:
             tmpf.write(self.valid_sample_cif_str)
             tmpf.flush()
@@ -782,9 +733,6 @@ _tag   {}
 
     @unittest.skipIf(not has_pycifrw(), "Unable to import PyCifRW")
     def test_has_partial_occupancies(self):
-        import tempfile
-        from aiida.orm.nodes.data.cif import CifData
-
         tests = [
             # Unreadable occupations should not count as a partial occupancy
             ('O 0.5 0.5(1) 0.5 ?', False),
@@ -814,9 +762,6 @@ _tag   {}
 
     @unittest.skipIf(not has_pycifrw(), "Unable to import PyCifRW")
     def test_has_unknown_species(self):
-        import tempfile
-        from aiida.orm.nodes.data.cif import CifData
-
         tests = [
             ('H2 O', False),  # No unknown species
             ('OsAx', True),   # Ax is an unknown specie
@@ -834,9 +779,6 @@ _tag   {}
 
     @unittest.skipIf(not has_pycifrw(), "Unable to import PyCifRW")
     def test_has_undefined_atomic_sites(self):
-        import tempfile
-        from aiida.orm.nodes.data.cif import CifData
-
         tests = [
             ('C 0.0 0.0 0.0', False),  # Should return False because all sites have valid coordinates
             ('C 0.0 0.0 ?', True),     # Should return True because one site has an undefined coordinate
@@ -863,36 +805,28 @@ class TestKindValidSymbols(AiidaTestCase):
         """
         Should not accept a non-existing symbol.
         """
-        from aiida.orm.nodes.data.structure import Kind
-
         with self.assertRaises(ValueError):
-            _ = Kind(symbols='Hxx')
+            Kind(symbols='Hxx')
 
     def test_empty_list_symbols(self):
         """
         Should not accept an empty list
         """
-        from aiida.orm.nodes.data.structure import Kind
-
         with self.assertRaises(ValueError):
-            _ = Kind(symbols=[])
+            Kind(symbols=[])
 
     def test_valid_list(self):
         """
         Should not raise any error.
         """
-        from aiida.orm.nodes.data.structure import Kind
-
-        _ = Kind(symbols=['H', 'He'], weights=[0.5, 0.5])
+        Kind(symbols=['H', 'He'], weights=[0.5, 0.5])
 
     def test_unknown_symbol(self):
         """
         Should test if symbol X is valid and defined
         in the elements dictionary.
         """
-        from aiida.orm.nodes.data.structure import Kind
-
-        _ = Kind(symbols=['X'])
+        Kind(symbols=['X'])
 
 
 class TestSiteValidWeights(AiidaTestCase):
@@ -904,74 +838,58 @@ class TestSiteValidWeights(AiidaTestCase):
         """
         Should not accept a non-list, non-number weight
         """
-        from aiida.orm.nodes.data.structure import Kind
-
         with self.assertRaises(ValueError):
-            _ = Kind(symbols='Ba', weights='aaa')
+            Kind(symbols='Ba', weights='aaa')
 
     def test_empty_list_weights(self):
         """
         Should not accept an empty list
         """
-        from aiida.orm.nodes.data.structure import Kind
-
         with self.assertRaises(ValueError):
-            _ = Kind(symbols='Ba', weights=[])
+            Kind(symbols='Ba', weights=[])
 
     def test_symbol_weight_mismatch(self):
         """
         Should not accept a size mismatch of the symbols and weights
         list.
         """
-        from aiida.orm.nodes.data.structure import Kind
+        with self.assertRaises(ValueError):
+            Kind(symbols=['Ba', 'C'], weights=[1.])
 
         with self.assertRaises(ValueError):
-            _ = Kind(symbols=['Ba', 'C'], weights=[1.])
-
-        with self.assertRaises(ValueError):
-            _ = Kind(symbols=['Ba'], weights=[0.1, 0.2])
+            Kind(symbols=['Ba'], weights=[0.1, 0.2])
 
     def test_negative_value(self):
         """
         Should not accept a negative weight
         """
-        from aiida.orm.nodes.data.structure import Kind
-
         with self.assertRaises(ValueError):
-            _ = Kind(symbols=['Ba', 'C'], weights=[-0.1, 0.3])
+            Kind(symbols=['Ba', 'C'], weights=[-0.1, 0.3])
 
     def test_sum_greater_one(self):
         """
         Should not accept a sum of weights larger than one
         """
-        from aiida.orm.nodes.data.structure import Kind
-
         with self.assertRaises(ValueError):
-            _ = Kind(symbols=['Ba', 'C'], weights=[0.5, 0.6])
+            Kind(symbols=['Ba', 'C'], weights=[0.5, 0.6])
 
     def test_sum_one_weights(self):
         """
         Should accept a sum equal to one
         """
-        from aiida.orm.nodes.data.structure import Kind
-
-        _ = Kind(symbols=['Ba', 'C'], weights=[1. / 3., 2. / 3.])
+        Kind(symbols=['Ba', 'C'], weights=[1. / 3., 2. / 3.])
 
     def test_sum_less_one_weights(self):
         """
         Should accept a sum equal less than one
         """
-        from aiida.orm.nodes.data.structure import Kind
-
-        _ = Kind(symbols=['Ba', 'C'], weights=[1. / 3., 1. / 3.])
+        Kind(symbols=['Ba', 'C'], weights=[1. / 3., 1. / 3.])
 
     def test_none(self):
         """
         Should accept None.
         """
-        from aiida.orm.nodes.data.structure import Kind
-
-        _ = Kind(symbols='Ba', weights=None)
+        Kind(symbols='Ba', weights=None)
 
 
 class TestKindTestGeneral(AiidaTestCase):
@@ -983,8 +901,6 @@ class TestKindTestGeneral(AiidaTestCase):
         """
         Should accept a sum equal to one
         """
-        from aiida.orm.nodes.data.structure import Kind
-
         a = Kind(symbols=['Ba', 'C'], weights=[1. / 3., 2. / 3.])
         self.assertTrue(a.is_alloy)
         self.assertFalse(a.has_vacancies)
@@ -993,8 +909,6 @@ class TestKindTestGeneral(AiidaTestCase):
         """
         Should accept a sum equal less than one
         """
-        from aiida.orm.nodes.data.structure import Kind
-
         a = Kind(symbols=['Ba', 'C'], weights=[1. / 3., 1. / 3.])
         self.assertTrue(a.is_alloy)
         self.assertTrue(a.has_vacancies)
@@ -1003,17 +917,13 @@ class TestKindTestGeneral(AiidaTestCase):
         """
         Should not accept a 'positions' parameter
         """
-        from aiida.orm.nodes.data.structure import Kind
-
         with self.assertRaises(ValueError):
-            _ = Kind(position=[0., 0., 0.], symbols=['Ba'], weights=[1.])
+            Kind(position=[0., 0., 0.], symbols=['Ba'], weights=[1.])
 
     def test_simple(self):
         """
         Should recognize a simple element.
         """
-        from aiida.orm.nodes.data.structure import Kind
-
         a = Kind(symbols='Ba')
         self.assertFalse(a.is_alloy)
         self.assertFalse(a.has_vacancies)
@@ -1030,8 +940,6 @@ class TestKindTestGeneral(AiidaTestCase):
         """
         Check the automatic name generator.
         """
-        from aiida.orm.nodes.data.structure import Kind
-
         a = Kind(symbols='Ba')
         self.assertEqual(a.name, 'Ba')
 
@@ -1064,7 +972,7 @@ class TestKindTestMasses(AiidaTestCase):
         """
         mass for elements with sum one
         """
-        from aiida.orm.nodes.data.structure import Kind, _atomic_masses
+        from aiida.orm.nodes.data.structure import _atomic_masses
 
         a = Kind(symbols=['Ba', 'C'], weights=[1. / 3., 2. / 3.])
         self.assertAlmostEqual(a.mass, (_atomic_masses['Ba'] + 2. * _atomic_masses['C']) / 3.)
@@ -1073,7 +981,7 @@ class TestKindTestMasses(AiidaTestCase):
         """
         mass for elements with sum less than one
         """
-        from aiida.orm.nodes.data.structure import Kind, _atomic_masses
+        from aiida.orm.nodes.data.structure import _atomic_masses
 
         a = Kind(symbols=['Ba', 'C'], weights=[1. / 3., 1. / 3.])
         self.assertAlmostEqual(a.mass, (_atomic_masses['Ba'] + _atomic_masses['C']) / 2.)
@@ -1082,7 +990,7 @@ class TestKindTestMasses(AiidaTestCase):
         """
         mass for a single element
         """
-        from aiida.orm.nodes.data.structure import Kind, _atomic_masses
+        from aiida.orm.nodes.data.structure import _atomic_masses
 
         a = Kind(symbols=['Ba'])
         self.assertAlmostEqual(a.mass, _atomic_masses['Ba'])
@@ -1091,8 +999,6 @@ class TestKindTestMasses(AiidaTestCase):
         """
         mass set manually
         """
-        from aiida.orm.nodes.data.structure import Kind
-
         a = Kind(symbols=['Ba', 'C'], weights=[1. / 3., 1. / 3.], mass=1000.)
         self.assertAlmostEqual(a.mass, 1000.)
 
@@ -1106,44 +1012,34 @@ class TestStructureDataInit(AiidaTestCase):
         """
         Wrong cell size (not 3x3)
         """
-        from aiida.orm.nodes.data.structure import StructureData
-
         with self.assertRaises(ValueError):
-            _ = StructureData(cell=((1., 2., 3.),))
+            StructureData(cell=((1., 2., 3.),))
 
     def test_cell_wrong_size_2(self):
         """
         Wrong cell size (not 3x3)
         """
-        from aiida.orm.nodes.data.structure import StructureData
-
         with self.assertRaises(ValueError):
-            _ = StructureData(cell=((1., 0., 0.), (0., 0., 3.), (0., 3.)))
+            StructureData(cell=((1., 0., 0.), (0., 0., 3.), (0., 3.)))
 
     def test_cell_zero_vector(self):
         """
         Wrong cell (one vector has zero length)
         """
-        from aiida.orm.nodes.data.structure import StructureData
-
         with self.assertRaises(ValueError):
-            _ = StructureData(cell=((0., 0., 0.), (0., 1., 0.), (0., 0., 1.)))
+            StructureData(cell=((0., 0., 0.), (0., 1., 0.), (0., 0., 1.)))
 
     def test_cell_zero_volume(self):
         """
         Wrong cell (volume is zero)
         """
-        from aiida.orm.nodes.data.structure import StructureData
-
         with self.assertRaises(ValueError):
-            _ = StructureData(cell=((1., 0., 0.), (0., 1., 0.), (1., 1., 0.)))
+            StructureData(cell=((1., 0., 0.), (0., 1., 0.), (1., 1., 0.)))
 
     def test_cell_ok_init(self):
         """
         Correct cell
         """
-        from aiida.orm.nodes.data.structure import StructureData
-
         cell = ((1., 0., 0.), (0., 2., 0.), (0., 0., 3.))
         a = StructureData(cell=cell)
         out_cell = a.cell
@@ -1156,8 +1052,6 @@ class TestStructureDataInit(AiidaTestCase):
         """
         Check the volume calculation
         """
-        from aiida.orm.nodes.data.structure import StructureData
-
         a = StructureData(cell=((1., 0., 0.), (0., 2., 0.), (0., 0., 3.)))
         self.assertAlmostEqual(a.get_cell_volume(), 6.)
 
@@ -1165,38 +1059,30 @@ class TestStructureDataInit(AiidaTestCase):
         """
         Wrong pbc parameter (not bool or iterable)
         """
-        from aiida.orm.nodes.data.structure import StructureData
-
         with self.assertRaises(ValueError):
             cell = ((1., 0., 0.), (0., 2., 0.), (0., 0., 3.))
-            _ = StructureData(cell=cell, pbc=1)
+            StructureData(cell=cell, pbc=1)
 
     def test_wrong_pbc_2(self):
         """
         Wrong pbc parameter (iterable but with wrong len)
         """
-        from aiida.orm.nodes.data.structure import StructureData
-
         with self.assertRaises(ValueError):
             cell = ((1., 0., 0.), (0., 2., 0.), (0., 0., 3.))
-            _ = StructureData(cell=cell, pbc=[True, True])
+            StructureData(cell=cell, pbc=[True, True])
 
     def test_wrong_pbc_3(self):
         """
         Wrong pbc parameter (iterable but with wrong len)
         """
-        from aiida.orm.nodes.data.structure import StructureData
-
         with self.assertRaises(ValueError):
             cell = ((1., 0., 0.), (0., 2., 0.), (0., 0., 3.))
-            _ = StructureData(cell=cell, pbc=[])
+            StructureData(cell=cell, pbc=[])
 
     def test_ok_pbc_1(self):
         """
         Single pbc value
         """
-        from aiida.orm.nodes.data.structure import StructureData
-
         cell = ((1., 0., 0.), (0., 2., 0.), (0., 0., 3.))
         a = StructureData(cell=cell, pbc=True)
         self.assertEquals(a.pbc, tuple([True, True, True]))
@@ -1208,8 +1094,6 @@ class TestStructureDataInit(AiidaTestCase):
         """
         One-element list
         """
-        from aiida.orm.nodes.data.structure import StructureData
-
         cell = ((1., 0., 0.), (0., 2., 0.), (0., 0., 3.))
         a = StructureData(cell=cell, pbc=[True])
         self.assertEqual(a.pbc, tuple([True, True, True]))
@@ -1221,8 +1105,6 @@ class TestStructureDataInit(AiidaTestCase):
         """
         Three-element list
         """
-        from aiida.orm.nodes.data.structure import StructureData
-
         cell = ((1., 0., 0.), (0., 2., 0.), (0., 0., 3.))
         a = StructureData(cell=cell, pbc=[True, False, True])
         self.assertEqual(a.pbc, tuple([True, False, True]))
@@ -1239,8 +1121,6 @@ class TestStructureData(AiidaTestCase):
         """
         Test the creation of a cell and the appending of atoms
         """
-        from aiida.orm.nodes.data.structure import StructureData
-
         cell = [[2., 0., 0.], [0., 2., 0.], [0., 0., 2.]]
 
         a = StructureData(cell=cell)
@@ -1274,8 +1154,6 @@ class TestStructureData(AiidaTestCase):
         Test the creation of a cell and the appending of atoms, including
         the unknown entry.
         """
-        from aiida.orm.nodes.data.structure import StructureData
-
         cell = [[2., 0., 0.], [0., 2., 0.], [0., 0., 2.]]
 
         a = StructureData(cell=cell)
@@ -1309,8 +1187,6 @@ class TestStructureData(AiidaTestCase):
         Test the management of kinds (automatic detection of kind of
         simple atoms).
         """
-        from aiida.orm.nodes.data.structure import StructureData
-
         a = StructureData(cell=((2., 0., 0.), (0., 2., 0.), (0., 0., 2.)))
 
         a.append_atom(position=(0., 0., 0.), symbols=['Ba'])
@@ -1326,8 +1202,6 @@ class TestStructureData(AiidaTestCase):
         Test the management of kinds (automatic detection of kind of
         simple atoms), inluding the unknown entry.
         """
-        from aiida.orm.nodes.data.structure import StructureData
-
         a = StructureData(cell=((2., 0., 0.), (0., 2., 0.), (0., 0., 2.)))
 
         a.append_atom(position=(0., 0., 0.), symbols=['X'])
@@ -1342,8 +1216,6 @@ class TestStructureData(AiidaTestCase):
         """
         Test the management of kinds (manual specification of kind name).
         """
-        from aiida.orm.nodes.data.structure import StructureData
-
         a = StructureData(cell=((2., 0., 0.), (0., 2., 0.), (0., 0., 2.)))
 
         a.append_atom(position=(0., 0., 0.), symbols=['Ba'], name='Ba1')
@@ -1359,8 +1231,6 @@ class TestStructureData(AiidaTestCase):
         Test the management of kinds (manual specification of kind name),
         including the unknown entry.
         """
-        from aiida.orm.nodes.data.structure import StructureData
-
         a = StructureData(cell=((2., 0., 0.), (0., 2., 0.), (0., 0., 2.)))
 
         a.append_atom(position=(0., 0., 0.), symbols=['X'], name='X1')
@@ -1375,8 +1245,6 @@ class TestStructureData(AiidaTestCase):
         """
         Test the management of kinds (adding an atom with different mass).
         """
-        from aiida.orm.nodes.data.structure import StructureData
-
         a = StructureData(cell=((2., 0., 0.), (0., 2., 0.), (0., 0., 2.)))
 
         a.append_atom(position=(0., 0., 0.), symbols=['Ba'], mass=100.)
@@ -1398,8 +1266,6 @@ class TestStructureData(AiidaTestCase):
         Test the management of kinds (adding an atom with different mass),
         including the unknown entry.
         """
-        from aiida.orm.nodes.data.structure import StructureData
-
         a = StructureData(cell=((2., 0., 0.), (0., 2., 0.), (0., 0., 2.)))
 
         a.append_atom(position=(0., 0., 0.), symbols=['X'], mass=100.)
@@ -1421,8 +1287,6 @@ class TestStructureData(AiidaTestCase):
         Test the management of kind (adding an atom with different symbols
         or weights).
         """
-        from aiida.orm.nodes.data.structure import StructureData
-
         a = StructureData(cell=((2., 0., 0.), (0., 2., 0.), (0., 0., 2.)))
 
         a.append_atom(position=(0., 0., 0.), symbols=['Ba', 'Ti'], weights=(1., 0.), name='mytype')
@@ -1453,8 +1317,6 @@ class TestStructureData(AiidaTestCase):
         Test the management of kind (adding an atom with different symbols
         or weights), including the unknown entry.
         """
-        from aiida.orm.nodes.data.structure import StructureData
-
         a = StructureData(cell=((2., 0., 0.), (0., 2., 0.), (0., 0., 2.)))
 
         a.append_atom(position=(0., 0., 0.), symbols=['X', 'Ti'], weights=(1., 0.), name='mytype')
@@ -1485,8 +1347,6 @@ class TestStructureData(AiidaTestCase):
         Test the management of kinds (automatic creation of new kind
         if name is not specified and properties are different).
         """
-        from aiida.orm.nodes.data.structure import StructureData
-
         a = StructureData(cell=((2., 0., 0.), (0., 2., 0.), (0., 0., 2.)))
 
         a.append_atom(position=(0., 0., 0.), symbols='Ba', mass=100.)
@@ -1512,8 +1372,6 @@ class TestStructureData(AiidaTestCase):
         if name is not specified and properties are different), including
         the unknown entry.
         """
-        from aiida.orm.nodes.data.structure import StructureData
-
         a = StructureData(cell=((2., 0., 0.), (0., 2., 0.), (0., 0., 2.)))
 
         a.append_atom(position=(0., 0., 0.), symbols='X', mass=100.)
@@ -1539,7 +1397,6 @@ class TestStructureData(AiidaTestCase):
         if name is not specified and properties are different).
         This test was failing in, e.g., commit f6a8f4b.
         """
-        from aiida.orm.nodes.data.structure import StructureData
         from aiida.common.constants import elements
 
         s = StructureData(cell=((6., 0., 0.), (0., 6., 0.), (0., 0., 6.)))
@@ -1565,7 +1422,6 @@ class TestStructureData(AiidaTestCase):
         This test was failing in, e.g., commit f6a8f4b. This also includes
         the unknown entry.
         """
-        from aiida.orm.nodes.data.structure import StructureData
         from aiida.common.constants import elements
 
         s = StructureData(cell=((6., 0., 0.), (0., 6., 0.), (0., 0., 6.)))
@@ -1589,7 +1445,6 @@ class TestStructureData(AiidaTestCase):
         """
         Same test as test_kind_5_bis, but using ase
         """
-        from aiida.orm.nodes.data.structure import StructureData
         import ase
 
         asecell = ase.Atoms('Fe5', cell=((6., 0., 0.), (0., 6., 0.), (0., 0., 6.)))
@@ -1620,7 +1475,6 @@ class TestStructureData(AiidaTestCase):
         """
         Same test as test_kind_5_bis_unknown, but using ase
         """
-        from aiida.orm.nodes.data.structure import StructureData
         import ase
 
         asecell = ase.Atoms('X5', cell=((6., 0., 0.), (0., 6., 0.), (0., 0., 6.)))
@@ -1651,8 +1505,6 @@ class TestStructureData(AiidaTestCase):
         Test the returning of kinds from the string name (most of the code
         copied from :py:meth:`.test_kind_5`).
         """
-        from aiida.orm.nodes.data.structure import StructureData
-
         a = StructureData(cell=((2., 0., 0.), (0., 2., 0.), (0., 0., 2.)))
 
         a.append_atom(position=(0., 0., 0.), symbols='Ba', mass=100.)
@@ -1680,8 +1532,6 @@ class TestStructureData(AiidaTestCase):
         Test the returning of kinds from the string name (most of the code
         copied from :py:meth:`.test_kind_5`), including the unknown entry.
         """
-        from aiida.orm.nodes.data.structure import StructureData
-
         a = StructureData(cell=((2., 0., 0.), (0., 2., 0.), (0., 0., 2.)))
 
         a.append_atom(position=(0., 0., 0.), symbols='X', mass=100.)
@@ -1708,8 +1558,6 @@ class TestStructureData(AiidaTestCase):
         """
         Test the functions returning the list of kinds, symbols, ...
         """
-        from aiida.orm.nodes.data.structure import StructureData
-
         a = StructureData(cell=((2., 0., 0.), (0., 2., 0.), (0., 0., 2.)))
 
         a.append_atom(position=(0., 0., 0.), symbols='Ba', mass=100.)
@@ -1726,8 +1574,6 @@ class TestStructureData(AiidaTestCase):
         Test the functions returning the list of kinds, symbols, ...
         including the unknown entry.
         """
-        from aiida.orm.nodes.data.structure import StructureData
-
         a = StructureData(cell=((2., 0., 0.), (0., 2., 0.), (0., 0., 2.)))
 
         a.append_atom(position=(0., 0., 0.), symbols='Ba', mass=100.)
@@ -1887,7 +1733,6 @@ class TestStructureData(AiidaTestCase):
         """
         Tests the conversion to CifData
         """
-        from aiida.orm.nodes.data.structure import StructureData
         import re
 
         a = StructureData(cell=((2., 0., 0.), (0., 2., 0.), (0., 0., 2.)))
@@ -2008,8 +1853,6 @@ class TestStructureDataLock(AiidaTestCase):
         """
         Start from a StructureData object, convert to raw and then back
         """
-        from aiida.orm.nodes.data.structure import StructureData, Kind, Site
-
         cell = ((1., 0., 0.), (0., 2., 0.), (0., 0., 3.))
         a = StructureData(cell=cell)
 
@@ -2063,8 +1906,6 @@ class TestStructureDataReload(AiidaTestCase):
         """
         Start from a StructureData object, convert to raw and then back
         """
-        from aiida.orm.nodes.data.structure import StructureData
-
         cell = ((1., 0., 0.), (0., 2., 0.), (0., 0., 3.))
         a = StructureData(cell=cell)
 
@@ -2110,8 +1951,6 @@ class TestStructureDataReload(AiidaTestCase):
         """
         Start from a StructureData object, clone it and see if it is preserved
         """
-        from aiida.orm.nodes.data.structure import StructureData
-
         cell = ((1., 0., 0.), (0., 2., 0.), (0., 0., 3.))
         a = StructureData(cell=cell)
 
@@ -2194,7 +2033,6 @@ class TestStructureDataFromAse(AiidaTestCase):
         """
         Tests roundtrip ASE -> StructureData -> ASE, with tags
         """
-        from aiida.orm.nodes.data.structure import StructureData
         import ase
 
         a = ase.Atoms('Si4Ge4', cell=(1., 2., 3.), pbc=(True, False, False))
@@ -2225,7 +2063,6 @@ class TestStructureDataFromAse(AiidaTestCase):
         Tests roundtrip ASE -> StructureData -> ASE, with tags, and 
         changing the atomic masses
         """
-        from aiida.orm.nodes.data.structure import StructureData
         import ase
 
         a = ase.Atoms('Si4', cell=(1., 2., 3.), pbc=(True, False, False))
@@ -2259,8 +2096,6 @@ class TestStructureDataFromAse(AiidaTestCase):
         """
         Tests StructureData -> ASE, with all sorts of kind names
         """
-        from aiida.orm.nodes.data.structure import StructureData
-
         a = StructureData()
         a.append_atom(position=(0., 0., 0.), symbols='Ba', name='Ba')
         a.append_atom(position=(0., 0., 0.), symbols='Ba', name='Ba1')
@@ -2289,7 +2124,6 @@ class TestStructureDataFromAse(AiidaTestCase):
         """
         Tests ASE -> StructureData -> ASE, in particular conversion tags / kind names
         """
-        from aiida.orm.nodes.data.structure import StructureData
         import ase
 
         atoms = ase.Atoms('Fe5')
@@ -2312,7 +2146,6 @@ class TestStructureDataFromAse(AiidaTestCase):
         Tests ASE -> StructureData -> ASE, in particular conversion tags / kind names
         (subtle variation of test_conversion_of_types_4)
         """
-        from aiida.orm.nodes.data.structure import StructureData
         import ase
 
         atoms = ase.Atoms('Fe5')
@@ -2334,8 +2167,6 @@ class TestStructureDataFromAse(AiidaTestCase):
         """
         Tests roundtrip StructureData -> ASE -> StructureData, with tags/kind names
         """
-        from aiida.orm.nodes.data.structure import StructureData
-
         a = StructureData(cell=[[4, 0, 0], [0, 4, 0], [0, 0, 4]])
         a.append_atom(position=(0, 0, 0), symbols='Ni', name='Ni1')
         a.append_atom(position=(2, 2, 2), symbols='Ni', name='Ni2')
@@ -2366,10 +2197,7 @@ class TestStructureDataFromPymatgen(AiidaTestCase):
         Test's input is derived from COD entry 9011963, processed with
         cif_mark_disorder (from cod-tools) and abbreviated.
         """
-        from aiida.orm.nodes.data.structure import StructureData
         from pymatgen.io.cif import CifParser
-
-        import tempfile
 
         with tempfile.NamedTemporaryFile(mode='w+', suffix=".cif") as tmpf:
             tmpf.write("""data_9011963
@@ -2438,10 +2266,7 @@ class TestStructureDataFromPymatgen(AiidaTestCase):
         Tests xyz -> pymatgen -> StructureData
         Input source: http://pymatgen.org/_static/Molecule.html
         """
-        from aiida.orm.nodes.data.structure import StructureData
         from pymatgen.io.xyz import XYZ
-
-        import tempfile
 
         with tempfile.NamedTemporaryFile(mode='w+', suffix=".xyz") as tmpf:
             tmpf.write("""5
@@ -2470,7 +2295,6 @@ class TestStructureDataFromPymatgen(AiidaTestCase):
         Tests pymatgen -> StructureData, with partial occupancies and spins.
         This should raise a ValueError.
         """
-        from aiida.orm.nodes.data.structure import StructureData
         import pymatgen
 
         Fe_spin_up = pymatgen.structure.Specie('Fe', 0, properties={'spin': 1})
@@ -2500,7 +2324,6 @@ class TestStructureDataFromPymatgen(AiidaTestCase):
         Tests that a structure with multiple sites with the same element but different
         partial occupancies, get their own unique kind name
         """
-        from aiida.orm.nodes.data.structure import StructureData
         import pymatgen
 
         Mg1 = pymatgen.structure.Composition({'Mg': 0.50})
@@ -2517,7 +2340,6 @@ class TestStructureDataFromPymatgen(AiidaTestCase):
         Tests that a structure with multiple sites with the same alloy symbols but different
         weights, get their own unique kind name
         """
-        from aiida.orm.nodes.data.structure import StructureData
         import pymatgen
 
         alloy_one = pymatgen.structure.Composition({'Mg': 0.25, 'Al': 0.75})
@@ -2536,8 +2358,7 @@ class TestPymatgenFromStructureData(AiidaTestCase):
     Tests the creation of pymatgen Structure and Molecule objects from
     StructureData.
     """
-    from aiida.orm.nodes.data.structure import has_ase, has_pymatgen, \
-        get_pymatgen_version
+    from aiida.orm.nodes.data.structure import has_ase, has_pymatgen, get_pymatgen_version
 
     @unittest.skipIf(not has_pymatgen(), "Unable to import pymatgen")
     def test_1(self):
@@ -2561,7 +2382,6 @@ class TestPymatgenFromStructureData(AiidaTestCase):
         """
         Tests ASE -> StructureData -> pymatgen
         """
-        from aiida.orm.nodes.data.structure import StructureData
         import ase
 
         aseatoms = ase.Atoms('Si4', cell=(1., 2., 3.), pbc=(True, True, True))
@@ -2589,7 +2409,6 @@ class TestPymatgenFromStructureData(AiidaTestCase):
         Tests the conversion of StructureData to pymatgen's Molecule
         (ASE -> StructureData -> pymatgen)
         """
-        from aiida.orm.nodes.data.structure import StructureData
         import ase
 
         aseatoms = ase.Atoms('Si4', cell=(10, 10, 10), pbc=(True, True, True))
@@ -2613,8 +2432,6 @@ class TestPymatgenFromStructureData(AiidaTestCase):
         Tests roundtrip StructureData -> pymatgen -> StructureData
         (no spins)
         """
-        from aiida.orm.nodes.data.structure import StructureData
-
         a = StructureData(cell=[[5.6, 0, 0], [0, 5.6, 0], [0, 0, 5.6]])
         a.append_atom(position=(0, 0, 0), symbols='Cl')
         a.append_atom(position=(2.8, 0, 2.8), symbols='Cl')
@@ -2638,8 +2455,6 @@ class TestPymatgenFromStructureData(AiidaTestCase):
         Tests roundtrip StructureData -> pymatgen -> StructureData
         (no spins, but with all kind of kind names)
         """
-        from aiida.orm.nodes.data.structure import StructureData
-
         a = StructureData(cell=[[5.6, 0, 0], [0, 5.6, 0], [0, 0, 5.6]])
         a.append_atom(position=(0, 0, 0), symbols='Cl', name='Cl')
         a.append_atom(position=(2.8, 0, 2.8), symbols='Cl', name='Cl10')
@@ -2666,8 +2481,6 @@ class TestPymatgenFromStructureData(AiidaTestCase):
         Tests roundtrip StructureData -> pymatgen -> StructureData
         (with spins)
         """
-        from aiida.orm.nodes.data.structure import StructureData
-
         a = StructureData(cell=[[5.6, 0, 0], [0, 5.6, 0], [0, 0, 5.6]])
         a.append_atom(position=(0, 0, 0), symbols='Mn', name='Mn1')
         a.append_atom(position=(2.8, 0, 2.8), symbols='Mn', name='Mn1')
@@ -2694,8 +2507,6 @@ class TestPymatgenFromStructureData(AiidaTestCase):
         Tests roundtrip StructureData -> pymatgen -> StructureData
         (with partial occupancies).
         """
-        from aiida.orm.nodes.data.structure import StructureData
-
         a = StructureData(cell=[[4.0, 0.0, 0.0], [-2., 3.5, 0.0], [0.0, 0.0, 16.]])
         a.append_atom(position=(0.0, 0.0, 13.5), symbols='Mn')
         a.append_atom(position=(0.0, 0.0, 2.6), symbols='Mn')
@@ -2762,8 +2573,6 @@ class TestPymatgenFromStructureData(AiidaTestCase):
         Tests StructureData -> pymatgen, with partial occupancies and spins.
         This should raise a ValueError.
         """
-        from aiida.orm.nodes.data.structure import StructureData
-
         a = StructureData(cell=[[4, 0, 0], [0, 4, 0], [0, 0, 4]])
         a.append_atom(position=(0, 0, 0), symbols=('Fe', 'Al'), weights=(0.8, 0.2), name='FeAl1')
         a.append_atom(position=(2, 2, 2), symbols=('Fe', 'Al'), weights=(0.8, 0.2), name='FeAl2')
@@ -2800,7 +2609,6 @@ class TestArrayData(AiidaTestCase):
         Check the methods to add, remove, modify, and get arrays and
         array shapes.
         """
-        from aiida.orm.nodes.data.array import ArrayData
         import numpy
 
         # Create a node with two arrays
@@ -2892,7 +2700,6 @@ class TestArrayData(AiidaTestCase):
         """
         Check the functionality of the get_iterarrays() iterator
         """
-        from aiida.orm.nodes.data.array import ArrayData
         import numpy
 
         # Create a node with two arrays
@@ -2924,7 +2731,6 @@ class TestTrajectoryData(AiidaTestCase):
         """
         Check the methods to set and retrieve a trajectory.
         """
-        from aiida.orm.nodes.data.array.trajectory import TrajectoryData
         import numpy
 
         # Create a node with two arrays
@@ -3105,8 +2911,6 @@ class TestTrajectoryData(AiidaTestCase):
         """
         Check the methods to export a given time step to a StructureData node.
         """
-        from aiida.orm.nodes.data.array.trajectory import TrajectoryData
-        from aiida.orm.nodes.data.structure import Kind
         import numpy
 
         # Create a node with two arrays
@@ -3206,9 +3010,6 @@ class TestTrajectoryData(AiidaTestCase):
         Check the method to create a TrajectoryData from list of AiiDA
         structures.
         """
-        from aiida.orm.nodes.data.structure import StructureData
-        from aiida.orm.nodes.data.array.trajectory import TrajectoryData
-
         cells = [[[
             2.,
             0.,
@@ -3266,8 +3067,6 @@ class TestTrajectoryData(AiidaTestCase):
         """
         import numpy
         import os
-        import tempfile
-        from aiida.orm.nodes.data.array.trajectory import TrajectoryData
         from aiida.orm.nodes.data.cif import has_pycifrw
 
         n = TrajectoryData()
@@ -3398,8 +3197,6 @@ class TestKpointsData(AiidaTestCase):
         """
         Check the methods to set and retrieve a mesh.
         """
-        from aiida.orm.nodes.data.array.kpoints import KpointsData
-
         # Create a node with two arrays
         k = KpointsData()
 
@@ -3434,7 +3231,6 @@ class TestKpointsData(AiidaTestCase):
         """
         Test the method to set and retrieve a kpoint list.
         """
-        from aiida.orm.nodes.data.array.kpoints import KpointsData
         import numpy
 
         k = KpointsData()
@@ -3484,7 +3280,6 @@ class TestKpointsData(AiidaTestCase):
         """
         Test how the list of kpoints is converted to cartesian coordinates
         """
-        from aiida.orm.nodes.data.array.kpoints import KpointsData
         import numpy
 
         k = KpointsData()
@@ -3524,7 +3319,6 @@ class TestKpointsData(AiidaTestCase):
         """
         Test the methods to generate automatically a list of kpoints
         """
-        from aiida.orm.nodes.data.array.kpoints import KpointsData
         import numpy
 
         k = KpointsData()
@@ -3585,9 +3379,6 @@ class TestKpointsData(AiidaTestCase):
         the same behavior of the old implementation
         """
         import numpy
-        from aiida.orm.nodes.data.dict import Dict
-        from aiida.orm.nodes.data.structure import StructureData
-        from aiida.orm.nodes.data.array.kpoints import KpointsData
         from aiida.tools.data.array.kpoints import get_explicit_kpoints_path
 
         # Shouldn't get anything without having set the cell
@@ -3677,8 +3468,6 @@ class TestKpointsData(AiidaTestCase):
         the same behavior of the old implementation
         """
         import numpy
-        from aiida.orm.nodes.data.dict import Dict
-        from aiida.orm.nodes.data.structure import StructureData
         from aiida.tools.data.array.kpoints import get_kpoints_path
 
         alat = 1.5
@@ -3726,7 +3515,6 @@ class TestSpglibTupleConversion(AiidaTestCase):
         """
         import numpy as np
         from aiida.tools import spglib_tuple_to_structure
-        from aiida.orm.nodes.data.structure import Kind
 
         cell = np.array([[4., 1., 0.], [0., 4., 0.], [0., 0., 4.]])
 
@@ -3788,7 +3576,6 @@ class TestSpglibTupleConversion(AiidaTestCase):
         Test conversion of an AiiDA structure to a spglib tuple
         """
         import numpy as np
-        from aiida.orm.nodes.data.structure import StructureData, Site, Kind
         from aiida.tools import structure_to_spglib_tuple
 
         cell = np.array([[4., 1., 0.], [0., 4., 0.], [0., 0., 4.]])
@@ -3818,7 +3605,6 @@ class TestSpglibTupleConversion(AiidaTestCase):
         Convert an AiiDA structure to a tuple and go back to see if we get the same results
         """
         import numpy as np
-        from aiida.orm.nodes.data.structure import StructureData, Site, Kind
         from aiida.tools import structure_to_spglib_tuple, spglib_tuple_to_structure
 
         cell = np.array([[4., 1., 0.], [0., 4., 0.], [0., 0., 4.]])
@@ -3925,7 +3711,6 @@ class TestSeekpathPath(AiidaTestCase):
     def test_simple(self):
         import numpy as np
         from aiida.plugins import DataFactory
-
         from aiida.tools import get_kpoints_path
 
         structure = DataFactory('structure')(cell=[[4, 0, 0], [0, 4, 0], [0, 0, 6]])
@@ -3996,8 +3781,6 @@ class TestBandsData(AiidaTestCase):
         """
         Check the methods to set and retrieve a mesh.
         """
-        from aiida.orm.nodes.data.array.bands import BandsData
-        from aiida.orm.nodes.data.array.kpoints import KpointsData
         import numpy
 
         # define a cell
@@ -4041,10 +3824,7 @@ class TestBandsData(AiidaTestCase):
         Export the band structure on a file, check if it is working
         """
         import numpy
-        import os
-        import tempfile
-        from aiida.orm.nodes.data.array.bands import BandsData
-        from aiida.orm.nodes.data.array.kpoints import KpointsData
+        from aiida.orm import BandsData, KpointsData
 
         # define a cell
         alat = 4.
@@ -4070,8 +3850,8 @@ class TestBandsData(AiidaTestCase):
         # It is not obvious how to check that the bands are correct.
         # I just check, for a few formats, that the file is correctly
         # created, at this stage
-        ## I use this to get a file. I then close it and ask the .export() function
-        ## to create it again. I have to remember to delete everything at the end.
+        # I use this to get a file. I then close it and ask the .export() function
+        # to create it again. I have to remember to delete everything at the end.
         handle, filename = tempfile.mkstemp()
         os.close(handle)
         os.remove(filename)

--- a/aiida/backends/tests/test_dbimporters.py
+++ b/aiida/backends/tests/test_dbimporters.py
@@ -16,10 +16,10 @@ from __future__ import division
 import io
 import unittest
 
-import six
 from six.moves import range
 
 from aiida.backends.testbase import AiidaTestCase
+
 
 class TestCodDbImporter(AiidaTestCase):
     """
@@ -143,8 +143,8 @@ class TestCodDbImporter(AiidaTestCase):
         """
         Tests the creation of CifData node from CodEntry.
         """
+        from aiida.orm import CifData
         from aiida.tools.dbimporters.plugins.cod import CodEntry
-        from aiida.orm.nodes.data.cif import CifData
 
         entry = CodEntry("http://www.crystallography.net/cod/1000000.cif")
         entry.cif = "data_test _publ_section_title 'Test structure'"

--- a/aiida/backends/tests/test_generic.py
+++ b/aiida/backends/tests/test_generic.py
@@ -50,19 +50,19 @@ class TestCode(AiidaTestCase):
 
         with self.assertRaises(ValueError):
             # remote_computer_exec has length 2 but is not a list or tuple
-            _ = Code(remote_computer_exec='ab')
+            Code(remote_computer_exec='ab')
 
         # invalid code path
         with self.assertRaises(ValueError):
-            _ = Code(remote_computer_exec=(self.computer, ''))
+            Code(remote_computer_exec=(self.computer, ''))
 
         # Relative path is invalid for remote code
         with self.assertRaises(ValueError):
-            _ = Code(remote_computer_exec=(self.computer, 'subdir/run.exe'))
+            Code(remote_computer_exec=(self.computer, 'subdir/run.exe'))
 
         # first argument should be a computer, not a string
         with self.assertRaises(TypeError):
-            _ = Code(remote_computer_exec=('localhost', '/bin/ls'))
+            Code(remote_computer_exec=('localhost', '/bin/ls'))
 
         code = Code(remote_computer_exec=(self.computer, '/bin/ls'))
         with tempfile.NamedTemporaryFile(mode='w+') as fhandle:
@@ -95,11 +95,9 @@ class TestCode(AiidaTestCase):
 class TestBool(AiidaTestCase):
 
     def test_bool_conversion(self):
-        from aiida.orm.nodes.data.bool import Bool
         for val in [True, False]:
-            self.assertEqual(val, bool(Bool(val)))
+            self.assertEqual(val, bool(orm.Bool(val)))
 
     def test_int_conversion(self):
-        from aiida.orm.nodes.data.bool import Bool
         for val in [True, False]:
-            self.assertEqual(int(val), int(Bool(val)))
+            self.assertEqual(int(val), int(orm.Bool(val)))

--- a/aiida/backends/tests/test_parsers.py
+++ b/aiida/backends/tests/test_parsers.py
@@ -77,7 +77,7 @@ def output_test(pk, testname, skip_uuids_from_inputs=[]):
         skipped
     """
     import os
-    import aiida.common.json as json
+    from aiida.common import json
 
     from aiida.common.folders import Folder
     from aiida.orm import CalcJobNode
@@ -173,7 +173,7 @@ class TestParsers(AiidaTestCase):
     def read_test(self, outfolder):
         import os
         import importlib
-        import aiida.common.json as json
+        from aiida.common import json
 
         from aiida.orm import CalcJobNode
         from aiida.orm.utils import load_node

--- a/aiida/backends/tests/test_plugin_loader.py
+++ b/aiida/backends/tests/test_plugin_loader.py
@@ -13,7 +13,7 @@ from __future__ import absolute_import
 
 from aiida.backends.testbase import AiidaTestCase
 from aiida.engine import CalcJob, WorkChain
-from aiida.orm.nodes.data import Data
+from aiida.orm import Data
 from aiida.parsers import Parser
 from aiida.plugins import factories
 from aiida.plugins.entry_point import get_entry_points

--- a/aiida/backends/tests/test_query.py
+++ b/aiida/backends/tests/test_query.py
@@ -7,19 +7,19 @@
 # For further information on the license, see the LICENSE.txt file        #
 # For further information please visit http://www.aiida.net               #
 ###########################################################################
-
 from __future__ import division
 from __future__ import absolute_import
 from __future__ import print_function
+
 import unittest
 
 from six.moves import range, zip
 
+from aiida import orm
+from aiida.backends import settings
 from aiida.backends.testbase import AiidaTestCase
-import aiida.backends.settings as settings
 from aiida.common.links import LinkType
-from aiida.orm import Node, Data
-from aiida.orm import CalculationNode
+
 
 class TestQueryBuilder(AiidaTestCase):
 
@@ -32,12 +32,9 @@ class TestQueryBuilder(AiidaTestCase):
         """
         This tests the classifications of the QueryBuilder
         """
-        from aiida.orm.querybuilder import QueryBuilder
-        from aiida.orm.nodes.data.structure import StructureData
-        from aiida.orm import Group, User, Node, Computer, Data
         from aiida.common.exceptions import DbContentError
 
-        qb = QueryBuilder()
+        qb = orm.QueryBuilder()
 
         # Asserting that improper declarations of the class type raise an error
         with self.assertRaises(DbContentError):
@@ -49,14 +46,14 @@ class TestQueryBuilder(AiidaTestCase):
 
         # Asserting that the query type string and plugin type string are returned:
         for cls, clstype, query_type_string in (
-            qb._get_ormclass(StructureData, None),
+            qb._get_ormclass(orm.StructureData, None),
             qb._get_ormclass(None, 'data.structure.StructureData.'),
         ):
-            self.assertEqual(clstype, StructureData._plugin_type_string)
-            self.assertEqual(query_type_string, StructureData._query_type_string)
+            self.assertEqual(clstype, orm.StructureData._plugin_type_string)
+            self.assertEqual(query_type_string, orm.StructureData._query_type_string)
 
         for cls, clstype, query_type_string in (
-                qb._get_ormclass(Group, None),
+                qb._get_ormclass(orm.Group, None),
                 qb._get_ormclass(None, 'group'),
                 qb._get_ormclass(None, 'Group'),
         ):
@@ -64,7 +61,7 @@ class TestQueryBuilder(AiidaTestCase):
             self.assertEqual(query_type_string, None)
 
         for cls, clstype, query_type_string in (
-                qb._get_ormclass(User, None),
+                qb._get_ormclass(orm.User, None),
                 qb._get_ormclass(None, "user"),
                 qb._get_ormclass(None, "User"),
         ):
@@ -72,7 +69,7 @@ class TestQueryBuilder(AiidaTestCase):
             self.assertEqual(query_type_string, None)
 
         for cls, clstype, query_type_string in (
-                qb._get_ormclass(Computer, None),
+                qb._get_ormclass(orm.Computer, None),
                 qb._get_ormclass(None, 'computer'),
                 qb._get_ormclass(None, 'Computer'),
         ):
@@ -80,43 +77,40 @@ class TestQueryBuilder(AiidaTestCase):
             self.assertEqual(query_type_string, None)
 
         for cls, clstype, query_type_string in (
-                qb._get_ormclass(Data, None),
+                qb._get_ormclass(orm.Data, None),
                 qb._get_ormclass(None, 'data.Data.'),
         ):
-            self.assertEqual(clstype, Data._plugin_type_string)
-            self.assertEqual(query_type_string, Data._query_type_string)
+            self.assertEqual(clstype, orm.Data._plugin_type_string)
+            self.assertEqual(query_type_string, orm.Data._query_type_string)
 
     def test_simple_query_1(self):
         """
         Testing a simple query
         """
-        from aiida.orm.querybuilder import QueryBuilder
-        from aiida.orm import Node, Data
-        from aiida.orm import CalculationNode
         from datetime import datetime
         from aiida.common.links import LinkType
 
-        n1 = Data()
+        n1 = orm.Data()
         n1.label = 'node1'
         n1.set_attribute('foo', ['hello', 'goodbye'])
         n1.store()
 
-        n2 = CalculationNode()
+        n2 = orm.CalculationNode()
         n2.label = 'node2'
         n2.set_attribute('foo', 1)
         n2.store()
 
-        n3 = Data()
+        n3 = orm.Data()
         n3.label = 'node3'
         n3.set_attribute('foo', 1.0000)  # Stored as fval
         n3.store()
 
-        n4 = CalculationNode()
+        n4 = orm.CalculationNode()
         n4.label = 'node4'
         n4.set_attribute('foo', 'bar')
         n4.store()
 
-        n5 = Data()
+        n5 = orm.Data()
         n5.label = 'node5'
         n5.set_attribute('foo', None)
         n5.store()
@@ -127,55 +121,52 @@ class TestQueryBuilder(AiidaTestCase):
         n4.add_incoming(n3, link_type=LinkType.INPUT_CALC, link_label='link3')
         n5.add_incoming(n4, link_type=LinkType.CREATE, link_label='link4')
 
-        qb1 = QueryBuilder()
-        qb1.append(Node, filters={'attributes.foo': 1.000})
+        qb1 = orm.QueryBuilder()
+        qb1.append(orm.Node, filters={'attributes.foo': 1.000})
 
         self.assertEqual(len(qb1.all()), 2)
 
-        qb2 = QueryBuilder()
-        qb2.append(Data)
+        qb2 = orm.QueryBuilder()
+        qb2.append(orm.Data)
         self.assertEqual(qb2.count(), 3)
 
-        qb2 = QueryBuilder()
+        qb2 = orm.QueryBuilder()
         qb2.append(type='data.Data.')
         self.assertEqual(qb2.count(), 3)
 
-        qb3 = QueryBuilder()
-        qb3.append(Node, project='label', tag='node1')
-        qb3.append(Node, project='label', tag='node2')
+        qb3 = orm.QueryBuilder()
+        qb3.append(orm.Node, project='label', tag='node1')
+        qb3.append(orm.Node, project='label', tag='node2')
         self.assertEqual(qb3.count(), 4)
 
-        qb4 = QueryBuilder()
-        qb4.append(CalculationNode, tag='node1')
-        qb4.append(Data, tag='node2')
+        qb4 = orm.QueryBuilder()
+        qb4.append(orm.CalculationNode, tag='node1')
+        qb4.append(orm.Data, tag='node2')
         self.assertEqual(qb4.count(), 2)
 
-        qb5 = QueryBuilder()
-        qb5.append(Data, tag='node1')
-        qb5.append(CalculationNode, tag='node2')
+        qb5 = orm.QueryBuilder()
+        qb5.append(orm.Data, tag='node1')
+        qb5.append(orm.CalculationNode, tag='node2')
         self.assertEqual(qb5.count(), 2)
 
-        qb6 = QueryBuilder()
-        qb6.append(Data, tag='node1')
-        qb6.append(Data, tag='node2')
+        qb6 = orm.QueryBuilder()
+        qb6.append(orm.Data, tag='node1')
+        qb6.append(orm.Data, tag='node2')
         self.assertEqual(qb6.count(), 0)
 
     def test_simple_query_2(self):
-        from aiida.orm.querybuilder import QueryBuilder
-        from aiida.orm import Node, Data
-        from aiida.orm import CalculationNode
         from datetime import datetime
         from aiida.common.exceptions import MultipleObjectsError, NotExistent
-        n0 = Data()
+        n0 = orm.Data()
         n0.label = 'hello'
         n0.description = ''
         n0.set_attribute('foo', 'bar')
 
-        n1 = CalculationNode()
+        n1 = orm.CalculationNode()
         n1.label = 'foo'
         n1.description = 'I am FoO'
 
-        n2 = Data()
+        n2 = orm.Data()
         n2.label = 'bar'
         n2.description = 'I am BaR'
 
@@ -185,18 +176,18 @@ class TestQueryBuilder(AiidaTestCase):
         for n in (n0, n1, n2):
             n.store()
 
-        qb1 = QueryBuilder()
-        qb1.append(Node, filters={'label': 'hello'})
+        qb1 = orm.QueryBuilder()
+        qb1.append(orm.Node, filters={'label': 'hello'})
         self.assertEqual(len(list(qb1.all())), 1)
 
         qh = {
             'path': [
                 {
-                    'cls': Node,
+                    'cls': orm.Node,
                     'tag': 'n1'
                 },
                 {
-                    'cls': Node,
+                    'cls': orm.Node,
                     'tag': 'n2',
                     'with_incoming': 'n1'
                 }
@@ -215,7 +206,7 @@ class TestQueryBuilder(AiidaTestCase):
             }
         }
 
-        qb2 = QueryBuilder(**qh)
+        qb2 = orm.QueryBuilder(**qh)
 
         resdict = qb2.dict()
         self.assertEqual(len(resdict), 1)
@@ -227,11 +218,11 @@ class TestQueryBuilder(AiidaTestCase):
         qh = {
             'path': [
                 {
-                    'cls': Node,
+                    'cls': orm.Node,
                     'tag': 'n1'
                 },
                 {
-                    'cls': Node,
+                    'cls': orm.Node,
                     'tag': 'n2',
                     'with_incoming': 'n1'
                 }
@@ -240,7 +231,7 @@ class TestQueryBuilder(AiidaTestCase):
                 'n1--n2': {'label': {'like': '%_2'}}
             }
         }
-        qb = QueryBuilder(**qh)
+        qb = orm.QueryBuilder(**qh)
         self.assertEqual(qb.count(), 1)
 
         # Test the hashing:
@@ -251,7 +242,7 @@ class TestQueryBuilder(AiidaTestCase):
         with self.assertRaises(NotExistent):
             qb.one()
         with self.assertRaises(MultipleObjectsError):
-            QueryBuilder().append(Node).one()
+            orm.QueryBuilder().append(orm.Node).one()
 
         query2 = qb.get_query()
         query3 = qb.get_query()
@@ -260,10 +251,7 @@ class TestQueryBuilder(AiidaTestCase):
         self.assertTrue(id(query2) == id(query3))
 
     def test_operators_eq_lt_gt(self):
-        from aiida.orm.querybuilder import QueryBuilder
-        from aiida.orm import Node
-
-        nodes = [Data() for _ in range(8)]
+        nodes = [orm.Data() for _ in range(8)]
 
         nodes[0].set_attribute('fa', 1)
         nodes[1].set_attribute('fa', 1.0)
@@ -276,151 +264,135 @@ class TestQueryBuilder(AiidaTestCase):
 
         [n.store() for n in nodes]
 
-        self.assertEqual(QueryBuilder().append(Node, filters={'attributes.fa': {'<': 1}}).count(), 0)
-        self.assertEqual(QueryBuilder().append(Node, filters={'attributes.fa': {'==': 1}}).count(), 2)
-        self.assertEqual(QueryBuilder().append(Node, filters={'attributes.fa': {'<': 1.02}}).count(), 3)
-        self.assertEqual(QueryBuilder().append(Node, filters={'attributes.fa': {'<=': 1.02}}).count(), 4)
-        self.assertEqual(QueryBuilder().append(Node, filters={'attributes.fa': {'>': 1.02}}).count(), 4)
-        self.assertEqual(QueryBuilder().append(Node, filters={'attributes.fa': {'>=': 1.02}}).count(), 5)
+        self.assertEqual(orm.QueryBuilder().append(orm.Node, filters={'attributes.fa': {'<': 1}}).count(), 0)
+        self.assertEqual(orm.QueryBuilder().append(orm.Node, filters={'attributes.fa': {'==': 1}}).count(), 2)
+        self.assertEqual(orm.QueryBuilder().append(orm.Node, filters={'attributes.fa': {'<': 1.02}}).count(), 3)
+        self.assertEqual(orm.QueryBuilder().append(orm.Node, filters={'attributes.fa': {'<=': 1.02}}).count(), 4)
+        self.assertEqual(orm.QueryBuilder().append(orm.Node, filters={'attributes.fa': {'>': 1.02}}).count(), 4)
+        self.assertEqual(orm.QueryBuilder().append(orm.Node, filters={'attributes.fa': {'>=': 1.02}}).count(), 5)
 
     def test_subclassing(self):
-        from aiida.orm.nodes.data.structure import StructureData
-        from aiida.orm.nodes.data.dict import Dict
-        from aiida.orm import Node, Data
-        from aiida.orm.querybuilder import QueryBuilder
-        s = StructureData()
+        s = orm.StructureData()
         s.set_attribute('cat', 'miau')
         s.store()
 
-        d = Data()
+        d = orm.Data()
         d.set_attribute('cat', 'miau')
         d.store()
 
-        p = Dict(dict=dict(cat='miau'))
+        p = orm.Dict(dict=dict(cat='miau'))
         p.store()
 
         # Now when asking for a node with attr.cat==miau, I want 3 esults:
-        qb = QueryBuilder().append(Node, filters={'attributes.cat': 'miau'})
+        qb = orm.QueryBuilder().append(orm.Node, filters={'attributes.cat': 'miau'})
         self.assertEqual(qb.count(), 3)
 
-        qb = QueryBuilder().append(Data, filters={'attributes.cat': 'miau'})
+        qb = orm.QueryBuilder().append(orm.Data, filters={'attributes.cat': 'miau'})
         self.assertEqual(qb.count(), 3)
 
         # If I'm asking for the specific lowest subclass, I want one result
-        for cls in (StructureData, Dict):
-            qb = QueryBuilder().append(cls, filters={'attributes.cat': 'miau'})
+        for cls in (orm.StructureData, orm.Dict):
+            qb = orm.QueryBuilder().append(cls, filters={'attributes.cat': 'miau'})
             self.assertEqual(qb.count(), 1)
 
         # Now I am not allow the subclassing, which should give 1 result for each
         for cls, count in (
-            (StructureData, 1),
-            (Dict, 1),
-            (Data, 1),
-            (Node, 0)):
-            qb = QueryBuilder().append(cls, filters={'attributes.cat': 'miau'}, subclassing=False)
+            (orm.StructureData, 1),
+            (orm.Dict, 1),
+            (orm.Data, 1),
+            (orm.Node, 0)):
+            qb = orm.QueryBuilder().append(cls, filters={'attributes.cat': 'miau'}, subclassing=False)
             self.assertEqual(qb.count(), count)
 
         # Now I am testing the subclassing with tuples:
-        qb = QueryBuilder().append(cls=(StructureData, Dict), filters={'attributes.cat': 'miau'})
+        qb = orm.QueryBuilder().append(cls=(orm.StructureData, orm.Dict), filters={'attributes.cat': 'miau'})
         self.assertEqual(qb.count(), 2)
-        qb = QueryBuilder().append(type=('data.structure.StructureData.', 'data.dict.Dict.'),
+        qb = orm.QueryBuilder().append(type=('data.structure.StructureData.', 'data.dict.Dict.'),
                                    filters={'attributes.cat': 'miau'})
         self.assertEqual(qb.count(), 2)
-        qb = QueryBuilder().append(cls=(StructureData, Dict), filters={'attributes.cat': 'miau'},
+        qb = orm.QueryBuilder().append(cls=(orm.StructureData, orm.Dict), filters={'attributes.cat': 'miau'},
                                    subclassing=False)
         self.assertEqual(qb.count(), 2)
-        qb = QueryBuilder().append(cls=(StructureData, Data), filters={'attributes.cat': 'miau'}, )
+        qb = orm.QueryBuilder().append(cls=(orm.StructureData, orm.Data), filters={'attributes.cat': 'miau'}, )
         self.assertEqual(qb.count(), 3)
-        qb = QueryBuilder().append(type=('data.structure.StructureData.', 'data.dict.Dict.'),
+        qb = orm.QueryBuilder().append(type=('data.structure.StructureData.', 'data.dict.Dict.'),
                                    filters={'attributes.cat': 'miau'}, subclassing=False)
         self.assertEqual(qb.count(), 2)
-        qb = QueryBuilder().append(type=('data.structure.StructureData.', 'data.Data.'),
+        qb = orm.QueryBuilder().append(type=('data.structure.StructureData.', 'data.Data.'),
                                    filters={'attributes.cat': 'miau'}, subclassing=False)
         self.assertEqual(qb.count(), 2)
 
     def test_list_behavior(self):
-        from aiida.orm import Node
-        from aiida.orm.querybuilder import QueryBuilder
-
         for i in range(4):
-            Data().store()
+            orm.Data().store()
 
-        self.assertEqual(len(QueryBuilder().append(Node).all()), 4)
-        self.assertEqual(len(QueryBuilder().append(Node, project='*').all()), 4)
-        self.assertEqual(len(QueryBuilder().append(Node, project=['*', 'id']).all()), 4)
-        self.assertEqual(len(QueryBuilder().append(Node, project=['id']).all()), 4)
-        self.assertEqual(len(QueryBuilder().append(Node).dict()), 4)
-        self.assertEqual(len(QueryBuilder().append(Node, project='*').dict()), 4)
-        self.assertEqual(len(QueryBuilder().append(Node, project=['*', 'id']).dict()), 4)
-        self.assertEqual(len(QueryBuilder().append(Node, project=['id']).dict()), 4)
-        self.assertEqual(len(list(QueryBuilder().append(Node).iterall())), 4)
-        self.assertEqual(len(list(QueryBuilder().append(Node, project='*').iterall())), 4)
-        self.assertEqual(len(list(QueryBuilder().append(Node, project=['*', 'id']).iterall())), 4)
-        self.assertEqual(len(list(QueryBuilder().append(Node, project=['id']).iterall())), 4)
-        self.assertEqual(len(list(QueryBuilder().append(Node).iterdict())), 4)
-        self.assertEqual(len(list(QueryBuilder().append(Node, project='*').iterdict())), 4)
-        self.assertEqual(len(list(QueryBuilder().append(Node, project=['*', 'id']).iterdict())), 4)
-        self.assertEqual(len(list(QueryBuilder().append(Node, project=['id']).iterdict())), 4)
+        self.assertEqual(len(orm.QueryBuilder().append(orm.Node).all()), 4)
+        self.assertEqual(len(orm.QueryBuilder().append(orm.Node, project='*').all()), 4)
+        self.assertEqual(len(orm.QueryBuilder().append(orm.Node, project=['*', 'id']).all()), 4)
+        self.assertEqual(len(orm.QueryBuilder().append(orm.Node, project=['id']).all()), 4)
+        self.assertEqual(len(orm.QueryBuilder().append(orm.Node).dict()), 4)
+        self.assertEqual(len(orm.QueryBuilder().append(orm.Node, project='*').dict()), 4)
+        self.assertEqual(len(orm.QueryBuilder().append(orm.Node, project=['*', 'id']).dict()), 4)
+        self.assertEqual(len(orm.QueryBuilder().append(orm.Node, project=['id']).dict()), 4)
+        self.assertEqual(len(list(orm.QueryBuilder().append(orm.Node).iterall())), 4)
+        self.assertEqual(len(list(orm.QueryBuilder().append(orm.Node, project='*').iterall())), 4)
+        self.assertEqual(len(list(orm.QueryBuilder().append(orm.Node, project=['*', 'id']).iterall())), 4)
+        self.assertEqual(len(list(orm.QueryBuilder().append(orm.Node, project=['id']).iterall())), 4)
+        self.assertEqual(len(list(orm.QueryBuilder().append(orm.Node).iterdict())), 4)
+        self.assertEqual(len(list(orm.QueryBuilder().append(orm.Node, project='*').iterdict())), 4)
+        self.assertEqual(len(list(orm.QueryBuilder().append(orm.Node, project=['*', 'id']).iterdict())), 4)
+        self.assertEqual(len(list(orm.QueryBuilder().append(orm.Node, project=['id']).iterdict())), 4)
 
     def test_append_validation(self):
-        from aiida.orm.querybuilder import QueryBuilder
-        from aiida.orm.nodes.data.structure import StructureData
         from aiida.common.exceptions import InputValidationError
-        from aiida.orm import ProcessNode
 
         # So here I am giving two times the same tag
         with self.assertRaises(InputValidationError):
-            QueryBuilder().append(StructureData, tag='n').append(StructureData, tag='n')
+            orm.QueryBuilder().append(orm.StructureData, tag='n').append(orm.StructureData, tag='n')
         # here I am giving a wrong filter specifications
         with self.assertRaises(InputValidationError):
-            QueryBuilder().append(StructureData, filters=['jajjsd'])
+            orm.QueryBuilder().append(orm.StructureData, filters=['jajjsd'])
         # here I am giving a nonsensical projection:
         with self.assertRaises(InputValidationError):
-            QueryBuilder().append(StructureData, project=True)
+            orm.QueryBuilder().append(orm.StructureData, project=True)
 
         # here I am giving a nonsensical projection for the edge:
         with self.assertRaises(InputValidationError):
-            QueryBuilder().append(ProcessNode).append(StructureData, edge_tag='t').add_projection('t', True)
+            orm.QueryBuilder().append(orm.ProcessNode).append(orm.StructureData, edge_tag='t').add_projection('t', True)
         # Giving a nonsensical limit
         with self.assertRaises(InputValidationError):
-            QueryBuilder().append(ProcessNode).limit(2.3)
+            orm.QueryBuilder().append(orm.ProcessNode).limit(2.3)
         # Giving a nonsensical offset
         with self.assertRaises(InputValidationError):
-            QueryBuilder(offset=2.3)
+            orm.QueryBuilder(offset=2.3)
 
         # So, I mess up one append, I want the QueryBuilder to clean it!
         with self.assertRaises(InputValidationError):
-            qb = QueryBuilder()
+            qb = orm.QueryBuilder()
             # This also checks if we correctly raise for wrong keywords
-            qb.append(StructureData, tag='s', randomkeyword={})
+            qb.append(orm.StructureData, tag='s', randomkeyword={})
 
         # Now I'm checking whether this keyword appears anywhere in the internal dictionaries:
         self.assertTrue('s' not in qb._projections)
         self.assertTrue('s' not in qb._filters)
         self.assertTrue('s' not in qb._tag_to_alias_map)
         self.assertTrue(len(qb._path) == 0)
-        self.assertTrue(StructureData not in qb._cls_to_tag_map)
+        self.assertTrue(orm.StructureData not in qb._cls_to_tag_map)
         # So this should work now:
-        qb.append(StructureData, tag='s').limit(2).dict()
+        qb.append(orm.StructureData, tag='s').limit(2).dict()
 
     def test_tags(self):
-        from aiida.orm.querybuilder import QueryBuilder
-        from aiida.orm import Node
-        from aiida.orm import ProcessNode
-        from aiida.orm.nodes.data.structure import StructureData
-        from aiida.orm.nodes.data.dict import Dict
-        from aiida.orm.computers import Computer
-        qb = QueryBuilder()
-        qb.append(Node, tag='n1')
-        qb.append(Node, tag='n2', edge_tag='e1', with_incoming='n1')
-        qb.append(Node, tag='n3', edge_tag='e2', with_incoming='n2')
-        qb.append(Computer, with_node='n3', tag='c1', edge_tag='nonsense')
+        qb = orm.QueryBuilder()
+        qb.append(orm.Node, tag='n1')
+        qb.append(orm.Node, tag='n2', edge_tag='e1', with_incoming='n1')
+        qb.append(orm.Node, tag='n3', edge_tag='e2', with_incoming='n2')
+        qb.append(orm.Computer, with_node='n3', tag='c1', edge_tag='nonsense')
         self.assertEqual(qb.get_used_tags(), ['n1', 'n2', 'e1', 'n3', 'e2', 'c1', 'nonsense'])
 
         # Now I am testing the default tags,
-        qb = QueryBuilder().append(StructureData).append(ProcessNode).append(
-            StructureData).append(
-            Dict, with_outgoing=ProcessNode)
+        qb = orm.QueryBuilder().append(orm.StructureData).append(orm.ProcessNode).append(
+            orm.StructureData).append(
+            orm.Dict, with_outgoing=orm.ProcessNode)
         self.assertEqual(qb.get_used_tags(), [
             'StructureData_1', 'ProcessNode_1',
             'StructureData_1--ProcessNode_1', 'StructureData_2',
@@ -444,52 +416,45 @@ class TestQueryHelp(AiidaTestCase):
         Here I test the queryhelp by seeing whether results are the same as using the append method.
         I also check passing of tuples.
         """
-
-        from aiida.orm.nodes.data.structure import StructureData
-        from aiida.orm.nodes.data.dict import Dict
-        from aiida.orm.nodes.data import Data
-        from aiida.orm.querybuilder import QueryBuilder
-        from aiida.orm.groups import Group
-        from aiida.orm.computers import Computer
-        g = Group(label='helloworld').store()
-        for cls in (StructureData, Dict, Data):
+        g = orm.Group(label='helloworld').store()
+        for cls in (orm.StructureData, orm.Dict, orm.Data):
             obj = cls()
             obj.set_attribute('foo-qh2', 'bar')
             obj.store()
             g.add_nodes(obj)
 
         for cls, expected_count, subclassing in (
-                (StructureData, 1, True),
-                (Dict, 1, True),
-                (Data, 3, True),
-                (Data, 1, False),
-                ((Dict, StructureData), 2, True),
-                ((Dict, StructureData), 2, False),
-                ((Dict, Data), 2, False),
-                ((Dict, Data), 3, True),
-                ((Dict, Data, StructureData), 3, False),
+                (orm.StructureData, 1, True),
+                (orm.Dict, 1, True),
+                (orm.Data, 3, True),
+                (orm.Data, 1, False),
+                ((orm.Dict, orm.StructureData), 2, True),
+                ((orm.Dict, orm.StructureData), 2, False),
+                ((orm.Dict, orm.Data), 2, False),
+                ((orm.Dict, orm.Data), 3, True),
+                ((orm.Dict, orm.Data, orm.StructureData), 3, False),
         ):
-            qb = QueryBuilder()
+            qb = orm.QueryBuilder()
             qb.append(cls, filters={'attributes.foo-qh2': 'bar'}, subclassing=subclassing, project='uuid')
             self.assertEqual(qb.count(), expected_count)
 
             qh = qb.get_json_compatible_queryhelp()
-            qb_new = QueryBuilder(**qh)
+            qb_new = orm.QueryBuilder(**qh)
             self.assertEqual(qb_new.count(), expected_count)
             self.assertEqual(
                 sorted([uuid for uuid, in qb.all()]),
                 sorted([uuid for uuid, in qb_new.all()]))
 
-        qb = QueryBuilder().append(Group, filters={'label': 'helloworld'})
+        qb = orm.QueryBuilder().append(orm.Group, filters={'label': 'helloworld'})
         self.assertEqual(qb.count(), 1)
 
-        qb = QueryBuilder().append((Group,), filters={'label': 'helloworld'})
+        qb = orm.QueryBuilder().append((orm.Group,), filters={'label': 'helloworld'})
         self.assertEqual(qb.count(), 1)
 
-        qb = QueryBuilder().append(Computer, )
+        qb = orm.QueryBuilder().append(orm.Computer, )
         self.assertEqual(qb.count(), 1)
 
-        qb = QueryBuilder().append(cls=(Computer,))
+        qb = orm.QueryBuilder().append(cls=(orm.Computer,))
         self.assertEqual(qb.count(), 1)
 
 
@@ -506,28 +471,24 @@ class TestQueryBuilderCornerCases(AiidaTestCase):
         decoding of a None value leads to an exception (this was the case
         under Django).
         """
-        from aiida.orm import Node, Data, Computer
-        from aiida.orm import ProcessNode
-        from aiida.orm.querybuilder import QueryBuilder
-
-        n1 = CalculationNode()
+        n1 = orm.CalculationNode()
         n1.label = 'node2'
         n1.set_attribute('foo', 1)
         n1.store()
 
         # Checking the correct retrieval of transport_params which is
         # a JSON field (in both backends).
-        qb = QueryBuilder()
-        qb.append(CalculationNode, project=['id'], tag='calc')
-        qb.append(Computer, project=['id', 'transport_params'],
+        qb = orm.QueryBuilder()
+        qb.append(orm.CalculationNode, project=['id'], tag='calc')
+        qb.append(orm.Computer, project=['id', 'transport_params'],
                   outerjoin=True, with_node='calc')
         qb.all()
 
         # Checking the correct retrieval of _metadata which is
         # a JSON field (in both backends).
-        qb = QueryBuilder()
-        qb.append(CalculationNode, project=['id'], tag='calc')
-        qb.append(Computer, project=['id', '_metadata'],
+        qb = orm.QueryBuilder()
+        qb.append(orm.CalculationNode, project=['id'], tag='calc')
+        qb.append(orm.Computer, project=['id', '_metadata'],
                   outerjoin=True, with_node='calc')
         qb.all()
 
@@ -535,19 +496,17 @@ class TestQueryBuilderCornerCases(AiidaTestCase):
 class TestAttributes(AiidaTestCase):
     def test_attribute_existence(self):
         # I'm storing a value under key whatever:
-        from aiida.orm import Node
-        from aiida.orm.querybuilder import QueryBuilder
         val = 1.
         res_uuids = set()
-        n1 = Data()
+        n1 = orm.Data()
         n1.set_attribute("whatever", 3.)
         n1.set_attribute("test_case", "test_attribute_existence")
         n1.store()
 
         # I want all the nodes where whatever is smaller than 1. or there is no such value:
 
-        qb = QueryBuilder()
-        qb.append(Data, filters={
+        qb = orm.QueryBuilder()
+        qb.append(orm.Data, filters={
             'or': [
                 {'attributes': {'!has_key': 'whatever'}},
                 {'attributes.whatever': {'<': val}}
@@ -557,10 +516,8 @@ class TestAttributes(AiidaTestCase):
         self.assertEqual(res_query, res_uuids)
 
     def test_attribute_type(self):
-        from aiida.orm import Node
-        from aiida.orm.querybuilder import QueryBuilder
         key = 'value_test_attr_type'
-        n_int, n_float, n_str, n_str2, n_bool, n_arr = [Data() for _ in range(6)]
+        n_int, n_float, n_str, n_str2, n_bool, n_arr = [orm.Data() for _ in range(6)]
         n_int.set_attribute(key, 1)
         n_float.set_attribute(key, 1.0)
         n_bool.set_attribute(key, True)
@@ -571,37 +528,37 @@ class TestAttributes(AiidaTestCase):
         # Here I am testing which values contain a number 1.
         # Both 1 and 1.0 are legitimate values if ask for either 1 or 1.0
         for val in (1.0, 1):
-            qb = QueryBuilder().append(Node,
+            qb = orm.QueryBuilder().append(orm.Node,
                     filters={'attributes.{}'.format(key): val}, project='uuid')
             res = [str(_) for _, in qb.all()]
             self.assertEqual(set(res), set((n_float.uuid, n_int.uuid)))
-            qb = QueryBuilder().append(Node,
+            qb = orm.QueryBuilder().append(orm.Node,
                     filters={'attributes.{}'.format(key): {'>': 0.5}}, project='uuid')
             res = [str(_) for _, in qb.all()]
             self.assertEqual(set(res), set((n_float.uuid, n_int.uuid)))
-            qb = QueryBuilder().append(Node,
+            qb = orm.QueryBuilder().append(orm.Node,
                     filters={'attributes.{}'.format(key): {'<': 1.5}}, project='uuid')
             res = [str(_) for _, in qb.all()]
             self.assertEqual(set(res), set((n_float.uuid, n_int.uuid)))
         # Now I am testing the boolean value:
-        qb = QueryBuilder().append(Node,
+        qb = orm.QueryBuilder().append(orm.Node,
                 filters={'attributes.{}'.format(key): True}, project='uuid')
         res = [str(_) for _, in qb.all()]
         self.assertEqual(set(res), set((n_bool.uuid,)))
 
-        qb = QueryBuilder().append(Node,
+        qb = orm.QueryBuilder().append(orm.Node,
                 filters={'attributes.{}'.format(key): {'like': '%n%'}}, project='uuid')
         res = [str(_) for _, in qb.all()]
         self.assertEqual(set(res), set((n_str2.uuid,)))
-        qb = QueryBuilder().append(Node,
+        qb = orm.QueryBuilder().append(orm.Node,
                 filters={'attributes.{}'.format(key): {'ilike': 'On%'}}, project='uuid')
         res = [str(_) for _, in qb.all()]
         self.assertEqual(set(res), set((n_str2.uuid,)))
-        qb = QueryBuilder().append(Node,
+        qb = orm.QueryBuilder().append(orm.Node,
                 filters={'attributes.{}'.format(key): {'like': '1'}}, project='uuid')
         res = [str(_) for _, in qb.all()]
         self.assertEqual(set(res), set((n_str.uuid,)))
-        qb = QueryBuilder().append(Node,
+        qb = orm.QueryBuilder().append(orm.Node,
                 filters={'attributes.{}'.format(key): {'==': '1'}}, project='uuid')
         res = [str(_) for _, in qb.all()]
         self.assertEqual(set(res), set((n_str.uuid,)))
@@ -610,7 +567,7 @@ class TestAttributes(AiidaTestCase):
             # so I exclude. Not the nicest way, But I would like to keep this piece
             # of code because of the initialization part, that would need to be
             # duplicated or wrapped otherwise.
-            qb = QueryBuilder().append(Node,
+            qb = orm.QueryBuilder().append(orm.Node,
                     filters={'attributes.{}'.format(key): {'of_length': 3}}, project='uuid')
             res = [str(_) for _, in qb.all()]
             self.assertEqual(set(res), set((n_arr.uuid,)))
@@ -620,16 +577,14 @@ class QueryBuilderDateTimeAttribute(AiidaTestCase):
     @unittest.skipIf(settings.BACKEND == u'sqlalchemy',
                      "SQLA doesn't have full datetime support in attributes")
     def test_date(self):
-        from aiida.orm.querybuilder import QueryBuilder
         from aiida.common import timezone
         from datetime import timedelta
-        from aiida.orm import Node
-        n = Data()
+        n = orm.Data()
         now = timezone.now()
         n.set_attribute('now', now)
         n.store()
 
-        qb = QueryBuilder().append(Node,
+        qb = orm.QueryBuilder().append(orm.Node,
                                    filters={'attributes.now': {"and": [
                                        {">": now - timedelta(seconds=1)},
                                        {"<": now + timedelta(seconds=1)},
@@ -640,17 +595,15 @@ class QueryBuilderDateTimeAttribute(AiidaTestCase):
 class QueryBuilderLimitOffsetsTest(AiidaTestCase):
 
     def test_ordering_limits_offsets_of_results_general(self):
-        from aiida.orm import Node
-        from aiida.orm.querybuilder import QueryBuilder
         # Creating 10 nodes with an attribute that can be ordered
         for i in range(10):
-            n = Data()
+            n = orm.Data()
             n.set_attribute('foo', i)
             n.store()
 
-        qb = QueryBuilder().append(
-            Node, project='attributes.foo'
-        ).order_by({Node: 'ctime'})
+        qb = orm.QueryBuilder().append(
+            orm.Node, project='attributes.foo'
+        ).order_by({orm.Node: 'ctime'})
 
         res = next(zip(*qb.all()))
         self.assertEqual(res, tuple(range(10)))
@@ -666,9 +619,9 @@ class QueryBuilderLimitOffsetsTest(AiidaTestCase):
         self.assertEqual(res, tuple(range(5, 8)))
 
         # Specifying the order  explicitly the order:
-        qb = QueryBuilder().append(
-            Node, project='attributes.foo'
-        ).order_by({Node: {'ctime': {'order': 'asc'}}})
+        qb = orm.QueryBuilder().append(
+            orm.Node, project='attributes.foo'
+        ).order_by({orm.Node: {'ctime': {'order': 'asc'}}})
 
         res = next(zip(*qb.all()))
         self.assertEqual(res, tuple(range(10)))
@@ -684,9 +637,9 @@ class QueryBuilderLimitOffsetsTest(AiidaTestCase):
         self.assertEqual(res, tuple(range(5, 8)))
 
         # Reversing the order:
-        qb = QueryBuilder().append(
-            Node, project='attributes.foo'
-        ).order_by({Node: {'ctime': {'order': 'desc'}}})
+        qb = orm.QueryBuilder().append(
+            orm.Node, project='attributes.foo'
+        ).order_by({orm.Node: {'ctime': {'order': 'desc'}}})
 
         res = next(zip(*qb.all()))
         self.assertEqual(res, tuple(range(9, -1, -1)))
@@ -704,21 +657,19 @@ class QueryBuilderLimitOffsetsTest(AiidaTestCase):
 
 class QueryBuilderJoinsTests(AiidaTestCase):
     def test_joins1(self):
-        from aiida.orm import Node, Data
-        from aiida.orm.querybuilder import QueryBuilder
         # Creating n1, who will be a parent:
-        parent = Data()
+        parent = orm.Data()
         parent.label = 'mother'
 
-        good_child = CalculationNode()
+        good_child = orm.CalculationNode()
         good_child.label = 'good_child'
         good_child.set_attribute('is_good', True)
 
-        bad_child = CalculationNode()
+        bad_child = orm.CalculationNode()
         bad_child.label = 'bad_child'
         bad_child.set_attribute('is_good', False)
 
-        unrelated = CalculationNode()
+        unrelated = orm.CalculationNode()
         unrelated.label = 'unrelated'
 
         for n in (good_child, bad_child, parent, unrelated):
@@ -728,23 +679,21 @@ class QueryBuilderJoinsTests(AiidaTestCase):
         bad_child.add_incoming(parent, link_type=LinkType.INPUT_CALC, link_label='parent')
 
         # Using a standard inner join
-        qb = QueryBuilder()
-        qb.append(Node, tag='parent')
-        qb.append(Node, tag='children', project='label', filters={'attributes.is_good': True})
+        qb = orm.QueryBuilder()
+        qb.append(orm.Node, tag='parent')
+        qb.append(orm.Node, tag='children', project='label', filters={'attributes.is_good': True})
         self.assertEqual(qb.count(), 1)
 
-        qb = QueryBuilder()
-        qb.append(Node, tag='parent')
-        qb.append(Node, tag='children', outerjoin=True, project='label', filters={'attributes.is_good': True})
+        qb = orm.QueryBuilder()
+        qb.append(orm.Node, tag='parent')
+        qb.append(orm.Node, tag='children', outerjoin=True, project='label', filters={'attributes.is_good': True})
         self.assertEqual(qb.count(), 1)
 
     def test_joins2(self):
-        from aiida.orm import Node, Data
-        from aiida.orm.querybuilder import QueryBuilder
         # Creating n1, who will be a parent:
 
-        students = [Data() for i in range(10)]
-        advisors = [CalculationNode() for i in range(3)]
+        students = [orm.Data() for i in range(10)]
+        advisors = [orm.CalculationNode() for i in range(3)]
         for i, a in enumerate(advisors):
             a.label = 'advisor {}'.format(i)
             a.set_attribute('advisor_id', i)
@@ -768,28 +717,25 @@ class QueryBuilderJoinsTests(AiidaTestCase):
         students[9].add_incoming(advisors[2], link_type=LinkType.CREATE, link_label='lover')
 
         self.assertEqual(
-            QueryBuilder().append(
-                Node
+            orm.QueryBuilder().append(
+                orm.Node
             ).append(
-                Node, edge_filters={'label': {'like': 'is\\_advisor\\_%'}}, tag='student'
+                orm.Node, edge_filters={'label': {'like': 'is\\_advisor\\_%'}}, tag='student'
             ).count(), 7)
 
         for adv_id, number_students in zip(list(range(3)), (2, 2, 3)):
-            self.assertEqual(QueryBuilder().append(
-                Node, filters={'attributes.advisor_id': adv_id}
+            self.assertEqual(orm.QueryBuilder().append(
+                orm.Node, filters={'attributes.advisor_id': adv_id}
             ).append(
-                Node, edge_filters={'label': {'like': 'is\\_advisor\\_%'}}, tag='student'
+                orm.Node, edge_filters={'label': {'like': 'is\\_advisor\\_%'}}, tag='student'
             ).count(), number_students)
 
     def test_joins3_user_group(self):
-        from aiida import orm
-
         # Create another user
         new_email = "newuser@new.n"
         user = orm.User(email=new_email).store()
 
         # Create a group that belongs to that user
-        from aiida.orm.groups import Group
         group = orm.Group(label="node_group")
         group.user = user
         group.store()
@@ -813,36 +759,34 @@ class QueryBuilderJoinsTests(AiidaTestCase):
 
 class QueryBuilderPath(AiidaTestCase):
     def test_query_path(self):
-        from aiida.orm.querybuilder import QueryBuilder
-        from aiida.orm import Node
         from aiida.common.links import LinkType
 
         q = self.backend.query_manager
-        n1 = Data()
+        n1 = orm.Data()
         n1.label = 'n1'
         n1.store()
-        n2 = CalculationNode()
+        n2 = orm.CalculationNode()
         n2.label = 'n2'
         n2.store()
-        n3 = Data()
+        n3 = orm.Data()
         n3.label = 'n3'
         n3.store()
-        n4 = Data()
+        n4 = orm.Data()
         n4.label = 'n4'
         n4.store()
-        n5 = CalculationNode()
+        n5 = orm.CalculationNode()
         n5.label = 'n5'
         n5.store()
-        n6 = Data()
+        n6 = orm.Data()
         n6.label = 'n6'
         n6.store()
-        n7 = CalculationNode()
+        n7 = orm.CalculationNode()
         n7.label = 'n7'
         n7.store()
-        n8 = Data()
+        n8 = orm.Data()
         n8.label = 'n8'
         n8.store()
-        n9 = Data()
+        n9 = orm.Data()
         n9.label = 'n9'
         n9.store()
 
@@ -868,52 +812,52 @@ class QueryBuilderPath(AiidaTestCase):
 
         # Yet, no links from 1 to 8
         self.assertEquals(
-            QueryBuilder().append(
-                Node, filters={'id': n1.pk}, tag='anc'
-            ).append(Node, with_ancestors='anc', filters={'id': n8.pk}
+            orm.QueryBuilder().append(
+                orm.Node, filters={'id': n1.pk}, tag='anc'
+            ).append(orm.Node, with_ancestors='anc', filters={'id': n8.pk}
                      ).count(), 0)
 
         self.assertEquals(
-            QueryBuilder().append(
-                Node, filters={'id': n8.pk}, tag='desc'
-            ).append(Node, with_descendants='desc', filters={'id': n1.pk}
+            orm.QueryBuilder().append(
+                orm.Node, filters={'id': n8.pk}, tag='desc'
+            ).append(orm.Node, with_descendants='desc', filters={'id': n1.pk}
                      ).count(), 0)
 
         n6.add_incoming(n5, link_type=LinkType.CREATE, link_label='link1')
         # Yet, now 2 links from 1 to 8
         self.assertEquals(
-            QueryBuilder().append(
-                Node, filters={'id': n1.pk}, tag='anc'
-            ).append(Node, with_ancestors='anc', filters={'id': n8.pk}
+            orm.QueryBuilder().append(
+                orm.Node, filters={'id': n1.pk}, tag='anc'
+            ).append(orm.Node, with_ancestors='anc', filters={'id': n8.pk}
                      ).count(), 2
         )
 
         self.assertEquals(
-            QueryBuilder().append(
-                Node, filters={'id': n8.pk}, tag='desc'
-            ).append(Node, with_descendants='desc', filters={'id': n1.pk}
+            orm.QueryBuilder().append(
+                orm.Node, filters={'id': n8.pk}, tag='desc'
+            ).append(orm.Node, with_descendants='desc', filters={'id': n1.pk}
                      ).count(), 2)
 
         self.assertEquals(
-            QueryBuilder().append(
-                Node, filters={'id': n8.pk}, tag='desc'
-            ).append(Node, with_descendants='desc', filters={'id': n1.pk}, edge_filters={'depth': {'<': 6}},
+            orm.QueryBuilder().append(
+                orm.Node, filters={'id': n8.pk}, tag='desc'
+            ).append(orm.Node, with_descendants='desc', filters={'id': n1.pk}, edge_filters={'depth': {'<': 6}},
                      ).count(), 2)
         self.assertEquals(
-            QueryBuilder().append(
-                Node, filters={'id': n8.pk}, tag='desc'
-            ).append(Node, with_descendants='desc', filters={'id': n1.pk}, edge_filters={'depth': 5},
+            orm.QueryBuilder().append(
+                orm.Node, filters={'id': n8.pk}, tag='desc'
+            ).append(orm.Node, with_descendants='desc', filters={'id': n1.pk}, edge_filters={'depth': 5},
                      ).count(), 2)
         self.assertEquals(
-            QueryBuilder().append(
-                Node, filters={'id': n8.pk}, tag='desc'
-            ).append(Node, with_descendants='desc', filters={'id': n1.pk}, edge_filters={'depth': {'<': 5}},
+            orm.QueryBuilder().append(
+                orm.Node, filters={'id': n8.pk}, tag='desc'
+            ).append(orm.Node, with_descendants='desc', filters={'id': n1.pk}, edge_filters={'depth': {'<': 5}},
                      ).count(), 0)
 
         # TODO write a query that can filter certain paths by traversed ID
-        qb = QueryBuilder().append(
-            Node, filters={'id': n8.pk}, tag='desc',
-        ).append(Node, with_descendants='desc', edge_project='path', filters={'id': n1.pk})
+        qb = orm.QueryBuilder().append(
+            orm.Node, filters={'id': n8.pk}, tag='desc',
+        ).append(orm.Node, with_descendants='desc', edge_project='path', filters={'id': n1.pk})
         queried_path_set = set([frozenset(p) for p, in qb.all()])
 
         paths_there_should_be = set([
@@ -923,10 +867,10 @@ class QueryBuilderPath(AiidaTestCase):
 
         self.assertTrue(queried_path_set == paths_there_should_be)
 
-        qb = QueryBuilder().append(
-            Node, filters={'id': n1.pk}, tag='anc'
+        qb = orm.QueryBuilder().append(
+            orm.Node, filters={'id': n1.pk}, tag='anc'
         ).append(
-            Node, with_ancestors='anc', filters={'id': n8.pk}, edge_project='path'
+            orm.Node, with_ancestors='anc', filters={'id': n8.pk}, edge_project='path'
         )
 
         self.assertTrue(set(
@@ -940,36 +884,36 @@ class QueryBuilderPath(AiidaTestCase):
         # Still two links...
 
         self.assertEquals(
-            QueryBuilder().append(
-                Node, filters={'id': n1.pk}, tag='anc'
-            ).append(Node, with_ancestors='anc', filters={'id': n8.pk}
+            orm.QueryBuilder().append(
+                orm.Node, filters={'id': n1.pk}, tag='anc'
+            ).append(orm.Node, with_ancestors='anc', filters={'id': n8.pk}
                      ).count(), 2
         )
 
         self.assertEquals(
-            QueryBuilder().append(
-                Node, filters={'id': n8.pk}, tag='desc'
-            ).append(Node, with_descendants='desc', filters={'id': n1.pk}
+            orm.QueryBuilder().append(
+                orm.Node, filters={'id': n8.pk}, tag='desc'
+            ).append(orm.Node, with_descendants='desc', filters={'id': n1.pk}
                      ).count(), 2)
         n9.add_incoming(n5, link_type=LinkType.CREATE, link_label='link6')
         # And now there should be 4 nodes
 
         self.assertEquals(
-            QueryBuilder().append(
-                Node, filters={'id': n1.pk}, tag='anc'
-            ).append(Node, with_ancestors='anc', filters={'id': n8.pk}
+            orm.QueryBuilder().append(
+                orm.Node, filters={'id': n1.pk}, tag='anc'
+            ).append(orm.Node, with_ancestors='anc', filters={'id': n8.pk}
                      ).count(), 4)
 
         self.assertEquals(
-            QueryBuilder().append(
-                Node, filters={'id': n8.pk}, tag='desc'
-            ).append(Node, with_descendants='desc', filters={'id': n1.pk}
+            orm.QueryBuilder().append(
+                orm.Node, filters={'id': n8.pk}, tag='desc'
+            ).append(orm.Node, with_descendants='desc', filters={'id': n1.pk}
                      ).count(), 4)
 
-        qb = QueryBuilder().append(
-            Node, filters={'id': n1.pk}, tag='anc'
+        qb = orm.QueryBuilder().append(
+            orm.Node, filters={'id': n1.pk}, tag='anc'
         ).append(
-            Node, with_ancestors='anc', filters={'id': n8.pk}, edge_tag='edge'
+            orm.Node, with_ancestors='anc', filters={'id': n8.pk}, edge_tag='edge'
         )
         qb.add_projection('edge', 'depth')
         self.assertTrue(set(next(zip(*qb.all()))), set([5, 6]))
@@ -982,20 +926,16 @@ class TestConsistency(AiidaTestCase):
         """
         Testing whether creating nodes within a iterall iteration changes the results.
         """
-        from aiida.orm import Node
-        from aiida.orm.querybuilder import QueryBuilder
-        import random
-
         for i in range(100):
-            n = Data()
+            n = orm.Data()
             n.store()
 
-        for idx, item in enumerate(QueryBuilder().append(Node, project=['id', 'label']).iterall(batch_size=10)):
+        for idx, item in enumerate(orm.QueryBuilder().append(orm.Node, project=['id', 'label']).iterall(batch_size=10)):
             if idx % 10 == 10:
-                n = Data()
+                n = orm.Data()
                 n.store()
         self.assertEqual(idx, 99)
-        self.assertTrue(len(QueryBuilder().append(Node, project=['id', 'label']).all(batch_size=10)) > 99)
+        self.assertTrue(len(orm.QueryBuilder().append(orm.Node, project=['id', 'label']).all(batch_size=10)) > 99)
 
     def test_len_results(self):
         """
@@ -1003,20 +943,17 @@ class TestConsistency(AiidaTestCase):
         See also https://github.com/aiidateam/aiida_core/issues/1600
         SQLAlchemy has a deduplication strategy that leads to strange behavior, tested against here
         """
-        from aiida.orm import Data
-        from aiida.orm import CalculationNode
-        from aiida.orm.querybuilder import QueryBuilder
-
-        parent = CalculationNode().store()
+        parent = orm.CalculationNode().store()
         # adding 5 links going out:
         for inode in range(5):
-            output_node = Data().store()
+            output_node = orm.Data().store()
             output_node.add_incoming(parent, link_type=LinkType.CREATE, link_label='link-{}'.format(inode))
         for projection in ('id', '*'):
-            qb = QueryBuilder()
-            qb.append(CalculationNode, filters={'id':parent.id}, tag='parent', project=projection)
-            qb.append(Data, with_incoming='parent')
+            qb = orm.QueryBuilder()
+            qb.append(orm.CalculationNode, filters={'id': parent.id}, tag='parent', project=projection)
+            qb.append(orm.Data, with_incoming='parent')
             self.assertEqual(len(qb.all()), qb.count())
+
 
 class TestManager(AiidaTestCase):
     def test_statistics(self):
@@ -1025,9 +962,6 @@ class TestManager(AiidaTestCase):
 
         I try to implement it in a way that does not depend on the past state.
         """
-        from aiida.orm import Node
-        from aiida.orm import ProcessNode
-        from aiida.plugins import DataFactory
         from collections import defaultdict
 
         def store_and_add(n, statistics):
@@ -1049,12 +983,10 @@ class TestManager(AiidaTestCase):
             'ctime_by_day': ctime_by_day
         }
 
-        Dict = DataFactory('dict')
-
-        store_and_add(Data(), expected_db_statistics)
-        store_and_add(Dict(), expected_db_statistics)
-        store_and_add(Dict(), expected_db_statistics)
-        store_and_add(CalculationNode(), expected_db_statistics)
+        store_and_add(orm.Data(), expected_db_statistics)
+        store_and_add(orm.Dict(), expected_db_statistics)
+        store_and_add(orm.Dict(), expected_db_statistics)
+        store_and_add(orm.CalculationNode(), expected_db_statistics)
 
         new_db_statistics = qmanager.get_creation_statistics()
         # I only check a few fields
@@ -1071,8 +1003,6 @@ class TestManager(AiidaTestCase):
 
         I try to implement it in a way that does not depend on the past state.
         """
-        from aiida.orm import Node, ProcessNode
-        from aiida.plugins import DataFactory
         from collections import defaultdict
 
         def store_and_add(n, statistics):
@@ -1093,12 +1023,10 @@ class TestManager(AiidaTestCase):
             'ctime_by_day': ctime_by_day
         }
 
-        Dict = DataFactory('dict')
-
-        store_and_add(Data(), expected_db_statistics)
-        store_and_add(Dict(), expected_db_statistics)
-        store_and_add(Dict(), expected_db_statistics)
-        store_and_add(CalculationNode(), expected_db_statistics)
+        store_and_add(orm.Data(), expected_db_statistics)
+        store_and_add(orm.Dict(), expected_db_statistics)
+        store_and_add(orm.Dict(), expected_db_statistics)
+        store_and_add(orm.CalculationNode(), expected_db_statistics)
 
         new_db_statistics = self.backend.query_manager.get_creation_statistics()
         # I only check a few fields

--- a/aiida/backends/tests/test_restapi.py
+++ b/aiida/backends/tests/test_restapi.py
@@ -14,20 +14,11 @@ from __future__ import division
 from __future__ import print_function
 from __future__ import absolute_import
 
+from aiida import orm
 from aiida.backends.testbase import AiidaTestCase
+from aiida.common import json
 from aiida.common.links import LinkType
-from aiida.orm import CalcJobNode
-from aiida.orm.computers import Computer
-from aiida.orm.nodes.data import Data
-from aiida.orm.querybuilder import QueryBuilder
-from aiida.plugins import DataFactory
 from aiida.restapi.api import App, AiidaApi
-import aiida.common.json as json
-
-StructureData = DataFactory('structure')  # pylint: disable=invalid-name
-CifData = DataFactory('cif')  # pylint: disable=invalid-name
-Dict = DataFactory('dict')  # pylint: disable=invalid-name
-KpointsData = DataFactory('array.kpoints')  # pylint: disable=invalid-name
 
 
 class RESTApiTestCase(AiidaTestCase):
@@ -45,8 +36,6 @@ class RESTApiTestCase(AiidaTestCase):
         Basides the standard setup we need to add few more objects in the
         database to be able to explore different requests/filters/orderings etc.
         """
-        from aiida import orm
-
         # call parent setUpClass method
         super(RESTApiTestCase, cls).setUpClass()
 
@@ -61,26 +50,26 @@ class RESTApiTestCase(AiidaTestCase):
 
         # create test inputs
         cell = ((2., 0., 0.), (0., 2., 0.), (0., 0., 2.))
-        structure = StructureData(cell=cell)
+        structure = orm.StructureData(cell=cell)
         structure.append_atom(position=(0., 0., 0.), symbols=['Ba'])
         structure.store()
 
-        cif = CifData(ase=structure.get_ase())
+        cif = orm.CifData(ase=structure.get_ase())
         cif.store()
 
-        parameter1 = Dict(dict={"a": 1, "b": 2})
+        parameter1 = orm.Dict(dict={"a": 1, "b": 2})
         parameter1.store()
 
-        parameter2 = Dict(dict={"c": 3, "d": 4})
+        parameter2 = orm.Dict(dict={"c": 3, "d": 4})
         parameter2.store()
 
-        kpoint = KpointsData()
+        kpoint = orm.KpointsData()
         kpoint.set_kpoints_mesh([4, 4, 4])
         kpoint.store()
 
         resources = {'num_machines': 1, 'num_mpiprocs_per_machine': 1}
 
-        calc = CalcJobNode(computer=cls.computer)
+        calc = orm.CalcJobNode(computer=cls.computer)
         calc.set_option('resources', resources)
         calc.set_attribute("attr1", "OK")  # pylint: disable=protected-access
         calc.set_attribute("attr2", "OK")  # pylint: disable=protected-access
@@ -90,7 +79,7 @@ class RESTApiTestCase(AiidaTestCase):
         calc.add_incoming(parameter1, link_type=LinkType.INPUT_CALC, link_label='link_parameter')
         kpoint.add_incoming(calc, link_type=LinkType.CREATE, link_label='create')
 
-        calc1 = CalcJobNode(computer=cls.computer)
+        calc1 = orm.CalcJobNode(computer=cls.computer)
         calc1.set_option('resources', resources)
         calc1.store()
 
@@ -141,8 +130,8 @@ class RESTApiTestCase(AiidaTestCase):
         # by their list index is very fragile and a pain to debug.
         # Please change this!
         computer_projections = ["id", "uuid", "name", "hostname", "transport_type", "scheduler_type"]
-        computers = QueryBuilder().append(
-            Computer, tag="comp", project=computer_projections).order_by({
+        computers = orm.QueryBuilder().append(
+            orm.Computer, tag="comp", project=computer_projections).order_by({
                 'comp': [{
                     'name': {
                         'order': 'asc'
@@ -158,8 +147,8 @@ class RESTApiTestCase(AiidaTestCase):
         cls._dummy_data["computers"] = computers
 
         calculation_projections = ["id", "uuid", "user_id", "type"]
-        calculations = QueryBuilder().append(
-            CalcJobNode, tag="calc", project=calculation_projections).order_by({
+        calculations = orm.QueryBuilder().append(
+            orm.CalcJobNode, tag="calc", project=calculation_projections).order_by({
                 'calc': [{
                     'id': {
                         'order': 'desc'
@@ -175,13 +164,13 @@ class RESTApiTestCase(AiidaTestCase):
 
         data_projections = ["id", "uuid", "user_id", "type"]
         data_types = {
-            'cifdata': CifData,
-            'parameterdata': Dict,
-            'structuredata': StructureData,
-            'data': Data,
+            'cifdata': orm.CifData,
+            'parameterdata': orm.Dict,
+            'structuredata': orm.StructureData,
+            'data': orm.Data,
         }
         for label, dataclass in data_types.items():
-            data = QueryBuilder().append(
+            data = orm.QueryBuilder().append(
                 dataclass, tag="data", project=data_projections).order_by({
                     'data': [{
                         'id': {
@@ -236,7 +225,7 @@ class RESTApiTestCase(AiidaTestCase):
         self.assertEqual(response["url"], "http://localhost" + url)
         self.assertEqual(response["url_root"], "http://localhost/")
 
-    ###### node details and list with limit, offset, page, perpage ####
+    # node details and list with limit, offset, page, perpage
     def process_test(self,
                      node_type,
                      url,
@@ -303,16 +292,6 @@ class RESTApiTestCase(AiidaTestCase):
 
                 self.compare_extra_response_data(node_type, url, response, uuid)
 
-    ######## check exception #########
-    # def node_exception(self, url, exception_type):
-    #     """
-    #     Assert exception if any unknown parameter is passed in url
-    #     :param url: web url
-    #     :param exception_type: exception to be thrown
-    #     :return:
-    #     """
-    #     self.assertRaises(exception_type, self.app.get(url))
-
 
 class RESTApiTestSuite(RESTApiTestCase):
     # pylint: disable=too-many-public-methods
@@ -320,7 +299,6 @@ class RESTApiTestSuite(RESTApiTestCase):
     Define unittests for rest api
     """
 
-    ############### single computer ########################
     def test_computers_details(self):
         """
         Requests the details of single computer
@@ -330,7 +308,6 @@ class RESTApiTestSuite(RESTApiTestCase):
         RESTApiTestCase.process_test(
             self, "computers", "/computers/" + str(node_uuid), expected_list_ids=[1], uuid=node_uuid)
 
-    ############### full list with limit, offset, page, perpage #############
     def test_computers_list(self):
         """
         Get the full list of computers from database

--- a/aiida/calculations/plugins/arithmetic/add.py
+++ b/aiida/calculations/plugins/arithmetic/add.py
@@ -14,10 +14,9 @@ from __future__ import absolute_import
 
 import six
 
+from aiida import orm
 from aiida.common.datastructures import CalcInfo, CodeInfo
 from aiida.engine import CalcJob
-from aiida.orm.nodes.data.float import Float
-from aiida.orm.nodes.data.int import Int
 
 
 class ArithmeticAddCalculation(CalcJob):
@@ -29,9 +28,9 @@ class ArithmeticAddCalculation(CalcJob):
         spec.input('metadata.options.input_filename', valid_type=six.string_types, default='aiida.in', non_db=True)
         spec.input('metadata.options.output_filename', valid_type=six.string_types, default='aiida.out', non_db=True)
         spec.input('metadata.options.parser_name', valid_type=six.string_types, default='arithmetic.add', non_db=True)
-        spec.input('x', valid_type=(Int, Float), help='The left operand.')
-        spec.input('y', valid_type=(Int, Float), help='The right operand.')
-        spec.output('sum', valid_type=(Int, Float), help='The sum of the left and right operand.')
+        spec.input('x', valid_type=(orm.Int, orm.Float), help='The left operand.')
+        spec.input('y', valid_type=(orm.Int, orm.Float), help='The right operand.')
+        spec.output('sum', valid_type=(orm.Int, orm.Float), help='The sum of the left and right operand.')
         spec.exit_code(
             100, 'ERROR_NO_RETRIEVED_FOLDER', message='The retrieved folder data node could not be accessed.')
         spec.exit_code(

--- a/aiida/calculations/plugins/templatereplacer.py
+++ b/aiida/calculations/plugins/templatereplacer.py
@@ -14,12 +14,10 @@ from __future__ import absolute_import
 
 import six
 
+from aiida import orm
 from aiida.common import exceptions
 from aiida.common.datastructures import CalcInfo, CodeInfo
 from aiida.engine import CalcJob
-from aiida.orm.nodes.data.dict import Dict
-from aiida.orm.nodes.data.remote import RemoteData
-from aiida.orm.nodes.data.singlefile import SinglefileData
 
 
 class TemplatereplacerCalculation(CalcJob):
@@ -71,13 +69,13 @@ class TemplatereplacerCalculation(CalcJob):
         super(TemplatereplacerCalculation, cls).define(spec)
         spec.input('metadata.options.parser_name', valid_type=six.string_types, default='templatereplacer.doubler',
             non_db=True)
-        spec.input('template', valid_type=Dict,
+        spec.input('template', valid_type=orm.Dict,
             help='A template for the input file.')
-        spec.input('parameters', valid_type=Dict, required=False,
+        spec.input('parameters', valid_type=orm.Dict, required=False,
             help='Parameters used to replace placeholders in the template.')
-        spec.input_namespace('files', valid_type=(RemoteData, SinglefileData), required=False)
+        spec.input_namespace('files', valid_type=(orm.RemoteData, orm.SinglefileData), required=False)
 
-        spec.output('output_parameters', valid_type=Dict, required=True)
+        spec.output('output_parameters', valid_type=orm.Dict, required=True)
         spec.default_output_node = 'output_parameters'
 
         spec.exit_code(100, 'ERROR_NO_RETRIEVED_FOLDER',
@@ -138,9 +136,9 @@ class TemplatereplacerCalculation(CalcJob):
             except AttributeError:
                 raise exceptions.InputValidationError("You are asking to copy a file link {}, "
                                                       "but there is no input link with such a name".format(link_name))
-            if isinstance(fileobj, SinglefileData):
+            if isinstance(fileobj, orm.SinglefileData):
                 local_copy_list.append((fileobj.get_file_abs_path(), dest_rel_path))
-            elif isinstance(fileobj, RemoteData):  # can be a folder
+            elif isinstance(fileobj, orm.RemoteData):  # can be a folder
                 remote_copy_list.append((fileobj.computer.uuid, fileobj.get_remote_path(), dest_rel_path))
             else:
                 raise exceptions.InputValidationError(

--- a/aiida/cmdline/commands/cmd_data/cmd_cif.py
+++ b/aiida/cmdline/commands/cmd_data/cmd_cif.py
@@ -39,7 +39,7 @@ def cif():
 @decorators.with_dbenv()
 def cif_list(raw, formula_mode, past_days, groups, all_users):
     """List store CifData objects."""
-    from aiida.orm.nodes.data.cif import CifData
+    from aiida.orm import CifData
     from tabulate import tabulate
 
     elements = None
@@ -122,7 +122,7 @@ def cif_export(**kwargs):
 @decorators.with_dbenv()
 def cif_import(filename):
     """Import structure into CifData object."""
-    from aiida.orm.nodes.data.cif import CifData
+    from aiida.orm import CifData
 
     try:
         node, _ = CifData.get_or_create(filename)

--- a/aiida/cmdline/commands/cmd_data/cmd_import.py
+++ b/aiida/cmdline/commands/cmd_data/cmd_import.py
@@ -23,7 +23,7 @@ def data_import_xyz(filename, **kwargs):
     Imports an XYZ-file.
     """
     from os.path import abspath
-    from aiida.orm.nodes.data.structure import StructureData
+    from aiida.orm import StructureData
 
     vacuum_addition = kwargs.pop('vacuum_addition')
     vacuum_factor = kwargs.pop('vacuum_factor')
@@ -91,7 +91,7 @@ def data_import_ase(filename, **kwargs):
     Imports a structure in a number of formats using the ASE routines.
     """
     from os.path import abspath
-    from aiida.orm.nodes.data.structure import StructureData
+    from aiida.orm import StructureData
 
     try:
         import ase.io

--- a/aiida/cmdline/commands/cmd_data/cmd_structure.py
+++ b/aiida/cmdline/commands/cmd_data/cmd_structure.py
@@ -42,8 +42,7 @@ def structure():
 @decorators.with_dbenv()
 def structure_list(elements, raw, formula_mode, past_days, groups, all_users):
     """List stored StructureData objects."""
-    from aiida.orm.nodes.data.structure import StructureData
-    from aiida.orm.nodes.data.structure import (get_formula, get_symbols_string)
+    from aiida.orm.nodes.data.structure import StructureData, get_formula, get_symbols_string
     from tabulate import tabulate
 
     elements_only = False

--- a/aiida/cmdline/commands/cmd_data/cmd_trajectory.py
+++ b/aiida/cmdline/commands/cmd_data/cmd_trajectory.py
@@ -39,7 +39,7 @@ def trajectory():
 @decorators.with_dbenv()
 def trajectory_list(raw, past_days, groups, all_users):
     """List trajectories stored in database."""
-    from aiida.orm.nodes.data.array.trajectory import TrajectoryData
+    from aiida.orm import TrajectoryData
     from tabulate import tabulate
 
     elements = None

--- a/aiida/cmdline/commands/cmd_data/cmd_upf.py
+++ b/aiida/cmdline/commands/cmd_data/cmd_upf.py
@@ -129,7 +129,7 @@ def upf_import(filename):
     """
     Import upf data object
     """
-    from aiida.orm.nodes.data.upf import UpfData
+    from aiida.orm import UpfData
 
     node, _ = UpfData.get_or_create(filename)
     echo.echo_success('Imported: {}'.format(node))

--- a/aiida/cmdline/commands/cmd_rehash.py
+++ b/aiida/cmdline/commands/cmd_rehash.py
@@ -11,6 +11,7 @@
 from __future__ import division
 from __future__ import print_function
 from __future__ import absolute_import
+
 import click
 
 from aiida.cmdline.commands.cmd_verdi import verdi
@@ -33,9 +34,7 @@ def rehash(nodes, entry_point):
 
     The set of nodes that will be rehashed can be filtered by their identifier and/or based on their class.
     """
-    from aiida.orm.nodes.data import Data
-    from aiida.orm import ProcessNode
-    from aiida.orm.querybuilder import QueryBuilder
+    from aiida.orm import Data, ProcessNode, QueryBuilder
 
     # If no explicit entry point is defined, rehash all nodes, which are either Data nodes or ProcessNodes
     if entry_point is None:

--- a/aiida/cmdline/utils/common.py
+++ b/aiida/cmdline/utils/common.py
@@ -86,8 +86,7 @@ def get_node_summary(node):
     :return: a string summary of the node
     """
     from plumpy import ProcessState
-    from aiida.orm.nodes.data.code import Code
-    from aiida.orm import ProcessNode
+    from aiida.orm import Code, ProcessNode
 
     table_headers = ['Property', 'Value']
     table = []
@@ -285,10 +284,8 @@ def get_workchain_report(node, levelname, indent_size=4, max_depth=None):
     """
     # pylint: disable=too-many-locals
     import itertools
-    from aiida.common.log import LOG_LEVELS
     from aiida import orm
-    from aiida.orm.querybuilder import QueryBuilder
-    from aiida.orm import WorkChainNode
+    from aiida.common.log import LOG_LEVELS
 
     def get_report_messages(uuid, depth, levelname):
         """Return list of log messages with given levelname and their depth for a node with a given uuid."""
@@ -304,10 +301,10 @@ def get_workchain_report(node, levelname, indent_size=4, max_depth=None):
         Get a nested tree of work calculation nodes and their nesting level starting from this uuid.
         The result is a list of uuid of these nodes.
         """
-        builder = QueryBuilder()
-        builder.append(cls=WorkChainNode, filters={'uuid': uuid}, tag='workcalculation')
+        builder = orm.QueryBuilder()
+        builder.append(cls=orm.WorkChainNode, filters={'uuid': uuid}, tag='workcalculation')
         builder.append(
-            cls=WorkChainNode,
+            cls=orm.WorkChainNode,
             project=['uuid'],
             # In the future, we should specify here the type of link
             # for now, CALL links are the only ones allowing calc-calc

--- a/aiida/cmdline/utils/echo.py
+++ b/aiida/cmdline/utils/echo.py
@@ -154,7 +154,7 @@ def echo_dictionary(dictionary, fmt='json+date'):
 
 def _format_dictionary_json_date(dictionary):
     """Return a dictionary formatted as a string using the json format and converting dates to strings."""
-    import aiida.common.json as json
+    from aiida.common import json
 
     def default_jsondump(data):
         """Function needed to decode datetimes, that would otherwise not be JSON-decodable."""

--- a/aiida/cmdline/utils/query/calculation.py
+++ b/aiida/cmdline/utils/query/calculation.py
@@ -95,8 +95,7 @@ class CalculationQueryBuilder(object):  # pylint: disable=useless-object-inherit
         """
         import datetime
 
-        from aiida.orm import ProcessNode
-        from aiida.orm.querybuilder import QueryBuilder
+        from aiida import orm
         from aiida.common import timezone
 
         # Define the list of projections for the QueryBuilder, which are all valid minus the compound projections
@@ -112,8 +111,8 @@ class CalculationQueryBuilder(object):  # pylint: disable=useless-object-inherit
         if past_days is not None:
             filters['ctime'] = {'>': timezone.now() - datetime.timedelta(days=past_days)}
 
-        builder = QueryBuilder()
-        builder.append(cls=ProcessNode, filters=filters, project=projected_attributes, tag='process')
+        builder = orm.QueryBuilder()
+        builder.append(cls=orm.ProcessNode, filters=filters, project=projected_attributes, tag='process')
 
         if relationships is not None:
             for tag, entity in relationships.items():

--- a/aiida/common/archive.py
+++ b/aiida/common/archive.py
@@ -23,7 +23,7 @@ from six.moves import range
 
 from aiida.common.exceptions import ContentNotExistent, InvalidOperation
 from aiida.common.folders import SandboxFolder
-import aiida.common.json as json
+from aiida.common import json
 
 
 class Archive(object):  # pylint: disable=useless-object-inheritance

--- a/aiida/common/folders.py
+++ b/aiida/common/folders.py
@@ -409,7 +409,7 @@ class Folder(object):  # pylint: disable=useless-object-inheritance
         if overwrite:
             self.erase()
         elif self.exists():
-            raise IOError("Location {} already exists, and overwrite is set to " "False".format(self.abspath))
+            raise IOError("Location {} already exists, and overwrite is set to False".format(self.abspath))
 
         # Create parent dir, if needed, with the right mode
         pardir = os.path.dirname(self.abspath)

--- a/aiida/engine/daemon/execmanager.py
+++ b/aiida/engine/daemon/execmanager.py
@@ -20,13 +20,12 @@ import os
 
 from six.moves import zip
 
-from aiida.common import AIIDA_LOGGER
-from aiida.common import exceptions
+from aiida.common import AIIDA_LOGGER, exceptions
 from aiida.common.datastructures import CalcJobState
 from aiida.common.folders import SandboxFolder
 from aiida.common.links import LinkType
+from aiida.orm import FolderData
 from aiida.orm.utils.log import get_dblogger_extra
-from aiida.orm.nodes.data.folder import FolderData
 from aiida.plugins import DataFactory
 from aiida.schedulers.datastructures import JobState
 
@@ -44,8 +43,7 @@ def upload_calculation(calculation, transport, calc_info, script_filename):
     :param calc_info: the calculation info datastructure returned by `CalcJobNode._presubmit`
     :param script_filename: the job launch script returned by `CalcJobNode._presubmit`
     """
-    from aiida.orm import load_node, Code
-    from aiida.orm.nodes.data.remote import RemoteData
+    from aiida.orm import load_node, Code, RemoteData
 
     computer = calculation.computer
 

--- a/aiida/engine/processes/functions.py
+++ b/aiida/engine/processes/functions.py
@@ -23,7 +23,7 @@ def calcfunction(function):
     A decorator to turn a standard python function into a calcfunction.
     Example usage:
 
-    >>> from aiida.orm.nodes.data.int import Int
+    >>> from aiida.orm import Int
     >>>
     >>> # Define the calcfunction
     >>> @calcfunction
@@ -49,16 +49,16 @@ def workfunction(function):
     A decorator to turn a standard python function into a workfunction.
     Example usage:
 
-    >>> from aiida.orm.nodes.data.int import Int
+    >>> from aiida.orm import Int
     >>>
     >>> # Define the workfunction
     >>> @workfunction
-    >>> def sum(a, b):
-    >>>    return a + b
+    >>> def select(a, b):
+    >>>    return a
     >>> # Run it with some input
-    >>> r = sum(Int(4), Int(5))
+    >>> r = select(Int(4), Int(5))
     >>> print(r)
-    9
+    4
     >>> r.get_incoming().all() # doctest: +SKIP
     [Neighbor(link_type='', link_label='result',
     node=<WorkFunctionNode: uuid: ce0c63b3-1c84-4bb8-ba64-7b70a36adf34 (pk: 3567)>)]
@@ -270,7 +270,7 @@ class FunctionProcess(Process):
     @override
     def run(self):
         """Run the process"""
-        from aiida.orm.nodes.data import Data
+        from aiida.orm import Data
         from .exit_code import ExitCode
 
         args = []

--- a/aiida/engine/processes/process.py
+++ b/aiida/engine/processes/process.py
@@ -548,7 +548,7 @@ class Process(plumpy.Process):
 
     def _setup_inputs(self):
         """Create the links between the input nodes and the ProcessNode that represents this process."""
-        from aiida.orm.nodes.data.code import Code
+        from aiida.orm import Code
 
         for name, node in self._flat_inputs().items():
 

--- a/aiida/engine/processes/process_spec.py
+++ b/aiida/engine/processes/process_spec.py
@@ -90,7 +90,7 @@ class CalcJobProcessSpec(ProcessSpec):
 
     @default_output_node.setter
     def default_output_node(self, port_name):
-        from aiida.orm.nodes.data.dict import Dict
+        from aiida.orm import Dict
 
         if port_name not in self.outputs:
             raise ValueError('{} is not a registered output port'.format(port_name))

--- a/aiida/manage/backup/backup_base.py
+++ b/aiida/manage/backup/backup_base.py
@@ -22,7 +22,7 @@ from dateutil.parser import parse
 from pytz import timezone as ptimezone
 
 from aiida.common import timezone as dtimezone
-import aiida.common.json as json
+from aiida.common import json
 
 
 @six.add_metaclass(ABCMeta)

--- a/aiida/manage/backup/backup_setup.py
+++ b/aiida/manage/backup/backup_setup.py
@@ -23,7 +23,7 @@ import sys
 from aiida.backends.profile import BACKEND_DJANGO
 from aiida.backends.profile import BACKEND_SQLA
 from aiida.backends.utils import load_dbenv, is_dbenv_loaded
-import aiida.common.json as json
+from aiida.common import json
 from aiida.manage.backup.backup_base import AbstractBackup, BackupError
 from aiida.manage.configuration.settings import AIIDA_CONFIG_FOLDER
 

--- a/aiida/manage/configuration/setup.py
+++ b/aiida/manage/configuration/setup.py
@@ -213,7 +213,7 @@ def delete_db(profile, non_interactive=True, verbose=False):
     """
     from aiida.manage.configuration import get_config
     from aiida.manage.external.postgres import Postgres
-    import aiida.common.json as json
+    from aiida.common import json
 
     pdict = profile.dictionary
 

--- a/aiida/manage/database/delete/nodes.py
+++ b/aiida/manage/database/delete/nodes.py
@@ -17,7 +17,6 @@ from six.moves import zip
 import click
 
 from aiida.cmdline.utils import echo
-from aiida.orm import User
 
 
 def delete_nodes(pks,
@@ -47,14 +46,10 @@ def delete_nodes(pks,
         The verbosity levels, 0 prints nothing, 1 prints just sums and total, 2 prints individual nodes.
     """
     # pylint: disable=too-many-arguments,too-many-branches,too-many-locals,too-many-statements
+    from aiida.backends.utils import delete_nodes_and_connections
     from aiida.common import exceptions
     from aiida.common.links import LinkType
-    from aiida.orm import Node
-    from aiida.orm import ProcessNode
-    from aiida.orm.nodes.data import Data
-    from aiida.orm.querybuilder import QueryBuilder
-    from aiida.orm import load_node
-    from aiida.backends.utils import delete_nodes_and_connections
+    from aiida.orm import User, Node, ProcessNode, Data, QueryBuilder, load_node
 
     user_email = User.objects.get_default().email
 

--- a/aiida/manage/database/integrity/sql/nodes.py
+++ b/aiida/manage/database/integrity/sql/nodes.py
@@ -3,8 +3,7 @@
 from __future__ import absolute_import
 
 from aiida.common.extendeddicts import AttributeDict
-from aiida.orm.nodes.data import Data
-from aiida.orm import CalculationNode, WorkflowNode
+from aiida.orm import Data, CalculationNode, WorkflowNode
 
 
 def format_type_string_regex(node_class):

--- a/aiida/orm/importexport.py
+++ b/aiida/orm/importexport.py
@@ -528,7 +528,7 @@ def import_data_dj(in_path, user_group=None, ignore_unknown_nodes=False,
     from aiida.common.folders import SandboxFolder, RepositoryFolder
     from aiida.backends.djsite.db import models
     from aiida.common.utils import get_object_from_string
-    import aiida.common.json as json
+    from aiida.common import json
 
     # This is the export version expected by this function
     expected_export_version = '0.4'
@@ -1147,7 +1147,7 @@ def import_data_sqla(in_path, user_group=None, ignore_unknown_nodes=False,
     from aiida.common.folders import SandboxFolder, RepositoryFolder
     from aiida.common.utils import get_object_from_string
     from aiida.common.links import LinkType
-    import aiida.common.json as json
+    from aiida.common import json
 
     # This is the export version expected by this function
     expected_export_version = '0.4'
@@ -2075,7 +2075,7 @@ def export_tree(what, folder, allowed_licenses=None, forbidden_licenses=None,
     from aiida.common.links import LinkType
     from aiida.common.folders import RepositoryFolder
     from aiida.orm.querybuilder import QueryBuilder
-    import aiida.common.json as json
+    from aiida.common import json
     from django.core.exceptions import ImproperlyConfigured
 
     if not silent:

--- a/aiida/orm/nodes/data/__init__.py
+++ b/aiida/orm/nodes/data/__init__.py
@@ -23,6 +23,7 @@ from .float import Float
 from .folder import FolderData
 from .int import Int
 from .list import List
+from .numeric import NumericType
 from .orbital import OrbitalData
 from .remote import RemoteData
 from .singlefile import SinglefileData
@@ -32,4 +33,4 @@ from .upf import UpfData
 
 __all__ = ('Data', 'BaseType', 'ArrayData', 'BandsData', 'KpointsData', 'ProjectionData', 'TrajectoryData', 'XyData',
            'Bool', 'CifData', 'Code', 'Float', 'FolderData', 'Int', 'List', 'OrbitalData', 'Dict', 'RemoteData',
-           'SinglefileData', 'Str', 'StructureData', 'UpfData')
+           'SinglefileData', 'Str', 'StructureData', 'UpfData', 'NumericType')

--- a/aiida/orm/nodes/data/array/bands.py
+++ b/aiida/orm/nodes/data/array/bands.py
@@ -11,10 +11,10 @@
 This module defines the classes related to band structures or dispersions
 in a Brillouin zone, and how to operate on them.
 """
-
 from __future__ import print_function
 from __future__ import absolute_import
 from __future__ import division
+
 import io
 from string import Template
 
@@ -22,9 +22,9 @@ import six
 from six.moves import range, zip
 import numpy
 
-from aiida.orm.nodes.data.array.kpoints import KpointsData
 from aiida.common.exceptions import ValidationError
 from aiida.common.utils import prettify_labels, join_labels
+from .kpoints import KpointsData
 
 
 def prepare_header_comment(uuid, plot_info, comment_char='#'):
@@ -87,7 +87,7 @@ def find_bandgap(bandsdata, number_electrons=None, fermi_energy=None):
             return int(num - .5)
 
     if fermi_energy and number_electrons:
-        raise ValueError("Specify either the number of electrons or the " "Fermi energy, but not both")
+        raise ValueError("Specify either the number of electrons or the Fermi energy, but not both")
 
     try:
         stored_bands = bandsdata.get_bands()
@@ -112,7 +112,7 @@ def find_bandgap(bandsdata, number_electrons=None, fermi_energy=None):
             try:
                 _, stored_occupations = bandsdata.get_bands(also_occupations=True)
             except KeyError:
-                raise KeyError("Cannot determine metallicity if I don't have " "either fermi energy, or occupations")
+                raise KeyError("Cannot determine metallicity if I don't have either fermi energy, or occupations")
 
             # put the occupations in the same order of bands, also in case of multiple bands
             if len(stored_occupations.shape) == 3:
@@ -189,9 +189,9 @@ def find_bandgap(bandsdata, number_electrons=None, fermi_energy=None):
         max_mins = [(max(i), min(i)) for i in levels]
 
         if fermi_energy > bands.max():
-            raise ValueError("The Fermi energy is above all band energies, " "don't know what to do")
+            raise ValueError("The Fermi energy is above all band energies, don't know what to do")
         if fermi_energy < bands.min():
-            raise ValueError("The Fermi energy is below all band energies, " "don't know what to do.")
+            raise ValueError("The Fermi energy is below all band energies, don't know what to do.")
 
         # one band is crossed by the fermi energy
         if any(i[1] < fermi_energy and fermi_energy < i[0] for i in max_mins):
@@ -209,7 +209,7 @@ def find_bandgap(bandsdata, number_electrons=None, fermi_energy=None):
             lumo = min([i[1] for i in max_mins if i[1] > fermi_energy])
             gap = lumo - homo
             if gap <= 0.:
-                raise Exception("Something wrong has been implemented. " "Revise the code!")
+                raise Exception("Something wrong has been implemented. Revise the code!")
             return True, gap
 
 
@@ -307,7 +307,7 @@ class BandsData(KpointsData):
             try:
                 [float(_) for _ in x.flatten() if _ is not None]
             except (TypeError, ValueError):
-                raise ValueError("The {} array can only contain " "float or None values".format(msg))
+                raise ValueError("The {} array can only contain float or None values".format(msg))
 
         # check the labels
         if labels is not None:
@@ -383,7 +383,7 @@ class BandsData(KpointsData):
         from aiida.orm.nodes.data.structure import get_valid_pbc
 
         if self.is_stored:
-            raise ModificationNotAllowed("The KpointsData object cannot be modified, " "it has already been stored")
+            raise ModificationNotAllowed("The KpointsData object cannot be modified, it has already been stored")
         the_pbc = get_valid_pbc(value)
         self.set_attribute('pbc1', the_pbc[0])
         self.set_attribute('pbc2', the_pbc[1])
@@ -845,7 +845,7 @@ class BandsData(KpointsData):
         For the possible parameters, see documentation of
         :py:meth:`~aiida.orm.nodes.data.array.bands.BandsData._matplotlib_get_dict`
         """
-        import aiida.common.json as json
+        from aiida.common import json
 
         all_data = self._matplotlib_get_dict(*args, **kwargs)
 
@@ -868,7 +868,7 @@ class BandsData(KpointsData):
         """
         import os
 
-        import aiida.common.json as json
+        from aiida.common import json
 
         all_data = self._matplotlib_get_dict(*args, main_file_name=main_file_name, **kwargs)
 
@@ -1001,7 +1001,7 @@ class BandsData(KpointsData):
         import subprocess
         import sys
 
-        import aiida.common.json as json
+        from aiida.common import json
 
         all_data = self._matplotlib_get_dict(*args, **kwargs)
 
@@ -1253,7 +1253,7 @@ class BandsData(KpointsData):
             format)
         """
         from aiida import get_file_header
-        import aiida.common.json as json
+        from aiida.common import json
 
         json_dict = self._get_band_segments(cartesian=True)
         json_dict['original_uuid'] = self.uuid

--- a/aiida/orm/nodes/data/array/kpoints.py
+++ b/aiida/orm/nodes/data/array/kpoints.py
@@ -15,14 +15,14 @@ import six
 from six.moves import range, zip
 import numpy
 
-from aiida.common.lang import classproperty
-from aiida.orm.nodes.data.array import ArrayData
+from .array import ArrayData
 
 
 DEPRECATION_DOCS_URL = 'http://aiida-core.readthedocs.io/en/latest/datatypes/kpoints.html#deprecated-methods'
 
 _default_epsilon_length = 1e-5
 _default_epsilon_angle = 1e-5
+
 
 class KpointsData(ArrayData):
     """
@@ -169,7 +169,7 @@ class KpointsData(ArrayData):
             raise ValueError("Index of label exceeding the list of kpoints")
 
         self.set_attribute('label_numbers', label_numbers)
-        self.set_attribute('labels', labels)    
+        self.set_attribute('labels', labels)
 
     def _change_reference(self, kpoints, to_cartesian=True):
         """
@@ -205,7 +205,7 @@ class KpointsData(ArrayData):
 
         :param structuredata: an instance of StructureData
         """
-        from aiida.orm.nodes.data.structure import StructureData
+        from aiida.orm import StructureData
 
         if not isinstance(structuredata, StructureData):
             raise ValueError("An instance of StructureData should be passed to "

--- a/aiida/orm/nodes/data/array/trajectory.py
+++ b/aiida/orm/nodes/data/array/trajectory.py
@@ -66,7 +66,7 @@ class TrajectoryData(ArrayData):
             numsteps = positions.shape[0]
         if cells is not None:
             if cells.shape != (numsteps, 3, 3):
-                raise ValueError("TrajectoryData.cells must have shape (s,3,3), " "with s=number of steps")
+                raise ValueError("TrajectoryData.cells must have shape (s,3,3), with s=number of steps")
         numatoms = len(symbols)
         if positions.shape != (numsteps, numatoms, 3):
             raise ValueError("TrajectoryData.positions must have shape (s,n,3), "
@@ -424,7 +424,7 @@ class TrajectoryData(ArrayData):
             raise NotImplementedError("XSF for alloys or systems with vacancies not implemented.")
         cells = self.get_cells()
         if cells is None:
-            raise ValueError("No cell parameters have been supplied for " "TrajectoryData")
+            raise ValueError("No cell parameters have been supplied for TrajectoryData")
         positions = self.get_positions()
         symbols = self.symbols
         atomic_numbers_list = [_atomic_numbers[s] for s in symbols]
@@ -760,7 +760,7 @@ class TrajectoryData(ArrayData):
 
         cells = self.get_cells()
         if cells is None:
-            raise ValueError("No cell parameters have been supplied for " "TrajectoryData")
+            raise ValueError("No cell parameters have been supplied for TrajectoryData")
         else:
             cell = np.array(cells[0])
         storage_dict = {s: {} for s in elements}

--- a/aiida/orm/nodes/data/array/xy.py
+++ b/aiida/orm/nodes/data/array/xy.py
@@ -12,7 +12,6 @@ This module defines the classes related to Xy data. That is data that contains
 collections of y-arrays bound to a single x-array, and the methods to operate
 on them.
 """
-
 from __future__ import division
 from __future__ import print_function
 from __future__ import absolute_import
@@ -21,8 +20,8 @@ import six
 from six.moves import range, zip
 
 import numpy as np
-from aiida.orm.nodes.data.array import ArrayData
 from aiida.common.exceptions import InputValidationError, NotExistent
+from .array import ArrayData
 
 
 def check_convert_single_to_tuple(item):
@@ -39,6 +38,7 @@ def check_convert_single_to_tuple(item):
     else:
         return [item]
 
+
 class XyData(ArrayData):
     """
     A subclass designed to handle arrays that have an "XY" relationship to
@@ -51,22 +51,17 @@ class XyData(ArrayData):
         of type basestring. Raises InputValidationError if this not the case.
         """
         if not isinstance(name, six.string_types):
-            raise InputValidationError("The name must always be an instance "
-                                       "of basestring.")
+            raise InputValidationError("The name must always be an instance of basestring.")
 
         if not isinstance(array, np.ndarray):
-            raise InputValidationError("The input array must always be a "
-                                       "numpy array")
+            raise InputValidationError("The input array must always be a numpy array")
         try:
             array.astype(float)
         except ValueError:
-            raise InputValidationError("The input array must only contain "
-                                       "floats")
+            raise InputValidationError("The input array must only contain floats")
         if not isinstance(units, six.string_types):
-            raise InputValidationError("The units must always be an instance"
-                                           " of basestring.")
+            raise InputValidationError("The units must always be an instance of basestring.")
 
-        
     def set_x(self, x_array, x_name, x_units):
         """
         Sets the array and the name for the x values.
@@ -80,7 +75,6 @@ class XyData(ArrayData):
         self.set_attribute("x_units", x_units)
         self.set_array("x_array", x_array)
 
-        
     def set_y(self, y_arrays, y_names, y_units):
         """
         Set array(s) for the y part of the dataset. Also checks if the
@@ -108,9 +102,8 @@ class XyData(ArrayData):
         except NotExistent:
             raise InputValidationError("X array has not been set yet")
         # validate each of the y_arrays
-        for num, (y_array, y_name, y_unit) in enumerate(
-                                            zip(y_arrays, y_names, y_units)):
-            self._arrayandname_validator(y_array,y_name,y_unit)
+        for num, (y_array, y_name, y_unit) in enumerate(zip(y_arrays, y_names, y_units)):
+            self._arrayandname_validator(y_array, y_name, y_unit)
             if np.shape(y_array) != np.shape(x_array):
                 raise InputValidationError("y_array {} did not have the "
                                            "same shape has the x_array!"
@@ -136,7 +129,7 @@ class XyData(ArrayData):
         except (KeyError, AttributeError):
             raise NotExistent("No x array has been set yet!")
         return x_name, x_array, x_units
-    
+
     def get_y(self):
         """
         Tries to retrieve the y arrays and the y names, raises a
@@ -161,26 +154,4 @@ class XyData(ArrayData):
         except (KeyError, AttributeError):
             raise NotExistent("Could not retrieve array associated with y array"
                               " {}".format(y_names[i]))
-        return list(zip(y_names,y_arrays,y_units))
-
-    # def plot_dosdata(self, dosdata_type, spin='',path='', fmt='pdf'):
-    #     """
-    #     Creates a plot of any of the dosdata_type that is dos of a given spin,
-    #     or the integrated dos array.
-    #
-    #     :param dosdata_type: str, descriptor of dosdata array
-    #     :param spin: optional parameter, to be passed to get_dos
-    #     :param path: str, if specified will save figure to path
-    #     :param fmt: str, specifies format to save figure, default pdf
-    #     """
-    #     plt.close()
-    #     dosdata_array = getattr(self, 'get_'+dosdata_type)(spin)
-    #     dosenergy_array = self.get_dos_energy()
-    #     dosdata_units = getattr(self, dosdata_type+'_units')
-    #     dosenergy_units = self.energy_units
-    #     plt.plot(dosenergy_array, dosdata_array)
-    #     plt.title(dosdata_type+' vs energy')
-    #     plt.xlabel('Energy in ('+dosenergy_units+')')
-    #     plt.ylabel(dosdata_type+' in ('+dosdata_units+')')
-    #     if path != '':
-    #         plt.savefig(path, format=fmt)
+        return list(zip(y_names, y_arrays, y_units))

--- a/aiida/orm/nodes/data/cif.py
+++ b/aiida/orm/nodes/data/cif.py
@@ -729,7 +729,7 @@ class CifData(SinglefileData):
             in which case they will be combined to a single disordered site. Defaults to 1e-4. (pymatgen only)
         :return: :py:class:`aiida.orm.nodes.data.structure.StructureData` node.
         """
-        from aiida.orm.nodes.data.dict import Dict
+        from aiida.orm import Dict
         from aiida.tools.data import cif as cif_tools
 
         parameters = Dict(dict=kwargs)

--- a/aiida/orm/nodes/data/structure.py
+++ b/aiida/orm/nodes/data/structure.py
@@ -54,7 +54,7 @@ def _get_valid_cell(inputcell):
         if any(len(i) != 3 for i in the_cell):
             raise ValueError
     except (IndexError, ValueError, TypeError):
-        raise ValueError("Cell must be a list of three vectors, each " "defined as a list of three coordinates.")
+        raise ValueError("Cell must be a list of three vectors, each defined as a list of three coordinates.")
 
     if abs(calc_cell_volume(the_cell)) < _volume_threshold:
         raise ValueError("The cell volume is zero. Invalid cell.")
@@ -88,7 +88,7 @@ def get_valid_pbc(inputpbc):
         else:
             raise ValueError("pbc elements are not booleans.")
     else:
-        raise ValueError("pbc must be a boolean or a list of three " "booleans.", inputpbc)
+        raise ValueError("pbc must be a boolean or a list of three booleans.", inputpbc)
 
     return the_pbc
 
@@ -217,7 +217,7 @@ def validate_weights_tuple(weights_tuple, threshold):
     """
     w_sum = sum(weights_tuple)
     if (any(i < 0. for i in weights_tuple) or (w_sum - 1. > threshold)):
-        raise ValueError("The weight list is not valid (each element " "must be positive, and the sum must be <= 1).")
+        raise ValueError("The weight list is not valid (each element must be positive, and the sum must be <= 1).")
 
 
 def is_valid_symbol(symbol):
@@ -821,7 +821,7 @@ class StructureData(Data):
         try:
             func = getattr(self, "set_pymatgen_{}".format(typestr.lower()))
         except AttributeError:
-            raise AttributeError("Converter for '{}' to AiiDA structure " "does not exist".format(typestr))
+            raise AttributeError("Converter for '{}' to AiiDA structure does not exist".format(typestr))
         func(obj, **kwargs)
 
     def set_pymatgen_molecule(self, mol, margin=5):
@@ -989,7 +989,7 @@ class StructureData(Data):
         """
         Write the given structure to a string of format CIF.
         """
-        from aiida.orm.nodes.data.cif import CifData
+        from aiida.orm import CifData
 
         cif = CifData(ase=self.get_ase())
         return cif._prepare_cif()
@@ -1008,7 +1008,7 @@ class StructureData(Data):
         import numpy as np
         from itertools import product
 
-        import aiida.common.json as json
+        from aiida.common import json
 
         supercell_factors = [1, 1, 1]
 
@@ -1329,12 +1329,12 @@ class StructureData(Data):
         from aiida.common.exceptions import ModificationNotAllowed
 
         if self.is_stored:
-            raise ModificationNotAllowed("The StructureData object cannot be modified, " "it has already been stored")
+            raise ModificationNotAllowed("The StructureData object cannot be modified, it has already been stored")
 
         new_kind = Kind(kind=kind)  # So we make a copy
 
         if kind.name in [k.name for k in self.kinds]:
-            raise ValueError("A kind with the same name ({}) already exists." "".format(kind.name))
+            raise ValueError("A kind with the same name ({}) already exists.".format(kind.name))
 
         # If here, no exceptions have been raised, so I add the site.
         self.append_to_attr('kinds', new_kind.get_raw())
@@ -1355,7 +1355,7 @@ class StructureData(Data):
         from aiida.common.exceptions import ModificationNotAllowed
 
         if self.is_stored:
-            raise ModificationNotAllowed("The StructureData object cannot be modified, " "it has already been stored")
+            raise ModificationNotAllowed("The StructureData object cannot be modified, it has already been stored")
 
         new_site = Site(site=site)  # So we make a copy
 
@@ -1409,7 +1409,7 @@ class StructureData(Data):
         else:
             position = kwargs.pop('position', None)
             if position is None:
-                raise ValueError("You have to specify the position of the " "new atom")
+                raise ValueError("You have to specify the position of the new atom")
             # all remaining parameters
             kind = Kind(**kwargs)
 
@@ -1475,7 +1475,7 @@ class StructureData(Data):
         from aiida.common.exceptions import ModificationNotAllowed
 
         if self.is_stored:
-            raise ModificationNotAllowed("The StructureData object cannot be modified, " "it has already been stored")
+            raise ModificationNotAllowed("The StructureData object cannot be modified, it has already been stored")
 
         self.set_attribute('kinds', [])
         self._internal_kind_tags = {}
@@ -1488,7 +1488,7 @@ class StructureData(Data):
         from aiida.common.exceptions import ModificationNotAllowed
 
         if self.is_stored:
-            raise ModificationNotAllowed("The StructureData object cannot be modified, " "it has already been stored")
+            raise ModificationNotAllowed("The StructureData object cannot be modified, it has already been stored")
 
         self.set_attribute('sites', [])
 
@@ -1570,7 +1570,7 @@ class StructureData(Data):
         from aiida.common.exceptions import ModificationNotAllowed
 
         if self.is_stored:
-            raise ModificationNotAllowed("The StructureData object cannot be modified, " "it has already been stored")
+            raise ModificationNotAllowed("The StructureData object cannot be modified, it has already been stored")
 
         the_cell = _get_valid_cell(value)
         self.set_attribute('cell', the_cell)
@@ -1630,7 +1630,7 @@ class StructureData(Data):
                     raise ValueError("Expecting a list of floats. Found instead {}".format(new_positions[i]))
 
                 if len(this_pos) != 3:
-                    raise ValueError("Expecting a list of lists of length 3. " "found instead {}".format(len(this_pos)))
+                    raise ValueError("Expecting a list of lists of length 3. found instead {}".format(len(this_pos)))
 
                 # now append this Site to the new_site list.
                 new_site = Site(site=self.sites[i])  # So we make a copy
@@ -1661,7 +1661,7 @@ class StructureData(Data):
         from aiida.common.exceptions import ModificationNotAllowed
 
         if self.is_stored:
-            raise ModificationNotAllowed("The StructureData object cannot be modified, " "it has already been stored")
+            raise ModificationNotAllowed("The StructureData object cannot be modified, it has already been stored")
         the_pbc = get_valid_pbc(value)
 
         # self._pbc = the_pbc
@@ -1851,7 +1851,7 @@ class StructureData(Data):
         from pymatgen.core.structure import Structure
 
         if self.pbc != (True, True, True):
-            raise ValueError("Periodic boundary conditions must apply in " "all three dimensions of real space")
+            raise ValueError("Periodic boundary conditions must apply in all three dimensions of real space")
 
         species = []
         additional_kwargs = {}
@@ -1863,7 +1863,7 @@ class StructureData(Data):
             for s in self.sites:
                 k = self.get_kind(s.kind_name)
                 if len(k.symbols) != 1 or (len(k.weights) != 1 or sum(k.weights) < 1.):
-                    raise ValueError("Cannot set partial occupancies and spins " "at the same time")
+                    raise ValueError("Cannot set partial occupancies and spins at the same time")
                 species.append(
                     Specie(
                         k.symbols[0],
@@ -1884,7 +1884,7 @@ class StructureData(Data):
                 additional_kwargs['site_properties'] = {'kind_name': self.get_site_kindnames()}
 
         if kwargs:
-            raise ValueError("Unrecognized parameters passed to pymatgen " "converter: {}".format(kwargs.keys()))
+            raise ValueError("Unrecognized parameters passed to pymatgen converter: {}".format(kwargs.keys()))
 
         positions = [list(x.position) for x in self.sites]
         return Structure(self.cell, species, positions, coords_are_cartesian=True, **additional_kwargs)
@@ -1905,7 +1905,7 @@ class StructureData(Data):
         from pymatgen.core.structure import Molecule
 
         if kwargs:
-            raise ValueError("Unrecognized parameters passed to pymatgen " "converter: {}".format(kwargs.keys()))
+            raise ValueError("Unrecognized parameters passed to pymatgen converter: {}".format(kwargs.keys()))
 
         species = []
         for s in self.sites:
@@ -1963,27 +1963,27 @@ class Kind(object):
         # Logic to create the site from the raw format
         if 'raw' in kwargs:
             if len(kwargs) != 1:
-                raise ValueError("If you pass 'raw', then you cannot pass " "any other parameter.")
+                raise ValueError("If you pass 'raw', then you cannot pass any other parameter.")
 
             raw = kwargs['raw']
 
             try:
                 self.set_symbols_and_weights(raw['symbols'], raw['weights'])
             except KeyError:
-                raise ValueError("You didn't specify either 'symbols' or " "'weights' in the raw site data.")
+                raise ValueError("You didn't specify either 'symbols' or 'weights' in the raw site data.")
             try:
                 self.mass = raw['mass']
             except KeyError:
-                raise ValueError("You didn't specify the site mass in the " "raw site data.")
+                raise ValueError("You didn't specify the site mass in the raw site data.")
 
             try:
                 self.name = raw['name']
             except KeyError:
-                raise ValueError("You didn't specify the name in the " "raw site data.")
+                raise ValueError("You didn't specify the name in the raw site data.")
 
         elif 'kind' in kwargs:
             if len(kwargs) != 1:
-                raise ValueError("If you pass 'kind', then you cannot pass " "any other parameter.")
+                raise ValueError("If you pass 'kind', then you cannot pass any other parameter.")
             oldkind = kwargs['kind']
 
             try:
@@ -1999,7 +1999,7 @@ class Kind(object):
         elif 'ase' in kwargs:
             aseatom = kwargs['ase']
             if len(kwargs) != 1:
-                raise ValueError("If you pass 'ase', then you cannot pass " "any other parameter.")
+                raise ValueError("If you pass 'ase', then you cannot pass any other parameter.")
 
             try:
                 import numpy
@@ -2034,7 +2034,7 @@ class Kind(object):
             except KeyError:
                 self.set_automatic_kind_name()
             if kwargs:
-                raise ValueError("Unrecognized parameters passed to Kind " "constructor: {}".format(kwargs.keys()))
+                raise ValueError("Unrecognized parameters passed to Kind constructor: {}".format(kwargs.keys()))
 
     def get_raw(self):
         """
@@ -2141,7 +2141,7 @@ class Kind(object):
                         "({} vs. {})".format(i + 1, self.weights[i], other_kind.weights[i]))
         # Check masses
         if abs(self.mass - other_kind.mass) > _mass_threshold:
-            return (False, "Masses are different ({} vs. {})" "".format(self.mass, other_kind.mass))
+            return (False, "Masses are different ({} vs. {})".format(self.mass, other_kind.mass))
 
         if self._internal_tag != other_kind._internal_tag:
             return (False, "Internal tags are different ({} vs. {})"
@@ -2217,7 +2217,7 @@ class Kind(object):
         if len(self._symbols) == 1:
             return self._symbols[0]
         else:
-            raise ValueError("This kind has more than one symbol (it is an " "alloy): {}".format(self._symbols))
+            raise ValueError("This kind has more than one symbol (it is an alloy): {}".format(self._symbols))
 
     @property
     def symbols(self):
@@ -2313,7 +2313,7 @@ class Site(object):
         if 'site' in kwargs:
             site = kwargs.pop('site')
             if kwargs:
-                raise ValueError("If you pass 'site', you cannot pass any " "further parameter to the Site constructor")
+                raise ValueError("If you pass 'site', you cannot pass any further parameter to the Site constructor")
             if not isinstance(site, Site):
                 raise ValueError("'site' must be of type Site")
             self.kind_name = site.kind_name
@@ -2321,12 +2321,12 @@ class Site(object):
         elif 'raw' in kwargs:
             raw = kwargs.pop('raw')
             if kwargs:
-                raise ValueError("If you pass 'raw', you cannot pass any " "further parameter to the Site constructor")
+                raise ValueError("If you pass 'raw', you cannot pass any further parameter to the Site constructor")
             try:
                 self.kind_name = raw['kind_name']
                 self.position = raw['position']
             except KeyError as exc:
-                raise ValueError("Invalid raw object, it does not contain any " "key {}".format(exc.args[0]))
+                raise ValueError("Invalid raw object, it does not contain any key {}".format(exc.args[0]))
             except TypeError:
                 raise ValueError("Invalid raw object, it is not a dictionary")
 
@@ -2411,10 +2411,10 @@ class Site(object):
                 found = True
                 break
         if not found:
-            raise ValueError("No kind '{}' has been found in the list of kinds" "".format(self.kind_name))
+            raise ValueError("No kind '{}' has been found in the list of kinds".format(self.kind_name))
 
         if kind.is_alloy or kind.has_vacancies:
-            raise ValueError("Cannot convert to ASE if the kind represents " "an alloy or it has vacancies.")
+            raise ValueError("Cannot convert to ASE if the kind represents an alloy or it has vacancies.")
         aseatom = ase.Atom(position=self.position, symbol=str(kind.symbols[0]), mass=kind.mass)
         if tag is not None:
             aseatom.tag = tag
@@ -2457,7 +2457,7 @@ class Site(object):
                 raise ValueError
         # value is not iterable or elements are not floats or len != 3
         except (ValueError, TypeError):
-            raise ValueError("Wrong format for position, must be a list of " "three float numbers.")
+            raise ValueError("Wrong format for position, must be a list of three float numbers.")
         self._position = internal_pos
 
     def __repr__(self):

--- a/aiida/orm/nodes/process/calculation/calcjob.py
+++ b/aiida/orm/nodes/process/calculation/calcjob.py
@@ -490,7 +490,7 @@ class CalcJobNode(CalculationNode):
         :return: the retrieved FolderData node
         :raise aiida.common.MultipleObjectsError: if no or more than one retrieved node is found.
         """
-        from aiida.orm.nodes.data.folder import FolderData
+        from aiida.orm import FolderData
         return self.get_outgoing(node_class=FolderData, link_label_filter=self.link_label_retrieved).one().node
 
     @property

--- a/aiida/orm/utils/links.py
+++ b/aiida/orm/utils/links.py
@@ -75,9 +75,7 @@ def validate_link(source, target, link_type, link_label):
     :raise ValueError: if the proposed link is invalid
     """
     from aiida.common.links import LinkType
-    from aiida.orm import Node
-    from aiida.orm.nodes.data import Data
-    from aiida.orm import CalculationNode, WorkflowNode
+    from aiida.orm import Node, Data, CalculationNode, WorkflowNode
 
     if not isinstance(link_type, LinkType):
         raise TypeError('the link_type should be a value from the LinkType enum')

--- a/aiida/orm/utils/loaders.py
+++ b/aiida/orm/utils/loaders.py
@@ -394,7 +394,7 @@ class CodeEntityLoader(OrmEntityLoader):
 
         :returns: the orm base class
         """
-        from aiida.orm.nodes.data.code import Code
+        from aiida.orm import Code
         return Code
 
     @classmethod
@@ -409,11 +409,11 @@ class CodeEntityLoader(OrmEntityLoader):
         :raises ValueError: if the identifier is invalid
         :raises aiida.common.NotExistent: if the orm base class does not support a LABEL like identifier
         """
-        from aiida.orm.computers import Computer
+        from aiida.orm import Computer
 
         try:
             label, sep, machinename = identifier.partition('@')
-        except AttributeError as exception:
+        except AttributeError:
             raise ValueError('the identifier needs to be a string')
 
         qb = QueryBuilder()
@@ -436,7 +436,7 @@ class ComputerEntityLoader(OrmEntityLoader):
 
         :returns: the orm base class
         """
-        from aiida.orm.computers import Computer
+        from aiida.orm import Computer
         return Computer
 
     @classmethod
@@ -468,7 +468,7 @@ class DataEntityLoader(OrmEntityLoader):
 
         :returns: the orm base class
         """
-        from aiida.orm.nodes.data import Data
+        from aiida.orm import Data
         return Data
 
     @classmethod

--- a/aiida/orm/utils/node.py
+++ b/aiida/orm/utils/node.py
@@ -135,7 +135,7 @@ def clean_value(value):
         values replaced where needed.
     """
     # Must be imported in here to avoid recursive imports
-    from aiida.orm.nodes.data import BaseType
+    from aiida.orm import BaseType
 
     def clean_builtin(val):
         """

--- a/aiida/parsers/plugins/arithmetic/add.py
+++ b/aiida/parsers/plugins/arithmetic/add.py
@@ -12,7 +12,7 @@ from __future__ import print_function
 from __future__ import absolute_import
 
 from aiida.common import exceptions
-from aiida.orm.nodes.data.int import Int
+from aiida.orm import Int
 from aiida.parsers.parser import Parser
 
 

--- a/aiida/parsers/plugins/templatereplacer/doubler.py
+++ b/aiida/parsers/plugins/templatereplacer/doubler.py
@@ -15,7 +15,7 @@ import io
 import os
 
 from aiida.common import exceptions
-from aiida.orm.nodes.data.dict import Dict
+from aiida.orm import Dict
 from aiida.parsers.parser import Parser
 from aiida.plugins import CalculationFactory
 

--- a/aiida/restapi/resources.py
+++ b/aiida/restapi/resources.py
@@ -395,7 +395,7 @@ class Code(Node):
 
         from aiida.restapi.translator.code import CodeTranslator
         self.trans = CodeTranslator(**kwargs)
-        from aiida.orm.nodes.data.code import Code as CodeTclass
+        from aiida.orm import Code as CodeTclass
         self.tclass = CodeTclass
 
         self.parse_pk_uuid = 'uuid'
@@ -425,7 +425,7 @@ class StructureData(Data):
         from aiida.restapi.translator.data.structure import \
             StructureDataTranslator
         self.trans = StructureDataTranslator(**kwargs)
-        from aiida.orm.nodes.data.structure import StructureData as StructureDataTclass
+        from aiida.orm import StructureData as StructureDataTclass
         self.tclass = StructureDataTclass
 
         self.parse_pk_uuid = 'uuid'
@@ -439,7 +439,7 @@ class KpointsData(Data):
 
         from aiida.restapi.translator.data.kpoints import KpointsDataTranslator
         self.trans = KpointsDataTranslator(**kwargs)
-        from aiida.orm.nodes.data.array.kpoints import KpointsData as KpointsDataTclass
+        from aiida.orm import KpointsData as KpointsDataTclass
         self.tclass = KpointsDataTclass
 
         self.parse_pk_uuid = 'uuid'
@@ -454,7 +454,7 @@ class BandsData(Data):
         from aiida.restapi.translator.data.bands import \
             BandsDataTranslator
         self.trans = BandsDataTranslator(**kwargs)
-        from aiida.orm.nodes.data.array.bands import BandsData as BandsDataTclass
+        from aiida.orm import BandsData as BandsDataTclass
         self.tclass = BandsDataTclass
 
         self.parse_pk_uuid = 'uuid'
@@ -470,7 +470,7 @@ class CifData(Data):
         from aiida.restapi.translator.data.cif import \
             CifDataTranslator
         self.trans = CifDataTranslator(**kwargs)
-        from aiida.orm.nodes.data.cif import CifData as CifDataTclass
+        from aiida.orm import CifData as CifDataTclass
         self.tclass = CifDataTclass
 
         self.parse_pk_uuid = 'uuid'
@@ -486,7 +486,7 @@ class UpfData(Data):
         from aiida.restapi.translator.data.upf import \
             UpfDataTranslator
         self.trans = UpfDataTranslator(**kwargs)
-        from aiida.orm.nodes.data.upf import UpfData as UpfDataTclass
+        from aiida.orm import UpfData as UpfDataTclass
         self.tclass = UpfDataTclass
 
         self.parse_pk_uuid = 'uuid'

--- a/aiida/restapi/translator/data/bands.py
+++ b/aiida/restapi/translator/data/bands.py
@@ -25,7 +25,7 @@ class BandsDataTranslator(DataTranslator):
     # A label associated to the present class (coincides with the resource name)
     __label__ = "bands"
     # The AiiDA class one-to-one associated to the present class
-    from aiida.orm.nodes.data.array.bands import BandsData
+    from aiida.orm import BandsData
     _aiida_class = BandsData
     # The string name of the AiiDA class
     _aiida_type = "data.array.bands.BandsData"

--- a/aiida/restapi/translator/data/cif.py
+++ b/aiida/restapi/translator/data/cif.py
@@ -23,7 +23,7 @@ class CifDataTranslator(DataTranslator):
     # A label associated to the present class (coincides with the resource name)
     __label__ = "cifs"
     # The AiiDA class one-to-one associated to the present class
-    from aiida.orm.nodes.data.cif import CifData
+    from aiida.orm import CifData
     _aiida_class = CifData
     # The string name of the AiiDA class
     _aiida_type = "data.cif.CifData"

--- a/aiida/restapi/translator/data/kpoints.py
+++ b/aiida/restapi/translator/data/kpoints.py
@@ -25,7 +25,7 @@ class KpointsDataTranslator(DataTranslator):
     # A label associated to the present class (coincides with the resource name)
     __label__ = "kpoints"
     # The AiiDA class one-to-one associated to the present class
-    from aiida.orm.nodes.data.array.kpoints import KpointsData
+    from aiida.orm import KpointsData
     _aiida_class = KpointsData
     # The string name of the AiiDA class
     _aiida_type = "data.array.kpoints.KpointsData"

--- a/aiida/restapi/translator/data/structure.py
+++ b/aiida/restapi/translator/data/structure.py
@@ -28,7 +28,7 @@ class StructureDataTranslator(DataTranslator):
     # A label associated to the present class (coincides with the resource name)
     __label__ = "structures"
     # The AiiDA class one-to-one associated to the present class
-    from aiida.orm.nodes.data.structure import StructureData
+    from aiida.orm import StructureData
     _aiida_class = StructureData
     # The string name of the AiiDA class
     _aiida_type = "data.structure.StructureData"

--- a/aiida/restapi/translator/data/upf.py
+++ b/aiida/restapi/translator/data/upf.py
@@ -27,7 +27,7 @@ class UpfDataTranslator(DataTranslator):
     # A label associated to the present class (coincides with the resource name)
     __label__ = "upfs"
     # The AiiDA class one-to-one associated to the present class
-    from aiida.orm.nodes.data.upf import UpfData
+    from aiida.orm import UpfData
     _aiida_class = UpfData
     # The string name of the AiiDA class
     _aiida_type = "data.upf.UpfData"

--- a/aiida/schedulers/datastructures.py
+++ b/aiida/schedulers/datastructures.py
@@ -590,7 +590,7 @@ class JobInfo(DefaultFieldsAttributeDict):
         Serialise the current data
         :return: A serialised representation of the current data
         """
-        import aiida.common.json as json
+        from aiida.common import json
 
         ser_data = {k: self.serialize_field(v, self._special_serializers.get(k, None)) for k, v in self.items()}
 
@@ -602,7 +602,7 @@ class JobInfo(DefaultFieldsAttributeDict):
         :param data: The data to load from
         :return: The value after loading
         """
-        import aiida.common.json as json
+        from aiida.common import json
 
         deser_data = json.loads(data)
 

--- a/aiida/sphinxext/tests/workchain_source/demo_workchain.py
+++ b/aiida/sphinxext/tests/workchain_source/demo_workchain.py
@@ -16,9 +16,7 @@ from __future__ import print_function
 from __future__ import absolute_import
 
 from aiida.engine import WorkChain
-from aiida.orm.nodes.data.bool import Bool
-from aiida.orm.nodes.data.float import Float
-from aiida.orm.nodes.data.int import Int
+from aiida.orm import Bool, Float, Int
 
 
 class DemoWorkChain(WorkChain):  # pylint: disable=abstract-method

--- a/aiida/tools/data/array/kpoints/__init__.py
+++ b/aiida/tools/data/array/kpoints/__init__.py
@@ -11,8 +11,7 @@ from __future__ import division
 from __future__ import print_function
 from __future__ import absolute_import
 
-from aiida.orm.nodes.data.array.kpoints import KpointsData
-from aiida.orm.nodes.data.dict import Dict
+from aiida.orm import KpointsData, Dict
 from aiida.tools.data.array.kpoints import legacy
 from aiida.tools.data.array.kpoints import seekpath
 

--- a/aiida/tools/data/array/kpoints/seekpath.py
+++ b/aiida/tools/data/array/kpoints/seekpath.py
@@ -11,8 +11,7 @@ from __future__ import division
 from __future__ import print_function
 from __future__ import absolute_import
 
-from aiida.orm.nodes.data.array.kpoints import KpointsData
-from aiida.orm.nodes.data.dict import Dict
+from aiida.orm import KpointsData, Dict
 
 __all__ = ('check_seekpath_is_installed', 'get_explicit_kpoints_path', 'get_kpoints_path')
 

--- a/aiida/tools/data/cif.py
+++ b/aiida/tools/data/cif.py
@@ -74,8 +74,7 @@ def _get_aiida_structure_ase_inline(cif, **kwargs):
     .. note:: unable to correctly import structures of alloys.
     .. note:: requires ASE module.
     """
-    from aiida.orm.nodes.data.dict import Dict
-    from aiida.orm.nodes.data.structure import StructureData
+    from aiida.orm import Dict, StructureData
 
     parameters = kwargs.get('parameters', {})
 
@@ -101,8 +100,7 @@ def _get_aiida_structure_pymatgen_inline(cif, **kwargs):
     .. note:: requires pymatgen module.
     """
     from pymatgen.io.cif import CifParser
-    from aiida.orm.nodes.data.dict import Dict
-    from aiida.orm.nodes.data.structure import StructureData
+    from aiida.orm import Dict, StructureData
 
     parameters = kwargs.get('parameters', {})
 

--- a/aiida/tools/data/structure/__init__.py
+++ b/aiida/tools/data/structure/__init__.py
@@ -32,7 +32,7 @@ def _get_cif_ase_inline(struct, parameters):
 
     .. note:: requires ASE module.
     """
-    from aiida.orm.nodes.data.cif import CifData
+    from aiida.orm import CifData
 
     kwargs = {}
     if parameters is not None:

--- a/aiida/tools/dbexporters/tcod.py
+++ b/aiida/tools/dbexporters/tcod.py
@@ -18,7 +18,7 @@ from six.moves import range
 import io
 
 from aiida.engine import calcfunction
-from aiida.orm.nodes.data.dict import Dict
+from aiida.orm import Dict
 from aiida.plugins import DataFactory
 
 aiida_executable_name = '_aiidasubmit.sh'
@@ -447,8 +447,7 @@ def _collect_calculation_data(calc):
     calculation.
     """
     from aiida.common.links import LinkType
-    from aiida.orm.nodes.data import Data
-    from aiida.orm import CalculationNode, CalcJobNode, CalcFunctionNode, WorkflowNode
+    from aiida.orm import Data, CalculationNode, CalcJobNode, CalcFunctionNode, WorkflowNode
     import hashlib
     import os
     calcs_now = []
@@ -585,7 +584,7 @@ def _collect_files(base, path=''):
         files = []
         files.append(get_dict(name=path, full_path=os.path.join(base, path)))
 
-        import aiida.common.json as json
+        from aiida.common import json
         with open(os.path.join(base,path)) as f:
             calcinfo = json.load(f)
         if 'local_copy_list' in calcinfo:
@@ -685,7 +684,7 @@ def _collect_tags(node, calc,parameters=None,
     from aiida.common.links import LinkType
     import os 
     import aiida
-    import aiida.common.json as json
+    from aiida.common import json
 
     tags = { '_audit_creation_method': "AiiDA version {}".format(aiida.__version__) }
 
@@ -748,7 +747,7 @@ def _collect_tags(node, calc,parameters=None,
         from aiida.common.exceptions import LicensingException
         from aiida.common.folders import SandboxFolder
         from aiida.orm.importexport import export_tree
-        import aiida.common.json as json
+        from aiida.common import json
 
         with SandboxFolder() as folder:
             try:
@@ -846,7 +845,7 @@ def _collect_tags(node, calc,parameters=None,
     # Describing Brillouin zone (if used)
 
     if calc is not None:
-        from aiida.orm.nodes.data.array.kpoints import KpointsData
+        from aiida.orm import KpointsData
         kpoints_list = calc.get_incoming(node_class=KpointsData, link_type=LinkType.INPUT_CALC).all()
         # TODO: stop if more than one KpointsData is used?
         if len(kpoints_list) == 1:

--- a/aiida/tools/dbimporters/baseclasses.py
+++ b/aiida/tools/dbimporters/baseclasses.py
@@ -283,7 +283,7 @@ class CifEntry(DbEntry):
             :py:class:`aiida.orm.nodes.data.cif.CifData`.
         """
         from six.moves import cStringIO as StringIO
-        from aiida.orm.nodes.data.cif import CifData
+        from aiida.orm import CifData
         return CifData.read_cif(StringIO(self.cif))
 
     def get_cif_node(self, store=False, parse_policy='lazy'):
@@ -293,7 +293,6 @@ class CifEntry(DbEntry):
 
         :return: :py:class:`aiida.orm.nodes.data.cif.CifData` object
         """
-        from aiida.common.files import md5_file
         from aiida.orm.nodes.data.cif import CifData
         import tempfile
 
@@ -316,7 +315,6 @@ class CifEntry(DbEntry):
         :return: AiiDA structure corresponding to the CIF file.
         """
         cif = self.get_cif_node(store=store, parse_policy='lazy')
-        
         return cif.get_structure(converter=converter, store=store, **kwargs)
 
     def get_parsed_cif(self):
@@ -340,8 +338,7 @@ class UpfEntry(DbEntry):
 
         :return: :py:class:`aiida.orm.nodes.data.upf.UpfData` object
         """
-        from aiida.common.files import md5_file
-        from aiida.orm.nodes.data.upf import UpfData
+        from aiida.orm import UpfData
         import tempfile
 
         upfnode = None

--- a/aiida/tools/dbimporters/plugins/icsd.py
+++ b/aiida/tools/dbimporters/plugins/icsd.py
@@ -690,7 +690,7 @@ class IcsdEntry(CifEntry):
         :return: ASE structure corresponding to the cif file.
         """
         from six.moves import cStringIO as StringIO
-        from aiida.orm.nodes.data.cif import CifData
+        from aiida.orm import CifData
 
         cif = correct_cif(self.cif)
         return CifData.read_cif(StringIO(cif))

--- a/aiida/tools/dbimporters/plugins/mpds.py
+++ b/aiida/tools/dbimporters/plugins/mpds.py
@@ -19,7 +19,7 @@ from six.moves import range
 import requests
 
 from aiida.tools.dbimporters.baseclasses import CifEntry, DbEntry, DbImporter, DbSearchResults
-import aiida.common.json as json
+from aiida.common import json
 
 
 class ApiFormat(enum.Enum):

--- a/aiida/tools/ipython/ipython_magics.py
+++ b/aiida/tools/ipython/ipython_magics.py
@@ -41,7 +41,7 @@ import six
 from IPython import version_info
 from IPython.core import magic
 
-import aiida.common.json as json
+from aiida.common import json
 
 
 def add_to_ns(local_ns, name, obj):

--- a/docs/source/concepts/caching.rst
+++ b/docs/source/concepts/caching.rst
@@ -15,7 +15,7 @@ Caching is also implemented for Data nodes. This is not very useful in practice 
 
     In [1]: from __future__ import print_function
 
-    In [2]: from aiida.orm.nodes.data.str import Str
+    In [2]: from aiida.orm import Str
 
     In [3]: n1 = Str('test string')
 
@@ -135,7 +135,7 @@ Finally, workchains can create links not only to nodes which they create themsel
 .. code:: python
 
     from aiida.engine import workfunction
-    from aiida.orm.nodes.data.int import Int
+    from aiida.orm import Int
 
     @workfunction
     def select(a, b):

--- a/docs/source/concepts/include/snippets/workflows/expose_inputs/child.py
+++ b/docs/source/concepts/include/snippets/workflows/expose_inputs/child.py
@@ -1,10 +1,10 @@
 # -*- coding: utf-8 -*-
-from aiida.orm.nodes.data.bool import Bool
-from aiida.orm.nodes.data.float import Float
-from aiida.orm.nodes.data.int import Int
-from aiida.engine import WorkChain 
+from aiida.orm import Bool, Float, Int
+from aiida.engine import WorkChain
+
 
 class ChildWorkChain(WorkChain):
+
     @classmethod
     def define(cls, spec):
         super(ChildWorkChain, cls).define(spec)

--- a/docs/source/concepts/include/snippets/workflows/expose_inputs/run_complex.py
+++ b/docs/source/concepts/include/snippets/workflows/expose_inputs/run_complex.py
@@ -2,9 +2,7 @@
 # -*- coding: utf-8 -*-
 from __future__ import print_function
 
-from aiida.orm.nodes.data.bool import Bool
-from aiida.orm.nodes.data.float import Float
-from aiida.orm.nodes.data.int import Int
+from aiida.orm import Bool, Float, Int
 from aiida.engine import run
 from complex_parent import ComplexParentWorkChain
 

--- a/docs/source/concepts/include/snippets/workflows/expose_inputs/run_simple.py
+++ b/docs/source/concepts/include/snippets/workflows/expose_inputs/run_simple.py
@@ -2,9 +2,7 @@
 # -*- coding: utf-8 -*-
 from __future__ import print_function
 
-from aiida.orm.nodes.data.bool import Bool
-from aiida.orm.nodes.data.float import Float
-from aiida.orm.nodes.data.int import Int
+from aiida.orm import Bool, Float, Int
 from aiida.engine import run
 from simple_parent import SimpleParentWorkChain
 

--- a/docs/source/concepts/include/snippets/workflows/workchains/example_problem_workchain.py
+++ b/docs/source/concepts/include/snippets/workflows/workchains/example_problem_workchain.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
-from aiida.orm.nodes.data.int import Int
 from aiida.engine.workchain import WorkChain
+from aiida.orm import Int
+
 
 class AddAndMultiplyWorkChain(WorkChain):
 

--- a/docs/source/concepts/include/snippets/workflows/workchains/run_workchain_builder.py
+++ b/docs/source/concepts/include/snippets/workflows/workchains/run_workchain_builder.py
@@ -1,10 +1,12 @@
 # -*- coding: utf-8 -*-
-from aiida.orm.nodes.data.int import Int
 from aiida.engine import submit
 from aiida.engine.workchain import WorkChain
+from aiida.orm import Int
+
 
 class AddAndMultiplyWorkChain(WorkChain):
-    ...
+    pass
+
 
 builder = AddAndMultiplyWorkChain.get_builder()
 builder.a = Int(1)

--- a/docs/source/concepts/include/snippets/workflows/workchains/run_workchain_expand.py
+++ b/docs/source/concepts/include/snippets/workflows/workchains/run_workchain_expand.py
@@ -1,10 +1,12 @@
 # -*- coding: utf-8 -*-
-from aiida.orm.nodes.data.int import Int
 from aiida.engine import run
 from aiida.engine.workchain import WorkChain
+from aiida.orm import Int
+
 
 class AddAndMultiplyWorkChain(WorkChain):
-    ...
+    pass
+
 
 inputs = {
     'a': Int(1),

--- a/docs/source/concepts/include/snippets/workflows/workchains/run_workchain_get_node_pid.py
+++ b/docs/source/concepts/include/snippets/workflows/workchains/run_workchain_get_node_pid.py
@@ -1,10 +1,12 @@
 # -*- coding: utf-8 -*-
-from aiida.orm.nodes.data.int import Int
 from aiida.engine import run_get_node, run_get_pid
 from aiida.engine.workchain import WorkChain
+from aiida.orm import Int
+
 
 class AddAndMultiplyWorkChain(WorkChain):
-    ...
+    pass
+
 
 result, node = run_get_node(AddAndMultiplyWorkChain, a=Int(1), b=Int(2), c=Int(3))
 result, pid = run_get_pid(AddAndMultiplyWorkChain, a=Int(1), b=Int(2), c=Int(3))

--- a/docs/source/concepts/include/snippets/workflows/workchains/run_workchain_keyword.py
+++ b/docs/source/concepts/include/snippets/workflows/workchains/run_workchain_keyword.py
@@ -1,9 +1,10 @@
 # -*- coding: utf-8 -*-
-from aiida.orm.nodes.data.int import Int
 from aiida.engine import run
 from aiida.engine.workchain import WorkChain
+from aiida.orm import Int
+
 
 class AddAndMultiplyWorkChain(WorkChain):
-    ...
+    pass
 
 result = run(AddAndMultiplyWorkChain, a=Int(1), b=Int(2), c=Int(3))

--- a/docs/source/concepts/include/snippets/workflows/workchains/run_workchain_submit.py
+++ b/docs/source/concepts/include/snippets/workflows/workchains/run_workchain_submit.py
@@ -1,9 +1,10 @@
 # -*- coding: utf-8 -*-
-from aiida.orm.nodes.data.int import Int
 from aiida.engine import submit
 from aiida.engine.workchain import WorkChain
+from aiida.orm import Int
+
 
 class AddAndMultiplyWorkChain(WorkChain):
-    ...
+    pass
 
 node = submit(AddAndMultiplyWorkChain, a=Int(1), b=Int(2), c=Int(3))

--- a/docs/source/concepts/include/snippets/workflows/workchains/run_workchain_submit_append.py
+++ b/docs/source/concepts/include/snippets/workflows/workchains/run_workchain_submit_append.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
-from aiida.orm.nodes.data.int import Int
-from aiida.engine.workchain import WorkChain, ToContext, append_
+from aiida.engine.workchain import WorkChain, append_
+
 
 class SomeWorkChain(WorkChain):
 

--- a/docs/source/concepts/include/snippets/workflows/workchains/run_workchain_submit_complete.py
+++ b/docs/source/concepts/include/snippets/workflows/workchains/run_workchain_submit_complete.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
-from aiida.orm.nodes.data.int import Int
 from aiida.engine.workchain import WorkChain, ToContext
+
 
 class SomeWorkChain(WorkChain):
 

--- a/docs/source/concepts/include/snippets/workflows/workchains/run_workchain_submit_internal.py
+++ b/docs/source/concepts/include/snippets/workflows/workchains/run_workchain_submit_internal.py
@@ -1,9 +1,9 @@
 # -*- coding: utf-8 -*-
-from aiida.orm.nodes.data.int import Int
 from aiida.engine.workchain import WorkChain
+from aiida.orm import Int
+
 
 class AddAndMultiplyWorkChain(WorkChain):
-    ...
 
     def submit_sub_workchain(self):
         node = self.submit(AddAndMultiplyWorkChain, a=Int(1), b=Int(2), c=Int(3))

--- a/docs/source/concepts/include/snippets/workflows/workchains/run_workchain_submit_parallel.py
+++ b/docs/source/concepts/include/snippets/workflows/workchains/run_workchain_submit_parallel.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
-from aiida.orm.nodes.data.int import Int
-from aiida.engine.workchain import WorkChain, ToContext
+from aiida.engine.workchain import WorkChain
+
 
 class SomeWorkChain(WorkChain):
 
@@ -16,7 +16,7 @@ class SomeWorkChain(WorkChain):
         for i in range(3):
             future = self.submit(SomeWorkChain)
             key = 'workchain_{}'.format(i)
-            self.to_context(**{key:future})
+            self.to_context(**{key: future})
 
     def inspect_workchains(self):
         for i in range(3):

--- a/docs/source/concepts/include/snippets/workflows/workfunctions/example_problem_workfunction_data_types.py
+++ b/docs/source/concepts/include/snippets/workflows/workfunctions/example_problem_workfunction_data_types.py
@@ -1,17 +1,20 @@
 # -*- coding: utf-8 -*-
-from aiida.orm.nodes.data.int import Int
 from aiida.engine import calcfunction
+from aiida.orm import Int
 
 a = Int(1)
 b = Int(2)
 c = Int(3)
 
+
 @calcfunction
 def add(a, b):
     return Int(a + b)
 
+
 @calcfunction
 def multiply(a, b):
     return Int(a * b)
+
 
 result = multiply(add(a, b), c)

--- a/docs/source/concepts/serialize_examples/serialize_workchain.py
+++ b/docs/source/concepts/serialize_examples/serialize_workchain.py
@@ -5,7 +5,9 @@ from aiida.orm.nodes.data import to_aiida_type
 # the 'to_aiida_type' function.
 from aiida.orm.nodes.data.base import *
 
+
 class SerializeWorkChain(WorkChain):
+
     @classmethod
     def define(cls, spec):
         super(SerializeWorkChain, cls).define(spec)

--- a/docs/source/developer_guide/core/extend_restapi.rst
+++ b/docs/source/developer_guide/core/extend_restapi.rst
@@ -49,8 +49,7 @@ Let's assume you've put the code in the file ``example.py``, reading:
         """
 
         def get(self):
-            from aiida.orm.querybuilder import QueryBuilder
-            from aiida.orm.nodes.data.dict import Dict
+            from aiida.orm import QueryBuilder, Dict
 
             qb = QueryBuilder()
             qb.append(Dict,
@@ -66,7 +65,7 @@ Let's assume you've put the code in the file ``example.py``, reading:
                         attributes=result[2])
 
         def post(self):
-            from aiida.orm.nodes.data.dict import Dict
+            from aiida.orm import Dict
 
             params = dict(property1="spam", property2="egg")
             paramsData = Dict(dict=params).store()
@@ -141,8 +140,7 @@ Then we define a class representing the additional resource:
         """
 
         def get(self):
-            from aiida.orm.querybuilder import QueryBuilder
-            from aiida.orm.nodes.data.dict import Dict
+            from aiida.orm import QueryBuilder, Dict
 
             qb = QueryBuilder()
             qb.append(Dict,
@@ -158,7 +156,7 @@ Then we define a class representing the additional resource:
                         attributes=result[2])
 
         def post(self):
-            from aiida.orm.nodes.data.dict import Dict
+            from aiida.orm import Dict
 
             params = dict(property1="spam", property2="egg")
             paramsData = Dict(dict=params).store()

--- a/docs/source/developer_guide/devel_tutorial/code_plugin_float_sum.rst
+++ b/docs/source/developer_guide/devel_tutorial/code_plugin_float_sum.rst
@@ -38,7 +38,7 @@ imagine that we want to introduce a new type of data node that simply
 stores a float number. We will call it ``FloatData``, and the class 
 implementation can look like this::
 
-   from aiida.orm.nodes.data import Data
+   from aiida.orm import Data
 
    class FloatData(Data):
 

--- a/docs/source/state/calculation_state.rst
+++ b/docs/source/state/calculation_state.rst
@@ -62,7 +62,7 @@ If you prefer, you can check the state of a calculation from within python. For 
     from aiida import load_dbenv
     load_dbenv()
 
-    from aiida.orm.nodes import CalcJobNode
+    from aiida.orm import CalcJobNode
 
     ## pk must be a valid integer pk
     calc = load_node(pk)

--- a/docs/source/working_with_aiida/groups.rst
+++ b/docs/source/working_with_aiida/groups.rst
@@ -58,7 +58,7 @@ be performed with Groups:
 
     From python interface::
 
-      In [3]: from aiida.orm.nodes.data.dict import Dict
+      In [3]: from aiida.orm import Dict
 
       In [4]: p = Dict().store()
 

--- a/examples/work/workchain.py
+++ b/examples/work/workchain.py
@@ -17,9 +17,7 @@ from __future__ import absolute_import
 from __future__ import print_function
 
 from aiida.engine import WorkChain, run
-from aiida.orm.nodes.data.base import NumericType
-from aiida.orm.nodes.data.float import Float
-from aiida.orm.nodes.data.int import Int
+from aiida.orm import NumericType, Float, Int
 
 
 class SumWorkChain(WorkChain):

--- a/examples/work/workchain_outline.py
+++ b/examples/work/workchain_outline.py
@@ -17,7 +17,7 @@ from __future__ import absolute_import
 from __future__ import print_function
 
 from aiida.engine import WorkChain, run, while_, if_
-from aiida.orm.nodes.data.int import Int
+from aiida.orm import Int
 
 
 class OutlineWorkChain(WorkChain):

--- a/examples/work/workfunction.py
+++ b/examples/work/workfunction.py
@@ -16,9 +16,8 @@ from __future__ import division
 from __future__ import absolute_import
 from __future__ import print_function
 
-from aiida.orm.nodes.data.float import Float
-from aiida.orm.nodes.data.int import Int
-from aiida.work import calcfunction
+from aiida.engine import calcfunction
+from aiida.orm import Float, Int
 
 
 @calcfunction


### PR DESCRIPTION
Fixes #2382 

All the important classes are now exposed on the `aiida.orm` level which
allows to simplify import statements from:

    `from aiida.orm.nodes.data.structure import StructureData`

to

    `from aiida.orm import StructureData`

Also the repository was scanned for instance of the pattern `" "` in
string literals, which occurred due to `yapf` joining a multiline string
onto a single line.