### PR TITLE
Release pinning of versions of `astroid` and `pylint`

### DIFF
--- a/setup.json
+++ b/setup.json
@@ -113,13 +113,11 @@
       "pytest-cov==2.6.1"
     ],
     "dev_precommit": [
-      "astroid==2.1.0; python_version>='3.0'",
-      "pylint==2.2.2; python_version>='3.0'",
       "pre-commit==1.14.4",
       "yapf==0.26.0",
       "prospector==1.1.5",
       "pylint-django==0.11.1; python_version<'3.0'",
-      "pylint-django==2.0.5; python_version>='3.0'",
+      "pylint-django==2.0.6; python_version>='3.0'",
       "pep8-naming==0.4.1",
       "toml==0.10.0"
     ],


### PR DESCRIPTION
Fixes #2546 

Versions of `astroid` and `pylint` were pinned in PR #2543 because of a
bug in `pylint-plugin-utils` after the release of `pylint==2.3.0`.
This has been resolved with the release of `pylint-plugin-utils==0.5`
and `pylint-django==2.0.6`