### PR TITLE
Add suggestion to run `verdi status` in installation documentation

### DIFF
--- a/docs/source/install/quick_installation.rst
+++ b/docs/source/install/quick_installation.rst
@@ -83,13 +83,25 @@ After completing the setup, your newly created profile should show up in the lis
 
 .. code-block:: bash
 
-    $ verdi profile list
+    verdi profile list
 
     Info: configuration folder: /path.to/.aiida
     Info: default profile is highlighted and marked by the * symbol
     * coding_day
 
-Time to :ref:`get started<get_started>`!
+To make sure all the required resources such as the database and RabbitMQ are up and running, you can run the following command:
+
+.. code-block:: bash
+
+    verdi status
+
+     ✓ profile:     On profile django
+     ✓ repository:  /repo/aiida_dev/django
+     ✓ postgres:    Connected to aiida@localhost:5432
+     ✓ rabbitmq:    Connected to amqp://127.0.0.1?heartbeat=600
+     ✓ daemon:      Daemon is running as PID 2809 since 2019-03-15 16:27:52
+
+If everything is up and running, it is time to :ref:`get started<get_started>`!
 
 If the quick installation failed at any point, please refer 
 to the :ref:`full installation guide<installation>` for more details 

--- a/docs/source/install/troubleshooting.rst
+++ b/docs/source/install/troubleshooting.rst
@@ -3,6 +3,21 @@
 Troubleshooting
 ===============
 
+If you experience any problems, first check that all services are up and running:
+
+.. code-block:: bash
+
+    verdi status
+
+     ✓ profile:     On profile django
+     ✓ repository:  /repo/aiida_dev/django
+     ✓ postgres:    Connected to aiida@localhost:5432
+     ✓ rabbitmq:    Connected to amqp://127.0.0.1?heartbeat=600
+     ✓ daemon:      Daemon is running as PID 2809 since 2019-03-15 16:27:52
+
+In the example output, all service have a green check mark and so should be running as expected.
+If all services are up and running and you are still experiencing problems, consider the commonly encountered problems below.
+
 Installation phase
 ------------------
 


### PR DESCRIPTION
Fixes #1646 

Also added it to the beginning of the troubleshooting section. This
should help with people that try to install `aiida-core` without having
any of the required services such as RabbitMQ and PostgresQL.