### PR TITLE
Redefine the structure of the `CalcInfo.local_copy_list`

### DIFF
--- a/aiida/calculations/plugins/templatereplacer.py
+++ b/aiida/calculations/plugins/templatereplacer.py
@@ -137,7 +137,7 @@ class TemplatereplacerCalculation(CalcJob):
                 raise exceptions.InputValidationError("You are asking to copy a file link {}, "
                                                       "but there is no input link with such a name".format(link_name))
             if isinstance(fileobj, orm.SinglefileData):
-                local_copy_list.append((fileobj.get_file_abs_path(), dest_rel_path))
+                local_copy_list.append((fileobj.uuid, fileobj.filename, dest_rel_path))
             elif isinstance(fileobj, orm.RemoteData):  # can be a folder
                 remote_copy_list.append((fileobj.computer.uuid, fileobj.get_remote_path(), dest_rel_path))
             else:

--- a/aiida/common/datastructures.py
+++ b/aiida/common/datastructures.py
@@ -64,7 +64,7 @@ class CalcInfo(DefaultFieldsAttributeDict):
         ('linkname_from calc to singlefile', 'subclass of singlefile', 'filename')
         Each tuple represents a file that will be retrieved from cluster and saved in SinglefileData nodes
 
-    * local_copy_list: a list of tuples with format ('localabspath', 'relativedestpath')
+    * local_copy_list: a list of tuples with format ('node_uuid', 'filename', relativedestpath')
     * remote_copy_list: a list of tuples with format ('remotemachinename', 'remoteabspath', 'relativedestpath')
     * remote_symlink_list: a list of tuples with format ('remotemachinename', 'remoteabspath', 'relativedestpath')
     * codes_info: a list of dictionaries used to pass the info of the execution of a code

--- a/aiida/engine/processes/calcjobs/calcjob.py
+++ b/aiida/engine/processes/calcjobs/calcjob.py
@@ -374,7 +374,7 @@ class CalcJob(Process):
         this_pk = self.node.pk if self.node.pk is not None else "[UNSTORED]"
         local_copy_list = calcinfo.local_copy_list
         try:
-            validate_list_of_string_tuples(local_copy_list, tuple_length=2)
+            validate_list_of_string_tuples(local_copy_list, tuple_length=3)
         except ValidationError as exc:
             raise PluginInternalError("[presubmission of calc {}] "
                                       "local_copy_list format problem: {}".format(this_pk, exc))

--- a/aiida/orm/nodes/data/singlefile.py
+++ b/aiida/orm/nodes/data/singlefile.py
@@ -36,13 +36,17 @@ class SinglefileData(Data):
         """
         return self.get_attribute('filename')
 
-    def open(self, mode='r'):  # pylint: disable=arguments-differ
+    def open(self, key=None, mode='r'):
         """Return an open file handle to the content of this data node.
 
+        :param key: optional key within the repository, by default is the `filename` set in the attributes
         :param mode: the mode with which to open the file handle
         :return: a file handle in read mode
         """
-        return self._repository.open(self.filename, mode=mode)
+        if key is None:
+            key = self.filename
+
+        return self._repository.open(key, mode=mode)
 
     def get_content(self):
         """Return the content of the single file stored for this data node.

--- a/aiida/orm/nodes/data/upf.py
+++ b/aiida/orm/nodes/data/upf.py
@@ -381,11 +381,11 @@ class UpfData(SinglefileData):
         if self.is_stored:
             return self
 
-        with self.open('r') as handle:
+        with self.open(mode='r') as handle:
             parsed_data = parse_upf(handle)
 
         # Open in binary mode which is required for generating the md5 checksum
-        with self.open('rb') as handle:
+        with self.open(mode='rb') as handle:
             md5 = md5_from_filelike(handle)
 
         try:
@@ -457,11 +457,11 @@ class UpfData(SinglefileData):
 
         super(UpfData, self)._validate()
 
-        with self.open('r') as handle:
+        with self.open(mode='r') as handle:
             parsed_data = parse_upf(handle)
 
         # Open in binary mode which is required for generating the md5 checksum
-        with self.open('rb') as handle:
+        with self.open(mode='rb') as handle:
             md5 = md5_from_filelike(handle)
 
         try:

--- a/aiida/orm/utils/serialize.py
+++ b/aiida/orm/utils/serialize.py
@@ -44,7 +44,7 @@ def represent_node(dumper, node):
     :return: the representation
     """
     if not node.is_stored:
-        raise ValueError("The node must be stored to be able to represent")
+        raise ValueError('node {}<{}> cannot be represented because it is not stored'.format(type(node), node.uuid))
     return dumper.represent_scalar(_NODE_TAG, u'%s' % node.uuid)
 
 
@@ -71,7 +71,7 @@ def represent_group(dumper, group):
     :return: the representation
     """
     if not group.is_stored:
-        raise ValueError("The group must be stored to be able to represent")
+        raise ValueError('group {} cannot be represented because it is not stored'.format(group))
     return dumper.represent_scalar(_GROUP_TAG, u'%s' % group.uuid)
 
 
@@ -98,7 +98,7 @@ def represent_computer(dumper, computer):
     :return: the representation
     """
     if not computer.is_stored:
-        raise ValueError("The computer must be stored to be able to represent")
+        raise ValueError('computer {} cannot be represented because it is not stored'.format(computer))
     return dumper.represent_scalar(_COMPUTER_TAG, u'%s' % computer.uuid)
 
 


### PR DESCRIPTION
Fixes #2573 

With the upcoming change of the node repository, files within it can no
longer be assumed to necessarily be stored on the local file system. It
is therefore impossible to address files within it through an absolute
file path, however, that is exactly what the `local_copy_list` expects
as the first item of its tuples.

Now, the `Node` class only exposes methods to get either the content of
a repository file or an filelike object. To comply with this change in
design the structure of the `local_copy_list` tuples is changed to
tuples of length three where each element represents:

 * UUID of the node
 * Relative key of the file within the node repository
 * Relative path within the working directory where to copy the file

The `upload_calculation` function of the execmanager has been updated to
this interface change, but because our `Transport` interface does not
yet provide a method to put an object from a filelike object, we have to
create a temporary file on the local file system whose absolute filepath
can be passed to the `Transport.put` call. Once the transport is updated
to provide a `put_object_from_filelike`, this inefficiency can be removed.