### PR TITLE
Improve the efficiency of `DbLog` migration for SqlAlchemy

### DIFF
--- a/aiida/backends/sqlalchemy/migrations/versions/041a79fc615f_dblog_cleaning.py
+++ b/aiida/backends/sqlalchemy/migrations/versions/041a79fc615f_dblog_cleaning.py
@@ -69,8 +69,8 @@ def get_logs_with_no_nodes_number(connection):
         text("""
         SELECT COUNT(*) FROM db_dblog
         WHERE
-            (db_dblog.objname LIKE 'node.%') AND
-            (db_dblog.objpk NOT IN (SELECT id FROM db_dbnode))
+            (db_dblog.objname LIKE 'node.%') AND NOT EXISTS
+            (SELECT 1 FROM db_dbnode WHERE db_dbnode.id = db_dblog.objpk LIMIT 1)
         """)).fetchall()[0][0]
 
 
@@ -112,8 +112,8 @@ def get_serialized_logs_with_no_nodes(connection):
         SELECT db_dblog.id, db_dblog.time, db_dblog.loggername, db_dblog.levelname, db_dblog.objpk, db_dblog.objname,
         db_dblog.message, db_dblog.metadata FROM db_dblog
         WHERE
-            (db_dblog.objname LIKE 'node.%') AND
-            (db_dblog.objpk NOT IN (SELECT id FROM db_dbnode))
+            (db_dblog.objname LIKE 'node.%') AND NOT EXISTS
+            (SELECT 1 FROM db_dbnode WHERE db_dbnode.id = db_dblog.objpk LIMIT 1)
         """))
     res = list()
     for row in query:
@@ -209,8 +209,8 @@ def export_and_clean_workflow_logs(connection):
         connection.execute(
             text("""
             DELETE FROM db_dblog WHERE
-            (db_dblog.objname LIKE 'node.%') AND
-            (db_dblog.objpk NOT IN (SELECT id FROM db_dbnode))
+            (db_dblog.objname LIKE 'node.%') AND NOT EXISTS
+            (SELECT 1 FROM db_dbnode WHERE db_dbnode.id = db_dblog.objpk LIMIT 1)
             """))
 
 


### PR DESCRIPTION
Fixes #2538 

The old implementation was using a `NOT IN` with the list of all node
ids to filter all log entries that had an `objpk` that did not
correspond to a node entry. This is extremely inefficient as it loads
the entire node pk column in memory and has to traverse it for each log
entry. In this commit, we change this to a construct that will simply
search for the objpk in the node table, which is indexed and simply
returns 1 if it exists, which is than checked in the filter of the logs.

Note: I did not touch the Django migration as I don't have a production database on which I could test it and it does the relevant queries through the Django ORM. I hope they will unwrap this into an efficient SQL query. What do you think?