### PR TITLE
Make various protected `Node` methods public

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -146,9 +146,6 @@
         aiida/orm/nodes/data/remote.py|
         aiida/orm/nodes/data/structure.py|
         aiida/orm/nodes/data/upf.py|
-        aiida/orm/nodes/process/calculation/calcjob.py|
-        aiida/orm/utils/__init__.py|
-        aiida/orm/utils/loaders.py|
         aiida/orm/utils/remote.py|
         aiida/parsers/plugins/arithmetic/add.py|
         aiida/parsers/plugins/templatereplacer/doubler.py|

--- a/aiida/backends/tests/cmdline/commands/test_calcjob.py
+++ b/aiida/backends/tests/cmdline/commands/test_calcjob.py
@@ -66,7 +66,7 @@ class TestVerdiCalculation(AiidaTestCase):
             calc.set_option('resources', {'num_machines': 1, 'num_mpiprocs_per_machine': 1})
             calc.store()
 
-            calc._set_process_state(ProcessState.RUNNING)
+            calc.set_process_state(ProcessState.RUNNING)
             cls.calcs.append(calc)
 
             if calculation_state == CalcJobState.PARSING:
@@ -93,8 +93,8 @@ class TestVerdiCalculation(AiidaTestCase):
         calc = CalcJobNode(computer=cls.computer)
         calc.set_option('resources', {'num_machines': 1, 'num_mpiprocs_per_machine': 1})
         calc.store()
-        calc._set_exit_status(cls.EXIT_STATUS)
-        calc._set_process_state(ProcessState.FINISHED)
+        calc.set_exit_status(cls.EXIT_STATUS)
+        calc.set_process_state(ProcessState.FINISHED)
         cls.calcs.append(calc)
 
         # Uncomment when issue 2342 is addressed

--- a/aiida/backends/tests/cmdline/commands/test_calculation.py
+++ b/aiida/backends/tests/cmdline/commands/test_calculation.py
@@ -66,7 +66,7 @@ class TestVerdiCalculation(AiidaTestCase):
             calc.set_option('resources', {'num_machines': 1, 'num_mpiprocs_per_machine': 1})
             calc.store()
 
-            calc._set_process_state(ProcessState.RUNNING)
+            calc.set_process_state(ProcessState.RUNNING)
             cls.calcs.append(calc)
 
             if calculation_state == CalcJobState.PARSING:
@@ -93,8 +93,8 @@ class TestVerdiCalculation(AiidaTestCase):
         calc = CalcJobNode(computer=cls.computer)
         calc.set_option('resources', {'num_machines': 1, 'num_mpiprocs_per_machine': 1})
         calc.store()
-        calc._set_exit_status(cls.EXIT_STATUS)
-        calc._set_process_state(ProcessState.FINISHED)
+        calc.set_exit_status(cls.EXIT_STATUS)
+        calc.set_process_state(ProcessState.FINISHED)
         cls.calcs.append(calc)
 
         # Uncomment when issue 2342 is addressed
@@ -113,7 +113,7 @@ class TestVerdiCalculation(AiidaTestCase):
         """Test verdi calculation res"""
         options = [str(self.result_job.uuid)]
         result = self.cli_runner.invoke(command.calculation_res, options)
-        self.assertIsNone(result.exception, result.output)
+        self.assertClickResultNoException(result)
         self.assertIn(self.KEY_ONE, result.output)
         self.assertIn(self.VAL_ONE, result.output)
         self.assertIn(self.KEY_TWO, result.output)
@@ -122,7 +122,7 @@ class TestVerdiCalculation(AiidaTestCase):
         for flag in ['-k', '--keys']:
             options = [flag, self.KEY_ONE, '--', str(self.result_job.uuid)]
             result = self.cli_runner.invoke(command.calculation_res, options)
-            self.assertIsNone(result.exception, result.output)
+            self.assertClickResultNoException(result)
             self.assertIn(self.KEY_ONE, result.output)
             self.assertIn(self.VAL_ONE, result.output)
             self.assertNotIn(self.KEY_TWO, result.output)
@@ -132,7 +132,7 @@ class TestVerdiCalculation(AiidaTestCase):
         """Test verdi calculation list with specific identifiers"""
         options = ['-r', '--project', 'pk', '--'] + [str(calc.pk) for calc in self.calcs[:2]]
         result = self.cli_runner.invoke(command.calculation_list, options)
-        self.assertIsNone(result.exception, result.output)
+        self.assertClickResultNoException(result)
 
         valid_pks = [calc.pk for calc in self.calcs]
         for line in get_result_lines(result):
@@ -143,7 +143,7 @@ class TestVerdiCalculation(AiidaTestCase):
         for flag in ['-A', '--all-users']:
             options = ['-r', '-a', flag]
             result = self.cli_runner.invoke(command.calculation_list, options)
-            self.assertIsNone(result.exception, result.output)
+            self.assertClickResultNoException(result)
             self.assertEqual(len(get_result_lines(result)), 6)
 
     def test_calculation_list_all(self):
@@ -152,13 +152,13 @@ class TestVerdiCalculation(AiidaTestCase):
         # Without the flag I should only get the "active" states, which should be five
         options = ['-r']
         result = self.cli_runner.invoke(command.calculation_list, options)
-        self.assertIsNone(result.exception, result.output)
+        self.assertClickResultNoException(result)
         self.assertEqual(len(get_result_lines(result)), 5, result.output)
 
         for flag in ['-a', '--all']:
             options = ['-r', flag]
             result = self.cli_runner.invoke(command.calculation_list, options)
-            self.assertIsNone(result.exception, result.output)
+            self.assertClickResultNoException(result)
             self.assertEqual(len(get_result_lines(result)), 6, result.output)
 
     def test_calculation_list_limit(self):
@@ -167,7 +167,7 @@ class TestVerdiCalculation(AiidaTestCase):
             limit = 1
             options = ['-r', flag, limit]
             result = self.cli_runner.invoke(command.calculation_list, options)
-            self.assertIsNone(result.exception, result.output)
+            self.assertClickResultNoException(result)
             self.assertEqual(len(get_result_lines(result)), limit)
 
     def test_calculation_list_project(self):
@@ -175,7 +175,7 @@ class TestVerdiCalculation(AiidaTestCase):
         for flag in ['-P', '--project']:
             options = ['-r', flag, 'pk']
             result = self.cli_runner.invoke(command.calculation_list, options)
-            self.assertIsNone(result.exception, result.output)
+            self.assertClickResultNoException(result)
 
             valid_pks = [calc.pk for calc in self.calcs]
             for line in get_result_lines(result):
@@ -189,7 +189,7 @@ class TestVerdiCalculation(AiidaTestCase):
                 options = ['-r', flag, state]
                 result = self.cli_runner.invoke(command.calculation_list, options)
 
-                self.assertIsNone(result.exception, result.output)
+                self.assertClickResultNoException(result)
 
                 if state == 'finished':
                     self.assertEqual(len(get_result_lines(result)), 1, result.output)
@@ -202,7 +202,7 @@ class TestVerdiCalculation(AiidaTestCase):
             options = ['-r', flag]
             result = self.cli_runner.invoke(command.calculation_list, options)
 
-            self.assertIsNone(result.exception, result.output)
+            self.assertClickResultNoException(result)
             self.assertEqual(len(get_result_lines(result)), 1, result.output)
 
     def test_calculation_list_exit_status(self):
@@ -212,7 +212,7 @@ class TestVerdiCalculation(AiidaTestCase):
                 options = ['-r', flag, exit_status]
                 result = self.cli_runner.invoke(command.calculation_list, options)
 
-                self.assertIsNone(result.exception, result.output)
+                self.assertClickResultNoException(result)
                 self.assertEqual(len(get_result_lines(result)), 1)
 
     def test_calculation_show(self):
@@ -221,7 +221,7 @@ class TestVerdiCalculation(AiidaTestCase):
         # Running without identifiers should not except and not print anything
         options = []
         result = self.cli_runner.invoke(command.calculation_show, options)
-        self.assertIsNone(result.exception, result.output)
+        self.assertClickResultNoException(result)
         self.assertEqual(len(get_result_lines(result)), 0)
 
         # Giving a single identifier should print a non empty string message
@@ -242,19 +242,19 @@ class TestVerdiCalculation(AiidaTestCase):
         # Running without identifiers should not except and not print anything
         options = []
         result = self.cli_runner.invoke(command.calculation_logshow, options)
-        self.assertIsNone(result.exception, result.output)
+        self.assertClickResultNoException(result)
         self.assertEqual(len(get_result_lines(result)), 0)
 
         # Giving a single identifier should print a non empty string message
         options = [str(self.calcs[0].pk)]
         result = self.cli_runner.invoke(command.calculation_logshow, options)
-        self.assertIsNone(result.exception, result.output)
+        self.assertClickResultNoException(result)
         self.assertTrue(len(get_result_lines(result)) > 0)
 
         # Giving multiple identifiers should print a non empty string message
         options = [str(calc.pk) for calc in self.calcs]
         result = self.cli_runner.invoke(command.calculation_logshow, options)
-        self.assertIsNone(result.exception, result.output)
+        self.assertClickResultNoException(result)
         self.assertTrue(len(get_result_lines(result)) > 0)
 
     @unittest.skip('reenable when issue #2342 is addressed')
@@ -268,11 +268,11 @@ class TestVerdiCalculation(AiidaTestCase):
         self.assertIsNotNone(result.exception)
 
         result = self.cli_runner.invoke(command.calculation_plugins, ['arithmetic.add'])
-        self.assertIsNone(result.exception, result.output)
+        self.assertClickResultNoException(result)
         self.assertTrue(len(get_result_lines(result)) > 0)
 
         result = self.cli_runner.invoke(command.calculation_plugins)
-        self.assertIsNone(result.exception, result.output)
+        self.assertClickResultNoException(result)
         self.assertTrue(len(get_result_lines(result)) > len(calculation_plugins))
 
     @unittest.skip('reenable when issue #2342 is addressed')
@@ -284,7 +284,7 @@ class TestVerdiCalculation(AiidaTestCase):
 
         options = [self.arithmetic_job.uuid]
         result = self.cli_runner.invoke(command.calculation_inputls, options)
-        self.assertIsNone(result.exception, result.output)
+        self.assertClickResultNoException(result)
         self.assertEqual(len(get_result_lines(result)), 3)
         self.assertIn('.aiida', get_result_lines(result))
         self.assertIn('aiida.in', get_result_lines(result))
@@ -292,7 +292,7 @@ class TestVerdiCalculation(AiidaTestCase):
 
         options = [self.arithmetic_job.uuid, '.aiida']
         result = self.cli_runner.invoke(command.calculation_inputls, options)
-        self.assertIsNone(result.exception, result.output)
+        self.assertClickResultNoException(result)
         self.assertEqual(len(get_result_lines(result)), 2)
         self.assertIn('calcinfo.json', get_result_lines(result))
         self.assertIn('job_tmpl.json', get_result_lines(result))
@@ -306,7 +306,7 @@ class TestVerdiCalculation(AiidaTestCase):
 
         options = [self.arithmetic_job.uuid]
         result = self.cli_runner.invoke(command.calculation_outputls, options)
-        self.assertIsNone(result.exception, result.output)
+        self.assertClickResultNoException(result)
         self.assertEqual(len(get_result_lines(result)), 3)
         self.assertIn('_scheduler-stderr.txt', get_result_lines(result))
         self.assertIn('_scheduler-stdout.txt', get_result_lines(result))
@@ -314,7 +314,7 @@ class TestVerdiCalculation(AiidaTestCase):
 
         options = [self.arithmetic_job.uuid, 'aiida.out']
         result = self.cli_runner.invoke(command.calculation_outputls, options)
-        self.assertIsNone(result.exception, result.output)
+        self.assertClickResultNoException(result)
         self.assertEqual(len(get_result_lines(result)), 1)
         self.assertIn('aiida.out', get_result_lines(result))
 
@@ -327,13 +327,13 @@ class TestVerdiCalculation(AiidaTestCase):
 
         options = [self.arithmetic_job.uuid]
         result = self.cli_runner.invoke(command.calculation_inputcat, options)
-        self.assertIsNone(result.exception, result.output)
+        self.assertClickResultNoException(result)
         self.assertEqual(len(get_result_lines(result)), 1)
         self.assertEqual(get_result_lines(result)[0], '2 3')
 
         options = [self.arithmetic_job.uuid, 'aiida.in']
         result = self.cli_runner.invoke(command.calculation_inputcat, options)
-        self.assertIsNone(result.exception, result.output)
+        self.assertClickResultNoException(result)
         self.assertEqual(len(get_result_lines(result)), 1)
         self.assertEqual(get_result_lines(result)[0], '2 3')
 
@@ -346,13 +346,13 @@ class TestVerdiCalculation(AiidaTestCase):
 
         options = [self.arithmetic_job.uuid]
         result = self.cli_runner.invoke(command.calculation_outputcat, options)
-        self.assertIsNone(result.exception, result.output)
+        self.assertClickResultNoException(result)
         self.assertEqual(len(get_result_lines(result)), 1)
         self.assertEqual(get_result_lines(result)[0], '5')
 
         options = [self.arithmetic_job.uuid, 'aiida.out']
         result = self.cli_runner.invoke(command.calculation_outputcat, options)
-        self.assertIsNone(result.exception, result.output)
+        self.assertClickResultNoException(result)
         self.assertEqual(len(get_result_lines(result)), 1)
         self.assertEqual(get_result_lines(result)[0], '5')
 
@@ -379,4 +379,4 @@ class TestVerdiCalculation(AiidaTestCase):
         # With force flag we should find one calculation
         options = ['-f', str(self.result_job.uuid)]
         result = self.cli_runner.invoke(command.calculation_cleanworkdir, options)
-        self.assertIsNone(result.exception, result.output)
+        self.assertClickResultNoException(result)

--- a/aiida/backends/tests/cmdline/commands/test_group.py
+++ b/aiida/backends/tests/cmdline/commands/test_group.py
@@ -173,8 +173,8 @@ class TestVerdiGroupSetup(AiidaTestCase):
         from aiida.orm import CalculationNode
 
         node = CalculationNode()
-        node.set_attribute('attr1', 'OK')  # pylint: disable=protected-access
-        node.set_attribute('attr2', 'OK')  # pylint: disable=protected-access
+        node.set_attribute('attr1', 'OK')
+        node.set_attribute('attr2', 'OK')
         node.store()
 
         result = self.cli_runner.invoke(group_addnodes, ['--force', '--group=dummygroup1', node.uuid])

--- a/aiida/backends/tests/cmdline/commands/test_process.py
+++ b/aiida/backends/tests/cmdline/commands/test_process.py
@@ -127,7 +127,6 @@ class TestVerdiProcess(AiidaTestCase):
 
     @classmethod
     def setUpClass(cls, *args, **kwargs):
-        # pylint: disable=protected-access
         super(TestVerdiProcess, cls).setUpClass(*args, **kwargs)
         from aiida.engine import ProcessState
         from aiida.orm.groups import Group
@@ -138,21 +137,21 @@ class TestVerdiProcess(AiidaTestCase):
         for state in ProcessState:
 
             calc = WorkFunctionNode()
-            calc._set_process_state(state)
+            calc.set_process_state(state)
 
             # Set the WorkFunctionNode as successful
             if state == ProcessState.FINISHED:
-                calc._set_exit_status(0)
+                calc.set_exit_status(0)
 
             calc.store()
             cls.calcs.append(calc)
 
             calc = WorkChainNode()
-            calc._set_process_state(state)
+            calc.set_process_state(state)
 
             # Set the WorkChainNode as failed
             if state == ProcessState.FINISHED:
-                calc._set_exit_status(1)
+                calc.set_exit_status(1)
 
             calc.store()
             cls.calcs.append(calc)

--- a/aiida/backends/tests/cmdline/commands/test_work.py
+++ b/aiida/backends/tests/cmdline/commands/test_work.py
@@ -7,7 +7,6 @@
 # For further information on the license, see the LICENSE.txt file        #
 # For further information please visit http://www.aiida.net               #
 ###########################################################################
-# pylint: disable=protected-access
 """Tests for `verdi work`."""
 from __future__ import division
 from __future__ import print_function
@@ -54,21 +53,21 @@ class TestVerdiWork(AiidaTestCase):
         for state in ProcessState:
 
             calc = WorkFunctionNode()
-            calc._set_process_state(state)
+            calc.set_process_state(state)
 
             # Set the WorkFunctionNode as successful
             if state == ProcessState.FINISHED:
-                calc._set_exit_status(0)
+                calc.set_exit_status(0)
 
             calc.store()
             calcs.append(calc)
 
             calc = WorkChainNode()
-            calc._set_process_state(state)
+            calc.set_process_state(state)
 
             # Set the WorkChainNode as failed
             if state == ProcessState.FINISHED:
-                calc._set_exit_status(1)
+                calc.set_exit_status(1)
 
             calc.store()
             calcs.append(calc)

--- a/aiida/backends/tests/cmdline/params/types/test_calculation.py
+++ b/aiida/backends/tests/cmdline/params/types/test_calculation.py
@@ -79,7 +79,7 @@ class TestCalculationParamType(AiidaTestCase):
         result = self.param.convert(identifier, None, None)
         self.assertEqual(result.uuid, self.entity_01.uuid)
 
-        identifier = '{}{}'.format(self.entity_02.label, OrmEntityLoader.LABEL_AMBIGUITY_BREAKER_CHARACTER)
+        identifier = '{}{}'.format(self.entity_02.label, OrmEntityLoader.label_ambiguity_breaker)
         result = self.param.convert(identifier, None, None)
         self.assertEqual(result.uuid, self.entity_02.uuid)
 
@@ -94,6 +94,6 @@ class TestCalculationParamType(AiidaTestCase):
         result = self.param.convert(identifier, None, None)
         self.assertEqual(result.uuid, self.entity_01.uuid)
 
-        identifier = '{}{}'.format(self.entity_03.label, OrmEntityLoader.LABEL_AMBIGUITY_BREAKER_CHARACTER)
+        identifier = '{}{}'.format(self.entity_03.label, OrmEntityLoader.label_ambiguity_breaker)
         result = self.param.convert(identifier, None, None)
         self.assertEqual(result.uuid, self.entity_03.uuid)

--- a/aiida/backends/tests/cmdline/params/types/test_code.py
+++ b/aiida/backends/tests/cmdline/params/types/test_code.py
@@ -88,7 +88,7 @@ class TestCodeParamType(AiidaTestCase):
         result = self.param_base.convert(identifier, None, None)
         self.assertEqual(result.uuid, self.entity_01.uuid)
 
-        identifier = '{}{}'.format(self.entity_02.label, OrmEntityLoader.LABEL_AMBIGUITY_BREAKER_CHARACTER)
+        identifier = '{}{}'.format(self.entity_02.label, OrmEntityLoader.label_ambiguity_breaker)
         result = self.param_base.convert(identifier, None, None)
         self.assertEqual(result.uuid, self.entity_02.uuid)
 
@@ -103,7 +103,7 @@ class TestCodeParamType(AiidaTestCase):
         result = self.param_base.convert(identifier, None, None)
         self.assertEqual(result.uuid, self.entity_01.uuid)
 
-        identifier = '{}{}'.format(self.entity_03.label, OrmEntityLoader.LABEL_AMBIGUITY_BREAKER_CHARACTER)
+        identifier = '{}{}'.format(self.entity_03.label, OrmEntityLoader.label_ambiguity_breaker)
         result = self.param_base.convert(identifier, None, None)
         self.assertEqual(result.uuid, self.entity_03.uuid)
 

--- a/aiida/backends/tests/cmdline/params/types/test_computer.py
+++ b/aiida/backends/tests/cmdline/params/types/test_computer.py
@@ -78,7 +78,7 @@ class TestComputerParamType(AiidaTestCase):
         result = self.param.convert(identifier, None, None)
         self.assertEqual(result.uuid, self.entity_01.uuid)
 
-        identifier = '{}{}'.format(self.entity_02.name, OrmEntityLoader.LABEL_AMBIGUITY_BREAKER_CHARACTER)
+        identifier = '{}{}'.format(self.entity_02.name, OrmEntityLoader.label_ambiguity_breaker)
         result = self.param.convert(identifier, None, None)
         self.assertEqual(result.uuid, self.entity_02.uuid)
 
@@ -93,6 +93,6 @@ class TestComputerParamType(AiidaTestCase):
         result = self.param.convert(identifier, None, None)
         self.assertEqual(result.uuid, self.entity_01.uuid)
 
-        identifier = '{}{}'.format(self.entity_03.name, OrmEntityLoader.LABEL_AMBIGUITY_BREAKER_CHARACTER)
+        identifier = '{}{}'.format(self.entity_03.name, OrmEntityLoader.label_ambiguity_breaker)
         result = self.param.convert(identifier, None, None)
         self.assertEqual(result.uuid, self.entity_03.uuid)

--- a/aiida/backends/tests/cmdline/params/types/test_data.py
+++ b/aiida/backends/tests/cmdline/params/types/test_data.py
@@ -75,7 +75,7 @@ class TestDataParamType(AiidaTestCase):
         result = self.param.convert(identifier, None, None)
         self.assertEqual(result.uuid, self.entity_01.uuid)
 
-        identifier = '{}{}'.format(self.entity_02.label, OrmEntityLoader.LABEL_AMBIGUITY_BREAKER_CHARACTER)
+        identifier = '{}{}'.format(self.entity_02.label, OrmEntityLoader.label_ambiguity_breaker)
         result = self.param.convert(identifier, None, None)
         self.assertEqual(result.uuid, self.entity_02.uuid)
 
@@ -90,6 +90,6 @@ class TestDataParamType(AiidaTestCase):
         result = self.param.convert(identifier, None, None)
         self.assertEqual(result.uuid, self.entity_01.uuid)
 
-        identifier = '{}{}'.format(self.entity_03.label, OrmEntityLoader.LABEL_AMBIGUITY_BREAKER_CHARACTER)
+        identifier = '{}{}'.format(self.entity_03.label, OrmEntityLoader.label_ambiguity_breaker)
         result = self.param.convert(identifier, None, None)
         self.assertEqual(result.uuid, self.entity_03.uuid)

--- a/aiida/backends/tests/cmdline/params/types/test_group.py
+++ b/aiida/backends/tests/cmdline/params/types/test_group.py
@@ -70,7 +70,7 @@ class TestGroupParamType(AiidaTestCase):
         result = self.param.convert(identifier, None, None)
         self.assertEqual(result.uuid, self.entity_01.uuid)
 
-        identifier = '{}{}'.format(self.entity_02.label, OrmEntityLoader.LABEL_AMBIGUITY_BREAKER_CHARACTER)
+        identifier = '{}{}'.format(self.entity_02.label, OrmEntityLoader.label_ambiguity_breaker)
         result = self.param.convert(identifier, None, None)
         self.assertEqual(result.uuid, self.entity_02.uuid)
 
@@ -85,6 +85,6 @@ class TestGroupParamType(AiidaTestCase):
         result = self.param.convert(identifier, None, None)
         self.assertEqual(result.uuid, self.entity_01.uuid)
 
-        identifier = '{}{}'.format(self.entity_03.label, OrmEntityLoader.LABEL_AMBIGUITY_BREAKER_CHARACTER)
+        identifier = '{}{}'.format(self.entity_03.label, OrmEntityLoader.label_ambiguity_breaker)
         result = self.param.convert(identifier, None, None)
         self.assertEqual(result.uuid, self.entity_03.uuid)

--- a/aiida/backends/tests/cmdline/params/types/test_node.py
+++ b/aiida/backends/tests/cmdline/params/types/test_node.py
@@ -74,7 +74,7 @@ class TestNodeParamType(AiidaTestCase):
         result = self.param.convert(identifier, None, None)
         self.assertEqual(result.uuid, self.entity_01.uuid)
 
-        identifier = '{}{}'.format(self.entity_02.label, OrmEntityLoader.LABEL_AMBIGUITY_BREAKER_CHARACTER)
+        identifier = '{}{}'.format(self.entity_02.label, OrmEntityLoader.label_ambiguity_breaker)
         result = self.param.convert(identifier, None, None)
         self.assertEqual(result.uuid, self.entity_02.uuid)
 
@@ -89,6 +89,6 @@ class TestNodeParamType(AiidaTestCase):
         result = self.param.convert(identifier, None, None)
         self.assertEqual(result.uuid, self.entity_01.uuid)
 
-        identifier = '{}{}'.format(self.entity_03.label, OrmEntityLoader.LABEL_AMBIGUITY_BREAKER_CHARACTER)
+        identifier = '{}{}'.format(self.entity_03.label, OrmEntityLoader.label_ambiguity_breaker)
         result = self.param.convert(identifier, None, None)
         self.assertEqual(result.uuid, self.entity_03.uuid)

--- a/aiida/backends/tests/manage/external/test_postgres.py
+++ b/aiida/backends/tests/manage/external/test_postgres.py
@@ -67,7 +67,7 @@ class PostgresTest(unittest.TestCase):
     @mock.patch('aiida.manage.external.postgres._try_subcmd')
     def test_fallback_on_subcmd(self, try_subcmd):
         """Ensure that accessing postgres via subcommand is tried if psycopg does not work."""
-        _postgres = self._setup_postgres()
+        self._setup_postgres()
         self.assertTrue(try_subcmd.call_count >= 1)
 
     def test_create_drop_db_user(self):

--- a/aiida/backends/tests/test_calculation_node.py
+++ b/aiida/backends/tests/test_calculation_node.py
@@ -73,7 +73,6 @@ class TestProcessNode(AiidaTestCase):
 
     def test_process_node_updatable_attribute(self):
         """Check that updatable attributes and only those can be mutated for a stored but unsealed CalculationNode."""
-        # pylint: disable=protected-access
         node = CalculationNode()
         attrs_to_set = {
             'bool': self.boolval,
@@ -126,11 +125,11 @@ class TestProcessNode(AiidaTestCase):
     def test_get_authinfo(self):
         """Test that we can get the AuthInfo object from the calculation instance."""
         from aiida.orm import AuthInfo
-        authinfo = self.calcjob._get_authinfo()  # pylint: disable=protected-access
+        authinfo = self.calcjob.get_authinfo()
         self.assertIsInstance(authinfo, AuthInfo)
 
     def test_get_transport(self):
         """Test that we can get the Transport object from the calculation instance."""
         from aiida.transports import Transport
-        transport = self.calcjob._get_transport()  # pylint: disable=protected-access
+        transport = self.calcjob.get_transport()
         self.assertIsInstance(transport, Transport)

--- a/aiida/backends/tests/test_export_and_import.py
+++ b/aiida/backends/tests/test_export_and_import.py
@@ -114,7 +114,6 @@ class TestSpecificImport(AiidaTestCase):
         structure.label = test_label
         structure.store()
 
-        # pylint: disable=protected-access
         parent_process = orm.CalculationNode()
         parent_process.set_attribute('key', 'value')
         parent_process.store()
@@ -1343,7 +1342,7 @@ class TestComputer(AiidaTestCase):
                 u'key2': 2
             }
             self.computer.set_name(comp1_name)
-            self.computer._set_metadata(comp1_metadata)
+            self.computer.set_metadata(comp1_metadata)
             self.computer.set_transport_params(comp1_transport_params)
 
             # Store a calculation

--- a/aiida/backends/tests/test_nodes.py
+++ b/aiida/backends/tests/test_nodes.py
@@ -191,7 +191,7 @@ class TestNodeHashing(AiidaTestCase):
         """
         node = orm.ProcessNode()
         hash1 = node.get_hash()
-        node._set_process_state('finished')
+        node.set_process_state('finished')
         hash2 = node.get_hash()
         self.assertNotEquals(hash1, None)
         self.assertEquals(hash1, hash2)

--- a/aiida/backends/tests/test_parsers.py
+++ b/aiida/backends/tests/test_parsers.py
@@ -221,7 +221,7 @@ class TestParsers(AiidaTestCase):
                 calc, retrieved_nodes, tests = self.read_test(folder)
             except SkipTestException:
                 return None
-            Parser = calc.get_parserclass()
+            Parser = calc.get_parser_class()
             if Parser is None:
                 raise NotImplementedError
             else:

--- a/aiida/backends/tests/test_restapi.py
+++ b/aiida/backends/tests/test_restapi.py
@@ -71,8 +71,8 @@ class RESTApiTestCase(AiidaTestCase):
 
         calc = orm.CalcJobNode(computer=cls.computer)
         calc.set_option('resources', resources)
-        calc.set_attribute("attr1", "OK")  # pylint: disable=protected-access
-        calc.set_attribute("attr2", "OK")  # pylint: disable=protected-access
+        calc.set_attribute("attr1", "OK")
+        calc.set_attribute("attr2", "OK")
         calc.store()
 
         calc.add_incoming(structure, link_type=LinkType.INPUT_CALC, link_label='link_structure')

--- a/aiida/cmdline/commands/cmd_calcjob.py
+++ b/aiida/cmdline/commands/cmd_calcjob.py
@@ -7,7 +7,7 @@
 # For further information on the license, see the LICENSE.txt file        #
 # For further information please visit http://www.aiida.net               #
 ###########################################################################
-# pylint: disable=protected-access,invalid-name,too-many-locals
+# pylint: disable=invalid-name,too-many-locals
 """`verdi calcjob` commands."""
 from __future__ import division
 from __future__ import print_function
@@ -39,11 +39,11 @@ def calcjob_gotocomputer(calcjob):
     from aiida.common.exceptions import NotExistent
 
     try:
-        transport = calcjob._get_transport()
+        transport = calcjob.get_transport()
     except NotExistent as exception:
         echo.echo_critical(exception)
 
-    remote_workdir = calcjob._get_remote_workdir()
+    remote_workdir = calcjob.get_remote_workdir()
 
     if not remote_workdir:
         echo.echo_critical('no remote work directory for this calcjob, maybe the daemon did not submit it yet')

--- a/aiida/cmdline/utils/common.py
+++ b/aiida/cmdline/utils/common.py
@@ -142,7 +142,6 @@ def get_node_info(node, include_summary=True):
     """
     from aiida.common.links import LinkType
     from aiida import orm
-    from aiida.orm import WorkChainNode
 
     if include_summary:
         result = get_node_summary(node)
@@ -194,10 +193,7 @@ def get_node_info(node, include_summary=True):
         table = []
         table_headers = ['Log messages']
         table.append(['There are {} log messages for this calculation'.format(len(log_messages))])
-        if isinstance(node, WorkChainNode):
-            table.append(["Run 'verdi work report {}' to see them".format(node.pk)])
-        else:
-            table.append(["Run 'verdi calculation logshow {}' to see them".format(node.pk)])
+        table.append(["Run 'verdi process report {}' to see them".format(node.pk)])
         result += '\n{}'.format(tabulate(table, headers=table_headers))
 
     return result
@@ -214,8 +210,8 @@ def get_calcjob_report(calcjob):
     from aiida.common.datastructures import CalcJobState
 
     log_messages = orm.Log.objects.get_logs_for(calcjob)
-    scheduler_out = calcjob.get_scheduler_output()
-    scheduler_err = calcjob.get_scheduler_error()
+    scheduler_out = calcjob.get_scheduler_stdout()
+    scheduler_err = calcjob.get_scheduler_stderr()
     calcjob_state = calcjob.get_state()
     scheduler_state = calcjob.get_scheduler_state()
 

--- a/aiida/engine/daemon/execmanager.py
+++ b/aiida/engine/daemon/execmanager.py
@@ -54,7 +54,7 @@ def upload_calculation(calculation, transport, calc_info, script_filename):
     input_codes = [load_node(_.code_uuid, sub_classes=(Code,)) for _ in codes_info]
 
     logger_extra = get_dblogger_extra(calculation)
-    transport._set_logger_extra(logger_extra)
+    transport.set_logger_extra(logger_extra)
 
     if calculation.has_cached_links():
         raise ValueError("Cannot submit calculation {} because it has "
@@ -131,7 +131,7 @@ def upload_calculation(calculation, transport, calc_info, script_filename):
 
     # I store the workdir of the calculation for later file retrieval
     workdir = transport.getcwd()
-    calculation._set_remote_workdir(workdir)
+    calculation.set_remote_workdir(workdir)
 
     # I first create the code files, so that the code can put
     # default files to be overwritten by the plugin itself.
@@ -231,9 +231,9 @@ def submit_calculation(calculation, transport, calc_info, script_filename):
     scheduler = calculation.computer.get_scheduler()
     scheduler.set_transport(transport)
 
-    workdir = calculation._get_remote_workdir()
+    workdir = calculation.get_remote_workdir()
     job_id = scheduler.submit_from_script(workdir, script_filename)
-    calculation._set_job_id(job_id)
+    calculation.set_job_id(job_id)
 
 
 def retrieve_calculation(calculation, transport, retrieved_temporary_folder):
@@ -251,7 +251,7 @@ def retrieve_calculation(calculation, transport, retrieved_temporary_folder):
     logger_extra = get_dblogger_extra(calculation)
 
     execlogger.debug("Retrieving calc {}".format(calculation.pk), extra=logger_extra)
-    workdir = calculation._get_remote_workdir()
+    workdir = calculation.get_remote_workdir()
 
     execlogger.debug(
         "[retrieval of calc {}] chdir {}".format(calculation.pk, workdir),
@@ -265,9 +265,9 @@ def retrieve_calculation(calculation, transport, retrieved_temporary_folder):
         transport.chdir(workdir)
 
         # First, retrieve the files of folderdata
-        retrieve_list = calculation._get_retrieve_list()
-        retrieve_temporary_list = calculation._get_retrieve_temporary_list()
-        retrieve_singlefile_list = calculation._get_retrieve_singlefile_list()
+        retrieve_list = calculation.get_retrieve_list()
+        retrieve_temporary_list = calculation.get_retrieve_temporary_list()
+        retrieve_singlefile_list = calculation.get_retrieve_singlefile_list()
 
         with SandboxFolder() as folder:
             retrieve_files_from_list(calculation, transport, folder.abspath, retrieve_list)
@@ -338,7 +338,7 @@ def parse_results(process, retrieved_temporary_folder=None):
     assert process.node.get_state() == CalcJobState.PARSING, \
         'the job should be in the PARSING state when calling this function yet it is {}'.format(process.node.get_state())
 
-    parser_class = process.node.get_parserclass()
+    parser_class = process.node.get_parser_class()
     exit_code = ExitCode()
     logger_extra = get_dblogger_extra(process.node)
 

--- a/aiida/engine/persistence.py
+++ b/aiida/engine/persistence.py
@@ -137,7 +137,7 @@ class AiiDAPersister(plumpy.Persister):
         from aiida.orm import load_node
 
         calc = load_node(pid)
-        calc.del_checkpoint()
+        calc.delete_checkpoint()
 
     def delete_process_checkpoints(self, pid):
         """

--- a/aiida/engine/processes/calcjobs/calcjob.py
+++ b/aiida/engine/processes/calcjobs/calcjob.py
@@ -100,7 +100,7 @@ class CalcJob(Process):
 
         .. note:: This has to be done before calling the super because that will seal the node after we cannot change it
         """
-        self.node._del_state()  # pylint: disable=protected-access
+        self.node.delete_state()
         super(CalcJob, self).on_terminated()
 
     @override
@@ -222,7 +222,7 @@ class CalcJob(Process):
         if not job_tmpl.sched_join_files:
             if (job_tmpl.sched_error_path is not None and job_tmpl.sched_error_path not in retrieve_list):
                 retrieve_list.append(job_tmpl.sched_error_path)
-        self.node._set_retrieve_list(retrieve_list)  # pylint: disable=protected-access
+        self.node.set_retrieve_list(retrieve_list)
 
         retrieve_singlefile_list = (calcinfo.retrieve_singlefile_list
                                     if calcinfo.retrieve_singlefile_list is not None else [])
@@ -233,12 +233,12 @@ class CalcJob(Process):
                 raise PluginInternalError(
                     "[presubmission of calc {}] retrieve_singlefile_list subclass problem: {} is "
                     "not subclass of SinglefileData".format(self.node.pk, file_sub_class.__name__))
-        self.node._set_retrieve_singlefile_list(retrieve_singlefile_list)  # pylint: disable=protected-access
+        self.node.set_retrieve_singlefile_list(retrieve_singlefile_list)
 
         # Handle the retrieve_temporary_list
         retrieve_temporary_list = (calcinfo.retrieve_temporary_list
                                    if calcinfo.retrieve_temporary_list is not None else [])
-        self.node._set_retrieve_temporary_list(retrieve_temporary_list)  # pylint: disable=protected-access
+        self.node.set_retrieve_temporary_list(retrieve_temporary_list)
 
         # the if is done so that if the method returns None, this is
         # not added. This has two advantages:

--- a/aiida/engine/processes/calcjobs/tasks.py
+++ b/aiida/engine/processes/calcjobs/tasks.py
@@ -87,7 +87,7 @@ def task_upload_job(node, transport_queue, calc_info, script_filename, cancellab
         raise TransportTaskException('upload_calculation failed {} times consecutively'.format(max_attempts))
     else:
         logger.info('uploading calculation<{}> successful'.format(node.pk))
-        node._set_state(CalcJobState.SUBMITTING)
+        node.set_state(CalcJobState.SUBMITTING)
         raise Return(result)
 
 
@@ -138,7 +138,7 @@ def task_submit_job(node, transport_queue, calc_info, script_filename, cancellab
         raise TransportTaskException('submit_calculation failed {} times consecutively'.format(max_attempts))
     else:
         logger.info('submitting CalcJob<{}> successful'.format(node.pk))
-        node._set_state(CalcJobState.WITHSCHEDULER)
+        node.set_state(CalcJobState.WITHSCHEDULER)
         raise Return(result)
 
 
@@ -178,11 +178,11 @@ def task_update_job(node, job_manager, cancellable):
 
         if job_info is None:
             # If the job is computed or not found assume it's done
-            node._set_scheduler_state(JobState.DONE)
+            node.set_scheduler_state(JobState.DONE)
             job_done = True
         else:
-            node._set_last_jobinfo(job_info)
-            node._set_scheduler_state(job_info.job_state)
+            node.set_last_job_info(job_info)
+            node.set_scheduler_state(job_info.job_state)
             job_done = job_info.job_state == JobState.DONE
 
         raise Return(job_done)
@@ -198,7 +198,7 @@ def task_update_job(node, job_manager, cancellable):
     else:
         logger.info('updating CalcJob<{}> successful'.format(node.pk))
         if job_done:
-            node._set_state(CalcJobState.RETRIEVING)
+            node.set_state(CalcJobState.RETRIEVING)
 
         raise Return(job_done)
 
@@ -246,7 +246,7 @@ def task_retrieve_job(node, transport_queue, retrieved_temporary_folder, cancell
         logger.warning('retrieving CalcJob<{}> failed'.format(node.pk))
         raise TransportTaskException('retrieve_calculation failed {} times consecutively'.format(max_attempts))
     else:
-        node._set_state(CalcJobState.PARSING)
+        node.set_state(CalcJobState.PARSING)
         logger.info('retrieving CalcJob<{}> successful'.format(node.pk))
         raise Return(result)
 
@@ -293,7 +293,7 @@ def task_kill_job(node, transport_queue, cancellable):
         raise TransportTaskException('kill_calculation failed {} times consecutively'.format(max_attempts))
     else:
         logger.info('killing CalcJob<{}> successful'.format(node.pk))
-        node._set_scheduler_state(JobState.DONE)
+        node.set_scheduler_state(JobState.DONE)
         raise Return(result)
 
 
@@ -322,7 +322,7 @@ class Waiting(plumpy.Waiting):
         else:
             command = self.data
 
-        node._set_process_status('Waiting for transport task: {}'.format(command))
+        node.set_process_status('Waiting for transport task: {}'.format(command))
 
         try:
 
@@ -359,10 +359,10 @@ class Waiting(plumpy.Waiting):
             self._killing.set_result(True)
             six.reraise(*exc_info)
         except Return:
-            node._set_process_status(None)
+            node.set_process_status(None)
             raise
         except (plumpy.Interruption, plumpy.CancelledError):
-            node._set_process_status('Transport task {} was interrupted'.format(command))
+            node.set_process_status('Transport task {} was interrupted'.format(command))
             raise
         finally:
             # If we were trying to kill but we didn't deal with it, make sure it's set here

--- a/aiida/engine/processes/process.py
+++ b/aiida/engine/processes/process.py
@@ -329,7 +329,7 @@ class Process(plumpy.Process):
         :param exc_info: the sys.exc_info() object
         """
         super(Process, self).on_except(exc_info)
-        self.node._set_exception(''.join(traceback.format_exception(exc_info[0], exc_info[1], None)))  # pylint: disable=protected-access
+        self.node.set_exception(''.join(traceback.format_exception(exc_info[0], exc_info[1], None)))
         self.report(''.join(traceback.format_exception(*exc_info)))
 
     @override
@@ -340,10 +340,10 @@ class Process(plumpy.Process):
         super(Process, self).on_finish(result, successful)
 
         if result is None or isinstance(result, int):
-            self.node._set_exit_status(result)  # pylint: disable=protected-access
+            self.node.set_exit_status(result)
         elif isinstance(result, ExitCode):
-            self.node._set_exit_status(result.status)  # pylint: disable=protected-access
-            self.node._set_exit_message(result.message)  # pylint: disable=protected-access
+            self.node.set_exit_status(result.status)
+            self.node.set_exit_message(result.message)
         else:
             raise ValueError('the result should be an integer, ExitCode or None, got {} {} {}'.format(
                 type(result), result, self.pid))
@@ -388,7 +388,7 @@ class Process(plumpy.Process):
         :param status: the status message
         """
         super(Process, self).set_status(status)
-        self.node._set_process_status(status)  # pylint: disable=protected-access
+        self.node.set_process_status(status)
 
     def submit(self, process, *args, **kwargs):
         return self.runner.submit(process, *args, **kwargs)
@@ -473,7 +473,7 @@ class Process(plumpy.Process):
 
     def update_node_state(self, state):
         self.update_outputs()
-        self.node._set_process_state(state.LABEL)  # pylint: disable=protected-access
+        self.node.set_process_state(state.LABEL)
 
     def update_outputs(self):
         """Attach any new outputs to the node since the last time this was called, if store provenance is True."""
@@ -511,9 +511,9 @@ class Process(plumpy.Process):
         assert not self.node.is_sealed, 'process node cannot be sealed when setting up the database record'
 
         # Store important process attributes in the node proxy
-        self.node._set_process_state(None)  # pylint: disable=protected-access
-        self.node._set_process_label(self.__class__.__name__)  # pylint: disable=protected-access
-        self.node._set_process_type(self.__class__)  # pylint: disable=protected-access
+        self.node.set_process_state(None)
+        self.node.set_process_label(self.__class__.__name__)
+        self.node.set_process_type(self.__class__)
 
         parent_calc = self.get_parent_calc()
 

--- a/aiida/orm/computers.py
+++ b/aiida/orm/computers.py
@@ -339,10 +339,10 @@ class Computer(entities.Entity):
     def hostname(self):
         return self._backend_entity.hostname
 
-    def _get_metadata(self):
+    def get_metadata(self):
         return self._backend_entity.get_metadata()
 
-    def _set_metadata(self, metadata_dict):
+    def set_metadata(self, metadata_dict):
         """
         Set the metadata.
 
@@ -352,33 +352,33 @@ class Computer(entities.Entity):
         """
         self._backend_entity.set_metadata(metadata_dict)
 
-    def _del_property(self, name, raise_exception=True):
+    def delete_property(self, name, raise_exception=True):
         """
         Delete a property from this computer
 
         :param name: the name of the property
         :param raise_exception: if True raise if the property does not exist, otherwise return None
         """
-        olddata = self._get_metadata()
+        olddata = self.get_metadata()
         try:
             del olddata[name]
-            self._set_metadata(olddata)
+            self.set_metadata(olddata)
         except KeyError:
             if raise_exception:
                 raise AttributeError("'{}' property not found".format(name))
 
-    def _set_property(self, name, value):
+    def set_property(self, name, value):
         """
         Set a property on this computer
 
         :param name: the property name
         :param value: the new value
         """
-        olddata = self._get_metadata()
+        olddata = self.get_metadata()
         olddata[name] = value
-        self._set_metadata(olddata)
+        self.set_metadata(olddata)
 
-    def _get_property(self, name, *args):
+    def get_property(self, name, *args):
         """
         Get a property of this computer
 
@@ -387,8 +387,8 @@ class Computer(entities.Entity):
         :return: the property value
         """
         if len(args) > 1:
-            raise TypeError("_get_property expected at most 2 arguments")
-        olddata = self._get_metadata()
+            raise TypeError("get_property expected at most 2 arguments")
+        olddata = self.get_metadata()
         try:
             return olddata[name]
         except KeyError:
@@ -397,16 +397,16 @@ class Computer(entities.Entity):
             return args[0]
 
     def get_prepend_text(self):
-        return self._get_property("prepend_text", "")
+        return self.get_property("prepend_text", "")
 
     def set_prepend_text(self, val):
-        self._set_property("prepend_text", six.text_type(val))
+        self.set_property("prepend_text", six.text_type(val))
 
     def get_append_text(self):
-        return self._get_property("append_text", "")
+        return self.get_property("append_text", "")
 
     def set_append_text(self, val):
-        self._set_property("append_text", six.text_type(val))
+        self.set_property("append_text", six.text_type(val))
 
     def get_mpirun_command(self):
         """
@@ -415,7 +415,7 @@ class Computer(entities.Entity):
 
         I also provide a sensible default that may be ok in many cases.
         """
-        return self._get_property("mpirun_command", ["mpirun", "-np", "{tot_num_mpiprocs}"])
+        return self.get_property("mpirun_command", ["mpirun", "-np", "{tot_num_mpiprocs}"])
 
     def set_mpirun_command(self, val):
         """
@@ -424,14 +424,14 @@ class Computer(entities.Entity):
         """
         if not isinstance(val, (tuple, list)) or not all(isinstance(i, six.string_types) for i in val):
             raise TypeError("the mpirun_command must be a list of strings")
-        self._set_property("mpirun_command", val)
+        self.set_property("mpirun_command", val)
 
     def get_default_mpiprocs_per_machine(self):
         """
         Return the default number of CPUs per machine (node) for this computer,
         or None if it was not set.
         """
-        return self._get_property("default_mpiprocs_per_machine", None)
+        return self.get_property("default_mpiprocs_per_machine", None)
 
     def set_default_mpiprocs_per_machine(self, def_cpus_per_machine):
         """
@@ -439,11 +439,11 @@ class Computer(entities.Entity):
         Accepts None if you do not want to set this value.
         """
         if def_cpus_per_machine is None:
-            self._del_property("default_mpiprocs_per_machine", raise_exception=False)
+            self.delete_property("default_mpiprocs_per_machine", raise_exception=False)
         else:
             if not isinstance(def_cpus_per_machine, six.integer_types):
                 raise TypeError("def_cpus_per_machine must be an integer (or None)")
-        self._set_property("default_mpiprocs_per_machine", def_cpus_per_machine)
+        self.set_property("default_mpiprocs_per_machine", def_cpus_per_machine)
 
     def get_minimum_job_poll_interval(self):
         """
@@ -453,8 +453,8 @@ class Computer(entities.Entity):
         :return: The minimum interval (in seconds)
         :rtype: float
         """
-        return self._get_property(self.PROPERTY_MINIMUM_SCHEDULER_POLL_INTERVAL,
-                                  self.PROPERTY_MINIMUM_SCHEDULER_POLL_INTERVAL__DEFAULT)
+        return self.get_property(self.PROPERTY_MINIMUM_SCHEDULER_POLL_INTERVAL,
+                                 self.PROPERTY_MINIMUM_SCHEDULER_POLL_INTERVAL__DEFAULT)
 
     def set_minimum_job_poll_interval(self, interval):
         """
@@ -464,7 +464,7 @@ class Computer(entities.Entity):
         :param interval: The minimum interval in seconds
         :type interval: float
         """
-        self._set_property(self.PROPERTY_MINIMUM_SCHEDULER_POLL_INTERVAL, interval)
+        self.set_property(self.PROPERTY_MINIMUM_SCHEDULER_POLL_INTERVAL, interval)
 
     def get_transport_params(self):
         return self._backend_entity.get_transport_params()
@@ -503,13 +503,13 @@ class Computer(entities.Entity):
         :return: The currently configured working directory
         :rtype: str
         """
-        return self._get_property(self.PROPERTY_WORKDIR, "/scratch/{username}/aiida_run/")
+        return self.get_property(self.PROPERTY_WORKDIR, "/scratch/{username}/aiida_run/")
 
     def set_workdir(self, val):
-        self._set_property(self.PROPERTY_WORKDIR, val)
+        self.set_property(self.PROPERTY_WORKDIR, val)
 
     def get_shebang(self):
-        return self._get_property(self.PROPERTY_SHEBANG, "#!/bin/bash")
+        return self.get_property(self.PROPERTY_SHEBANG, "#!/bin/bash")
 
     def set_shebang(self, val):
         """
@@ -519,9 +519,9 @@ class Computer(entities.Entity):
             raise ValueError("{} is invalid. Input has to be a string".format(val))
         if not val.startswith('#!'):
             raise ValueError("{} is invalid. A shebang line has to start with #!".format(val))
-        metadata = self._get_metadata()
+        metadata = self.get_metadata()
         metadata['shebang'] = val
-        self._set_metadata(metadata)
+        self.set_metadata(metadata)
 
     def get_name(self):
         return self._backend_entity.get_name()

--- a/aiida/orm/implementation/authinfos.py
+++ b/aiida/orm/implementation/authinfos.py
@@ -102,7 +102,7 @@ class BackendAuthInfo(backends.BackendEntity):
         """
 
     @abc.abstractmethod
-    def _get_metadata(self):
+    def get_metadata(self):
         """
         Get the metadata dictionary
 
@@ -110,21 +110,21 @@ class BackendAuthInfo(backends.BackendEntity):
         """
 
     @abc.abstractmethod
-    def _set_metadata(self, metadata):
+    def set_metadata(self, metadata):
         """
         Replace the metadata dictionary in the DB with the provided dictionary
         """
 
     def get_property(self, name):
         try:
-            return self._get_metadata()[name]
+            return self.get_metadata()[name]
         except KeyError:
             raise ValueError('Unknown property: {}'.format(name))
 
     def set_property(self, name, value):
-        metadata = self._get_metadata()
+        metadata = self.get_metadata()
         metadata[name] = value
-        self._set_metadata(metadata)
+        self.set_metadata(metadata)
 
 
 @six.add_metaclass(abc.ABCMeta)

--- a/aiida/orm/implementation/django/authinfos.py
+++ b/aiida/orm/implementation/django/authinfos.py
@@ -104,7 +104,7 @@ class DjangoAuthInfo(entities.DjangoModelEntity[DbAuthInfo], BackendAuthInfo):
         # Raises ValueError if data is not JSON-serializable
         self._dbmodel.auth_params = json.dumps(auth_params)
 
-    def _get_metadata(self):
+    def get_metadata(self):
         """
         Get the metadata dictionary from the DB
 
@@ -117,7 +117,7 @@ class DjangoAuthInfo(entities.DjangoModelEntity[DbAuthInfo], BackendAuthInfo):
                 "Error while reading metadata for dbauthinfo, aiidauser={}, computer={}".format(
                     self.aiidauser.email, self.dbcomputer.hostname))
 
-    def _set_metadata(self, metadata):
+    def set_metadata(self, metadata):
         """
         Replace the metadata dictionary in the DB with the provided dictionary
         """

--- a/aiida/orm/implementation/sqlalchemy/authinfos.py
+++ b/aiida/orm/implementation/sqlalchemy/authinfos.py
@@ -93,7 +93,7 @@ class SqlaAuthInfo(entities.SqlaModelEntity[DbAuthInfo], BackendAuthInfo):
         # Raises ValueError if data is not JSON-serializable
         self._dbmodel.auth_params = auth_params
 
-    def _get_metadata(self):
+    def get_metadata(self):
         """
         Get the metadata dictionary from the DB
 
@@ -101,7 +101,7 @@ class SqlaAuthInfo(entities.SqlaModelEntity[DbAuthInfo], BackendAuthInfo):
         """
         return self._dbmodel._metadata  # pylint: disable=protected-access
 
-    def _set_metadata(self, metadata):
+    def set_metadata(self, metadata):
         """
         Replace the metadata dictionary in the DB with the provided dictionary
         """

--- a/aiida/orm/nodes/data/array/trajectory.py
+++ b/aiida/orm/nodes/data/array/trajectory.py
@@ -524,7 +524,7 @@ class TrajectoryData(ArrayData):
            Renamed from _get_cif
         """
         struct = self.get_structure(index=index, **kwargs)
-        cif = struct.get_cif(**kwargs)  # pylint: disable=protected-access
+        cif = struct.get_cif(**kwargs)
         return cif
 
     def _parse_xyz_pos(self, inputstring):

--- a/aiida/orm/nodes/data/remote.py
+++ b/aiida/orm/nodes/data/remote.py
@@ -44,7 +44,7 @@ class RemoteData(Data):
         """
         Check if remote folder is empty
         """
-        authinfo = self._get_authinfo()
+        authinfo = self.get_authinfo()
         transport = authinfo.get_transport()
 
         with transport:
@@ -64,7 +64,7 @@ class RemoteData(Data):
         :param destpath: A path on the local computer to get the file
         :return: a string with the file content
         """
-        authinfo = self._get_authinfo()
+        authinfo = self.get_authinfo()
         t = authinfo.get_transport()
 
         with t:
@@ -88,7 +88,7 @@ class RemoteData(Data):
         :param relpath: If 'relpath' is specified, lists the content of the given subfolder.
         :return: a flat list of file/directory names (as strings).
         """
-        authinfo = self._get_authinfo()
+        authinfo = self.get_authinfo()
         t = authinfo.get_transport()
 
         with t:
@@ -126,7 +126,7 @@ class RemoteData(Data):
         :param relpath: If 'relpath' is specified, lists the content of the given subfolder.
         :return: a list of dictionaries, where the documentation is in :py:class:Transport.listdir_withattributes.
         """
-        authinfo = self._get_authinfo()
+        authinfo = self.get_authinfo()
         t = authinfo.get_transport()
 
         with t:
@@ -163,7 +163,7 @@ class RemoteData(Data):
         """
         from aiida.orm.utils.remote import clean_remote
 
-        authinfo = self._get_authinfo()
+        authinfo = self.get_authinfo()
         transport = authinfo.get_transport()
         remote_dir = self.get_remote_path()
 
@@ -184,5 +184,5 @@ class RemoteData(Data):
         if computer is None:
             raise ValidationError("Remote computer not set.")
 
-    def _get_authinfo(self):
+    def get_authinfo(self):
         return AuthInfo.objects.get(dbcomputer=self.computer, aiidauser=self.user)

--- a/aiida/orm/nodes/node.py
+++ b/aiida/orm/nodes/node.py
@@ -1007,7 +1007,7 @@ class Node(Entity):
 
         # For each node of a cached incoming link, check that all its incoming links are stored
         for link_triple in self._incoming_cache:
-            link_triple.node.verify_are_parents_stored()  # pylint: disable=protected-access
+            link_triple.node.verify_are_parents_stored()
 
         for link_triple in self._incoming_cache:
             if not link_triple.node.is_stored:

--- a/aiida/orm/nodes/process/process.py
+++ b/aiida/orm/nodes/process/process.py
@@ -98,7 +98,7 @@ class ProcessNode(Sealable, Node):
 
         return process_class
 
-    def _set_process_type(self, process_class):
+    def set_process_type(self, process_class):
         """
         Set the process type
 
@@ -125,7 +125,7 @@ class ProcessNode(Sealable, Node):
         """
         return self.get_attribute(self.PROCESS_LABEL_KEY, None)
 
-    def _set_process_label(self, label):
+    def set_process_label(self, label):
         """
         Set the process label
 
@@ -147,7 +147,7 @@ class ProcessNode(Sealable, Node):
 
         return ProcessState(state)
 
-    def _set_process_state(self, state):
+    def set_process_state(self, state):
         """
         Set the process state
 
@@ -168,7 +168,7 @@ class ProcessNode(Sealable, Node):
         """
         return self.get_attribute(self.PROCESS_STATUS_KEY, None)
 
-    def _set_process_status(self, status):
+    def set_process_status(self, status):
         """
         Set the process status
 
@@ -271,7 +271,7 @@ class ProcessNode(Sealable, Node):
         """
         return self.get_attribute(self.EXIT_STATUS_KEY, None)
 
-    def _set_exit_status(self, status):
+    def set_exit_status(self, status):
         """
         Set the exit status of the process
 
@@ -297,7 +297,7 @@ class ProcessNode(Sealable, Node):
         """
         return self.get_attribute(self.EXIT_MESSAGE_KEY, None)
 
-    def _set_exit_message(self, message):
+    def set_exit_message(self, message):
         """
         Set the exit message of the process, if None nothing will be done
 
@@ -325,7 +325,7 @@ class ProcessNode(Sealable, Node):
 
         return None
 
-    def _set_exception(self, exception):
+    def set_exception(self, exception):
         """
         Set the exception of the process
 
@@ -353,7 +353,7 @@ class ProcessNode(Sealable, Node):
         """
         return self.set_attribute(self.CHECKPOINT_KEY, checkpoint)
 
-    def del_checkpoint(self):
+    def delete_checkpoint(self):
         """
         Delete the checkpoint bundle set for the process
         """

--- a/aiida/orm/utils/__init__.py
+++ b/aiida/orm/utils/__init__.py
@@ -7,6 +7,7 @@
 # For further information on the license, see the LICENSE.txt file        #
 # For further information please visit http://www.aiida.net               #
 ###########################################################################
+"""Utilities related to the ORM."""
 from __future__ import division
 from __future__ import print_function
 from __future__ import absolute_import
@@ -16,10 +17,16 @@ import six
 __all__ = ('load_code', 'load_computer', 'load_group', 'load_node')
 
 
-def load_entity(entity_loader=None, identifier=None, pk=None, uuid=None, label=None, sub_classes=None,
+def load_entity(entity_loader=None,
+                identifier=None,
+                pk=None,
+                uuid=None,
+                label=None,
+                sub_classes=None,
                 query_with_dashes=True):
+    # pylint: disable=too-many-arguments
     """
-    Load a Code instance by one of its identifiers: pk, uuid or label
+    Load an entity instance by one of its identifiers: pk, uuid or label
 
     If the type of the identifier is unknown simply pass it without a keyword and the loader will attempt to
     automatically infer the type.
@@ -76,8 +83,8 @@ def load_entity(entity_loader=None, identifier=None, pk=None, uuid=None, label=N
         identifier = str(identifier)
         identifier_type = None
 
-    return entity_loader.load_entity(identifier, identifier_type, sub_classes=sub_classes,
-                                     query_with_dashes=query_with_dashes)
+    return entity_loader.load_entity(
+        identifier, identifier_type, sub_classes=sub_classes, query_with_dashes=query_with_dashes)
 
 
 def load_code(identifier=None, pk=None, uuid=None, label=None, sub_classes=None, query_with_dashes=True):
@@ -101,8 +108,14 @@ def load_code(identifier=None, pk=None, uuid=None, label=None, sub_classes=None,
     :raise aiida.common.MultipleObjectsError: if more than one Code was found
     """
     from aiida.orm.utils.loaders import CodeEntityLoader
-    return load_entity(CodeEntityLoader, identifier=identifier, pk=pk, uuid=uuid, label=label, sub_classes=sub_classes,
-                       query_with_dashes=query_with_dashes)
+    return load_entity(
+        CodeEntityLoader,
+        identifier=identifier,
+        pk=pk,
+        uuid=uuid,
+        label=label,
+        sub_classes=sub_classes,
+        query_with_dashes=query_with_dashes)
 
 
 def load_computer(identifier=None, pk=None, uuid=None, label=None, sub_classes=None, query_with_dashes=True):
@@ -126,8 +139,14 @@ def load_computer(identifier=None, pk=None, uuid=None, label=None, sub_classes=N
     :raise aiida.common.MultipleObjectsError: if more than one Computer was found
     """
     from aiida.orm.utils.loaders import ComputerEntityLoader
-    return load_entity(ComputerEntityLoader, identifier=identifier, pk=pk, uuid=uuid, label=label,
-                       sub_classes=sub_classes, query_with_dashes=query_with_dashes)
+    return load_entity(
+        ComputerEntityLoader,
+        identifier=identifier,
+        pk=pk,
+        uuid=uuid,
+        label=label,
+        sub_classes=sub_classes,
+        query_with_dashes=query_with_dashes)
 
 
 def load_group(identifier=None, pk=None, uuid=None, label=None, sub_classes=None, query_with_dashes=True):
@@ -151,8 +170,14 @@ def load_group(identifier=None, pk=None, uuid=None, label=None, sub_classes=None
     :raise aiida.common.MultipleObjectsError: if more than one Group was found
     """
     from aiida.orm.utils.loaders import GroupEntityLoader
-    return load_entity(GroupEntityLoader, identifier=identifier, pk=pk, uuid=uuid, label=label, sub_classes=sub_classes,
-                       query_with_dashes=query_with_dashes)
+    return load_entity(
+        GroupEntityLoader,
+        identifier=identifier,
+        pk=pk,
+        uuid=uuid,
+        label=label,
+        sub_classes=sub_classes,
+        query_with_dashes=query_with_dashes)
 
 
 def load_node(identifier=None, pk=None, uuid=None, label=None, sub_classes=None, query_with_dashes=True):
@@ -174,5 +199,11 @@ def load_node(identifier=None, pk=None, uuid=None, label=None, sub_classes=None,
     :raise aiida.common.MultipleObjectsError: if more than one Node was found
     """
     from aiida.orm.utils.loaders import NodeEntityLoader
-    return load_entity(NodeEntityLoader, identifier=identifier, pk=pk, uuid=uuid, label=label, sub_classes=sub_classes,
-                       query_with_dashes=query_with_dashes)
+    return load_entity(
+        NodeEntityLoader,
+        identifier=identifier,
+        pk=pk,
+        uuid=uuid,
+        label=label,
+        sub_classes=sub_classes,
+        query_with_dashes=query_with_dashes)

--- a/aiida/orm/utils/loaders.py
+++ b/aiida/orm/utils/loaders.py
@@ -7,9 +7,11 @@
 # For further information on the license, see the LICENSE.txt file        #
 # For further information please visit http://www.aiida.net               #
 ###########################################################################
+"""Module with `OrmEntityLoader` and its sub classes that simplify loading entities through their identifiers."""
 from __future__ import division
 from __future__ import print_function
 from __future__ import absolute_import
+
 from abc import ABCMeta
 from enum import Enum
 
@@ -19,15 +21,12 @@ from aiida.common.exceptions import MultipleObjectsError, NotExistent
 from aiida.common.lang import abstractclassmethod, classproperty
 from aiida.orm.querybuilder import QueryBuilder
 
-__all__ = (
-    'get_loader', 'OrmEntityLoader', 'CalculationEntityLoader', 'CodeEntityLoader', 'ComputerEntityLoader',
-    'GroupEntityLoader', 'NodeEntityLoader'
-)
+__all__ = ('get_loader', 'OrmEntityLoader', 'CalculationEntityLoader', 'CodeEntityLoader', 'ComputerEntityLoader',
+           'GroupEntityLoader', 'NodeEntityLoader')
 
 
 def get_loader(orm_class):
-    """
-    Get the correct OrmEntityLoader for the given orm class
+    """Return the correct OrmEntityLoader for the given orm class.
 
     :param orm_class: the orm class
     :returns: a subclass of OrmEntityLoader
@@ -37,14 +36,17 @@ def get_loader(orm_class):
 
     if issubclass(orm_class, Code):
         return CodeEntityLoader
-    elif issubclass(orm_class, Computer):
+
+    if issubclass(orm_class, Computer):
         return ComputerEntityLoader
-    elif issubclass(orm_class, Group):
+
+    if issubclass(orm_class, Group):
         return GroupEntityLoader
-    elif issubclass(orm_class, Node):
+
+    if issubclass(orm_class, Node):
         return NodeEntityLoader
-    else:
-        raise ValueError('no OrmEntityLoader available for {}'.format(orm_class))
+
+    raise ValueError('no OrmEntityLoader available for {}'.format(orm_class))
 
 
 class IdentifierType(Enum):
@@ -53,6 +55,7 @@ class IdentifierType(Enum):
     The ID is always an integer, the UUID a base 16 encoded integer with optional dashes and the LABEL can
     be any string based label or name, the format of which will vary per orm class
     """
+    # pylint: disable=invalid-name
 
     ID = 'ID'
     UUID = 'UUID'
@@ -61,11 +64,14 @@ class IdentifierType(Enum):
 
 @six.add_metaclass(ABCMeta)
 class OrmEntityLoader(object):
+    """Base class for entity loaders."""
 
-    LABEL_AMBIGUITY_BREAKER_CHARACTER = '!'
+    # pylint: disable=useless-object-inheritance
+
+    label_ambiguity_breaker = '!'
 
     @classproperty
-    def orm_base_class(cls):
+    def orm_base_class(self):
         """
         Return the orm base class to which loaded entities should be mapped. Actual queries to load an entity
         may further narrow the query set by defining a more specific set of orm classes, as long as each of
@@ -76,7 +82,7 @@ class OrmEntityLoader(object):
         raise NotImplementedError
 
     @abstractclassmethod
-    def _get_query_builder_label_identifier(self, identifier, classes):
+    def _get_query_builder_label_identifier(cls, identifier, classes):
         """
         Return the query builder instance that attempts to map the identifier onto an entity of the orm class,
         defined for this loader class, interpreting the identifier as a LABEL like identifier
@@ -90,7 +96,7 @@ class OrmEntityLoader(object):
         raise NotImplementedError
 
     @classmethod
-    def _get_query_builder_id_identifier(self, identifier, classes):
+    def _get_query_builder_id_identifier(cls, identifier, classes):
         """
         Return the query builder instance that attempts to map the identifier onto an entity of the orm class,
         defined for this loader class, interpreting the identifier as an ID like identifier
@@ -99,14 +105,14 @@ class OrmEntityLoader(object):
         :param classes: a tuple of orm classes to which the identifier should be mapped
         :returns: the query builder instance
         """
-        qb = QueryBuilder()
-        qb.append(cls=classes, tag='entity', project=['*'])
-        qb.add_filter('entity', {'id': identifier})
+        builder = QueryBuilder()
+        builder.append(cls=classes, tag='entity', project=['*'])
+        builder.add_filter('entity', {'id': identifier})
 
-        return qb
+        return builder
 
     @classmethod
-    def _get_query_builder_uuid_identifier(self, identifier, classes, query_with_dashes):
+    def _get_query_builder_uuid_identifier(cls, identifier, classes, query_with_dashes):
         """
         Return the query builder instance that attempts to map the identifier onto an entity of the orm class,
         defined for this loader class, interpreting the identifier as a UUID like identifier
@@ -124,18 +130,18 @@ class OrmEntityLoader(object):
                 if len(uuid) > dash_pos:
                     uuid = '{}-{}'.format(uuid[:dash_pos], uuid[dash_pos:])
 
-        qb = QueryBuilder()
-        qb.append(cls=classes, tag='entity', project=['*'])
+        builder = QueryBuilder()
+        builder.append(cls=classes, tag='entity', project=['*'])
 
         # If a UUID can be constructed from the identifier, it is a full UUID and the query can use an equality operator
         try:
             UUID(uuid)
         except ValueError:
-            qb.add_filter('entity', {'uuid': {'like': '{}%'.format(uuid)}})
+            builder.add_filter('entity', {'uuid': {'like': '{}%'.format(uuid)}})
         else:
-            qb.add_filter('entity', {'uuid': uuid})
+            builder.add_filter('entity', {'uuid': uuid})
 
-        return qb
+        return builder
 
     @classmethod
     def get_query_builder(cls, identifier, identifier_type=None, sub_classes=None, query_with_dashes=True):
@@ -155,11 +161,11 @@ class OrmEntityLoader(object):
             identifier, identifier_type = cls.infer_identifier_type(identifier)
 
         if identifier_type == IdentifierType.ID:
-            qb = cls._get_query_builder_id_identifier(identifier, classes)
+            builder = cls._get_query_builder_id_identifier(identifier, classes)
         elif identifier_type == IdentifierType.UUID:
-            qb = cls._get_query_builder_uuid_identifier(identifier, classes, query_with_dashes)
+            builder = cls._get_query_builder_uuid_identifier(identifier, classes, query_with_dashes)
         elif identifier_type == IdentifierType.LABEL:
-            qb = cls._get_query_builder_label_identifier(identifier, classes)
+            builder = cls._get_query_builder_label_identifier(identifier, classes)
 
         query_parameters = {
             'classes': classes,
@@ -167,7 +173,7 @@ class OrmEntityLoader(object):
             'identifier_type': identifier_type,
         }
 
-        return qb, query_parameters
+        return builder, query_parameters
 
     @classmethod
     def load_entity(cls, identifier, identifier_type=None, sub_classes=None, query_with_dashes=True):
@@ -182,15 +188,15 @@ class OrmEntityLoader(object):
         :raises aiida.common.MultipleObjectsError: if the identifier maps onto multiple entities
         :raises aiida.common.NotExistent: if the identifier maps onto not a single entity
         """
-        qb, query_parameters = cls.get_query_builder(identifier, identifier_type, sub_classes, query_with_dashes)
-        qb.limit(2)
+        builder, query_parameters = cls.get_query_builder(identifier, identifier_type, sub_classes, query_with_dashes)
+        builder.limit(2)
 
         classes = ' or '.join([sub_class.__name__ for sub_class in query_parameters['classes']])
         identifier = query_parameters['identifier']
         identifier_type = query_parameters['identifier_type'].value
 
         try:
-            entity = qb.one()[0]
+            entity = builder.one()[0]
         except MultipleObjectsError:
             error = 'multiple {} entries found with {}<{}>'.format(classes, identifier_type, identifier)
             raise MultipleObjectsError(error)
@@ -260,9 +266,9 @@ class OrmEntityLoader(object):
             value = str(value)
 
         # If the final character of the value is the special marker, we enforce LABEL interpretation
-        if value[-1] == cls.LABEL_AMBIGUITY_BREAKER_CHARACTER:
+        if value[-1] == cls.label_ambiguity_breaker:
 
-            identifier = value.rstrip(cls.LABEL_AMBIGUITY_BREAKER_CHARACTER)
+            identifier = value.rstrip(cls.label_ambiguity_breaker)
             identifier_type = IdentifierType.LABEL
 
         else:
@@ -275,7 +281,7 @@ class OrmEntityLoader(object):
 
                 # If the value is a valid base sixteen encoded integer, after dashes are removed, interpret it as a UUID
                 try:
-                    hexadecimal = int(value.replace('-', ''), 16)
+                    int(value.replace('-', ''), 16)
                     identifier = value
                     identifier_type = IdentifierType.UUID
 
@@ -288,9 +294,10 @@ class OrmEntityLoader(object):
 
 
 class ProcessEntityLoader(OrmEntityLoader):
+    """Loader for the `Process` entity and sub classes."""
 
     @classproperty
-    def orm_base_class(cls):
+    def orm_base_class(self):
         """
         Return the orm base class to which loaded entities should be mapped. Actual queries to load an entity
         may further narrow the query set by defining a more specific set of orm classes, as long as each of
@@ -313,16 +320,17 @@ class ProcessEntityLoader(OrmEntityLoader):
         :raises ValueError: if the identifier is invalid
         :raises aiida.common.NotExistent: if the orm base class does not support a LABEL like identifier
         """
-        qb = QueryBuilder()
-        qb.append(cls=classes, tag='process', project=['*'], filters={'label': {'==': identifier}})
+        builder = QueryBuilder()
+        builder.append(cls=classes, tag='process', project=['*'], filters={'label': {'==': identifier}})
 
-        return qb
+        return builder
 
 
 class CalculationEntityLoader(OrmEntityLoader):
+    """Loader for the `Calculation` entity and sub classes."""
 
     @classproperty
-    def orm_base_class(cls):
+    def orm_base_class(self):
         """
         Return the orm base class to which loaded entities should be mapped. Actual queries to load an entity
         may further narrow the query set by defining a more specific set of orm classes, as long as each of
@@ -345,16 +353,17 @@ class CalculationEntityLoader(OrmEntityLoader):
         :raises ValueError: if the identifier is invalid
         :raises aiida.common.NotExistent: if the orm base class does not support a LABEL like identifier
         """
-        qb = QueryBuilder()
-        qb.append(cls=classes, tag='calculation', project=['*'], filters={'label': {'==': identifier}})
+        builder = QueryBuilder()
+        builder.append(cls=classes, tag='calculation', project=['*'], filters={'label': {'==': identifier}})
 
-        return qb
+        return builder
 
 
 class WorkflowEntityLoader(OrmEntityLoader):
+    """Loader for the `Workflow` entity and sub classes."""
 
     @classproperty
-    def orm_base_class(cls):
+    def orm_base_class(self):
         """
         Return the orm base class to which loaded entities should be mapped. Actual queries to load an entity
         may further narrow the query set by defining a more specific set of orm classes, as long as each of
@@ -377,16 +386,17 @@ class WorkflowEntityLoader(OrmEntityLoader):
         :raises ValueError: if the identifier is invalid
         :raises aiida.common.NotExistent: if the orm base class does not support a LABEL like identifier
         """
-        qb = QueryBuilder()
-        qb.append(cls=classes, tag='workflow', project=['*'], filters={'label': {'==': identifier}})
+        builder = QueryBuilder()
+        builder.append(cls=classes, tag='workflow', project=['*'], filters={'label': {'==': identifier}})
 
-        return qb
+        return builder
 
 
 class CodeEntityLoader(OrmEntityLoader):
+    """Loader for the `Code` entity and sub classes."""
 
     @classproperty
-    def orm_base_class(cls):
+    def orm_base_class(self):
         """
         Return the orm base class to which loaded entities should be mapped. Actual queries to load an entity
         may further narrow the query set by defining a more specific set of orm classes, as long as each of
@@ -412,23 +422,24 @@ class CodeEntityLoader(OrmEntityLoader):
         from aiida.orm import Computer
 
         try:
-            label, sep, machinename = identifier.partition('@')
+            label, _, machinename = identifier.partition('@')
         except AttributeError:
             raise ValueError('the identifier needs to be a string')
 
-        qb = QueryBuilder()
-        qb.append(cls=classes, tag='code', project=['*'], filters={'label': {'==': label}})
+        builder = QueryBuilder()
+        builder.append(cls=classes, tag='code', project=['*'], filters={'label': {'==': label}})
 
         if machinename:
-            qb.append(Computer, filters={'name': {'==': machinename}}, with_node='code')
+            builder.append(Computer, filters={'name': {'==': machinename}}, with_node='code')
 
-        return qb
+        return builder
 
 
 class ComputerEntityLoader(OrmEntityLoader):
+    """Loader for the `Computer` entity and sub classes."""
 
     @classproperty
-    def orm_base_class(cls):
+    def orm_base_class(self):
         """
         Return the orm base class to which loaded entities should be mapped. Actual queries to load an entity
         may further narrow the query set by defining a more specific set of orm classes, as long as each of
@@ -451,16 +462,17 @@ class ComputerEntityLoader(OrmEntityLoader):
         :raises ValueError: if the identifier is invalid
         :raises aiida.common.NotExistent: if the orm base class does not support a LABEL like identifier
         """
-        qb = QueryBuilder()
-        qb.append(cls=classes, tag='computer', project=['*'], filters={'name': {'==': identifier}})
+        builder = QueryBuilder()
+        builder.append(cls=classes, tag='computer', project=['*'], filters={'name': {'==': identifier}})
 
-        return qb
+        return builder
 
 
 class DataEntityLoader(OrmEntityLoader):
+    """Loader for the `Data` entity and sub classes."""
 
     @classproperty
-    def orm_base_class(cls):
+    def orm_base_class(self):
         """
         Return the orm base class to which loaded entities should be mapped. Actual queries to load an entity
         may further narrow the query set by defining a more specific set of orm classes, as long as each of
@@ -483,16 +495,17 @@ class DataEntityLoader(OrmEntityLoader):
         :raises ValueError: if the identifier is invalid
         :raises aiida.common.NotExistent: if the orm base class does not support a LABEL like identifier
         """
-        qb = QueryBuilder()
-        qb.append(cls=classes, tag='calculation', project=['*'], filters={'label': {'==': identifier}})
+        builder = QueryBuilder()
+        builder.append(cls=classes, tag='calculation', project=['*'], filters={'label': {'==': identifier}})
 
-        return qb
+        return builder
 
 
 class GroupEntityLoader(OrmEntityLoader):
+    """Loader for the `Group` entity and sub classes."""
 
     @classproperty
-    def orm_base_class(cls):
+    def orm_base_class(self):
         """
         Return the orm base class to which loaded entities should be mapped. Actual queries to load an entity
         may further narrow the query set by defining a more specific set of orm classes, as long as each of
@@ -515,16 +528,17 @@ class GroupEntityLoader(OrmEntityLoader):
         :raises ValueError: if the identifier is invalid
         :raises aiida.common.NotExistent: if the orm base class does not support a LABEL like identifier
         """
-        qb = QueryBuilder()
-        qb.append(cls=classes, tag='group', project=['*'], filters={'label': {'==': identifier}})
+        builder = QueryBuilder()
+        builder.append(cls=classes, tag='group', project=['*'], filters={'label': {'==': identifier}})
 
-        return qb
+        return builder
 
 
 class NodeEntityLoader(OrmEntityLoader):
+    """Loader for the `Node` entity and sub classes."""
 
     @classproperty
-    def orm_base_class(cls):
+    def orm_base_class(self):
         """
         Return the orm base class to which loaded entities should be mapped. Actual queries to load an entity
         may further narrow the query set by defining a more specific set of orm classes, as long as each of
@@ -547,7 +561,7 @@ class NodeEntityLoader(OrmEntityLoader):
         :raises ValueError: if the identifier is invalid
         :raises aiida.common.NotExistent: if the orm base class does not support a LABEL like identifier
         """
-        qb = QueryBuilder()
-        qb.append(cls=classes, tag='node', project=['*'], filters={'label': {'==': identifier}})
+        builder = QueryBuilder()
+        builder.append(cls=classes, tag='node', project=['*'], filters={'label': {'==': identifier}})
 
-        return qb
+        return builder

--- a/aiida/tools/dbexporters/tcod.py
+++ b/aiida/tools/dbexporters/tcod.py
@@ -475,8 +475,8 @@ def _collect_calculation_data(calc):
         while stderr_name in [files_in,files_out]:
             stderr_name = '_{}'.format(stderr_name)
         # Output/error of schedulers are converted to bytes as file contents have to be bytes.
-        if calc.get_scheduler_output() is not None:
-            scheduler_output = calc.get_scheduler_output().encode('utf-8')
+        if calc.get_scheduler_stdout() is not None:
+            scheduler_output = calc.get_scheduler_stdout().encode('utf-8')
             files_out.append({
                 'name'    : stdout_name,
                 'contents': scheduler_output,
@@ -486,8 +486,8 @@ def _collect_calculation_data(calc):
                 'type'    : 'file',
                 })
             this_calc['stdout'] = stdout_name
-        if calc.get_scheduler_error() is not None:
-            scheduler_error = calc.get_scheduler_error().encode('utf-8')
+        if calc.get_scheduler_stderr() is not None:
+            scheduler_error = calc.get_scheduler_stderr().encode('utf-8')
             files_out.append({
                 'name'    : stderr_name,
                 'contents': scheduler_error,

--- a/aiida/transports/transport.py
+++ b/aiida/transports/transport.py
@@ -121,7 +121,7 @@ class Transport(object):
     def __str__(self):
         return "[Transport class or subclass]"
 
-    def _set_logger_extra(self, logger_extra):
+    def set_logger_extra(self, logger_extra):
         """
         Pass the data that should be passed automatically to self.logger
         as 'extra' keyword. This is typically useful if you pass data
@@ -191,7 +191,7 @@ class Transport(object):
     def logger(self):
         """
         Return the internal logger.
-        If you have set extra parameters using _set_logger_extra(), a
+        If you have set extra parameters using set_logger_extra(), a
         suitable LoggerAdapter instance is created, bringing with itself
         also the extras.
         """


### PR DESCRIPTION
Fixes #2538 

These methods are intended to be called from outside the class hierarchy
but were made protected (by prefixing them with an underscore) merely to
hide them from auto-completion and signal to users that they should not
be called by the user. However, this is the wrong usage of this feature
and methods that should be callable from the outside should not be
protected.