### PR TITLE
Update verdi export and import

### DIFF
--- a/aiida/backends/tests/cmdline/commands/test_export.py
+++ b/aiida/backends/tests/cmdline/commands/test_export.py
@@ -89,7 +89,6 @@ class TestVerdiExport(AiidaTestCase):
     def setUp(self):
         self.cli_runner = CliRunner()
 
-    @unittest.skip('reenable when issue #2342 is addressed')
     def test_create_file_already_exists(self):
         """Test that using a file that already exists, which is the case when using NamedTemporaryFile, will raise."""
         with tempfile.NamedTemporaryFile() as handle:
@@ -97,7 +96,6 @@ class TestVerdiExport(AiidaTestCase):
             result = self.cli_runner.invoke(cmd_export.create, options)
             self.assertIsNotNone(result.exception)
 
-    @unittest.skip('reenable when issue #2342 is addressed')
     def test_create_force(self):
         """
         Test that using a file that already exists, which is the case when using NamedTemporaryFile, will work
@@ -112,7 +110,6 @@ class TestVerdiExport(AiidaTestCase):
             result = self.cli_runner.invoke(cmd_export.create, options)
             self.assertIsNone(result.exception, result.output)
 
-    @unittest.skip('reenable when issue #2342 is addressed')
     def test_create_zip(self):
         """Test that creating an archive for a set of various ORM entities works with the zip format."""
         filename = next(tempfile._get_candidate_names())  # pylint: disable=protected-access
@@ -128,7 +125,6 @@ class TestVerdiExport(AiidaTestCase):
         finally:
             delete_temporary_file(filename)
 
-    @unittest.skip('reenable when issue #2342 is addressed')
     def test_create_zip_uncompressed(self):
         """Test that creating an archive for a set of various ORM entities works with the zip-uncompressed format."""
         filename = next(tempfile._get_candidate_names())  # pylint: disable=protected-access
@@ -144,7 +140,6 @@ class TestVerdiExport(AiidaTestCase):
         finally:
             delete_temporary_file(filename)
 
-    @unittest.skip('reenable when issue #2342 is addressed')
     def test_create_tar_gz(self):
         """Test that creating an archive for a set of various ORM entities works with the tar.gz format."""
         filename = next(tempfile._get_candidate_names())  # pylint: disable=protected-access
@@ -160,11 +155,13 @@ class TestVerdiExport(AiidaTestCase):
         finally:
             delete_temporary_file(filename)
 
+    @unittest.skip("Reenable when issue #2426 has been solved (migrate exported files from 0.3 to 0.4)")
     def test_migrate_versions_old(self):
         """Migrating archives with a version older than the current should work."""
         archives = [
             'export_v0.1.aiida',
             'export_v0.2.aiida',
+            'export_v0.3.aiida'
         ]
 
         for archive in archives:
@@ -181,10 +178,11 @@ class TestVerdiExport(AiidaTestCase):
             finally:
                 delete_temporary_file(filename_output)
 
+    @unittest.skip("Reenable when issue #2426 has been solved (migrate exported files from 0.3 to 0.4)")
     def test_migrate_versions_recent(self):
         """Migrating an archive with the current version should exit with non-zero status."""
         archives = [
-            'export_v0.3.aiida',
+            'export_v0.4.aiida',
         ]
 
         for archive in archives:
@@ -268,12 +266,14 @@ class TestVerdiExport(AiidaTestCase):
                 finally:
                     delete_temporary_file(filename_output)
 
+    @unittest.skip("Reenable when issue #2426 has been solved (migrate exported files from 0.3 to 0.4)")
     def test_inspect(self):
         """Test the functionality of `verdi export inspect`."""
         archives = [
             ('export_v0.1.aiida', '0.1'),
             ('export_v0.2.aiida', '0.2'),
             ('export_v0.3.aiida', '0.3'),
+            ('export_v0.4.aiida', '0.4')
         ]
 
         for archive, version_number in archives:

--- a/aiida/backends/tests/cmdline/commands/test_import.py
+++ b/aiida/backends/tests/cmdline/commands/test_import.py
@@ -13,6 +13,7 @@ from __future__ import print_function
 from __future__ import absolute_import
 import os
 
+import unittest
 from click.testing import CliRunner
 
 from aiida.backends.testbase import AiidaTestCase
@@ -55,19 +56,37 @@ class TestVerdiImport(AiidaTestCase):
 
         self.assertIsNotNone(result.exception)
 
+    @unittest.skip("Reenable when issue #2426 has been solved (migrate exported files from 0.3 to 0.4)")
     def test_import_archive(self):
         """
         Test import for archive files from disk
 
-        Note that when the export format version is upped, the test export_v0.3.aiida archive will have to be
+        NOTE: When the export format version is upped, the test export_v0.4.aiida archive will have to be
         replaced with the version of the new format
         """
         archives = [
             get_archive_file('calcjob/arithmetic.add.aiida'),
-            get_archive_file('export/migrate/export_v0.3.aiida')
+            get_archive_file('export/migrate/export_v0.4.aiida')
         ]
 
         options = [] + archives
         result = self.cli_runner.invoke(cmd_import.cmd_import, options)
 
         self.assertIsNone(result.exception, result.output)
+
+    @unittest.skip("Reenable when issue #2426 has been solved (migrate exported files from 0.3 to 0.4)")
+    def test_comment_mode(self):
+        """
+        Test comment mode flag works as intended
+        """
+        archives = [get_archive_file('export/migrate/export_v0.4.aiida')]
+
+        options = ['--comment-mode', 'newest'] + archives
+        result = self.cli_runner.invoke(cmd_import.cmd_import, options)
+        self.assertIsNone(result.exception, result.output)
+        self.assertIn('Comment mode: newest', result.output)
+
+        options = ['--comment-mode', 'overwrite'] + archives
+        result = self.cli_runner.invoke(cmd_import.cmd_import, options)
+        self.assertIsNone(result.exception, result.output)
+        self.assertIn('Comment mode: overwrite', result.output)

--- a/aiida/backends/tests/test_export_and_import.py
+++ b/aiida/backends/tests/test_export_and_import.py
@@ -1381,9 +1381,9 @@ class TestComputer(AiidaTestCase):
             shutil.rmtree(export_file_tmp_folder, ignore_errors=True)
             shutil.rmtree(unpack_tmp_folder, ignore_errors=True)
 
-    @unittest.skip('reenable when issue #2342 is addressed')
+    @unittest.skip("Reenable when issue #2426 has been solved (migrate exported files from 0.3 to 0.4)")
     def test_import_of_django_sqla_export_file(self):
-        """Check why sqla import manages to import the django export file correctly"""
+        """Check that sqla import manages to import the django export file correctly"""
         from aiida.backends.tests.utils.fixtures import import_archive_fixture
 
         for archive in ['export/compare/django.aiida', 'export/compare/sqlalchemy.aiida']:

--- a/aiida/orm/importexport.py
+++ b/aiida/orm/importexport.py
@@ -717,6 +717,11 @@ def import_data_dj(in_path, user_group=None, ignore_unknown_nodes=False,
                     else:
                         new_entries[model_name] = data['export_data'][model_name].copy()
 
+            # Show Comment mode if not silent and Comments exist in existing_entries
+            if not silent:
+                if COMMENT_ENTITY_NAME in existing_entries:
+                    print("Comment mode: {}".format(comment_mode))
+
             # I import data from the given model
             for model_name in model_order:
                 cls_signature = entity_names_to_signatures[model_name]
@@ -1426,6 +1431,10 @@ def import_data_sqla(in_path, user_group=None, ignore_unknown_nodes=False,
                         # Why the copy:
                         new_entries[entity_name] = data['export_data'][entity_name].copy()
 
+            # Show Comment mode if not silent and Comments exist in existing_entries
+            if not silent:
+                if COMMENT_ENTITY_NAME in existing_entries:
+                    print("Comment mode: {}".format(comment_mode))
 
             # I import data from the given model
             for entity_sig in entity_sig_order:
@@ -2255,7 +2264,7 @@ def export_tree(what, folder, allowed_licenses=None, forbidden_licenses=None,
 
     ## Universal "entities" attributed to all types of nodes
     # Logs
-    if include_logs:
+    if include_logs and to_be_exported:
         # Get related log(s) - universal for all nodes
         builder = QueryBuilder()
         builder.append(Log, filters={'dbnode_id': {'in': to_be_exported}}, project=['id'])
@@ -2263,7 +2272,7 @@ def export_tree(what, folder, allowed_licenses=None, forbidden_licenses=None,
         given_log_entry_ids.update(res)
 
     # Comments
-    if include_comments:
+    if include_comments and to_be_exported:
         # Get related log(s) - universal for all nodes
         builder = QueryBuilder()
         builder.append(Comment, filters={'dbnode_id': {'in': to_be_exported}}, project=['id'])


### PR DESCRIPTION
Skip specific cmd_import and cmd_export tests until issue #2426 has been solved.
Some were previously related to issue #2342.

Fixes issue #2342.

Open access to `verdi export create`.

Do recursive migration of export files when calling `verdi export migrate` in order to always create an export file that respects the latest export version.

Note! The migration from v0.3 to v0.4 is as of yet still not implemented. It is underway with PR #2478.