### PR TITLE
Fix bug in templatereplacer input check

### DIFF
--- a/aiida/calculations/plugins/templatereplacer.py
+++ b/aiida/calculations/plugins/templatereplacer.py
@@ -174,7 +174,7 @@ class TemplatereplacerCalculation(CalcJob):
         codeinfo = CodeInfo()
         codeinfo.cmdline_params = cmdline_params
 
-        if input_through_stdin is not None:
+        if input_through_stdin:
             codeinfo.stdin_name = input_file_name
 
         if output_file_name:


### PR DESCRIPTION
`input_through_stdin` was not honoured correctly in `templatereplacer` (it was always a boolean, and so in the line above it was always entering the `if` block.