### PR TITLE
upgrade pgtest to 1.2.0

### DIFF
--- a/aiida/backends/tests/manage/external/test_postgres.py
+++ b/aiida/backends/tests/manage/external/test_postgres.py
@@ -30,7 +30,7 @@ class PostgresTest(unittest.TestCase):
 
     def setUp(self):
         """Set up a temporary database cluster for testing potentially destructive operations"""
-        self.pg_test = PGTest(max_connections=11)  # set to 11 to avoid https://github.com/jamesnunn/pgtest/issues/9
+        self.pg_test = PGTest()
         self.dbuser = 'aiida'
         self.dbpass = 'password'
         self.dbname = 'aiida_db'

--- a/aiida/manage/fixtures.py
+++ b/aiida/manage/fixtures.py
@@ -150,7 +150,7 @@ class FixtureManager(object):  # pylint: disable=too-many-public-methods,useless
 
     def create_db_cluster(self):
         if not self.pg_cluster:
-            self.pg_cluster = PGTest(max_connections=256)
+            self.pg_cluster = PGTest()
         self.db_params.update(self.pg_cluster.dsn)
 
     def create_aiida_db(self):

--- a/docs/requirements_for_rtd.txt
+++ b/docs/requirements_for_rtd.txt
@@ -43,7 +43,7 @@ paramiko==2.4.2
 passlib==1.7.1
 pathlib2; python_version<'3.5'
 pg8000<1.13.0
-pgtest==1.1.0
+pgtest==1.2.0
 plumpy==0.13.0
 psutil==5.5.1
 pyblake2==1.1.2; python_version<'3.6'

--- a/setup.json
+++ b/setup.json
@@ -101,7 +101,7 @@
     ],
     "testing": [
       "unittest2==1.1.0; python_version<'3.5'",
-      "pgtest==1.1.0",
+      "pgtest==1.2.0",
       "pg8000<1.13.0",
       "sqlalchemy-diff==0.1.3",
       "coverage==4.5.2",


### PR DESCRIPTION
version 1.1.0 had problems with invalid # connections set for
postgres 10 on ubuntu 18.04.
this is fixed in pgtest 1.2.0 and we can take the default
max_connections value.