### PR TITLE
Implement `__getitem__` on `Dict` node sub class

### DIFF
--- a/aiida/backends/tests/__init__.py
+++ b/aiida/backends/tests/__init__.py
@@ -108,6 +108,7 @@ db_test_list = {
         'orm.authinfos': ['aiida.backends.tests.orm.test_authinfos'],
         'orm.comments': ['aiida.backends.tests.orm.test_comments'],
         'orm.computers': ['aiida.backends.tests.orm.test_computers'],
+        'orm.data.dict': ['aiida.backends.tests.orm.data.test_dict'],
         'orm.data.remote': ['aiida.backends.tests.orm.data.test_remote'],
         'orm.data.singlefile': ['aiida.backends.tests.orm.data.test_singlefile'],
         'orm.data.upf': ['aiida.backends.tests.orm.data.test_upf'],

--- a/aiida/backends/tests/orm/data/test_dict.py
+++ b/aiida/backends/tests/orm/data/test_dict.py
@@ -1,0 +1,36 @@
+# -*- coding: utf-8 -*-
+"""Tests for the `Dict` class."""
+from __future__ import division
+from __future__ import print_function
+from __future__ import absolute_import
+
+from aiida.backends.testbase import AiidaTestCase
+from aiida.orm import Dict
+
+
+class TestDict(AiidaTestCase):
+    """Test for the `Dict` class."""
+
+    @classmethod
+    def setUpClass(cls, *args, **kwargs):
+        super(TestDict, cls).setUpClass(*args, **kwargs)
+        cls.dictionary = {'value': 1, 'nested': {'dict': 'ionary'}}
+        cls.node = Dict(dict=cls.dictionary)
+
+    def test_keys(self):
+        """Test the `keys` method."""
+        self.assertEqual(sorted(self.node.keys()), sorted(self.dictionary.keys()))
+
+    def test_get_dict(self):
+        """Test the `get_dict` method."""
+        self.assertEqual(self.node.get_dict(), self.dictionary)
+
+    def test_dict_property(self):
+        """Test the `dict` property."""
+        self.assertEqual(self.node.dict.value, self.dictionary['value'])
+        self.assertEqual(self.node.dict.nested, self.dictionary['nested'])
+
+    def test_get_item(self):
+        """Test the `__getitem__` method."""
+        self.assertEqual(self.node['value'], self.dictionary['value'])
+        self.assertEqual(self.node['nested'], self.dictionary['nested'])

--- a/aiida/orm/nodes/data/dict.py
+++ b/aiida/orm/nodes/data/dict.py
@@ -39,6 +39,9 @@ class Dict(Data):
         if dictionary:
             self.set_dict(dictionary)
 
+    def __getitem__(self, key):
+        return self.get_dict()[key]
+
     def set_dict(self, dictionary):
         """ Replace the current dictionary with another one.
 


### PR DESCRIPTION
Fixes #2667 

This shortcut will allow users to directly use `node[key]` instead of
having to go through either `get_dict` or `dict` property.