### PR TITLE
Add unit tests for super call check in `Process.define`

### DIFF
--- a/aiida/backends/tests/engine/test_calc_job.py
+++ b/aiida/backends/tests/engine/test_calc_job.py
@@ -43,3 +43,19 @@ class TestCalcJob(AiidaTestCase):
 
         with self.assertRaises(exceptions.InvalidOperation):
             launch.submit(CalcJob)
+
+    def test_define_not_calling_super(self):
+        """A `CalcJob` that does not call super in `define` classmethod should raise."""
+
+        class IncompleteDefineCalcJob(CalcJob):
+            """Test class with incomplete define method"""
+
+            @classmethod
+            def define(cls, spec):
+                pass
+
+            def prepare_for_submission(self, folder):
+                pass
+
+        with self.assertRaises(AssertionError):
+            launch.run(IncompleteDefineCalcJob)

--- a/aiida/backends/tests/engine/test_work_chain.py
+++ b/aiida/backends/tests/engine/test_work_chain.py
@@ -353,6 +353,18 @@ class TestWorkchain(AiidaTestCase):
         with self.assertRaises(TypeError):
             Wf.spec()
 
+    def test_define_not_calling_super(self):
+        """A `WorkChain` that does not call super in `define` classmethod should raise."""
+
+        class IncompleteDefineWorkChain(WorkChain):
+
+            @classmethod
+            def define(cls, spec):
+                pass
+
+        with self.assertRaises(AssertionError):
+            launch.run(IncompleteDefineWorkChain)
+
     def test_same_input_node(self):
 
         class Wf(WorkChain):


### PR DESCRIPTION
Fixes #1707

Sub classes of `Process` such as `CalcJob` and `WorkChain` will
themselves be sub classed by users and they will have to implement the
`define` classmethod. It is crucial that the `super` is called here or
the instance will not work. To ensure this, there is a check in the
`Process.spec` class method, which verifies that the spec is set, which
indirectly means the `define` of the base class is called. This commit
adds two unit tests for `WorkChain` and `CalcJob` to make sure the
engine throws an `AssertionError` otherwise.