### PR TITLE
Make `Port.non_db` attribute inheritable from `PortNamespace`

### DIFF
--- a/aiida/backends/tests/__init__.py
+++ b/aiida/backends/tests/__init__.py
@@ -84,6 +84,7 @@ db_test_list = {
         'engine.futures': ['aiida.backends.tests.engine.test_futures'],
         'engine.launch': ['aiida.backends.tests.engine.test_launch'],
         'engine.persistence': ['aiida.backends.tests.engine.test_persistence'],
+        'engine.ports': ['aiida.backends.tests.engine.test_ports'],
         'engine.process': ['aiida.backends.tests.engine.test_process'],
         'engine.process_builder': ['aiida.backends.tests.engine.test_process_builder'],
         'engine.process_function': ['aiida.backends.tests.engine.test_process_function'],

--- a/aiida/backends/tests/engine/test_ports.py
+++ b/aiida/backends/tests/engine/test_ports.py
@@ -1,0 +1,66 @@
+# -*- coding: utf-8 -*-
+###########################################################################
+# Copyright (c), The AiiDA team. All rights reserved.                     #
+# This file is part of the AiiDA code.                                    #
+#                                                                         #
+# The code is hosted on GitHub at https://github.com/aiidateam/aiida_core #
+# For further information on the license, see the LICENSE.txt file        #
+# For further information please visit http://www.aiida.net               #
+###########################################################################
+"""Tests for process spec ports."""
+from __future__ import division
+from __future__ import print_function
+from __future__ import absolute_import
+
+from aiida.backends.testbase import AiidaTestCase
+from aiida.engine.processes.ports import InputPort, PortNamespace
+
+
+class TestInputPort(AiidaTestCase):
+    """Tests for the `InputPort` class."""
+
+    def test_with_non_db(self):
+        """Test the functionality of the `non_db` attribute upon construction and setting."""
+
+        # When not specifying, it should get the default value and `non_db_explicitly_set` should be `False`
+        port = InputPort('port')
+        self.assertEqual(port.non_db, False)
+        self.assertEqual(port.non_db_explicitly_set, False)
+
+        # Using the setter to change the value should toggle both properties
+        port.non_db = True
+        self.assertEqual(port.non_db, True)
+        self.assertEqual(port.non_db_explicitly_set, True)
+
+        # Explicitly setting to `False` upon construction
+        port = InputPort('port', non_db=False)
+        self.assertEqual(port.non_db, False)
+        self.assertEqual(port.non_db_explicitly_set, True)
+
+        # Explicitly setting to `True` upon construction
+        port = InputPort('port', non_db=True)
+        self.assertEqual(port.non_db, True)
+        self.assertEqual(port.non_db_explicitly_set, True)
+
+
+class TestPortNamespace(AiidaTestCase):
+    """Tests for the `PortNamespace` class."""
+
+    def test_with_non_db(self):
+        """Ports inserted to a `PortNamespace` should inherit the `non_db` attribute if not explicitly set."""
+        namespace_non_db = True
+        port_namespace = PortNamespace('namespace', non_db=namespace_non_db)
+
+        # When explicitly set upon port construction, value should not be inherited even when different
+        port = InputPort('storable', non_db=False)
+        port_namespace['storable'] = port
+        self.assertEqual(port.non_db, False)
+
+        port = InputPort('not_storable', non_db=True)
+        port_namespace['not_storable'] = port
+        self.assertEqual(port.non_db, True)
+
+        # If not explicitly defined, it should inherit from parent namespace
+        port = InputPort('not_storable')
+        port_namespace['not_storable'] = port
+        self.assertEqual(port.non_db, namespace_non_db)

--- a/aiida/engine/processes/calcjobs/calcjob.py
+++ b/aiida/engine/processes/calcjobs/calcjob.py
@@ -31,7 +31,7 @@ class CalcJob(Process):
     """Implementation of the CalcJob process."""
 
     _node_class = orm.CalcJobNode
-    _spec_type = CalcJobProcessSpec
+    _spec_class = CalcJobProcessSpec
     link_label_retrieved = 'retrieved'
 
     def __init__(self, *args, **kwargs):
@@ -54,45 +54,45 @@ class CalcJob(Process):
             help='Filename to which the content of stdout of the scheduler will be written.')
         spec.input('metadata.options.scheduler_stderr', valid_type=six.string_types, default='_scheduler-stderr.txt',
             help='Filename to which the content of stderr of the scheduler will be written.')
-        spec.input('metadata.options.resources', valid_type=dict, non_db=True, required=True,
+        spec.input('metadata.options.resources', valid_type=dict, required=True,
             help='Set the dictionary of resources to be used by the scheduler plugin, like the number of nodes, '
                  'cpus etc. This dictionary is scheduler-plugin dependent. Look at the documentation of the '
                  'scheduler for more details.')
-        spec.input('metadata.options.max_wallclock_seconds', valid_type=int, non_db=True, required=False,
+        spec.input('metadata.options.max_wallclock_seconds', valid_type=int, required=False,
             help='Set the wallclock in seconds asked to the scheduler')
-        spec.input('metadata.options.custom_scheduler_commands', valid_type=six.string_types, non_db=True, default='',
+        spec.input('metadata.options.custom_scheduler_commands', valid_type=six.string_types, default='',
             help='Set a (possibly multiline) string with the commands that the user wants to manually set for the '
                  'scheduler. The difference of this option with respect to the `prepend_text` is the position in '
                  'the scheduler submission file where such text is inserted: with this option, the string is '
                  'inserted before any non-scheduler command')
-        spec.input('metadata.options.queue_name', valid_type=six.string_types, non_db=True, required=False,
+        spec.input('metadata.options.queue_name', valid_type=six.string_types, required=False,
             help='Set the name of the queue on the remote computer')
-        spec.input('metadata.options.account', valid_type=six.string_types, non_db=True, required=False,
+        spec.input('metadata.options.account', valid_type=six.string_types, required=False,
             help='Set the account to use in for the queue on the remote computer')
-        spec.input('metadata.options.qos', valid_type=six.string_types, non_db=True, required=False,
+        spec.input('metadata.options.qos', valid_type=six.string_types, required=False,
             help='Set the quality of service to use in for the queue on the remote computer')
-        spec.input('metadata.options.computer', valid_type=orm.Computer, non_db=True, required=False,
+        spec.input('metadata.options.computer', valid_type=orm.Computer, required=False,
             help='Set the computer to be used by the calculation')
-        spec.input('metadata.options.withmpi', valid_type=bool, non_db=True, default=True,
+        spec.input('metadata.options.withmpi', valid_type=bool, default=True,
             help='Set the calculation to use mpi',)
-        spec.input('metadata.options.mpirun_extra_params', valid_type=(list, tuple), non_db=True, default=[],
+        spec.input('metadata.options.mpirun_extra_params', valid_type=(list, tuple), default=[],
             help='Set the extra params to pass to the mpirun (or equivalent) command after the one provided in '
                  'computer.mpirun_command. Example: mpirun -np 8 extra_params[0] extra_params[1] ... exec.x',)
-        spec.input('metadata.options.import_sys_environment', valid_type=bool, non_db=True, default=True,
+        spec.input('metadata.options.import_sys_environment', valid_type=bool, default=True,
             help='If set to true, the submission script will load the system environment variables',)
-        spec.input('metadata.options.environment_variables', valid_type=dict, non_db=True, default={},
+        spec.input('metadata.options.environment_variables', valid_type=dict, default={},
             help='Set a dictionary of custom environment variables for this calculation',)
-        spec.input('metadata.options.priority', valid_type=six.string_types[0], non_db=True, required=False,
+        spec.input('metadata.options.priority', valid_type=six.string_types[0], required=False,
             help='Set the priority of the job to be queued')
-        spec.input('metadata.options.max_memory_kb', valid_type=int, non_db=True, required=False,
+        spec.input('metadata.options.max_memory_kb', valid_type=int, required=False,
             help='Set the maximum memory (in KiloBytes) to be asked to the scheduler')
-        spec.input('metadata.options.prepend_text', valid_type=six.string_types[0], non_db=True, default='',
+        spec.input('metadata.options.prepend_text', valid_type=six.string_types[0], default='',
             help='Set the calculation-specific prepend text, which is going to be prepended in the scheduler-job '
                  'script, just before the code execution',)
-        spec.input('metadata.options.append_text', valid_type=six.string_types[0], non_db=True, default='',
+        spec.input('metadata.options.append_text', valid_type=six.string_types[0], default='',
             help='Set the calculation-specific append text, which is going to be appended in the scheduler-job '
                  'script, just after the code execution',)
-        spec.input('metadata.options.parser_name', valid_type=six.string_types[0], non_db=True, required=False,
+        spec.input('metadata.options.parser_name', valid_type=six.string_types[0], required=False,
             help='Set a string for the output parser. Can be None if no output plugin is available or needed')
 
         spec.output('remote_folder', valid_type=orm.RemoteData,

--- a/aiida/engine/processes/process.py
+++ b/aiida/engine/processes/process.py
@@ -54,7 +54,7 @@ class Process(plumpy.Process):
     # pylint: disable=too-many-public-methods
 
     _node_class = ProcessNode
-    _spec_type = ProcessSpec
+    _spec_class = ProcessSpec
 
     SINGLE_OUTPUT_LINKNAME = 'result'
 
@@ -68,12 +68,11 @@ class Process(plumpy.Process):
     @classmethod
     def define(cls, spec):
         super(Process, cls).define(spec)
-        spec.input_namespace(spec.metadata_key, required=False, non_db=True, default={})
+        spec.input_namespace(spec.metadata_key, required=False, non_db=True)
         spec.input_namespace('{}.{}'.format(spec.metadata_key, spec.options_key), required=False)
-        spec.input('{}.store_provenance'.format(spec.metadata_key), valid_type=bool, default=True, non_db=True)
-        spec.input(
-            '{}.description'.format(spec.metadata_key), valid_type=six.string_types[0], required=False, non_db=True)
-        spec.input('{}.label'.format(spec.metadata_key), valid_type=six.string_types[0], required=False, non_db=True)
+        spec.input('{}.store_provenance'.format(spec.metadata_key), valid_type=bool, default=True)
+        spec.input('{}.description'.format(spec.metadata_key), valid_type=six.string_types[0], required=False)
+        spec.input('{}.label'.format(spec.metadata_key), valid_type=six.string_types[0], required=False)
         spec.inputs.valid_type = (orm.Data,)
         spec.outputs.valid_type = (orm.Data,)
 

--- a/aiida/engine/processes/workchains/workchain.py
+++ b/aiida/engine/processes/workchains/workchain.py
@@ -44,7 +44,7 @@ class WorkChain(Process):
     A WorkChain, the base class for AiiDA workflows.
     """
     _node_class = WorkChainNode
-    _spec_type = WorkChainSpec
+    _spec_class = WorkChainSpec
     _STEPPER_STATE = 'stepper_state'
     _CONTEXT = 'CONTEXT'
 

--- a/docs/requirements_for_rtd.txt
+++ b/docs/requirements_for_rtd.txt
@@ -46,7 +46,7 @@ pathlib2; python_version<'3.5'
 pg8000<1.13.0
 pgtest==1.1.0
 pika==1.0.0b1
-plumpy==0.12.1
+plumpy==0.12.2
 psutil==5.5.1
 pyblake2==1.1.2; python_version<'3.6'
 pymatgen<=2018.12.12

--- a/environment.yml
+++ b/environment.yml
@@ -36,7 +36,7 @@ dependencies:
 - paramiko==2.4.2
 - ecdsa==0.13
 - ipython>=4.0,<6.0
-- plumpy==0.12.1
+- plumpy==0.12.2
 - kiwipy[rmq]==0.4.2
 - pika==1.0.0b1
 - circus==0.15.0

--- a/setup.json
+++ b/setup.json
@@ -47,7 +47,7 @@
     "paramiko==2.4.2",
     "ecdsa==0.13",
     "ipython>=4.0,<6.0",
-    "plumpy==0.12.1",
+    "plumpy==0.12.2",
     "kiwipy[rmq]==0.4.2",
     "pika==1.0.0b1",
     "circus==0.15.0",


### PR DESCRIPTION
Fixes #2598 

If the `non_db` attribute is not explicitly defined, either upon
construction or through the setter, the value will inherited from the
namespace to which the port is added. This removes the requirement to
specify `non_db=True` for every port explicitly if the parent namespace
is already marked as non storable as well.