### PR TITLE
Allow the definition of `None` as default in process functions

### DIFF
--- a/aiida/engine/processes/functions.py
+++ b/aiida/engine/processes/functions.py
@@ -192,10 +192,19 @@ class FunctionProcess(Process):
                 if i >= first_default_pos:
                     default = defaults[i - first_default_pos]
 
+                # If the keyword was already specified, simply override the default
                 if spec.has_input(arg):
                     spec.inputs[arg].default = default
                 else:
-                    spec.input(arg, valid_type=orm.Data, default=default)
+                    # If the default is `None` make sure that the port also accepts a `NoneType`
+                    # Note that we cannot use `None` because the validation will call `isinstance` which does not work
+                    # when passing `None`, but it does work with `NoneType` which is returned by calling `type(None)`
+                    if default is None:
+                        valid_type = (orm.Data, type(None))
+                    else:
+                        valid_type = (orm.Data,)
+
+                    spec.input(arg, valid_type=valid_type, default=default)
 
             # If the function support kwargs then allow dynamic inputs, otherwise disallow
             spec.inputs.dynamic = keywords is not None

--- a/aiida/engine/processes/process.py
+++ b/aiida/engine/processes/process.py
@@ -588,6 +588,10 @@ class Process(plumpy.Process):
 
         for name, node in self._flat_inputs().items():
 
+            # Certain processes allow to specify ports with `None` as acceptable values
+            if node is None:
+                continue
+
             # Special exception: set computer if node is a remote Code and our node does not yet have a computer set
             if isinstance(node, Code) and not node.is_local() and not self.node.computer:
                 self.node.computer = node.get_remote_computer()


### PR DESCRIPTION
Fixes #1210 

It was impossible to define a process function with a keyword argument
that had `None` as default, because the dynamically created ports always
only specified `orm.Data` as valid types. So the validation of the
default value would fail during the spec definition. Here we detect if
`None` is passed as the default in the function signature, in which case
we define the tuple of `orm.Data` and `type(None)` to be a valid type.
Note that we need to use `type(None)` because the port validation later
on will call `isinstance(input, valid_types)` which will not work if one
of the values in `valid_types` is simply `None`.

The `Process._setup_inputs` had to be adjusted to skip values of `None`
because they cannot be linked to obviously but they can now potentially
be passed as inputs to a `Process`.