### PR TITLE
pyproject: remove reentry from requirements

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,3 @@
 [build-system]
 # Minimum requirements for the build system to execute.
-requires = ["pip>=18.1", "setuptools", "wheel", "reentry==1.2.2"]
+requires = ["pip>=18.1", "setuptools", "wheel"]


### PR DESCRIPTION
The problem is that reentry starts to scan the entrypoints after
installation which picks up the current AiiDA directory as well, but
aiida-core is not yet installed.

I verified that pip is still able to build a wheel with `pip wheel .`