### PR TITLE
Implement division and integer division operators for `NumericType`

### DIFF
--- a/aiida/backends/tests/test_base_dataclasses.py
+++ b/aiida/backends/tests/test_base_dataclasses.py
@@ -202,6 +202,22 @@ class TestFloat(AiidaTestCase):
         res = a ** b
         self.assertAlmostEqual(res.value, 16.)
 
+    def test_division(self):
+        """Test the normal division operator."""
+        a = Float(3)
+        b = Float(2)
+
+        self.assertAlmostEqual(a / b, 1.5)
+        self.assertIsInstance(a / b, Float)
+
+    def test_division_integer(self):
+        """Test the integer division operator."""
+        a = Float(3)
+        b = Float(2)
+
+        self.assertAlmostEqual(a // b, 1.0)
+        self.assertIsInstance(a // b, Float)
+
     def test_modulo(self):
         a = Float(12.0)
         b = Float(10.0)
@@ -229,6 +245,22 @@ class TestFloatIntMix(AiidaTestCase):
 
 
 class TestInt(AiidaTestCase):
+
+    def test_division(self):
+        """Test the normal division operator."""
+        a = Int(3)
+        b = Int(2)
+
+        self.assertAlmostEqual(a / b, 1.5)
+        self.assertIsInstance(a / b, Float)
+
+    def test_division_integer(self):
+        """Test the integer division operator."""
+        a = Int(3)
+        b = Int(2)
+
+        self.assertAlmostEqual(a // b, 1)
+        self.assertIsInstance(a // b, Int)
 
     def test_modulo(self):
         a = Int(12)

--- a/aiida/orm/nodes/data/numeric.py
+++ b/aiida/orm/nodes/data/numeric.py
@@ -71,6 +71,30 @@ class NumericType(BaseType):
         return other * self
 
     @_left_operator
+    def __div__(self, other):
+        return self / other
+
+    @_right_operator
+    def __rdiv__(self, other):
+        return other / self
+
+    @_left_operator
+    def __truediv__(self, other):
+        return self / other
+
+    @_right_operator
+    def __rtruediv__(self, other):
+        return other / self
+
+    @_left_operator
+    def __floordiv__(self, other):
+        return self // other
+
+    @_right_operator
+    def __rfloordiv__(self, other):
+        return other // self
+
+    @_left_operator
     def __pow__(self, power):
         return self**power
 


### PR DESCRIPTION
Fixes #2620 

This now allows one to do `Int(1) / Int(2)` or `Int(1) // Int(2)`
The `from __future__ import division` will ensure that the right
behavior is triggered for both python 2 and python 3.