### PR TITLE
Fix bug in `Parser.get_outputs_for_parsing`

### DIFF
--- a/aiida/backends/tests/__init__.py
+++ b/aiida/backends/tests/__init__.py
@@ -123,6 +123,7 @@ db_test_list = {
         'orm.utils.node': ['aiida.backends.tests.orm.utils.test_node'],
         'orm.utils.loaders': ['aiida.backends.tests.orm.utils.test_loaders'],
         'orm.utils.repository': ['aiida.backends.tests.orm.utils.test_repository'],
+        'parsers.parser': ['aiida.backends.tests.parsers.test_parser'],
         'parsers': ['aiida.backends.tests.test_parsers'],
         'plugin_loader': ['aiida.backends.tests.test_plugin_loader'],
         'query': ['aiida.backends.tests.test_query'],

--- a/aiida/backends/tests/cmdline/commands/test_data.py
+++ b/aiida/backends/tests/cmdline/commands/test_data.py
@@ -405,7 +405,7 @@ class TestVerdiDataDict(AiidaTestCase):
         for format in supported_formats:
             options = [str(self.p.id)]
             res = self.cli_runner.invoke(cmd_dict.dictionary_show, options, catch_exceptions=False)
-            self.assertEqual(res.exit_code, 0, "The command verdi data dict show did not" " finish correctly")
+            self.assertEqual(res.exit_code, 0, "The command verdi data dict show did not finish correctly")
         self.assertIn(b'"a": 1', res.stdout_bytes, 'The string "a": 1 was not found in the output'
                                                    ' of verdi data dict show')
 
@@ -440,7 +440,7 @@ class TestVerdiDataRemote(AiidaTestCase):
     def test_remoteshow(self):
         options = [str(self.r.id)]
         res = self.cli_runner.invoke(cmd_remote.remote_show, options, catch_exceptions=False)
-        self.assertEqual(res.exit_code, 0, "The command verdi data remote show did not" " finish correctly")
+        self.assertEqual(res.exit_code, 0, "The command verdi data remote show did not finish correctly")
         self.assertIn(b'Remote computer name:', res.stdout_bytes,
                       'The string "Remote computer name:" was not found in the'
                       ' output of verdi data remote show')
@@ -455,7 +455,7 @@ class TestVerdiDataRemote(AiidaTestCase):
     def test_remotels(self):
         options = ['--long', str(self.r.id)]
         res = self.cli_runner.invoke(cmd_remote.remote_ls, options, catch_exceptions=False)
-        self.assertEqual(res.exit_code, 0, "The command verdi data remote ls did not" " finish correctly")
+        self.assertEqual(res.exit_code, 0, "The command verdi data remote ls did not finish correctly")
         self.assertIn(b'file.txt', res.stdout_bytes, 'The file "file.txt" was not found in the output'
                                                      ' of verdi data remote ls')
 
@@ -466,7 +466,7 @@ class TestVerdiDataRemote(AiidaTestCase):
     def test_remotecat(self):
         options = [str(self.r.id), 'file.txt']
         res = self.cli_runner.invoke(cmd_remote.remote_cat, options, catch_exceptions=False)
-        self.assertEqual(res.exit_code, 0, "The command verdi data remote cat did not" " finish correctly")
+        self.assertEqual(res.exit_code, 0, "The command verdi data remote cat did not finish correctly")
         self.assertIn(b'test string', res.stdout_bytes, 'The string "test string" was not found in the output'
                                                         ' of verdi data remote cat file.txt')
 

--- a/aiida/backends/tests/cmdline/commands/test_node.py
+++ b/aiida/backends/tests/cmdline/commands/test_node.py
@@ -401,7 +401,7 @@ class TestVerdiDataDict(AiidaTestCase):
         for format in supported_formats:
             options = [str(self.p.id)]
             res = self.cli_runner.invoke(cmd_dict.dictionary_show, options, catch_exceptions=False)
-            self.assertEqual(res.exit_code, 0, "The command verdi data dict show did not" " finish correctly")
+            self.assertEqual(res.exit_code, 0, "The command verdi data dict show did not finish correctly")
         self.assertIn(b'"a": 1', res.stdout_bytes, 'The string "a": 1 was not found in the output'
                                                    ' of verdi data dict show')
 
@@ -438,7 +438,7 @@ class TestVerdiDataRemote(AiidaTestCase):
     def test_remoteshow(self):
         options = [str(self.r.id)]
         res = self.cli_runner.invoke(cmd_remote.remote_show, options, catch_exceptions=False)
-        self.assertEqual(res.exit_code, 0, "The command verdi data remote show did not" " finish correctly")
+        self.assertEqual(res.exit_code, 0, "The command verdi data remote show did not finish correctly")
         self.assertIn(b'Remote computer name:', res.stdout_bytes,
                       'The string "Remote computer name:" was not found in the'
                       ' output of verdi data remote show')
@@ -453,7 +453,7 @@ class TestVerdiDataRemote(AiidaTestCase):
     def test_remotels(self):
         options = ['--long', str(self.r.id)]
         res = self.cli_runner.invoke(cmd_remote.remote_ls, options, catch_exceptions=False)
-        self.assertEqual(res.exit_code, 0, "The command verdi data remote ls did not" " finish correctly")
+        self.assertEqual(res.exit_code, 0, "The command verdi data remote ls did not finish correctly")
         self.assertIn(b'file.txt', res.stdout_bytes, 'The file "file.txt" was not found in the output'
                                                      ' of verdi data remote ls')
 
@@ -464,7 +464,7 @@ class TestVerdiDataRemote(AiidaTestCase):
     def test_remotecat(self):
         options = [str(self.r.id), 'file.txt']
         res = self.cli_runner.invoke(cmd_remote.remote_cat, options, catch_exceptions=False)
-        self.assertEqual(res.exit_code, 0, "The command verdi data remote cat did not" " finish correctly")
+        self.assertEqual(res.exit_code, 0, "The command verdi data remote cat did not finish correctly")
         self.assertIn(b'test string', res.stdout_bytes, 'The string "test string" was not found in the output'
                                                         ' of verdi data remote cat file.txt')
 

--- a/aiida/backends/tests/engine/test_process.py
+++ b/aiida/backends/tests/engine/test_process.py
@@ -190,8 +190,8 @@ class TestProcess(AiidaTestCase):
         expected_process_type = 'aiida.calculations:{}'.format(entry_point)
         self.assertEqual(process.node.process_type, expected_process_type)
 
-        # Verify that load_process_class on the calculation node returns the original entry point class
-        recovered_process = process.node.load_process_class()
+        # Verify that process_class on the calculation node returns the original entry point class
+        recovered_process = process.node.process_class
         self.assertEqual(recovered_process, process_class)
 
     def test_process_type_without_entry_point(self):
@@ -203,8 +203,8 @@ class TestProcess(AiidaTestCase):
         expected_process_type = '{}.{}'.format(process.__class__.__module__, process.__class__.__name__)
         self.assertEqual(process.node.process_type, expected_process_type)
 
-        # Verify that load_process_class on the calculation node returns the original entry point class
-        recovered_process = process.node.load_process_class()
+        # Verify that process_class on the calculation node returns the original entry point class
+        recovered_process = process.node.process_class
         self.assertEqual(recovered_process, process.__class__)
 
     def test_validation_error(self):

--- a/aiida/backends/tests/parsers/test_parser.py
+++ b/aiida/backends/tests/parsers/test_parser.py
@@ -1,0 +1,71 @@
+# -*- coding: utf-8 -*-
+"""Test for the `Parser` base class."""
+from __future__ import absolute_import
+
+from aiida import orm
+from aiida.backends.testbase import AiidaTestCase
+from aiida.common import LinkType
+from aiida.engine import CalcJob
+from aiida.parsers import Parser
+from aiida.plugins import CalculationFactory
+
+ArithmeticAddCalculation = CalculationFactory('arithmetic.add')  # pylint: disable=invalid-name
+
+
+class CustomCalcJob(CalcJob):
+    """`CalcJob` implementation with output namespace and additional output node that should be passed to parser."""
+
+    @classmethod
+    def define(cls, spec):
+        super(CustomCalcJob, cls).define(spec)
+        spec.input('in', valid_type=orm.Data)
+        spec.output('output', pass_to_parser=True)
+        spec.output_namespace('out.space', dynamic=True)
+
+    def prepare_for_submission(self):  # pylint: disable=arguments-differ
+        pass
+
+
+class TestParser(AiidaTestCase):
+    """Test backend entities and their collections"""
+
+    def test_parser_retrieved(self):
+        """Verify that the `retrieved` property returns the retrieved `FolderData` node."""
+        node = orm.CalcJobNode(computer=self.computer, process_type=ArithmeticAddCalculation.build_process_type())
+        node.set_option('resources', {'num_machines': 1, 'num_mpiprocs_per_machine': 1})
+        node.set_option('max_wallclock_seconds', 1800)
+        node.store()
+
+        retrieved = orm.FolderData().store()
+        retrieved.add_incoming(node, link_type=LinkType.CREATE, link_label='retrieved')
+
+        parser = Parser(node)
+        self.assertEqual(parser.node.uuid, node.uuid)
+        self.assertEqual(parser.retrieved.uuid, retrieved.uuid)
+
+    def test_parser_exit_codes(self):
+        """Ensure that exit codes from the `CalcJob` can be retrieved through the parser instance."""
+        node = orm.CalcJobNode(computer=self.computer, process_type=ArithmeticAddCalculation.build_process_type())
+        parser = Parser(node)
+        self.assertEqual(parser.exit_codes, ArithmeticAddCalculation.spec().exit_codes)
+
+    def test_parser_get_outputs_for_parsing(self):
+        """Make sure that the `get_output_for_parsing` method returns the correct output nodes."""
+        ArithmeticAddCalculation.define = CustomCalcJob.define
+        node = orm.CalcJobNode(computer=self.computer, process_type=CustomCalcJob.build_process_type())
+        node.set_option('resources', {'num_machines': 1, 'num_mpiprocs_per_machine': 1})
+        node.set_option('max_wallclock_seconds', 1800)
+        node.store()
+
+        retrieved = orm.FolderData().store()
+        retrieved.add_incoming(node, link_type=LinkType.CREATE, link_label='retrieved')
+
+        output = orm.Data().store()
+        output.add_incoming(node, link_type=LinkType.CREATE, link_label='output')
+
+        parser = Parser(node)
+        outputs_for_parsing = parser.get_outputs_for_parsing()
+        self.assertIn('retrieved', outputs_for_parsing)
+        self.assertEqual(outputs_for_parsing['retrieved'].uuid, retrieved.uuid)
+        self.assertIn('output', outputs_for_parsing)
+        self.assertEqual(outputs_for_parsing['output'].uuid, output.uuid)

--- a/aiida/cmdline/commands/cmd_computer.py
+++ b/aiida/cmdline/commands/cmd_computer.py
@@ -540,7 +540,7 @@ def computer_test(user, print_traceback, computer):
         warning_string = ("** NOTE! Computer is disabled for the "
                           "specified user!\n   Do you really want to test it? [y/N] ")
     if not computer.is_enabled():
-        warning_string = ("** NOTE! Computer is disabled!\n" "   Do you really want to test it? [y/N] ")
+        warning_string = ("** NOTE! Computer is disabled!\n   Do you really want to test it? [y/N] ")
     if warning_string:
         if not click.confirm(warning_string):
             sys.exit(0)

--- a/aiida/cmdline/commands/cmd_data/cmd_show.py
+++ b/aiida/cmdline/commands/cmd_data/cmd_show.py
@@ -225,7 +225,7 @@ def _show_xmgrace(exec_name, list_bands):
         print("Note: the call to {} ended with an error.".format(exec_name))
     except OSError as err:
         if err.errno == 2:
-            print("No executable '{}' found. Add to the path," " or try with an absolute path.".format(exec_name))
+            print("No executable '{}' found. Add to the path, or try with an absolute path.".format(exec_name))
             sys.exit(1)
         else:
             raise

--- a/aiida/common/archive.py
+++ b/aiida/common/archive.py
@@ -273,7 +273,7 @@ def extract_zip(infile, folder, nodes_export_subfolder="nodes", silent=False):
                     continue
                 handle.extract(path=folder.abspath, member=membername)
     except zipfile.BadZipfile:
-        raise ValueError("The input file format for import is not valid (not" " a zip file)")
+        raise ValueError("The input file format for import is not valid (not a zip file)")
 
 
 def extract_tar(infile, folder, nodes_export_subfolder="nodes", silent=False):

--- a/aiida/orm/implementation/django/querybuilder.py
+++ b/aiida/orm/implementation/django/querybuilder.py
@@ -336,7 +336,7 @@ class DjangoQueryBuilder(BackendQueryBuilder):
             if column_name in ('attributes', 'extras'):
                 entity = alias.id
             else:
-                raise NotImplementedError("Whatever you asked for ({}) is not implemented" "".format(column_name))
+                raise NotImplementedError("Whatever you asked for ({}) is not implemented".format(column_name))
         else:
             aliased_attributes = aliased(getattr(alias, column_name).prop.mapper.class_)
 

--- a/aiida/orm/implementation/sqlalchemy/computers.py
+++ b/aiida/orm/implementation/sqlalchemy/computers.py
@@ -75,7 +75,7 @@ class SqlaComputer(entities.SqlaModelEntity[DbComputer], BackendComputer):
         try:
             self._dbmodel.save()
         except SQLAlchemyError:
-            raise ValueError("Integrity error, probably the hostname already exists in the" " DB")
+            raise ValueError("Integrity error, probably the hostname already exists in the DB")
 
         return self
 

--- a/aiida/orm/nodes/data/array/bands.py
+++ b/aiida/orm/nodes/data/array/bands.py
@@ -1164,9 +1164,9 @@ class BandsData(KpointsData):
         import math
         # load the x and y of every set
         if color_number > max_num_agr_colors:
-            raise ValueError("Color number is too high (should be less than {})" "".format(max_num_agr_colors))
+            raise ValueError("Color number is too high (should be less than {})".format(max_num_agr_colors))
         if color_number2 > max_num_agr_colors:
-            raise ValueError("Color number 2 is too high (should be less than {})" "".format(max_num_agr_colors))
+            raise ValueError("Color number 2 is too high (should be less than {})".format(max_num_agr_colors))
 
         bands = plot_info['y']
         x = plot_info['x']

--- a/aiida/orm/nodes/process/calculation/calcjob.py
+++ b/aiida/orm/nodes/process/calculation/calcjob.py
@@ -107,30 +107,6 @@ class CalcJobNode(CalculationNode):
         return super(CalcJobNode, self).get_hash(
             ignore_errors=ignore_errors, ignored_folder_content=ignored_folder_content, **kwargs)
 
-    @property
-    def process_class(self):
-        """Return the CalcJob class that was used to create this node.
-
-        :return: CalcJob class
-        :raises ValueError: if no process type is defined or it is an invalid process type string
-        """
-        from aiida.common.exceptions import MultipleEntryPointError, MissingEntryPointError, LoadingEntryPointError
-        from aiida.plugins.entry_point import load_entry_point_from_string
-
-        if not self.process_type:
-            raise ValueError('no process type for CalcJobNode<{}>: cannot recreate process class'.format(self.pk))
-
-        try:
-            process_class = load_entry_point_from_string(self.process_type)
-        except ValueError:
-            raise ValueError('process type for CalcJobNode<{}> contains an invalid entry point string: {}'.format(
-                self.pk, self.process_type))
-        except (MissingEntryPointError, MultipleEntryPointError, LoadingEntryPointError) as exception:
-            raise ValueError('could not load process class for entry point {} for CalcJobNode<{}>: {}'.format(
-                self.pk, self.process_type, exception))
-
-        return process_class
-
     def get_builder_restart(self):
         """
         Return a CalcJobBuilder instance, tailored for this calculation instance

--- a/aiida/orm/nodes/process/process.py
+++ b/aiida/orm/nodes/process/process.py
@@ -86,24 +86,34 @@ class ProcessNode(Sealable, Node):
         from aiida.orm.utils.log import create_logger_adapter
         return create_logger_adapter(self._logger, self)
 
-    def load_process_class(self):
-        """
-        For nodes that were ran by a Process, the process_type will be set. This can either be an entry point
-        string or a module path, which is the identifier for that Process. This method will attempt to load
-        the Process class and return
-        """
-        import importlib
-        from aiida.plugins.entry_point import load_entry_point_from_string, is_valid_entry_point_string
+    @property
+    def process_class(self):
+        """Return the process class that was used to create this node.
 
-        if self.process_type is None:
-            return None
+        :return: `Process` class
+        :raises ValueError: if no process type is defined, it is an invalid process type string or cannot be resolved
+            to load the corresponding class
+        """
+        from aiida.common.exceptions import MultipleEntryPointError, MissingEntryPointError, LoadingEntryPointError
+        from aiida.plugins.entry_point import load_entry_point_from_string
 
-        if is_valid_entry_point_string(self.process_type):
+        if not self.process_type:
+            raise ValueError('no process type for CalcJobNode<{}>: cannot recreate process class'.format(self.pk))
+
+        try:
             process_class = load_entry_point_from_string(self.process_type)
-        else:
-            class_module, class_name = self.process_type.rsplit('.', 1)
-            module = importlib.import_module(class_module)
-            process_class = getattr(module, class_name)
+        except (MissingEntryPointError, MultipleEntryPointError, LoadingEntryPointError) as exception:
+            raise ValueError('could not load process class for entry point {} for CalcJobNode<{}>: {}'.format(
+                self.pk, self.process_type, exception))
+        except ValueError:
+            try:
+                import importlib
+                module_name, class_name = self.process_type.rsplit('.', 1)
+                module = importlib.import_module(module_name)
+                process_class = getattr(module, class_name)
+            except (ValueError, ImportError):
+                raise ValueError('could not load process class CalcJobNode<{}> given its `process_type`: {}'.format(
+                    self.pk, self.process_type))
 
         return process_class
 

--- a/aiida/orm/querybuilder.py
+++ b/aiida/orm/querybuilder.py
@@ -1102,7 +1102,7 @@ class QueryBuilder(object):
             elif isinstance(projection, six.string_types):
                 _thisprojection = {projection: {}}
             else:
-                raise InputValidationError("Cannot deal with projection specification {}\n" "".format(projection))
+                raise InputValidationError("Cannot deal with projection specification {}\n".format(projection))
             for p, spec in _thisprojection.items():
                 if not isinstance(spec, dict):
                     raise InputValidationError("\nThe value of a key-value pair in a projection\n"

--- a/aiida/parsers/parser.py
+++ b/aiida/parsers/parser.py
@@ -15,9 +15,9 @@ from __future__ import division
 from __future__ import print_function
 from __future__ import absolute_import
 
-from aiida.common import exceptions
-from aiida.common import extendeddicts
+from aiida.common import exceptions, extendeddicts
 from aiida.engine import calcfunction
+from aiida.engine.processes.ports import CalcJobOutputPort
 
 __all__ = ('Parser',)
 
@@ -96,7 +96,7 @@ class Parser(object):  # pylint: disable=useless-object-inheritance
         result = {}
 
         for label, port in self.node.process_class.spec().outputs.items():
-            if port.pass_to_parser:
+            if isinstance(port, CalcJobOutputPort) and port.pass_to_parser:
                 try:
                     result[label] = link_triples.get_node_by_label(label)
                 except exceptions.NotExistent:

--- a/aiida/restapi/translator/base.py
+++ b/aiida/restapi/translator/base.py
@@ -536,7 +536,7 @@ class BaseTranslator(object):
         try:
             pk = qbobj.one()[0].pk
         except MultipleObjectsError:
-            raise RestValidationError("More than one node found." " Provide longer starting pattern" " for id.")
+            raise RestValidationError("More than one node found. Provide longer starting pattern for id.")
         except NotExistent:
             raise RestValidationError("either no object's id starts"
                                       " with '{}' or the corresponding object"

--- a/aiida/schedulers/plugins/lsf.py
+++ b/aiida/schedulers/plugins/lsf.py
@@ -527,7 +527,7 @@ fi
             if len(job) != num_fields:
                 # I skip this calculation
                 # (I don't append anything to job_list before continuing)
-                self.logger.error("Wrong line length in squeue output! '{}'" "".format(job))
+                self.logger.error("Wrong line length in squeue output! '{}'".format(job))
                 continue
 
             this_job = JobInfo()
@@ -666,7 +666,7 @@ fi
         try:
             return stdout.strip().split('Job <')[1].split('>')[0]
         except IndexError:
-            raise SchedulerParsingError("Cannot parse submission output: {}" "".format(stdout))
+            raise SchedulerParsingError("Cannot parse submission output: {}".format(stdout))
 
     def _parse_time_string(self, string, fmt='%b %d %H:%M'):
         """

--- a/aiida/schedulers/plugins/pbsbaseclasses.py
+++ b/aiida/schedulers/plugins/pbsbaseclasses.py
@@ -437,7 +437,7 @@ class PbsBaseClass(Scheduler):
             # There are lines without equals sign: this is bad
             if lines_without_equals_sign:
                 # Should I only warn?
-                _LOGGER.error("There are lines without equals sign! {}" "".format(lines_without_equals_sign))
+                _LOGGER.error("There are lines without equals sign! {}".format(lines_without_equals_sign))
                 raise SchedulerParsingError("There are lines without equals sign.")
 
             raw_data = {

--- a/aiida/schedulers/plugins/slurm.py
+++ b/aiida/schedulers/plugins/slurm.py
@@ -511,7 +511,7 @@ class SlurmScheduler(aiida.schedulers.Scheduler):
             except KeyError:
                 # I skip this calculation if I couldn't find this basic info
                 # (I don't append anything to job_list before continuing)
-                self.logger.error("Wrong line length in squeue output! '{}'" "".format(job))
+                self.logger.error("Wrong line length in squeue output! '{}'".format(job))
                 continue
 
             try:

--- a/aiida/transports/plugins/local.py
+++ b/aiida/transports/plugins/local.py
@@ -68,7 +68,7 @@ class LocalTransport(Transport):
             self.logger.debug('machine was passed, but it is not localhost')
         self._safe_open_interval = kwargs.pop('safe_interval', self._DEFAULT_SAFE_OPEN_INTERVAL)
         if kwargs:
-            raise ValueError("Input parameters to LocalTransport" " are not recognized")
+            raise ValueError("Input parameters to LocalTransport are not recognized")
 
     def open(self):
         """

--- a/aiida/transports/plugins/test_all_plugins.py
+++ b/aiida/transports/plugins/test_all_plugins.py
@@ -63,7 +63,7 @@ def get_all_custom_transports():
         module = importlib.import_module(".".join([modulename, m]))
         custom_transport = module.__dict__.get('plugin_transport', None)
         if custom_transport is None:
-            print("Define the plugin_transport variable inside the {} module!" "".format(m))
+            print("Define the plugin_transport variable inside the {} module!".format(m))
         else:
             all_custom_transports[m] = custom_transport
 


### PR DESCRIPTION
Fixes #2665 

The method creates the mapping of outputs that will be passed to the
parse method by looping over the ports in the outputs namespace and
checking if their property `pass_to_parser` is set. Except, this
property is only defined for `CalcJobOutputPorts` but the namespace can
also contain normal `PortNamespaces` which would cause an exception.
An explicit check is added to prevent this from happening.

Additionally, the `process_class` property was essentially redefining
the `load_process_class` of its base `Process` class, but did not allow
a fallback loading mechanism for process types that were not based on an
entry point string. The `CalcJob.process_class` has been removed and the
`Process.load_process_class` method has been turned into a property and
renamed to `process_class`. From the point of view of the `CalcJob`
nothing changes, except that now it *is* possible to load the process
class if it is a local module path and not an entry point string.