### PR TITLE
Rename `aiida.engine.run_get_pid` to `aiida.engine.run_get_pk`

### DIFF
--- a/aiida/backends/tests/engine/test_calc_job.py
+++ b/aiida/backends/tests/engine/test_calc_job.py
@@ -46,7 +46,7 @@ class TestCalcJob(AiidaTestCase):
             launch.run_get_node(CalcJob)
 
         with self.assertRaises(exceptions.InvalidOperation):
-            launch.run_get_pid(CalcJob)
+            launch.run_get_pk(CalcJob)
 
         with self.assertRaises(exceptions.InvalidOperation):
             launch.submit(CalcJob)

--- a/aiida/backends/tests/engine/test_launch.py
+++ b/aiida/backends/tests/engine/test_launch.py
@@ -12,7 +12,7 @@ from __future__ import print_function
 from __future__ import absolute_import
 
 from aiida.backends.testbase import AiidaTestCase
-from aiida.engine import run, run_get_node, run_get_pid, Process, WorkChain, calcfunction
+from aiida.engine import run, run_get_node, run_get_pk, Process, WorkChain, calcfunction
 from aiida.orm import Int, WorkChainNode, CalcFunctionNode
 
 
@@ -57,10 +57,10 @@ class TestLaunchers(AiidaTestCase):
         self.assertEquals(result, self.result)
         self.assertTrue(isinstance(node, CalcFunctionNode))
 
-    def test_calcfunction_run_get_pid(self):
-        result, pid = run_get_pid(add, a=self.a, b=self.b)
+    def test_calcfunction_run_get_pk(self):
+        result, pk = run_get_pk(add, a=self.a, b=self.b)
         self.assertEquals(result, self.result)
-        self.assertTrue(isinstance(pid, int))
+        self.assertTrue(isinstance(pk, int))
 
     def test_workchain_run(self):
         result = run(AddWorkChain, a=self.a, b=self.b)
@@ -71,10 +71,10 @@ class TestLaunchers(AiidaTestCase):
         self.assertEquals(result['result'], self.result)
         self.assertTrue(isinstance(node, WorkChainNode))
 
-    def test_workchain_run_get_pid(self):
-        result, pid = run_get_pid(AddWorkChain, a=self.a, b=self.b)
+    def test_workchain_run_get_pk(self):
+        result, pk = run_get_pk(AddWorkChain, a=self.a, b=self.b)
         self.assertEquals(result['result'], self.result)
-        self.assertTrue(isinstance(pid, int))
+        self.assertTrue(isinstance(pk, int))
 
     def test_workchain_builder_run(self):
         builder = AddWorkChain.get_builder()
@@ -91,10 +91,10 @@ class TestLaunchers(AiidaTestCase):
         self.assertEquals(result['result'], self.result)
         self.assertTrue(isinstance(node, WorkChainNode))
 
-    def test_workchain_builder_run_get_pid(self):
+    def test_workchain_builder_run_get_pk(self):
         builder = AddWorkChain.get_builder()
         builder.a = self.a
         builder.b = self.b
-        result, pid = run_get_pid(builder)
+        result, pk = run_get_pk(builder)
         self.assertEquals(result['result'], self.result)
-        self.assertTrue(isinstance(pid, int))
+        self.assertTrue(isinstance(pk, int))

--- a/aiida/backends/tests/engine/test_process.py
+++ b/aiida/backends/tests/engine/test_process.py
@@ -18,7 +18,7 @@ from plumpy.utils import AttributesFrozendict
 from aiida.backends.testbase import AiidaTestCase
 from aiida.backends.tests.utils import processes as test_processes
 from aiida.common.lang import override
-from aiida.engine import Process, run, run_get_pid
+from aiida.engine import Process, run, run_get_pk
 from aiida.orm import load_node, Dict, Int, Str, WorkflowNode
 
 
@@ -123,8 +123,8 @@ class TestProcess(AiidaTestCase):
         run(test_processes.DummyProcess)
 
     def test_seal(self):
-        pid = run_get_pid(test_processes.DummyProcess).pid
-        self.assertTrue(load_node(pk=pid).is_sealed)
+        result, pk = run_get_pk(test_processes.DummyProcess)
+        self.assertTrue(load_node(pk=pk).is_sealed)
 
     def test_description(self):
         dp = test_processes.DummyProcess(inputs={'metadata': {'description': "Rockin' process"}})

--- a/aiida/backends/tests/engine/test_work_chain.py
+++ b/aiida/backends/tests/engine/test_work_chain.py
@@ -308,7 +308,7 @@ class TestWorkchain(AiidaTestCase):
             launch.run_get_node(WorkChain)
 
         with self.assertRaises(exceptions.InvalidOperation):
-            launch.run_get_pid(WorkChain)
+            launch.run_get_pk(WorkChain)
 
         with self.assertRaises(exceptions.InvalidOperation):
             launch.submit(WorkChain)

--- a/aiida/engine/launch.py
+++ b/aiida/engine/launch.py
@@ -16,13 +16,11 @@ from aiida.manage import manager
 from .processes.process import Process
 from .utils import is_process_function, instantiate_process
 
-__all__ = ('run', 'run_get_pid', 'run_get_node', 'submit')
+__all__ = ('run', 'run_get_pk', 'run_get_node', 'submit')
 
 
 def run(process, *args, **inputs):
-    """
-    Run the process with the supplied inputs in a local runner that will block until the process is completed.
-    The return value will be the results of the completed process
+    """Run the process with the supplied inputs in a local runner that will block until the process is completed.
 
     :param process: the process class or process function to run
     :param inputs: the inputs to be passed to the process
@@ -37,13 +35,11 @@ def run(process, *args, **inputs):
 
 
 def run_get_node(process, *args, **inputs):
-    """
-    Run the process with the supplied inputs in a local runner that will block until the process is completed.
-    The return value will be the results of the completed process
+    """Run the process with the supplied inputs in a local runner that will block until the process is completed.
 
     :param process: the process class or process function to run
     :param inputs: the inputs to be passed to the process
-    :return: tuple of the outputs of the process and the calculation node
+    :return: tuple of the outputs of the process and the process node
     """
     if isinstance(process, Process):
         runner = process.runner
@@ -53,27 +49,23 @@ def run_get_node(process, *args, **inputs):
     return runner.run_get_node(process, *args, **inputs)
 
 
-def run_get_pid(process, *args, **inputs):
-    """
-    Run the process with the supplied inputs in a local runner that will block until the process is completed.
-    The return value will be the results of the completed process
+def run_get_pk(process, *args, **inputs):
+    """Run the process with the supplied inputs in a local runner that will block until the process is completed.
 
     :param process: the process class or process function to run
     :param inputs: the inputs to be passed to the process
-    :return: tuple of the outputs of the process and process pid
+    :return: tuple of the outputs of the process and process node pk
     """
     if isinstance(process, Process):
         runner = process.runner
     else:
         runner = manager.get_manager().get_runner()
 
-    return runner.run_get_pid(process, *args, **inputs)
+    return runner.run_get_pk(process, *args, **inputs)
 
 
 def submit(process, **inputs):
-    """
-    Submit the process with the supplied inputs to the daemon runners immediately returning control to
-    the interpreter. The return value will be the calculation node of the submitted process.
+    """Submit the process with the supplied inputs to the daemon immediately returning control to the interpreter.
 
     :param process: the process class to submit
     :param inputs: the inputs to be passed to the process
@@ -94,6 +86,6 @@ def submit(process, **inputs):
     return process.node
 
 
-# Allow one to also use run.get_node and run.get_pid as a shortcut, without having to import the functions themselves
+# Allow one to also use run.get_node and run.get_pk as a shortcut, without having to import the functions themselves
 run.get_node = run_get_node
-run.get_pid = run_get_pid
+run.get_pk = run_get_pk

--- a/aiida/engine/runners.py
+++ b/aiida/engine/runners.py
@@ -31,7 +31,7 @@ __all__ = ('Runner',)
 LOGGER = logging.getLogger(__name__)
 
 ResultAndNode = namedtuple('ResultAndNode', ['result', 'node'])
-ResultAndPid = namedtuple('ResultAndPid', ['result', 'pid'])
+ResultAndPk = namedtuple('ResultAndPk', ['result', 'pk'])
 
 
 class Runner(object):  # pylint: disable=useless-object-inheritance
@@ -218,17 +218,17 @@ class Runner(object):  # pylint: disable=useless-object-inheritance
         result, node = self._run(process, *args, **inputs)
         return ResultAndNode(result, node)
 
-    def run_get_pid(self, process, *args, **inputs):
+    def run_get_pk(self, process, *args, **inputs):
         """
         Run the process with the supplied inputs in this runner that will block until the process is completed.
         The return value will be the results of the completed process
 
         :param process: the process class or process function to run
         :param inputs: the inputs to be passed to the process
-        :return: tuple of the outputs of the process and process pid
+        :return: tuple of the outputs of the process and process node pk
         """
         result, node = self._run(process, *args, **inputs)
-        return ResultAndPid(result, node.pk)
+        return ResultAndPk(result, node.pk)
 
     def call_on_calculation_finish(self, pk, callback):
         """


### PR DESCRIPTION
Fixes #2612 

What is actually returned is the node pk, which just so happens to also
be used as the pid for the process, but that is not what the user would
use the value for, so `pk` is clearer than `pid`.