### PR TITLE
Fix exit code of verdi status

### DIFF
--- a/aiida/backends/tests/cmdline/commands/test_status.py
+++ b/aiida/backends/tests/cmdline/commands/test_status.py
@@ -15,6 +15,7 @@ from click.testing import CliRunner
 
 from aiida.backends.testbase import AiidaTestCase
 from aiida.cmdline.commands import cmd_status
+from aiida.backends.tests.utils.configuration import with_temporary_config_instance
 
 
 class TestVerdiStatus(AiidaTestCase):
@@ -23,9 +24,16 @@ class TestVerdiStatus(AiidaTestCase):
     def setUp(self):
         self.cli_runner = CliRunner()
 
+    @with_temporary_config_instance
     def test_status_1(self):
-        """Check running the command."""
+        """Test running verdi status.
+
+        Note: The exit status may differ depending on the environment in which the tests are run.
+        """
         options = []
         result = self.cli_runner.invoke(cmd_status.verdi_status, options)
-        self.assertClickResultNoException(result)
-        self.assertTrue(result.exit_code == 0)
+        self.assertIsInstance(result.exception, SystemExit)
+        self.assertIn("profile", result.output)
+        self.assertIn("postgres", result.output)
+        self.assertIn("rabbitmq", result.output)
+        self.assertIn("daemon", result.output)

--- a/aiida/cmdline/commands/cmd_status.py
+++ b/aiida/cmdline/commands/cmd_status.py
@@ -12,13 +12,12 @@ from __future__ import division
 from __future__ import print_function
 from __future__ import absolute_import
 
+import sys
 from enum import IntEnum
 import click
 
 from aiida.cmdline.commands.cmd_verdi import verdi
-from aiida.cmdline.utils.daemon import get_daemon_status
-from aiida.common.utils import Capturing, get_repository_folder
-from aiida.manage.manager import get_manager
+from ..utils.echo import ExitCode
 
 
 class ServiceStatus(IntEnum):
@@ -48,10 +47,14 @@ STATUS_SYMBOLS = {
 @verdi.command('status')
 def verdi_status():
     """Print status of AiiDA services."""
-    # pylint: disable=broad-except
+    # pylint: disable=broad-except,too-many-statements
     from aiida.manage.external.rmq import get_rmq_url
     from aiida.manage.external.postgres import Postgres
+    from aiida.cmdline.utils.daemon import get_daemon_status
+    from aiida.common.utils import Capturing, get_repository_folder
+    from aiida.manage.manager import get_manager
 
+    exit_code = ExitCode.SUCCESS
     manager = get_manager()
 
     # getting the profile
@@ -61,13 +64,15 @@ def verdi_status():
 
     except Exception as exc:
         print_status(ServiceStatus.ERROR, 'profile', "Unable to read AiiDA profile")
-        raise exc  # without a profile, we cannot access anything
+        exit_code = ExitCode.CRITICAL
+        sys.exit(exit_code)  # stop here - without a profile we cannot access anything
 
     # getting the repository
     try:
         repo_folder = get_repository_folder()
     except Exception as exc:
         print_status(ServiceStatus.ERROR, 'repository', "Error with repo folder", exception=exc)
+        exit_code = ExitCode.CRITICAL
 
     print_status(ServiceStatus.UP, 'repository', repo_folder)
 
@@ -85,6 +90,7 @@ def verdi_status():
         else:
             print_status(ServiceStatus.DOWN, 'postgres', "Unable to connect to {}:{}".format(
                 dbinfo['host'], dbinfo['port']))
+            exit_code = ExitCode.CRITICAL
 
     except Exception as exc:
         pd_dict = profile.dictionary
@@ -93,6 +99,7 @@ def verdi_status():
             'postgres',
             "Error connecting to {}:{}".format(pd_dict['AIIDADB_HOST'], pd_dict['AIIDADB_PORT']),
             exception=exc)
+        exit_code = ExitCode.CRITICAL
 
     # getting the rmq status
     try:
@@ -104,6 +111,7 @@ def verdi_status():
 
     except Exception as exc:
         print_status(ServiceStatus.ERROR, 'rabbitmq', "Unable to connect to rabbitmq", exception=exc)
+        exit_code = ExitCode.CRITICAL
 
     # getting the daemon status
     try:
@@ -115,11 +123,15 @@ def verdi_status():
             print_status(ServiceStatus.UP, 'daemon', daemon_status)
         else:
             print_status(ServiceStatus.DOWN, 'daemon', daemon_status)
+            exit_code = ExitCode.CRITICAL
 
     except Exception as exc:
         print_status(ServiceStatus.ERROR, 'daemon', "Error getting daemon status", exception=exc)
+        exit_code = ExitCode.CRITICAL
 
-    return 0
+    # Note: click does not forward return values to the exit code, see
+    # https://github.com/pallets/click/issues/747
+    sys.exit(exit_code)
 
 
 def print_status(status, service, msg="", exception=None):

--- a/aiida/cmdline/utils/echo.py
+++ b/aiida/cmdline/utils/echo.py
@@ -132,7 +132,7 @@ def echo_deprecated(message, bold=False, nl=True, err=True, exit=False):
     click.secho(message, bold=bold, nl=nl, err=err)
 
     if exit:
-        sys.exit(ExitCode.DEPRECATED.value)
+        sys.exit(ExitCode.DEPRECATED)
 
 
 def echo_dictionary(dictionary, fmt='json+date'):

--- a/aiida/cmdline/utils/echo.py
+++ b/aiida/cmdline/utils/echo.py
@@ -12,7 +12,7 @@ from __future__ import division
 from __future__ import print_function
 from __future__ import absolute_import
 
-import enum
+from enum import IntEnum
 import sys
 
 import click
@@ -21,11 +21,12 @@ __all__ = ('echo', 'echo_info', 'echo_success', 'echo_warning', 'echo_error', 'e
 
 
 # pylint: disable=too-few-public-methods
-class ExitCode(enum.Enum):
+class ExitCode(IntEnum):
     """Exit codes for the verdi command line."""
     CRITICAL = 1
     DEPRECATED = 80
     UNKNOWN = 99
+    SUCCESS = 0
 
 
 # pylint: disable=invalid-name
@@ -110,7 +111,7 @@ def echo_critical(message, bold=False, nl=True, err=True):
     """
     click.secho('Critical: ', fg='red', bold=True, nl=False, err=err)
     click.secho(message, bold=bold, nl=nl, err=err)
-    sys.exit(ExitCode.CRITICAL.value)
+    sys.exit(ExitCode.CRITICAL)
 
 
 # pylint: disable=redefined-builtin


### PR DESCRIPTION
verdi status should return exit code 0 if all services are up, otherwise exit code 1

(Note: this is also the behavior of clis like `service` of `systemd`, e.g. if `apach2` is down, `service apache2 status` will return a non-zero exit code)