### PR TITLE
Add `uuid` property to the `Process` class

### DIFF
--- a/aiida/engine/daemon/execmanager.py
+++ b/aiida/engine/daemon/execmanager.py
@@ -336,7 +336,7 @@ def parse_results(process, retrieved_temporary_folder=None):
     from aiida.engine import ExitCode
 
     assert process.node.get_state() == CalcJobState.PARSING, \
-        'the job should be in the PARSING state when calling this function yet it is {}'.format(process.node.get_state())
+        'job should be in the PARSING state when calling this function yet it is {}'.format(process.node.get_state())
 
     parser_class = process.node.get_parser_class()
     exit_code = ExitCode()
@@ -371,19 +371,14 @@ def parse_results(process, retrieved_temporary_folder=None):
             exit_code = ExitCode(0)
 
         if not isinstance(exit_code, ExitCode):
-            raise ValueError("parse_from_calc returned an 'exit_code' of invalid_type: {}. It should be an ExitCode "
-                "instance or None".format(type(exit_code)))
+            raise ValueError('parse should return an `ExitCode` or None, and not {}'.format(type(exit_code)))
+
+        if exit_code.status:
+            parser.logger.error('parser returned exit code<{}>: {}'.format(exit_code.status, exit_code.message))
 
         for link_label, node in parser.outputs.items():
             node.add_incoming(process.node, link_type=LinkType.CREATE, link_label=link_label)
             node.store()
-
-    if exit_code.status != 0:
-        execlogger.error("[parsing of calc {}] "
-                         "The parser returned an error, but it should have "
-                         "created an output node with some partial results "
-                         "and warnings. Check there for more information on "
-                         "the problem".format(process.node.pk), extra=logger_extra)
 
     return exit_code
 

--- a/aiida/engine/processes/process.py
+++ b/aiida/engine/processes/process.py
@@ -168,6 +168,14 @@ class Process(plumpy.Process):
         return self._node
 
     @property
+    def uuid(self):
+        """Return the UUID of the process which corresponds to the UUID of its associated `ProcessNode`.
+
+        :return: the UUID associated to this process instance
+        """
+        return self.node.uuid
+
+    @property
     def metadata(self):
         """Return the metadata passed when launching this process.
 
@@ -438,10 +446,13 @@ class Process(plumpy.Process):
 
     @protected
     def report(self, msg, *args, **kwargs):
-        """
-        Log a message to the logger, which should get saved to the
-        database through the attached DbLogHandler. The class name and function
-        name of the caller are prepended to the given message
+        """Log a message to the logger, which should get saved to the database through the attached DbLogHandler.
+
+        The pk, class name and function name of the caller are prepended to the given message
+
+        :param msg: message to log
+        :param args: args to pass to the log call
+        :param kwargs: kwargs to pass to the log call
         """
         message = '[{}|{}|{}]: {}'.format(self.node.pk, self.__class__.__name__, inspect.stack()[1][3], msg)
         self.logger.log(LOG_LEVEL_REPORT, message, *args, **kwargs)


### PR DESCRIPTION
Fixes #2565 

This serves as a proxy to the UUID of the underlying `ProcessNode`.