### PR TITLE
Fig bug for process functions allowing kwargs

### DIFF
--- a/aiida/backends/tests/engine/test_process_function.py
+++ b/aiida/backends/tests/engine/test_process_function.py
@@ -200,13 +200,22 @@ class TestProcessFunction(AiidaTestCase):
         """Simple process function that defines keyword arguments."""
         kwargs = {'data_a': orm.Int(DEFAULT_INT)}
 
-        result = self.function_kwargs()
+        result, node = self.function_kwargs.run_get_node()
         self.assertTrue(isinstance(result, dict))
+        self.assertEqual(len(node.get_incoming().all()), 0)
         self.assertEqual(result, {})
 
-        result = self.function_kwargs(**kwargs)
+        result, node = self.function_kwargs.run_get_node(**kwargs)
         self.assertTrue(isinstance(result, dict))
+        self.assertEqual(len(node.get_incoming().all()), 1)
         self.assertEqual(result, kwargs)
+
+        # Calling with any number of positional arguments should raise
+        with self.assertRaises(TypeError):
+            self.function_kwargs.run_get_node(orm.Int(1))
+
+        with self.assertRaises(TypeError):
+            self.function_kwargs.run_get_node(orm.Int(1), b=orm.Int(2))
 
     def test_function_args_and_kwargs(self):
         """Simple process function that defines a positional argument and keyword arguments."""
@@ -221,6 +230,13 @@ class TestProcessFunction(AiidaTestCase):
         result = self.function_args_and_kwargs(*args, **kwargs)
         self.assertTrue(isinstance(result, dict))
         self.assertEqual(result, {'data_a': args[0], 'data_b': kwargs['data_b']})
+
+        # Calling with more positional arguments than defined in the signature should raise
+        with self.assertRaises(TypeError):
+            self.function_kwargs.run_get_node(orm.Int(1), orm.Int(2))
+
+        with self.assertRaises(TypeError):
+            self.function_kwargs.run_get_node(orm.Int(1), orm.Int(2), b=orm.Int(2))
 
     def test_function_args_and_kwargs_default(self):
         """Simple process function that defines a positional argument and an argument with a default."""


### PR DESCRIPTION
Fixes #2618 

A process function that supported `**kwargs` could be called with more
positional arguments then the function signature declares, causing them
to be interpreted as keyword arguments, except that now the engine could
not determine their name, since it is neither in the signature, nor in
the function call and so no links would be created. This bug allowed
a process function to be called that would have missing input links.

To fix this we add an explicit check on call time that if a function is
dynamic, i.e. its signature allows `**kwargs` then the number of
positional arguments may not surpass the number of named parameters
defined in the signature.