### PR TITLE
Add efficient `count` method for `aiida.orm.groups.Group`

### DIFF
--- a/aiida/backends/tests/orm/test_groups.py
+++ b/aiida/backends/tests/orm/test_groups.py
@@ -25,6 +25,17 @@ class TestGroups(AiidaTestCase):
         for group in orm.Group.objects.all():
             orm.Group.objects.delete(group.id)
 
+    def test_count(self):
+        """Test the `count` method."""
+        node_00 = orm.Data().store()
+        node_01 = orm.Data().store()
+        nodes = [node_00, node_01]
+
+        group = orm.Group(label='label', description='description').store()
+        group.add_nodes(nodes)
+
+        self.assertEqual(group.count(), len(nodes))
+
     def test_creation(self):
         """Test the creation of Groups."""
         node = orm.Data()

--- a/aiida/cmdline/commands/cmd_group.py
+++ b/aiida/cmdline/commands/cmd_group.py
@@ -278,7 +278,7 @@ def group_list(all_users, user_email, all_types, group_type, with_description, c
         'pk': lambda group: str(group.pk),
         'label': lambda group: group.label,
         'type_string': lambda group: group.type_string,
-        'count': lambda group: len(group.nodes),
+        'count': lambda group: group.count(),
         'user': lambda group: group.user.email.strip(),
         'description': lambda group: group.description
     }

--- a/aiida/orm/groups.py
+++ b/aiida/orm/groups.py
@@ -251,6 +251,13 @@ class Group(entities.Entity):
         """
         return self._backend_entity.uuid
 
+    def count(self):
+        """Return the number of entities in this group.
+
+        :return: integer number of entities contained within the group
+        """
+        return self._backend_entity.count()
+
     @property
     def nodes(self):
         """

--- a/aiida/orm/implementation/django/groups.py
+++ b/aiida/orm/implementation/django/groups.py
@@ -109,6 +109,13 @@ class DjangoGroup(entities.DjangoModelEntity[models.DbGroup], BackendGroup):  # 
         # To allow to do directly g = Group(...).store()
         return self
 
+    def count(self):
+        """Return the number of entities in this group.
+
+        :return: integer number of entities contained within the group
+        """
+        return self._dbmodel.dbnodes.count()
+
     @property
     def nodes(self):
         """Get an iterator to the nodes in the group"""

--- a/aiida/orm/implementation/groups.py
+++ b/aiida/orm/implementation/groups.py
@@ -144,6 +144,13 @@ class BackendGroup(backends.BackendEntity):
         the number of nodes in the group using len().
         """
 
+    @abc.abstractproperty
+    def count(self):
+        """Return the number of entities in this group.
+
+        :return: integer number of entities contained within the group
+        """
+
     def add_nodes(self, nodes, **kwargs):  # pylint: disable=unused-argument
         """Add a set of nodes to the group.
 

--- a/aiida/orm/implementation/sqlalchemy/groups.py
+++ b/aiida/orm/implementation/sqlalchemy/groups.py
@@ -124,6 +124,15 @@ class SqlaGroup(entities.SqlaModelEntity[DbGroup], BackendGroup):  # pylint: dis
         self._dbmodel.save()
         return self
 
+    def count(self):
+        """Return the number of entities in this group.
+
+        :return: integer number of entities contained within the group
+        """
+        from aiida.backends.sqlalchemy import get_scoped_session
+        session = get_scoped_session()
+        return session.query(self.MODEL_CLASS).join(self.MODEL_CLASS.dbnodes).filter(DbGroup.id == self.pk).count()
+
     @property
     def nodes(self):
         """Get an iterator to all the nodes in the group"""


### PR DESCRIPTION
Fixes #1948 

Before the only way to get the number of entries in a `Group` was
through the iterator `nodes` and call `len()` on it. However, this is
almost always not the fastest way. Given that the count is used often in
for example `verdi group list -C` it is worthwhile to have a `count`
method that operates as direct on the database layer as possible.