### PR TITLE
Remove default valid types from the base process specification

### DIFF
--- a/aiida/backends/tests/engine/test_process_spec.py
+++ b/aiida/backends/tests/engine/test_process_spec.py
@@ -24,6 +24,8 @@ class TestProcessSpec(AiidaTestCase):
         super(TestProcessSpec, self).setUp()
         self.assertIsNone(Process.current())
         self.spec = Process.spec()
+        self.spec.inputs.valid_type = Data
+        self.spec.outputs.valid_type = Data
 
     def tearDown(self):
         super(TestProcessSpec, self).tearDown()

--- a/aiida/backends/tests/utils/processes.py
+++ b/aiida/backends/tests/utils/processes.py
@@ -14,7 +14,7 @@ from __future__ import absolute_import
 
 import plumpy
 
-from aiida.orm import WorkflowNode
+from aiida.orm import Data, WorkflowNode
 from aiida.engine import Process
 
 
@@ -26,8 +26,8 @@ class DummyProcess(Process):
     @classmethod
     def define(cls, spec):
         super(DummyProcess, cls).define(spec)
-        spec.inputs.dynamic = True
-        spec.outputs.dynamic = True
+        spec.inputs.valid_type = Data
+        spec.outputs.valid_type = Data
 
     def run(self):
         pass
@@ -57,7 +57,7 @@ class BadOutput(Process):
     @classmethod
     def define(cls, spec):
         super(BadOutput, cls).define(spec)
-        spec.outputs.dynamic = True
+        spec.outputs.valid_type = Data
 
     def run(self):
         self.out("bad_output", 5)

--- a/aiida/engine/processes/process.py
+++ b/aiida/engine/processes/process.py
@@ -73,8 +73,6 @@ class Process(plumpy.Process):
         spec.input('{}.store_provenance'.format(spec.metadata_key), valid_type=bool, default=True)
         spec.input('{}.description'.format(spec.metadata_key), valid_type=six.string_types[0], required=False)
         spec.input('{}.label'.format(spec.metadata_key), valid_type=six.string_types[0], required=False)
-        spec.inputs.valid_type = (orm.Data,)
-        spec.outputs.valid_type = (orm.Data,)
 
     @classmethod
     def get_builder(cls):


### PR DESCRIPTION
Fixes #2669 

The idea was that it would make it easy to define processes as
developers would not have to define valid types for the input and
output namespaces, but the reality is that instead it often hides subtle
bugs if users forget to define an explicit port or mistype an in- or
output. To prevent these suprises, the base process specification will
now have input and output namespace that are **not** dynamic.