### PR TITLE
Rename `verdi data parameter` to `verdi data dict`

### DIFF
--- a/aiida/backends/tests/cmdline/commands/test_data.py
+++ b/aiida/backends/tests/cmdline/commands/test_data.py
@@ -29,7 +29,7 @@ from aiida.backends.testbase import AiidaTestCase
 from aiida.cmdline.commands.cmd_data import cmd_array
 from aiida.cmdline.commands.cmd_data import cmd_bands
 from aiida.cmdline.commands.cmd_data import cmd_cif
-from aiida.cmdline.commands.cmd_data import cmd_parameter
+from aiida.cmdline.commands.cmd_data import cmd_dict
 from aiida.cmdline.commands.cmd_data import cmd_remote
 from aiida.cmdline.commands.cmd_data import cmd_structure
 from aiida.cmdline.commands.cmd_data import cmd_trajectory
@@ -244,13 +244,13 @@ class TestVerdiData(AiidaTestCase):
         verdi data array
         verdi data bands
         verdi data cif
-        verdi data parameter
+        verdi data dict
         verdi data remote
         verdi data structure
         verdi data trajectory
         verdi data upf
         """
-        subcommands = ['array', 'bands', 'cif', 'parameter', 'remote', 'structure', 'trajectory', 'upf']
+        subcommands = ['array', 'bands', 'cif', 'dict', 'remote', 'structure', 'trajectory', 'upf']
         for sub_cmd in subcommands:
             output = sp.check_output(['verdi', 'data', sub_cmd, '--help'])
             self.assertIn(b'Usage:', output, "Sub-command verdi data {} --help failed.".format(sub_cmd))
@@ -380,14 +380,14 @@ class TestVerdiDataBands(AiidaTestCase, TestVerdiDataListable):
         self.assertIn(b"[1.0, 3.0]", res.stdout_bytes, 'The string [1.0, 3.0] was not found in the bands' 'export')
 
 
-class TestVerdiDataParameter(AiidaTestCase):
+class TestVerdiDataDict(AiidaTestCase):
     """
-    Testing verdi data parameter 
+    Testing verdi data dict
     """
 
     @classmethod
     def setUpClass(cls):
-        super(TestVerdiDataParameter, cls).setUpClass()
+        super(TestVerdiDataDict, cls).setUpClass()
 
     def setUp(self):
         self.p = Dict()
@@ -396,18 +396,18 @@ class TestVerdiDataParameter(AiidaTestCase):
 
         self.cli_runner = CliRunner()
 
-    def test_parametershowhelp(self):
-        output = sp.check_output(['verdi', 'data', 'parameter', 'show', '--help'])
-        self.assertIn(b'Usage:', output, "Sub-command verdi data parameter show --help failed.")
+    def test_dictshowhelp(self):
+        output = sp.check_output(['verdi', 'data', 'dict', 'show', '--help'])
+        self.assertIn(b'Usage:', output, "Sub-command verdi data dict show --help failed.")
 
-    def test_parametershow(self):
+    def test_dictshow(self):
         supported_formats = ['json_date']
         for format in supported_formats:
             options = [str(self.p.id)]
-            res = self.cli_runner.invoke(cmd_parameter.parameter_show, options, catch_exceptions=False)
-            self.assertEqual(res.exit_code, 0, "The command verdi data parameter show did not" " finish correctly")
+            res = self.cli_runner.invoke(cmd_dict.dictionary_show, options, catch_exceptions=False)
+            self.assertEqual(res.exit_code, 0, "The command verdi data dict show did not" " finish correctly")
         self.assertIn(b'"a": 1', res.stdout_bytes, 'The string "a": 1 was not found in the output'
-                                                   ' of verdi data parameter show')
+                                                   ' of verdi data dict show')
 
 
 class TestVerdiDataRemote(AiidaTestCase):
@@ -466,7 +466,7 @@ class TestVerdiDataRemote(AiidaTestCase):
     def test_remotecat(self):
         options = [str(self.r.id), 'file.txt']
         res = self.cli_runner.invoke(cmd_remote.remote_cat, options, catch_exceptions=False)
-        self.assertEqual(res.exit_code, 0, "The command verdi data parameter cat did not" " finish correctly")
+        self.assertEqual(res.exit_code, 0, "The command verdi data remote cat did not" " finish correctly")
         self.assertIn(b'test string', res.stdout_bytes, 'The string "test string" was not found in the output'
                                                         ' of verdi data remote cat file.txt')
 

--- a/aiida/backends/tests/cmdline/commands/test_node.py
+++ b/aiida/backends/tests/cmdline/commands/test_node.py
@@ -28,7 +28,7 @@ from aiida.backends.testbase import AiidaTestCase
 from aiida.cmdline.commands.cmd_data import cmd_array
 from aiida.cmdline.commands.cmd_data import cmd_bands
 from aiida.cmdline.commands.cmd_data import cmd_cif
-from aiida.cmdline.commands.cmd_data import cmd_parameter
+from aiida.cmdline.commands.cmd_data import cmd_dict
 from aiida.cmdline.commands.cmd_data import cmd_remote
 from aiida.cmdline.commands.cmd_data import cmd_structure
 from aiida.cmdline.commands.cmd_data import cmd_trajectory
@@ -242,13 +242,13 @@ class TestVerdiData(AiidaTestCase):
         verdi data array
         verdi data bands
         verdi data cif
-        verdi data parameter
+        verdi data dict
         verdi data remote
         verdi data structure
         verdi data trajectory
         verdi data upf
         """
-        subcommands = ['array', 'bands', 'cif', 'parameter', 'remote', 'structure', 'trajectory', 'upf']
+        subcommands = ['array', 'bands', 'cif', 'dict', 'remote', 'structure', 'trajectory', 'upf']
         for sub_cmd in subcommands:
             output = sp.check_output(['verdi', 'data', sub_cmd, '--help'])
             self.assertIn(b'Usage:', output, "Sub-command verdi data {} --help failed.".format(sub_cmd))
@@ -376,14 +376,14 @@ class TestVerdiDataBands(AiidaTestCase, TestVerdiDataListable):
         self.assertIn(b"[1.0, 3.0]", res.stdout_bytes, 'The string [1.0, 3.0] was not found in the bands' 'export')
 
 
-class TestVerdiDataParameter(AiidaTestCase):
+class TestVerdiDataDict(AiidaTestCase):
     """
-    Testing verdi data parameter
+    Testing verdi data dict
     """
 
     @classmethod
     def setUpClass(cls):
-        super(TestVerdiDataParameter, cls).setUpClass()
+        super(TestVerdiDataDict, cls).setUpClass()
 
     def setUp(self):
         self.p = Dict()
@@ -392,18 +392,18 @@ class TestVerdiDataParameter(AiidaTestCase):
 
         self.cli_runner = CliRunner()
 
-    def test_parametershowhelp(self):
-        output = sp.check_output(['verdi', 'data', 'parameter', 'show', '--help'])
-        self.assertIn(b'Usage:', output, "Sub-command verdi data parameter show --help failed.")
+    def test_dictshowhelp(self):
+        output = sp.check_output(['verdi', 'data', 'dict', 'show', '--help'])
+        self.assertIn(b'Usage:', output, "Sub-command verdi data dict show --help failed.")
 
-    def test_parametershow(self):
+    def test_dictshow(self):
         supported_formats = ['json_date']
         for format in supported_formats:
             options = [str(self.p.id)]
-            res = self.cli_runner.invoke(cmd_parameter.parameter_show, options, catch_exceptions=False)
-            self.assertEqual(res.exit_code, 0, "The command verdi data parameter show did not" " finish correctly")
+            res = self.cli_runner.invoke(cmd_dict.dictionary_show, options, catch_exceptions=False)
+            self.assertEqual(res.exit_code, 0, "The command verdi data dict show did not" " finish correctly")
         self.assertIn(b'"a": 1', res.stdout_bytes, 'The string "a": 1 was not found in the output'
-                                                   ' of verdi data parameter show')
+                                                   ' of verdi data dict show')
 
 
 class TestVerdiDataRemote(AiidaTestCase):
@@ -464,7 +464,7 @@ class TestVerdiDataRemote(AiidaTestCase):
     def test_remotecat(self):
         options = [str(self.r.id), 'file.txt']
         res = self.cli_runner.invoke(cmd_remote.remote_cat, options, catch_exceptions=False)
-        self.assertEqual(res.exit_code, 0, "The command verdi data parameter cat did not" " finish correctly")
+        self.assertEqual(res.exit_code, 0, "The command verdi data remote cat did not" " finish correctly")
         self.assertIn(b'test string', res.stdout_bytes, 'The string "test string" was not found in the output'
                                                         ' of verdi data remote cat file.txt')
 

--- a/aiida/cmdline/commands/__init__.py
+++ b/aiida/cmdline/commands/__init__.py
@@ -24,5 +24,5 @@ from aiida.cmdline.commands import (cmd_calcjob, cmd_code, cmd_comment, cmd_comp
                                     cmd_rehash, cmd_restapi, cmd_run, cmd_setup, cmd_shell, cmd_status, cmd_user)
 
 # Import to populate the `verdi data` sub commands
-from aiida.cmdline.commands.cmd_data import (cmd_array, cmd_bands, cmd_cif, cmd_parameter, cmd_remote, cmd_structure,
+from aiida.cmdline.commands.cmd_data import (cmd_array, cmd_bands, cmd_cif, cmd_dict, cmd_remote, cmd_structure,
                                              cmd_trajectory, cmd_upf)

--- a/aiida/cmdline/commands/cmd_data/cmd_dict.py
+++ b/aiida/cmdline/commands/cmd_data/cmd_dict.py
@@ -7,7 +7,7 @@
 # For further information on the license, see the LICENSE.txt file        #
 # For further information please visit http://www.aiida.net               #
 ###########################################################################
-"""`verdi data parameter` command."""
+"""`verdi data dict` command."""
 from __future__ import division
 from __future__ import print_function
 from __future__ import absolute_import
@@ -16,17 +16,16 @@ from aiida.cmdline.commands.cmd_data import verdi_data
 from aiida.cmdline.params import arguments, types
 
 
-@verdi_data.group('parameter')
-def parameter():
+@verdi_data.group('dict')
+def dictionary():
     """View and manipulate Dict objects."""
 
 
-@parameter.command('show')
+@dictionary.command('show')
 @arguments.DATA(type=types.DataParamType(sub_classes=('aiida.data:dict',)))
-def parameter_show(data):
+def dictionary_show(data):
     """Show contents of Dict nodes."""
     from aiida.cmdline.utils.echo import echo_dictionary
 
     for node in data:
-        the_dict = node.get_dict()
-        echo_dictionary(the_dict, 'json+date')
+        echo_dictionary(node.get_dict(), 'json+date')

--- a/docs/source/verdi/verdi_user_guide.rst
+++ b/docs/source/verdi/verdi_user_guide.rst
@@ -361,7 +361,7 @@ Below is a list with all available subcommands.
       array       Manipulate ArrayData objects.
       bands       Manipulate BandsData objects.
       cif         Manipulation of CIF data objects.
-      parameter   View and manipulate Dict objects.
+      dict        View and manipulate Dict objects.
       plugins     Print a list of registered data plugins or details of a...
       remote      Managing RemoteData objects.
       structure   Manipulation of StructureData objects.


### PR DESCRIPTION
Fixes #2662 

This was apparently missed when the `ParameterData` node was renamed to
`Dict` in a recent commit.