### PR TITLE
Prevent launching or construction of `WorkChain` and `CalcJob` base class

### DIFF
--- a/aiida/backends/tests/__init__.py
+++ b/aiida/backends/tests/__init__.py
@@ -79,6 +79,7 @@ db_test_list = {
         'dataclasses': ['aiida.backends.tests.test_dataclasses'],
         'dbimporters': ['aiida.backends.tests.test_dbimporters'],
         'engine.daemon.client': ['aiida.backends.tests.engine.daemon.test_client'],
+        'engine.calc_job': ['aiida.backends.tests.engine.test_calc_job'],
         'engine.calcfunctions': ['aiida.backends.tests.engine.test_calcfunctions'],
         'engine.class_loader': ['aiida.backends.tests.engine.test_class_loader'],
         'engine.daemon': ['aiida.backends.tests.engine.test_daemon'],

--- a/aiida/backends/tests/engine/test_calc_job.py
+++ b/aiida/backends/tests/engine/test_calc_job.py
@@ -1,0 +1,35 @@
+# -*- coding: utf-8 -*-
+"""Test for the `CalcJob` process sub class."""
+from __future__ import absolute_import
+from aiida.backends.testbase import AiidaTestCase
+from aiida.common import exceptions
+from aiida.engine import launch, CalcJob, Process
+
+
+class TestCalcJob(AiidaTestCase):
+    """Test for the `CalcJob` process sub class."""
+
+    def setUp(self):
+        super(TestCalcJob, self).setUp()
+        self.assertIsNone(Process.current())
+
+    def tearDown(self):
+        super(TestCalcJob, self).tearDown()
+        self.assertIsNone(Process.current())
+
+    def test_run_base_class(self):
+        """Verify that it is impossible to run, submit or instantiate a base `CalcJob` class."""
+        with self.assertRaises(exceptions.InvalidOperation):
+            CalcJob()
+
+        with self.assertRaises(exceptions.InvalidOperation):
+            launch.run(CalcJob)
+
+        with self.assertRaises(exceptions.InvalidOperation):
+            launch.run_get_node(CalcJob)
+
+        with self.assertRaises(exceptions.InvalidOperation):
+            launch.run_get_pid(CalcJob)
+
+        with self.assertRaises(exceptions.InvalidOperation):
+            launch.submit(CalcJob)

--- a/aiida/backends/tests/engine/test_work_chain.py
+++ b/aiida/backends/tests/engine/test_work_chain.py
@@ -21,9 +21,11 @@ from tornado import gen
 
 from aiida import orm
 from aiida.backends.testbase import AiidaTestCase
+from aiida.common import exceptions
 from aiida.common.links import LinkType
 from aiida.common.utils import Capturing
-from aiida.engine import ExitCode, Process, ToContext, WorkChain, if_, while_, return_, run, run_get_node
+from aiida.engine import ExitCode, Process, ToContext, WorkChain, if_, while_, return_, run, run_get_node, submit
+from aiida.engine import launch
 from aiida.engine.persistence import ObjectLoader
 from aiida.manage.manager import get_manager
 from aiida.orm import load_node, Bool, Float, Int, Str
@@ -266,7 +268,7 @@ class IfTest(WorkChain):
 class TestContext(AiidaTestCase):
 
     def test_attributes(self):
-        wc = WorkChain()
+        wc = IfTest()
         wc.ctx.new_attr = 5
         self.assertEqual(wc.ctx.new_attr, 5)
 
@@ -275,7 +277,7 @@ class TestContext(AiidaTestCase):
             wc.ctx.new_attr
 
     def test_dict(self):
-        wc = WorkChain()
+        wc = IfTest()
         wc.ctx['new_attr'] = 5
         self.assertEqual(wc.ctx['new_attr'], 5)
 
@@ -293,6 +295,23 @@ class TestWorkchain(AiidaTestCase):
     def tearDown(self):
         super(TestWorkchain, self).tearDown()
         self.assertIsNone(Process.current())
+
+    def test_run_base_class(self):
+        """Verify that it is impossible to run, submit or instantiate a base `WorkChain` class."""
+        with self.assertRaises(exceptions.InvalidOperation):
+            WorkChain()
+
+        with self.assertRaises(exceptions.InvalidOperation):
+            launch.run(WorkChain)
+
+        with self.assertRaises(exceptions.InvalidOperation):
+            launch.run_get_node(WorkChain)
+
+        with self.assertRaises(exceptions.InvalidOperation):
+            launch.run_get_pid(WorkChain)
+
+        with self.assertRaises(exceptions.InvalidOperation):
+            launch.submit(WorkChain)
 
     def test_run(self):
         A = Str('A')

--- a/aiida/engine/processes/calcjobs/calcjob.py
+++ b/aiida/engine/processes/calcjobs/calcjob.py
@@ -24,6 +24,13 @@ class CalcJob(Process):
     _spec_type = CalcJobProcessSpec
     link_label_retrieved = 'retrieved'
 
+    def __init__(self, *args, **kwargs):
+        """Construct the instance only if it is a sub class of `CalcJob` otherwise raise `InvalidOperation`."""
+        if self.__class__ == CalcJob:
+            raise exceptions.InvalidOperation('cannot construct or launch a base `CalcJob` class.')
+
+        super(CalcJob, self).__init__(*args, **kwargs)
+
     @classmethod
     def define(cls, spec):
         # yapf: disable


### PR DESCRIPTION
Fixes #2493 and fixes #2474 

The `WorkChain` and `CalcJob` classes are base classes that are meant to
be sub classed as they miss the necessary functionality to successfully
run. However, it was still possible to launch these base classes through
the launchers or straight up constructing them. They would immediately
fail when launched, but they would create a node in the provenance graph
nonetheless. To prevent this from happening, a check is placed in the
constructors to make sure that it is actually a sub class that is being
constructed.