### PR TITLE
Make sure exit code != 0 if incompatible archive version

### DIFF
--- a/aiida/backends/tests/__init__.py
+++ b/aiida/backends/tests/__init__.py
@@ -64,6 +64,7 @@ db_test_list = {
         'cmdline.params.types.group': ['aiida.backends.tests.cmdline.params.types.test_group'],
         'cmdline.params.types.identifier': ['aiida.backends.tests.cmdline.params.types.test_identifier'],
         'cmdline.params.types.node': ['aiida.backends.tests.cmdline.params.types.test_node'],
+        'cmdline.params.types.path': ['aiida.backends.tests.cmdline.params.types.test_path'],
         'cmdline.params.types.plugin': ['aiida.backends.tests.cmdline.params.types.test_plugin'],
         'cmdline.utils.common': ['aiida.backends.tests.cmdline.utils.test_common'],
         'common.archive': ['aiida.backends.tests.common.test_archive'],

--- a/aiida/backends/tests/cmdline/params/types/test_path.py
+++ b/aiida/backends/tests/cmdline/params/types/test_path.py
@@ -1,0 +1,70 @@
+# -*- coding: utf-8 -*-
+###########################################################################
+# Copyright (c), The AiiDA team. All rights reserved.                     #
+# This file is part of the AiiDA code.                                    #
+#                                                                         #
+# The code is hosted on GitHub at https://github.com/aiidateam/aiida_core #
+# For further information on the license, see the LICENSE.txt file        #
+# For further information please visit http://www.aiida.net               #
+###########################################################################
+"""Tests for Path types"""
+from __future__ import division
+from __future__ import print_function
+from __future__ import absolute_import
+
+from aiida.backends.testbase import AiidaTestCase
+from aiida.cmdline.params.types import ImportPath
+
+
+class TestImportPath(AiidaTestCase):
+    """Tests `ImportPath`"""
+
+    def test_default_timeout(self):
+        """Test the default timeout_seconds value is correct"""
+        from aiida.cmdline.params.types.path import URL_TIMEOUT_SECONDS
+
+        import_path = ImportPath()
+
+        self.assertEqual(import_path.timeout_seconds, URL_TIMEOUT_SECONDS)
+
+    def test_valid_timeout(self):
+        """Test a valid timeout_seconds value"""
+
+        valid_values = [42, "42"]
+
+        for value in valid_values:
+            import_path = ImportPath(timeout_seconds=value)
+
+            self.assertEqual(import_path.timeout_seconds, int(value))
+
+    def test_none_timeout(self):
+        """Test a TypeError is raised when a None value is given for timeout_seconds"""
+
+        with self.assertRaises(TypeError):
+            ImportPath(timeout_seconds=None)
+
+    def test_wrong_type_timeout(self):
+        """Test a TypeError is raised when wrong type is given for timeout_seconds"""
+
+        with self.assertRaises(TypeError):
+            ImportPath(timeout_seconds="test")
+
+    def test_range_timeout(self):
+        """Test timeout_seconds defines extrema when out of range
+        Range of timeout_seconds is [0;60], extrema included.
+        """
+
+        range_timeout = [0, 60]
+        lower = range_timeout[0] - 5
+        upper = range_timeout[1] + 5
+
+        lower_path = ImportPath(timeout_seconds=lower)
+        upper_path = ImportPath(timeout_seconds=upper)
+
+        msg_lower = "timeout_seconds should have been corrected to the lower bound: '{}', but instead it is {}".format(
+            range_timeout[0], lower_path.timeout_seconds)
+        self.assertEqual(lower_path.timeout_seconds, range_timeout[0], msg_lower)
+
+        msg_upper = "timeout_seconds should have been corrected to the upper bound: '{}', but instead it is {}".format(
+            range_timeout[1], upper_path.timeout_seconds)
+        self.assertEqual(upper_path.timeout_seconds, range_timeout[1], msg_upper)

--- a/aiida/cmdline/commands/cmd_import.py
+++ b/aiida/cmdline/commands/cmd_import.py
@@ -8,6 +8,7 @@
 # For further information please visit http://www.aiida.net               #
 ###########################################################################
 """`verdi import` command."""
+# pylint: disable=too-many-locals
 from __future__ import division
 from __future__ import print_function
 from __future__ import absolute_import
@@ -16,7 +17,7 @@ import click
 
 from aiida.cmdline.commands.cmd_verdi import verdi
 from aiida.cmdline.params.options import MultipleValueOption
-from aiida.cmdline.params.types import GroupParamType
+from aiida.cmdline.params.types import GroupParamType, ImportPath
 from aiida.cmdline.utils import decorators, echo
 from aiida.common import exceptions
 
@@ -36,7 +37,7 @@ class ExtrasImportCode(Enum):
 
 
 @verdi.command('import')
-@click.argument('archives', nargs=-1, type=click.Path(exists=True, readable=True))
+@click.argument('archives', nargs=-1, type=ImportPath(exists=True, readable=True))
 @click.option(
     '-w',
     '--webpages',
@@ -127,8 +128,7 @@ def cmd_import(archives, webpages, group, extras_mode_existing, extras_mode_new,
                 extras_mode_new=extras_mode_new,
                 comment_mode=comment_mode)
         except exceptions.IncompatibleArchiveVersionError as exception:
-            echo.echo_warning('{} cannot be imported: {}'.format(archive, exception))
-            continue
+            echo.echo_critical('{} cannot be imported: {}'.format(archive, exception))
         except Exception:
             echo.echo_error('an exception occurred while importing the archive {}'.format(archive))
             echo.echo(traceback.format_exc())
@@ -158,9 +158,10 @@ def cmd_import(archives, webpages, group, extras_mode_existing, extras_mode_new,
                     extras_mode_new=extras_mode_new,
                     comment_mode=comment_mode)
             except exceptions.IncompatibleArchiveVersionError as exception:
-                echo.echo_warning('{} cannot be imported: {}'.format(archive, exception))
-                echo.echo_warning('download the archive file and run `verdi export migrate` to update it')
-                continue
+                crit_message = '{} cannot be imported.\n' \
+                    'Download the archive file and run `verdi export migrate` to update it.\n{}'.format(
+                    archive, exception)
+                echo.echo_critical(crit_message)
             except Exception:
                 echo.echo_error('an exception occurred while importing the archive {}'.format(archive))
                 echo.echo(traceback.format_exc())

--- a/aiida/cmdline/params/types/__init__.py
+++ b/aiida/cmdline/params/types/__init__.py
@@ -24,7 +24,7 @@ from .multiple import MultipleValueParamType
 from .node import NodeParamType
 from .process import ProcessParamType
 from .nonemptystring import NonEmptyStringParamType
-from .path import AbsolutePathParamType
+from .path import AbsolutePathParamType, ImportPath
 from .plugin import PluginParamType
 from .profile import ProfileParamType
 from .user import UserParamType
@@ -35,4 +35,4 @@ __all__ = ('LazyChoice', 'IdentifierParamType', 'CalculationParamType', 'CodePar
            'ConfigOptionParamType', 'DataParamType', 'GroupParamType', 'NodeParamType', 'MpirunCommandParamType',
            'MultipleValueParamType', 'NonEmptyStringParamType', 'PluginParamType', 'AbsolutePathParamType',
            'ShebangParamType', 'UserParamType', 'TestModuleParamType', 'ProfileParamType', 'WorkflowParamType',
-           'ProcessParamType')
+           'ProcessParamType', 'ImportPath')

--- a/aiida/cmdline/params/types/path.py
+++ b/aiida/cmdline/params/types/path.py
@@ -14,6 +14,8 @@ from __future__ import absolute_import
 import os
 import click
 
+URL_TIMEOUT_SECONDS = 10
+
 
 class AbsolutePathParamType(click.Path):
     """
@@ -31,3 +33,66 @@ class AbsolutePathParamType(click.Path):
 
     def __repr__(self):
         return 'ABSOLUTEPATH'
+
+
+class ImportPath(click.Path):
+    """AiiDA extension of Click's Path-type to include URLs
+    An ImportPath can either be a `click.Path`-type or a URL.
+    :param timeout_seconds: Timeout time in seconds that a URL response is expected.
+    :value timeout_seconds: Must be an int in the range [0;60], extrema included.
+    If an int outside the range [0;60] is given, the value will be set to the respective extremum value.
+    If any other type than int is given a TypeError will be raised.
+    """
+
+    # pylint: disable=protected-access
+
+    def __init__(self, timeout_seconds=URL_TIMEOUT_SECONDS, **kwargs):
+        super(ImportPath, self).__init__(**kwargs)
+
+        self.timeout_seconds = timeout_seconds
+
+    def convert(self, value, param, ctx):
+        """Overwrite `convert`
+        Check first if `click.Path`-type, then check if URL.
+        """
+        try:
+            # Check if `click.Path`-type
+            return super(ImportPath, self).convert(value, param, ctx)
+        except click.exceptions.BadParameter:
+            # Check if URL
+            return self.checks_url(value, param, ctx)
+
+    def checks_url(self, value, param, ctx):
+        """Do checks for possible URL path"""
+        from six.moves import urllib
+        from socket import timeout
+
+        url = value
+
+        try:
+            urllib.request.urlopen(url, data=None, timeout=self.timeout_seconds)
+        except (urllib.error.URLError, urllib.error.HTTPError, timeout):
+            self.fail(
+                '{0} "{1}" could not be reached within {2} s.\n'
+                'It may be neither a valid {3} nor a valid URL.'.format(
+                    self.path_type, click._compat.filename_to_ui(url), self.timeout_seconds, self.name), param, ctx)
+
+        return url
+
+    @property
+    def timeout_seconds(self):
+        return self._timeout_seconds
+
+    # pylint: disable=attribute-defined-outside-init
+    @timeout_seconds.setter
+    def timeout_seconds(self, value):
+        try:
+            self._timeout_seconds = int(value)
+        except ValueError:
+            raise TypeError("timeout_seconds should be an integer but got: {}".format(type(value)))
+
+        if self._timeout_seconds < 0:
+            self._timeout_seconds = 0
+
+        if self._timeout_seconds > 60:
+            self._timeout_seconds = 60


### PR DESCRIPTION
Fixes #2633.

For `verdi import`:
Change the warning to a critical if exception "IncompatibleArchiveVersionError" is raised.

Added test `test_import_old_versions`.
It checks a non-zero value is returned, when an archives with old versions are imported.
Also, added asserts of exit code for other `verdi import` tests.