### PR TITLE
Add type check in the `PortNamespace.serialize` method

### DIFF
--- a/aiida/backends/tests/engine/test_calc_job.py
+++ b/aiida/backends/tests/engine/test_calc_job.py
@@ -11,6 +11,8 @@
 from __future__ import division
 from __future__ import print_function
 from __future__ import absolute_import
+
+from aiida import orm
 from aiida.backends.testbase import AiidaTestCase
 from aiida.common import exceptions
 from aiida.engine import launch, CalcJob, Process
@@ -18,6 +20,11 @@ from aiida.engine import launch, CalcJob, Process
 
 class TestCalcJob(AiidaTestCase):
     """Test for the `CalcJob` process sub class."""
+
+    @classmethod
+    def setUpClass(cls, *args, **kwargs):
+        super(TestCalcJob, cls).setUpClass(*args, **kwargs)
+        cls.code = orm.Code(remote_computer_exec=(cls.computer, '/bin/true')).store()
 
     def setUp(self):
         super(TestCalcJob, self).setUp()
@@ -59,3 +66,20 @@ class TestCalcJob(AiidaTestCase):
 
         with self.assertRaises(AssertionError):
             launch.run(IncompleteDefineCalcJob)
+
+    def test_invalid_options_type(self):
+        """Verify that passing an invalid type to `metadata.options` raises a `TypeError`."""
+
+        class SimpleCalcJob(CalcJob):
+            """Simple `CalcJob` implementation"""
+
+            @classmethod
+            def define(cls, spec):
+                super(SimpleCalcJob, cls).define(spec)
+
+            def prepare_for_submission(self, folder):
+                pass
+
+        # The `metadata.options` input expects a plain dict and not a node `Dict`
+        with self.assertRaises(TypeError):
+            launch.run(SimpleCalcJob, code=self.code, metadata={'options': orm.Dict(dict={'a': 1})})

--- a/aiida/engine/launch.py
+++ b/aiida/engine/launch.py
@@ -13,8 +13,8 @@ from __future__ import print_function
 from __future__ import absolute_import
 
 from aiida.manage import manager
-from .processes.process import Process, instantiate_process
-from .utils import is_process_function
+from .processes.process import Process
+from .utils import is_process_function, instantiate_process
 
 __all__ = ('run', 'run_get_pid', 'run_get_node', 'submit')
 

--- a/aiida/engine/processes/__init__.py
+++ b/aiida/engine/processes/__init__.py
@@ -13,10 +13,12 @@ from __future__ import division
 from __future__ import print_function
 from __future__ import absolute_import
 
+from .builder import *
 from .calcjobs import *
 from .exit_code import *
 from .functions import *
 from .process import *
 from .workchains import *
 
-__all__ = (calcjobs.__all__ + exit_code.__all__ + functions.__all__ + process.__all__ + workchains.__all__)
+__all__ = (
+    builder.__all__ + calcjobs.__all__ + exit_code.__all__ + functions.__all__ + process.__all__ + workchains.__all__)

--- a/aiida/engine/processes/ports.py
+++ b/aiida/engine/processes/ports.py
@@ -12,6 +12,7 @@ from __future__ import division
 from __future__ import print_function
 from __future__ import absolute_import
 
+from collections import Mapping
 from plumpy import ports
 
 
@@ -105,8 +106,12 @@ class PortNamespace(WithNonDb, ports.PortNamespace):
         :param mapping: a mapping of values to be serialized
         :returns: the serialized mapping
         """
+        from aiida.common.lang import type_check
+
         if mapping is None:
             return None
+
+        type_check(mapping, Mapping)
 
         result = {}
 

--- a/aiida/engine/processes/process.py
+++ b/aiida/engine/processes/process.py
@@ -7,7 +7,6 @@
 # For further information on the license, see the LICENSE.txt file        #
 # For further information please visit http://www.aiida.net               #
 ###########################################################################
-# pylint: disable=cyclic-import
 """The AiiDA process class"""
 from __future__ import division
 from __future__ import print_function
@@ -43,40 +42,6 @@ from .ports import InputPort, PortNamespace
 from .process_spec import ProcessSpec
 
 __all__ = ('Process', 'ProcessState')
-
-
-def instantiate_process(runner, process, *args, **inputs):
-    """
-    Return an instance of the process with the given inputs. The function can deal with various types
-    of the `process`:
-
-        * Process instance: will simply return the instance
-        * ProcessBuilder instance: will instantiate the Process from the class and inputs defined within it
-        * Process class: will instantiate with the specified inputs
-
-    If anything else is passed, a ValueError will be raised
-
-    :param process: Process instance or class, CalcJobNode class or ProcessBuilder instance
-    :param inputs: the inputs for the process to be instantiated with
-    """
-    if isinstance(process, Process):
-        assert not args
-        assert not inputs
-        assert runner is process.runner
-        return process
-
-    if isinstance(process, ProcessBuilder):
-        builder = process
-        process_class = builder.process_class
-        inputs.update(**builder)
-    elif issubclass(process, Process):
-        process_class = process
-    else:
-        raise ValueError('invalid process {}, needs to be Process or ProcessBuilder'.format(type(process)))
-
-    process = process_class(runner=runner, inputs=inputs)
-
-    return process
 
 
 @plumpy.auto_persist('_parent_pid', '_enable_persistence')

--- a/aiida/engine/runners.py
+++ b/aiida/engine/runners.py
@@ -21,8 +21,8 @@ import plumpy
 
 from aiida.orm import load_node
 from .processes import futures
-from .processes.process import instantiate_process
 from .processes.calcjobs import manager
+from .utils import instantiate_process
 from . import transports
 from . import utils
 


### PR DESCRIPTION
Fixes #2578 

The serialization is called before the input validation, because the
type of the input might not be correct before serialization. This means
however that if a wrong value is passed for an input port, for example
the user by accident passes a `orm.Dict` instance to `metadata.options`
for a `CalcJob` instead of a plain dict, cryptic messages can be thrown
because the `serialize` method will assume the passed value is iterable.
To prevent this we add an explicit type check before serializing the
port value.