### PR TITLE
Replace .inp and .out for Node with .inputs and .outputs for CalculationNode and WorkflowNode

### DIFF
--- a/.ci/polish/cli.py
+++ b/.ci/polish/cli.py
@@ -154,7 +154,7 @@ def launch(expression, code, use_calculations, use_calcfunctions, sleep, timeout
                 sys.exit(1)
 
             try:
-                result = workchain.out.result
+                result = workchain.outputs.result
             except AttributeError:
                 click.secho('Failed: ', fg='red', bold=True, nl=False)
                 click.secho('the workchain<{}> did not return a result output node'.format(workchain.pk), bold=True)

--- a/.ci/polish/lib/template/workchain.tpl
+++ b/.ci/polish/lib/template/workchain.tpl
@@ -81,7 +81,7 @@ ${outline}
             return self.ERROR_NO_JOB_CALCULATION
 
         try:
-            self.ctx.result = calculation.out.sum % self.inputs.modulo
+            self.ctx.result = calculation.outputs.sum % self.inputs.modulo
         except AttributeError as exception:
             self.report('no output node found')
             return self.ERROR_NO_OUTPUT_NODE
@@ -118,7 +118,7 @@ ${outline}
     def post_raise_power(self):
         sub_result = prod(self.ctx.iterators_sign)
         for workchain in self.ctx.workchains:
-            sub_result *= workchain.out.result.value
+            sub_result *= workchain.outputs.result.value
             sub_result %= self.inputs.modulo.value
 
         self.ctx.result += sub_result

--- a/.ci/test_daemon.py
+++ b/.ci/test_daemon.py
@@ -86,7 +86,7 @@ def validate_calculations(expected_results):
             valid = False
 
         try:
-            actual_dict = calc.out.output_parameters.get_dict()
+            actual_dict = calc.outputs.output_parameters.get_dict()
         except exceptions.NotExistent:
             print('Could not retrieve `output_parameters` node for Calculation<{}>'.format(pk))
             print_report(pk)
@@ -112,7 +112,7 @@ def validate_workchains(expected_results):
         this_valid = True
         try:
             calc = load_node(pk)
-            actual_value = calc.out.output
+            actual_value = calc.outputs.output
         except (exceptions.NotExistent, AttributeError) as exception:
             print("* UNABLE TO RETRIEVE VALUE for workchain pk={}: I expected {}, I got {}: {}"
                   .format(pk, expected_value, type(exception), exception))

--- a/.ci/workchains.py
+++ b/.ci/workchains.py
@@ -47,7 +47,7 @@ class NestedWorkChain(WorkChain):
         if self.should_submit():
             self.report('Getting sub-workchain output.')
             sub_workchain = self.ctx.workchain[0]
-            self.out('output', sub_workchain.out.output + 1)
+            self.out('output', sub_workchain.outputs.output + 1)
         else:
             self.report('Bottom-level workchain reached.')
             self.out('output', Int(0))

--- a/aiida/backends/tests/engine/test_calcfunctions.py
+++ b/aiida/backends/tests/engine/test_calcfunctions.py
@@ -67,9 +67,9 @@ class TestCalcFunction(AiidaTestCase):
         """Verify that a calcfunction that returns a single Data node gets a default link label."""
         _, node = self.test_calcfunction.run_get_node(self.default_int)
 
-        self.assertEqual(node.out.result, self.default_int.value + 1)
-        self.assertEqual(getattr(node.out, Process.SINGLE_OUTPUT_LINKNAME), self.default_int.value + 1)
-        self.assertEqual(node.out[Process.SINGLE_OUTPUT_LINKNAME], self.default_int.value + 1)
+        self.assertEqual(node.outputs.result, self.default_int.value + 1)
+        self.assertEqual(getattr(node.outputs, Process.SINGLE_OUTPUT_LINKNAME), self.default_int.value + 1)
+        self.assertEqual(node.outputs[Process.SINGLE_OUTPUT_LINKNAME], self.default_int.value + 1)
 
     def test_calcfunction_caching(self):
         """Verify that a calcfunction can be cached."""

--- a/aiida/backends/tests/engine/test_work_chain.py
+++ b/aiida/backends/tests/engine/test_work_chain.py
@@ -409,15 +409,15 @@ class TestWorkchain(AiidaTestCase):
                 return ToContext(r1=self.submit(ReturnA), r2=self.submit(ReturnB))
 
             def s2(self):
-                test_case.assertEquals(self.ctx.r1.out.res, A)
-                test_case.assertEquals(self.ctx.r2.out.res, B)
+                test_case.assertEquals(self.ctx.r1.outputs.res, A)
+                test_case.assertEquals(self.ctx.r2.outputs.res, B)
 
                 # Try overwriting r1
                 return ToContext(r1=self.submit(ReturnB))
 
             def s3(self):
-                test_case.assertEquals(self.ctx.r1.out.res, B)
-                test_case.assertEquals(self.ctx.r2.out.res, B)
+                test_case.assertEquals(self.ctx.r1.outputs.res, B)
+                test_case.assertEquals(self.ctx.r2.outputs.res, B)
 
         run_and_check_success(Wf)
 
@@ -519,7 +519,7 @@ class TestWorkchain(AiidaTestCase):
 
             def check(self):
                 pass
-                assert self.ctx.subwc.out.value == Int(5)
+                assert self.ctx.subwc.outputs.value == Int(5)
 
         class SubWorkChain(WorkChain):
 
@@ -547,7 +547,7 @@ class TestWorkchain(AiidaTestCase):
                 return ToContext(subwc=self.submit(SubWorkChain))
 
             def check(self):
-                assert self.ctx.subwc.out.value == Int(5)
+                assert self.ctx.subwc.outputs.value == Int(5)
 
         class SubWorkChain(WorkChain):
 
@@ -649,8 +649,8 @@ class TestWorkchain(AiidaTestCase):
                 return ToContext(result_b=self.submit(SimpleWc))
 
             def result(self):
-                test_case.assertEquals(self.ctx.result_a.out._return, val)
-                test_case.assertEquals(self.ctx.result_b.out._return, val)
+                test_case.assertEquals(self.ctx.result_a.outputs._return, val)
+                test_case.assertEquals(self.ctx.result_b.outputs._return, val)
 
         run_and_check_success(Workchain)
 

--- a/aiida/backends/tests/engine/test_workfunctions.py
+++ b/aiida/backends/tests/engine/test_workfunctions.py
@@ -66,9 +66,9 @@ class TestWorkFunction(AiidaTestCase):
         """Verify that a workfunction that returns a single Data node gets a default link label."""
         _, node = self.test_workfunction.run_get_node(self.default_int)
 
-        self.assertEqual(node.out.result, self.default_int)
-        self.assertEqual(getattr(node.out, Process.SINGLE_OUTPUT_LINKNAME), self.default_int)
-        self.assertEqual(node.out[Process.SINGLE_OUTPUT_LINKNAME], self.default_int)
+        self.assertEqual(node.outputs.result, self.default_int)
+        self.assertEqual(getattr(node.outputs, Process.SINGLE_OUTPUT_LINKNAME), self.default_int)
+        self.assertEqual(node.outputs[Process.SINGLE_OUTPUT_LINKNAME], self.default_int)
 
     def test_workfunction_caching(self):
         """Verify that a workfunction cannot be cached."""

--- a/aiida/backends/tests/test_parsers.py
+++ b/aiida/backends/tests/test_parsers.py
@@ -103,7 +103,7 @@ def output_test(pk, testname, skip_uuids_from_inputs=[]):
     folder = Folder(outfolder)
     to_export = [c.dbnode] + inputs
     try:
-        to_export.append(c.out.retrieved.dbnode)
+        to_export.append(c.outputs.retrieved.dbnode)
     except AttributeError:
         raise ValueError("No output retrieved node; without it, we cannot test the parser!")
     export_tree(to_export, folder=folder, also_parents=False, also_calc_outputs=False)
@@ -188,7 +188,7 @@ class TestParsers(AiidaTestCase):
                 calc = c
                 break
 
-        retrieved = calc.out.retrieved
+        retrieved = calc.outputs.retrieved
 
         try:
             with io.open(os.path.join(outfolder, '_aiida_checks.json', encoding='utf8')) as fhandle:

--- a/aiida/cmdline/commands/cmd_calcjob.py
+++ b/aiida/cmdline/commands/cmd_calcjob.py
@@ -132,7 +132,7 @@ def calcjob_outputcat(calcjob, path):
                 entry_point.name))
 
     try:
-        retrieved = calcjob.out.retrieved
+        retrieved = calcjob.outputs.retrieved
     except AttributeError:
         echo.echo_critical("No 'retrieved' node found. Have the calcjob files already been retrieved?")
 
@@ -178,7 +178,7 @@ def calcjob_outputls(calcjob, path, color):
     from aiida.cmdline.utils.repository import list_repository_contents
 
     try:
-        retrieved = calcjob.out.retrieved
+        retrieved = calcjob.outputs.retrieved
     except AttributeError:
         echo.echo_critical("No 'retrieved' node found. Have the calcjob files already been retrieved?")
 

--- a/aiida/cmdline/utils/shell.py
+++ b/aiida/cmdline/utils/shell.py
@@ -14,6 +14,7 @@ from __future__ import print_function
 from __future__ import absolute_import
 
 DEFAULT_MODULES_LIST = [
+    ('aiida.common.links', 'LinkType', 'LinkType'),
     ('aiida.orm', 'Node', 'Node'),
     ('aiida.orm', 'ProcessNode', 'ProcessNode'),
     ('aiida.orm', 'CalculationNode', 'CalculationNode'),

--- a/aiida/orm/nodes/data/data.py
+++ b/aiida/orm/nodes/data/data.py
@@ -128,14 +128,14 @@ class Data(Node):
         self.source = source
 
     @property
-    def created_by(self):
+    def creator(self):
         """Return the creator of this node or None if it does not exist.
 
         :return: the creating node or None
         """
         inputs = self.get_incoming(link_type=LinkType.CREATE)
         if inputs:
-            return inputs.first()
+            return inputs.first().node
 
         return None
 

--- a/aiida/orm/nodes/node.py
+++ b/aiida/orm/nodes/node.py
@@ -27,7 +27,6 @@ from aiida.manage.manager import get_manager
 from aiida.orm.utils.links import LinkManager, LinkTriple
 from aiida.orm.utils.repository import Repository
 from aiida.orm.utils.node import AbstractNodeMeta, clean_value
-from aiida.orm.utils.managers import NodeInputManager, NodeOutputManager
 
 from ..comments import Comment
 from ..computers import Computer
@@ -972,28 +971,6 @@ class Node(Entity):
         :return: boolean, True when there are links in the incoming cache, False otherwise
         """
         return bool(self._incoming_cache)
-
-    @property
-    def out(self):
-        """Return an instance of `NodeOutputManager`
-
-        The `NodeOutputManager` allows you to easily explore the nodes that have outgoing links from this node.
-        The outgoing nodes are reachable by their link labels which are attributes of the manager.
-
-        :return: `NodeOutputManager`
-        """
-        return NodeOutputManager(self)
-
-    @property
-    def inp(self):
-        """Return an instance of `NodeInputManager`
-
-        The `NodeInputManager` allows you to easily explore the nodes that have incoming links to this node.
-        The incoming nodes are reachable by their link labels which are attributes of the manager.
-
-        :return: `NodeInputManager`
-        """
-        return NodeInputManager(self)
 
     def store_all(self, with_transaction=True, use_cache=None):
         """Store the node, together with all input links.

--- a/aiida/orm/nodes/process/calculation/calculation.py
+++ b/aiida/orm/nodes/process/calculation/calculation.py
@@ -2,6 +2,9 @@
 """Module with `Node` sub class for calculation processes."""
 from __future__ import absolute_import
 
+from aiida.common.links import LinkType
+from aiida.orm.utils.managers import NodeLinksManager
+
 from ..process import ProcessNode
 
 __all__ = ('CalculationNode',)
@@ -16,3 +19,27 @@ class CalculationNode(ProcessNode):
     # Calculation nodes are storable
     _storable = True
     _unstorable_message = 'storing for this node has been disabled'
+
+    @property
+    def inputs(self):
+        """Return an instance of `NodeLinksManager` to manage incoming INPUT_CALC links
+
+        The returned Manager allows you to easily explore the nodes connected to this node
+        via an incoming INPUT_CALC link.
+        The incoming nodes are reachable by their link labels which are attributes of the manager.
+
+        :return: `NodeLinksManager`
+        """
+        return NodeLinksManager(node=self, link_type=LinkType.INPUT_CALC, incoming=True)
+
+    @property
+    def outputs(self):
+        """Return an instance of `NodeLinksManager` to manage outgoing CREATE links
+
+        The returned Manager allows you to easily explore the nodes connected to this node
+        via an outgoing CREATE link.
+        The outgoing nodes are reachable by their link labels which are attributes of the manager.
+
+        :return: `NodeLinksManager`
+        """
+        return NodeLinksManager(node=self, link_type=LinkType.CREATE, incoming=False)

--- a/aiida/orm/nodes/process/process.py
+++ b/aiida/orm/nodes/process/process.py
@@ -406,15 +406,15 @@ class ProcessNode(Sealable, Node):
         return descendants
 
     @property
-    def called_by(self):
+    def caller(self):
         """
         Return the process node that called this process node, or None if it does not have a caller
 
         :returns: process node that called this process node instance or None
         """
-        called_by = self.get_incoming(link_type=(LinkType.CALL_CALC, LinkType.CALL_WORK))
-        if called_by:
-            return called_by.first()
+        caller = self.get_incoming(link_type=(LinkType.CALL_CALC, LinkType.CALL_WORK))
+        if caller:
+            return caller.first().node
 
         return None
 

--- a/aiida/orm/nodes/process/workflow/workflow.py
+++ b/aiida/orm/nodes/process/workflow/workflow.py
@@ -2,6 +2,9 @@
 """Module with `Node` sub class for workflow processes."""
 from __future__ import absolute_import
 
+from aiida.common.links import LinkType
+from aiida.orm.utils.managers import NodeLinksManager
+
 from ..process import ProcessNode
 
 __all__ = ('WorkflowNode',)
@@ -15,3 +18,27 @@ class WorkflowNode(ProcessNode):
     # Workflow nodes are storable
     _storable = True
     _unstorable_message = 'storing for this node has been disabled'
+
+    @property
+    def inputs(self):
+        """Return an instance of `NodeLinksManager` to manage incoming INPUT_WORK links
+
+        The returned Manager allows you to easily explore the nodes connected to this node
+        via an incoming INPUT_WORK link.
+        The incoming nodes are reachable by their link labels which are attributes of the manager.
+
+        :return: `NodeLinksManager`
+        """
+        return NodeLinksManager(node=self, link_type=LinkType.INPUT_WORK, incoming=True)
+
+    @property
+    def outputs(self):
+        """Return an instance of `NodeLinksManager` to manage outgoing RETURN links
+
+        The returned Manager allows you to easily explore the nodes connected to this node
+        via an outgoing RETURN link.
+        The outgoing nodes are reachable by their link labels which are attributes of the manager.
+
+        :return: `NodeLinksManager`
+        """
+        return NodeLinksManager(node=self, link_type=LinkType.RETURN, incoming=False)

--- a/aiida/orm/utils/links.py
+++ b/aiida/orm/utils/links.py
@@ -245,8 +245,16 @@ class LinkManager(object):  # pylint: disable=useless-object-inheritance
         :return: node that corresponds to the given label
         :raises aiida.common.NotExistent: if the label is not present among the link_triples
         """
+        matching_entry = None
         for entry in self.link_triples:
             if entry.link_label == label:
-                return entry.node
+                if matching_entry is None:
+                    matching_entry = entry.node
+                else:
+                    raise exceptions.MultipleObjectsError(
+                        'more than one neighbor with the label {} found'.format(label))
 
-        raise exceptions.NotExistent('no neighbor with the label {} found'.format(label))
+        if matching_entry is None:
+            raise exceptions.NotExistent('no neighbor with the label {} found'.format(label))
+
+        return matching_entry

--- a/aiida/parsers/plugins/templatereplacer/doubler.py
+++ b/aiida/parsers/plugins/templatereplacer/doubler.py
@@ -26,7 +26,7 @@ class TemplatereplacerDoublerParser(Parser):
 
     def parse(self, **kwargs):
         """Parse the contents of the output files retrieved in the `FolderData`."""
-        template = self.node.inp.template.get_dict()
+        template = self.node.inputs.template.get_dict()
 
         try:
             output_folder = self.retrieved

--- a/aiida/restapi/translator/calculation/__init__.py
+++ b/aiida/restapi/translator/calculation/__init__.py
@@ -160,7 +160,7 @@ class CalculationTranslator(NodeTranslator):
         """
         if node.node_type.startswith("process.calculation.calcjob"):
 
-            retrieved_folder = node.out.retrieved
+            retrieved_folder = node.outputs.retrieved
             response = {}
 
             if retrieved_folder is None:

--- a/aiida/tools/dbexporters/tcod_plugins/__init__.py
+++ b/aiida/tools/dbexporters/tcod_plugins/__init__.py
@@ -52,7 +52,7 @@ class BaseTcodtranslator(object):
         this computation.
         """
         try:
-            code = calc.inp.code
+            code = calc.inputs.code
             if not code.is_local():
                 return code.get_attribute('remote_exec_path')
         except Exception:

--- a/docs/source/developer_guide/core/internals.rst
+++ b/docs/source/developer_guide/core/internals.rst
@@ -91,47 +91,47 @@ Link management methods
 
 Assume that the user wants to see the available links of a node in order to understand the structure of the graph and maybe traverse it. In the following example, we load a specific node and we list its input and output links. The returned dictionaries have as keys the link name and as value the linked ``node``. Here is the code::
 
-	In [1]: # Let's load a node with a specific pk
+  In [1]: # Let's load a node with a specific pk
 
-	In [2]: c = load_node(139168)
+  In [2]: c = load_node(139168)
 
-	In [3]: c.get_incoming()
-	Out[3]:
-	[Neighbor(link_type='inputlink', label='code',
-	node=<Code: Remote code 'cp-5.1' on daint, pk: 75709, uuid: 3c9cdb7f-0cda-402e-b898-4dd0d06aa5a4>),
-	Neighbor(link_type='inputlink', label='parameters',
-	node=<Dict: uuid: 94efe64f-7f7e-46ea-922a-fe64a7fba8a5 (pk: 139166)>)
-	Neighbor(link_type='inputlink', label='parent_calc_folder',
-	node=<RemoteData: uuid: becb4894-c50c-4779-b84f-713772eaceff (pk: 139118)>)
-	Neighbor(link_type='inputlink', label='pseudo_Ba',
-	node=<UpfData: uuid: 5e53b22d-5757-4d50-bbe0-51f3b9ac8b7c (pk: 1905)>)
-	Neighbor(link_type='inputlink', label='pseudo_O',
-	node=<UpfData: uuid: 5cccd0d9-7944-4c67-b3c7-a39a1f467906 (pk: 1658)>)
-	Neighbor(link_type='inputlink', label='pseudo_Ti',
-	node=<UpfData: uuid: e5744077-8615-4927-9f97-c5f7b36ba421 (pk: 1660)>)
-	Neighbor(link_type='inputlink', label='settings',
-	node=<Dict: uuid: a5a828b8-fdd8-4d75-b674-2e2d62792de0 (pk: 139167)>)
-	Neighbor(link_type='inputlink', label='structure',
-	node=<StructureData: uuid: 3096f83c-6385-48c4-8cb2-24a427ce11b1 (pk: 139001)>)]
+  In [3]: c.get_incoming()
+  Out[3]:
+  [Neighbor(link_type='inputlink', label='code',
+  node=<Code: Remote code 'cp-5.1' on daint, pk: 75709, uuid: 3c9cdb7f-0cda-402e-b898-4dd0d06aa5a4>),
+  Neighbor(link_type='inputlink', label='parameters',
+  node=<Dict: uuid: 94efe64f-7f7e-46ea-922a-fe64a7fba8a5 (pk: 139166)>)
+  Neighbor(link_type='inputlink', label='parent_calc_folder',
+  node=<RemoteData: uuid: becb4894-c50c-4779-b84f-713772eaceff (pk: 139118)>)
+  Neighbor(link_type='inputlink', label='pseudo_Ba',
+  node=<UpfData: uuid: 5e53b22d-5757-4d50-bbe0-51f3b9ac8b7c (pk: 1905)>)
+  Neighbor(link_type='inputlink', label='pseudo_O',
+  node=<UpfData: uuid: 5cccd0d9-7944-4c67-b3c7-a39a1f467906 (pk: 1658)>)
+  Neighbor(link_type='inputlink', label='pseudo_Ti',
+  node=<UpfData: uuid: e5744077-8615-4927-9f97-c5f7b36ba421 (pk: 1660)>)
+  Neighbor(link_type='inputlink', label='settings',
+  node=<Dict: uuid: a5a828b8-fdd8-4d75-b674-2e2d62792de0 (pk: 139167)>)
+  Neighbor(link_type='inputlink', label='structure',
+  node=<StructureData: uuid: 3096f83c-6385-48c4-8cb2-24a427ce11b1 (pk: 139001)>)]
 
-	In [4]: c.get_outgoing()
-	Out[4]:
-	[Neighbor(link_type='createlink', label='output_parameters',
-	node=<Dict: uuid: f7a3ca96-4594-497f-a128-9843a1f12f7f (pk: 139257)>),
-	Neighbor(link_type='createlink', label='output_parameters_139257',
-	node=<Dict: uuid: f7a3ca96-4594-497f-a128-9843a1f12f7f (pk: 139257)>),
-	Neighbor(link_type='createlink', label='output_trajectory',
-	node=<TrajectoryData: uuid: 7c5b65bc-22bb-4b87-ac92-e8a78cf145c3 (pk: 139256)>),
-	Neighbor(link_type='createlink', label='output_trajectory_139256',
-	node=<TrajectoryData: uuid: 7c5b65bc-22bb-4b87-ac92-e8a78cf145c3 (pk: 139256)>),
-	Neighbor(link_type='createlink', label='remote_folder',
-	node=<RemoteData: uuid: 17642a1c-8cac-4e7f-8bd0-1dcebe974aa4 (pk: 139169)>),
-	Neighbor(link_type='createlink', label='remote_folder_139169',
-	node=<RemoteData: uuid: 17642a1c-8cac-4e7f-8bd0-1dcebe974aa4 (pk: 139169)>),
-	Neighbor(link_type='createlink', label='retrieved',
-	node=<FolderData: uuid: a9037dc0-3d84-494d-9616-42b8df77083f (pk: 139255)>),
-	Neighbor(link_type='createlink', label='retrieved_139255',
-	node=<FolderData: uuid: a9037dc0-3d84-494d-9616-42b8df77083f (pk: 139255)>)]
+  In [4]: c.get_outgoing()
+  Out[4]:
+  [Neighbor(link_type='createlink', label='output_parameters',
+  node=<Dict: uuid: f7a3ca96-4594-497f-a128-9843a1f12f7f (pk: 139257)>),
+  Neighbor(link_type='createlink', label='output_parameters_139257',
+  node=<Dict: uuid: f7a3ca96-4594-497f-a128-9843a1f12f7f (pk: 139257)>),
+  Neighbor(link_type='createlink', label='output_trajectory',
+  node=<TrajectoryData: uuid: 7c5b65bc-22bb-4b87-ac92-e8a78cf145c3 (pk: 139256)>),
+  Neighbor(link_type='createlink', label='output_trajectory_139256',
+  node=<TrajectoryData: uuid: 7c5b65bc-22bb-4b87-ac92-e8a78cf145c3 (pk: 139256)>),
+  Neighbor(link_type='createlink', label='remote_folder',
+  node=<RemoteData: uuid: 17642a1c-8cac-4e7f-8bd0-1dcebe974aa4 (pk: 139169)>),
+  Neighbor(link_type='createlink', label='remote_folder_139169',
+  node=<RemoteData: uuid: 17642a1c-8cac-4e7f-8bd0-1dcebe974aa4 (pk: 139169)>),
+  Neighbor(link_type='createlink', label='retrieved',
+  node=<FolderData: uuid: a9037dc0-3d84-494d-9616-42b8df77083f (pk: 139255)>),
+  Neighbor(link_type='createlink', label='retrieved_139255',
+  node=<FolderData: uuid: a9037dc0-3d84-494d-9616-42b8df77083f (pk: 139255)>)]
 
 
 *Understanding link names*
@@ -147,75 +147,9 @@ The input/output links of the node can be accessed by the following methods.
 
 - :py:meth:`~aiida.orm.nodes.Node.get_incoming` returns the iterator of input nodes
 
-- :py:meth:`~aiida.orm.nodes.Node.inp` returns a :py:meth:`~aiida.orm.utils.managers.NodeInputManager` object that can be used to access the node's parents.
-
 *Methods to get the output data*
 
 - :py:meth:`~aiida.orm.nodes.Node.get_outgoing` returns the iterator of output nodes.
-
-- :py:meth:`~aiida.orm.nodes.Node.out` returns a :py:meth:`~aiida.orm.utils.managers.NodeOutputManager` object that can be used to access the node's children.
-
-*Navigating in the ``node`` graph*
-
-The user can easily use the :py:meth:`~aiida.orm.utils.managers.NodeInputManager` and the :py:meth:`~aiida.orm.utils.managers.NodeOutputManager` objects of a ``node`` (provided by the :py:meth:`~aiida.orm.nodes.Node.inp` and :py:meth:`~aiida.orm.nodes.Node.out` respectively) to traverse the ``node`` graph and access other connected ``nodes``. :py:meth:`~aiida.orm.nodes.Node.inp` will give us access to the input ``nodes`` and :py:meth:`~aiida.orm.nodes.Node.out` to the output ``nodes``. For example::
-
-	In [1]: # Let's load a node with a specific pk
-
-	In [2]: c = load_node(139168)
-
-	In [3]: c
-	Out[3]: <CpCalculation: uuid: 49084dcf-c708-4422-8bcf-808e4c3382c2 (pk: 139168)>
-
-	In [4]: # Let's traverse the inputs of this node.
-
-	In [5]: # By typing c.inp. we get all the input links
-
-	In [6]: c.inp.
-	c.inp.code                c.inp.parent_calc_folder  c.inp.pseudo_O            c.inp.settings
-	c.inp.parameters          c.inp.pseudo_Ba           c.inp.pseudo_Ti           c.inp.structure
-
-	In [7]: # We may follow any of these links to access other nodes. For example, let's follow the parent_calc_folder
-
-	In [8]: c.inp.parent_calc_folder
-	Out[8]: <RemoteData: uuid: becb4894-c50c-4779-b84f-713772eaceff (pk: 139118)>
-
-	In [9]: # Let's assign to r the node reached by the parent_calc_folder link
-
-	In [10]: r = c.inp.parent_calc_folder
-
-	In [11]: r.inp.__dir__()
-	Out[11]:
-	['__class__',
-	 '__delattr__',
-	 '__dict__',
-	 '__dir__',
-	 '__doc__',
-	 '__format__',
-	 '__getattr__',
-	 '__getattribute__',
-	 '__getitem__',
-	 '__hash__',
-	 '__init__',
-	 '__iter__',
-	 '__module__',
-	 '__new__',
-	 '__reduce__',
-	 '__reduce_ex__',
-	 '__repr__',
-	 '__setattr__',
-	 '__sizeof__',
-	 '__str__',
-	 '__subclasshook__',
-	 '__weakref__',
-	 u'remote_folder']
-
-	In [12]: r.out.
-	r.out.parent_calc_folder         r.out.parent_calc_folder_139168
-
-	In [13]: # By following the same link from node r, you will get node c
-
-	In [14]: r.out.parent_calc_folder
-	Out[14]: <CpCalculation: uuid: 49084dcf-c708-4422-8bcf-808e4c3382c2 (pk: 139168)>
 
 
 Attributes related methods
@@ -321,10 +255,93 @@ Objects of this class correspond to the repository folders. The :py:class:`~aiid
 
 - :py:meth:`~aiida.common.folders.SandboxFolder.__exit__` destroys the folder on exit.
 
+Data
+++++
+
+Navigating inputs and outputs
+*****************************
+- :py:meth:`~aiida.orm.nodes.data.Data.creator` returns 
+  either the CalculationNode that created it or ``None`` if this Data node
+  created by a calculation.
 
 
-Calculation
+ProcessNode
 +++++++++++
+Navigating inputs and outputs
+*****************************
+- :py:meth:`~aiida.orm.nodes.process.ProcessNode.caller` returns 
+  either the caller WorkflowNode or ``None`` if this ProcessNode was not called
+  by a process
+
+CalculationNode
++++++++++++++++
+
+Navigating inputs and outputs
+*****************************
+- :py:meth:`~aiida.orm.nodes.process.calculation.CalculationNode.inputs` returns 
+  a :py:meth:`~aiida.orm.utils.managers.NodeLinksManager` object that can be used 
+  to access the node's incoming INPUT_CALC links.
+
+  The ``NodeLinksManager`` can be used to quickly go from a node to a neighboring node.
+  For example::
+
+    In [1]: # Let's load a node with a specific pk
+
+    In [2]: c = load_node(139168)
+
+    In [3]: c
+    Out[3]: <CpCalculation: uuid: 49084dcf-c708-4422-8bcf-808e4c3382c2 (pk: 139168)>
+
+    In [4]: # Let's traverse the inputs of this node.
+
+    In [5]: # By typing c.inputs.<TAB> we get all the input links
+
+    In [6]: c.inputs.
+    c.inputs.code                c.inputs.parent_calc_folder  c.inputs.pseudo_O            c.inputs.settings
+    c.inputs.parameters          c.inputs.pseudo_Ba           c.inputs.pseudo_Ti           c.inputs.structure
+
+    In [7]: # We may follow any of these links to access other nodes. For example, let's follow the parent_calc_folder
+
+    In [8]: c.inputs.parent_calc_folder
+    Out[8]: <RemoteData: uuid: becb4894-c50c-4779-b84f-713772eaceff (pk: 139118)>
+
+    In [9]: # Let's assign to r the node reached by the parent_calc_folder link
+
+    In [10]: r = c.inputs.parent_calc_folder
+
+    In [11]: r.inputs.__dir__()
+    Out[11]:
+    ['__class__',
+    '__delattr__',
+    '__dict__',
+    '__dir__',
+    '__doc__',
+    '__format__',
+    '__getattr__',
+    '__getattribute__',
+    '__getitem__',
+    '__hash__',
+    '__init__',
+    '__iter__',
+    '__module__',
+    '__new__',
+    '__reduce__',
+    '__reduce_ex__',
+    '__repr__',
+    '__setattr__',
+    '__sizeof__',
+    '__str__',
+    '__subclasshook__',
+    '__weakref__',
+    u'remote_folder']
+
+  The ``.inputs`` manager for ``WorkflowNode`` and the ``.outputs`` manager
+  both for ``CalculationNode`` and ``WorkflowNode`` work in the same way 
+  (see below).
+
+- :py:meth:`~aiida.orm.nodes.process.calculation.CalculationNode.outputs` 
+  returns a :py:meth:`~aiida.orm.utils.managers.NodeLinksManager` object 
+  that can be used to access the node's outgoing CREATE links.
 
 .. _calculation updatable attributes:
 
@@ -335,6 +352,21 @@ However, for a ``Calculation`` to be runnable it needs to be stored, but that wo
 To solve this issue the :py:class:`~aiida.orm.utils.mixins.Sealable` mixin is introduced. This mixin can be used for subclasses of ``Node`` that need to have updatable attributes even after the node has been stored in the database.
 The mixin defines the ``_updatable_attributes`` tuple, which defines the attributes that are considered to be mutable even when the node is stored.
 It also allows the node to be *sealed*, after which even the updatable attributes become immutable.
+
+WorkflowNode
+++++++++++++
+
+Navigating inputs and outputs
+*****************************
+- :py:meth:`~aiida.orm.nodes.process.workflow.WorkflowNode.inputs` returns a 
+  :py:meth:`~aiida.orm.utils.managers.NodeLinksManager` object that can be used to 
+  access the node's incoming INPUT_WORK links.
+
+- :py:meth:`~aiida.orm.nodes.process.workflow.WorkflowNode.outputs` returns a 
+  :py:meth:`~aiida.orm.utils.managers.NodeLinksManager` object that can be used 
+  to access the node's outgoing RETURN links.
+
+
 
 ORM overview
 ++++++++++++

--- a/docs/source/working_with_aiida/resultmanager.rst
+++ b/docs/source/working_with_aiida/resultmanager.rst
@@ -71,43 +71,38 @@ provides a parser.
 
 .. _db_input_output:
 
-Node input and output
-=====================
+Calculations and workflows inputs and outputs
+=============================================
 
-In the following, we will show the methods to access the input and output nodes of a given node.
+In the following, we will show the methods to access the input and output nodes of a given calculation or workflow.
 
 Again, we start by loading a node from the database. Unlike before, this can be any type of node. For example, we can load the node with PK 17::
 
     from aiida.orm import load_node
-    node = load_node(17)
+    calc = load_node(17)
 
-Now, we want to find the nodes which have a direct link to this node. The node has several methods to extract this information: :meth:`get_outgoing() <aiida.orm.nodes.Node.get_outgoing>`, :meth:`get_incoming() <aiida.orm.nodes.Node.get_incoming>`. The most practical way to access this information, especially when working on the ``verdi shell``, is by means of the ``inp`` and ``out`` attributes.
+Now, we want to find the nodes which have a direct input or output link to this node. 
+The node has several methods to extract this information: :meth:`get_outgoing() <aiida.orm.nodes.Node.get_outgoing>`, 
+:meth:`get_incoming() <aiida.orm.nodes.Node.get_incoming>`. 
+The most practical way to access this information for a calculation (or workflow), when limiting solely to 
+``INPUT_CALC`` and ``CREATE`` (or ``INPUT_WORK`` and ``RETURN``, respectively), especially when working on the ``verdi shell``, 
+is by means of the ``.inputs`` and ``.outputs`` attributes.
 
-The ``inp`` attribute can be used to list and access the nodes with a direct link to 
-``node`` in input. The names of the input links can be printed by ``list(node.inp)`` or interactively by ``node.inp. + TAB``. As an example, suppose that ``node`` has an input ``KpointsData`` object under the linkname ``kpoints``. The command
+The ``.inputs`` attribute can be used to list and access the input nodes. 
+The names of the input links can be printed by ``list(calc.inputs)`` 
+or interactively by ``calc.inputs. + TAB``. 
+As an example, suppose that ``calc`` has an input ``KpointsData`` object under the linkname ``kpoints``. The command
 ::
 
-    node.inp.kpoints
+    calc.inputs.kpoints
   
 returns the ``KpointsData`` object.
 
-Similarly the ``out`` attribute can be used to display the names of links in output from ``node`` and access these nodes. Suppose that ``node`` has an output ``FolderData`` with linkname ``retrieved``, then the command
+Similarly the ``.outputs`` attribute can be used to display the outputs of ``calc``. 
+Suppose that ``calc`` has an output ``FolderData`` with linkname ``retrieved``, then the command
 ::
 
-  node.out.retrieved
+  calc.outputs.retrieved
   
 returns the ``FolderData`` object. 
-
-.. note:: 
-    For the input, there can be only one object for a given linkname. In contrast, there can be more than one output object with the same linkname. For example, a code object can be used by several calculations with the same linkname ``code``. For this reason, we append the string ``_pk`` indicating the pk of the output code to the linkname. A linkname without ``_pk`` still exists, and refers to the oldest link. 
-    
-    As an example, imagine that ``node`` is a code, which is used by calculation #18 and #19. The linknames shown by ``node.out`` are
-    ::
-  
-        node.out.  >>
-          * code
-          * code_18
-          * code_19
-    
-    The attributes ``node.out.code_18`` and ``node.out.code_19`` will return two different calculation objects, and ``node.out.code`` will return the older one of the two. 
 


### PR DESCRIPTION
Now:

- CalculationNode have a `.inputs.<LABEL>` property that returns
  a manager to navigate incoming INPUT_CALC nodes
- CalculationNode have a `.outputs.<LABEL>` property that returns
  a manager to navigate outgoing CREATE nodes
- WorkflowNode have a `.inputs.<LABEL>` property that returns
  a manager to navigate incoming INPUT_WORK nodes
- WorkflowNode have a `.outputs.<LABEL>` property that returns
  a manager to navigate outgoing RETURN nodes
- Node *does not have anymore* `.inp` and `.out` as these were
  referring to incoming and outgoing and were ambiguous

Moreover, `Data.created_by` and `ProcessNode.called_by` methods were
already implemented and have been renamed to `Data.creator` and
`ProcessNode.caller`.

Also tests added for all these methods, including the already existing
ones. This fixes #2230.

Moreover, `LinkType` has been added to the classes pre-loaded in 
the shell (fixes #2560), and we now ensure that `get_node_by_label`
raises in case there is more than one matching node with the same label
(fixes #2558).
