### PR TITLE
Temporarily pin `pylint==2.2.2` and `astroid==2.1.0` for python 3

### DIFF
--- a/setup.json
+++ b/setup.json
@@ -113,6 +113,8 @@
       "pytest-cov==2.6.1"
     ],
     "dev_precommit": [
+      "astroid==2.1.0; python_version>='3.0'",
+      "pylint==2.2.2; python_version>='3.0'",
       "pre-commit==1.14.4",
       "yapf==0.26.0",
       "prospector==1.1.5",


### PR DESCRIPTION
Version `2.3.0` of `pylint` that was released two hours ago, breaks on
python 3 with their `pylint-plugin-utils==0.4`. See `pylint-plugin-utils` issue:

  https://github.com/PyCQA/pylint-plugin-utils/issues/12

Similarly, `astroid==2.2.0` was just released which also causes pylint to
fail on python 3 so we pin this to `astroid==2.1.0`. See `astroid` issue:

  https://github.com/PyCQA/astroid/issues/649