### PR TITLE
silence psycopg2 warning

### DIFF
--- a/aiida/__init__.py
+++ b/aiida/__init__.py
@@ -57,6 +57,9 @@ else:
 if six.PY2:
     warnings.warn('python 2 will be deprecated in `aiida-core v2.0.0`', DeprecationWarning)  # pylint: disable=no-member
 
+# Disable psycopg2 warning. Remove this after upgrading psycopg2 to 2.8
+warnings.filterwarnings("ignore", category=UserWarning, module='psycopg2')
+
 
 def try_load_dbenv(*argc, **argv):
     """

--- a/aiida/__init__.py
+++ b/aiida/__init__.py
@@ -58,7 +58,7 @@ if six.PY2:
     warnings.warn('python 2 will be deprecated in `aiida-core v2.0.0`', DeprecationWarning)  # pylint: disable=no-member
 
 # Disable psycopg2 warning. Remove this after upgrading psycopg2 to 2.8
-warnings.filterwarnings("ignore", category=UserWarning, module='psycopg2')
+warnings.filterwarnings("ignore", category=UserWarning, module='psycopg2')  # pylint: disable=no-member
 
 
 def try_load_dbenv(*argc, **argv):


### PR DESCRIPTION
I think we have been warned enough:

UserWarning: The psycopg2 wheel package will be renamed from release
2.8; in order to keep installing from binary please use "pip install
psycopg2-binary" instead. For details see:
<http://initd.org/psycopg/docs/install.html#binary-install-from-pypi>.