### PR TITLE
Various fixes and improvements to `verdi group`

### DIFF
--- a/aiida/backends/tests/cmdline/commands/test_group.py
+++ b/aiida/backends/tests/cmdline/commands/test_group.py
@@ -7,43 +7,34 @@
 # For further information on the license, see the LICENSE.txt file        #
 # For further information please visit http://www.aiida.net               #
 ###########################################################################
-"""
-Test suite to test verdi group command
-"""
-
+"""Tests for the `verdi group` command."""
 from __future__ import division
 from __future__ import print_function
 from __future__ import absolute_import
-from click.testing import CliRunner
-import traceback
+
+from aiida import orm
 from aiida.backends.testbase import AiidaTestCase
 from aiida.cmdline.commands.cmd_group import (group_list, group_create, group_delete, group_rename, group_description,
-                                              group_addnodes, group_removenodes, group_show, group_copy)
+                                              group_add_nodes, group_remove_nodes, group_show, group_copy)
 
 
-class TestVerdiGroupSetup(AiidaTestCase):
-    """
-    Test suite to test verdi group command
-    """
+class TestVerdiGroup(AiidaTestCase):
+    """Tests for the `verdi group` command."""
 
     @classmethod
     def setUpClass(cls, *args, **kwargs):
-        super(TestVerdiGroupSetup, cls).setUpClass(*args, **kwargs)
-        from aiida.orm import Group
-        for grp in ["dummygroup1", "dummygroup2", "dummygroup3", "dummygroup4"]:
-            Group(label=grp).store()
+        super(TestVerdiGroup, cls).setUpClass(*args, **kwargs)
+        for group in ['dummygroup1', 'dummygroup2', 'dummygroup3', 'dummygroup4']:
+            orm.Group(label=group).store()
 
     def setUp(self):
-        """
-        Create runner object to run tests
-        """
+        """Create runner object to run tests."""
+        from click.testing import CliRunner
         self.cli_runner = CliRunner()
 
     def test_help(self):
-        """
-        Tests help text for all group sub commands
-        """
-        options = ["--help"]
+        """Tests help text for all group sub commands."""
+        options = ['--help']
 
         # verdi group list
         result = self.cli_runner.invoke(group_list, options)
@@ -71,12 +62,12 @@ class TestVerdiGroupSetup(AiidaTestCase):
         self.assertIn('Usage', result.output)
 
         # verdi group addnodes
-        result = self.cli_runner.invoke(group_addnodes, options)
+        result = self.cli_runner.invoke(group_add_nodes, options)
         self.assertIsNone(result.exception, result.output)
         self.assertIn('Usage', result.output)
 
         # verdi group removenodes
-        result = self.cli_runner.invoke(group_removenodes, options)
+        result = self.cli_runner.invoke(group_remove_nodes, options)
         self.assertIsNone(result.exception, result.output)
         self.assertIn('Usage', result.output)
 
@@ -91,105 +82,105 @@ class TestVerdiGroupSetup(AiidaTestCase):
         self.assertIn('Usage', result.output)
 
     def test_create(self):
-        """Test group create command."""
-        result = self.cli_runner.invoke(group_create, ["dummygroup5"])
+        """Test `verdi group create` command."""
+        result = self.cli_runner.invoke(group_create, ['dummygroup5'])
         self.assertClickResultNoException(result)
 
         # check if newly added group in present in list
         result = self.cli_runner.invoke(group_list)
         self.assertClickResultNoException(result)
 
-        self.assertIn("dummygroup5", result.output)
+        self.assertIn('dummygroup5', result.output)
 
     def test_list(self):
-        """Test group list command."""
+        """Test `verdi group list` command."""
         result = self.cli_runner.invoke(group_list)
         self.assertClickResultNoException(result)
 
-        for grp in ["dummygroup1", "dummygroup2"]:
+        for grp in ['dummygroup1', 'dummygroup2']:
             self.assertIn(grp, result.output)
 
     def test_copy(self):
-        """Test group copy command."""
-        result = self.cli_runner.invoke(group_copy, ["dummygroup1", "dummygroup2"])
+        """Test `verdi group copy` command."""
+        result = self.cli_runner.invoke(group_copy, ['dummygroup1', 'dummygroup2'])
         self.assertClickResultNoException(result)
 
-        self.assertIn("Success", result.output)
+        self.assertIn('Success', result.output)
 
     def test_delete(self):
-        """
-        Test group delete command
-        """
-        result = self.cli_runner.invoke(group_delete, ["--force", "dummygroup3"])
+        """Test `verdi group delete` command."""
+        result = self.cli_runner.invoke(group_delete, ['--force', 'dummygroup3'])
         self.assertClickResultNoException(result)
 
         # check if removed group is not present in list
         result = self.cli_runner.invoke(group_list)
         self.assertClickResultNoException(result)
-        self.assertNotIn("dummygroup3", result.output)
+        self.assertNotIn('dummygroup3', result.output)
 
     def test_show(self):
-        """
-        Test group show command
-        """
-        result = self.cli_runner.invoke(group_show, ["dummygroup1"])
+        """Test `verdi group show` command."""
+        result = self.cli_runner.invoke(group_show, ['dummygroup1'])
         self.assertClickResultNoException(result)
 
         for grpline in [
-            "Group label", "dummygroup1", "Group type_string", "user", "Group description", "<no description>"
+            'Group label', 'dummygroup1', 'Group type_string', 'user', 'Group description', '<no description>'
         ]:
             self.assertIn(grpline, result.output)
 
     def test_description(self):
-        """
-        Test group description command
-        """
-        result = self.cli_runner.invoke(group_description, ["dummygroup2", "It is a new description"])
+        """Test `verdi group description` command."""
+        result = self.cli_runner.invoke(group_description, ['dummygroup2', 'It is a new description'])
         self.assertIsNone(result.exception, result.output)
 
-        result = self.cli_runner.invoke(group_show, ["dummygroup2"])
+        result = self.cli_runner.invoke(group_show, ['dummygroup2'])
         self.assertClickResultNoException(result)
-        self.assertIn("Group description", result.output)
-        self.assertNotIn("<no description>", result.output)
-        self.assertIn("It is a new description", result.output)
+        self.assertIn('Group description', result.output)
+        self.assertNotIn('<no description>', result.output)
+        self.assertIn('It is a new description', result.output)
 
     def test_rename(self):
-        """
-        Test group rename command
-        """
-        result = self.cli_runner.invoke(group_rename, ["dummygroup4", "renamedgroup"])
+        """Test `verdi group rename` command."""
+        result = self.cli_runner.invoke(group_rename, ['dummygroup4', 'renamedgroup'])
         self.assertIsNone(result.exception, result.output)
 
         # check if group list command shows changed group name
         result = self.cli_runner.invoke(group_list)
         self.assertClickResultNoException(result)
-        self.assertNotIn("dummygroup4", result.output)
-        self.assertIn("renamedgroup", result.output)
+        self.assertNotIn('dummygroup4', result.output)
+        self.assertIn('renamedgroup', result.output)
 
-    def test_addremovenodes(self):
-        """
-        Test group addnotes command
-        """
+    def test_add_remove_nodes(self):
+        """Test `verdi group remove-nodes` command."""
         from aiida.orm import CalculationNode
 
-        node = CalculationNode()
-        node.set_attribute('attr1', 'OK')
-        node.set_attribute('attr2', 'OK')
-        node.store()
+        node_01 = CalculationNode().store()
+        node_02 = CalculationNode().store()
+        node_03 = CalculationNode().store()
 
-        result = self.cli_runner.invoke(group_addnodes, ['--force', '--group=dummygroup1', node.uuid])
-        self.assertIsNone(result.exception, result.output)
-        # check if node is added in group using group show command
+        result = self.cli_runner.invoke(group_add_nodes, ['--force', '--group=dummygroup1', node_01.uuid])
+        self.assertClickResultNoException(result)
+
+        # Check if node is added in group using group show command
         result = self.cli_runner.invoke(group_show, ['dummygroup1'])
         self.assertClickResultNoException(result)
         self.assertIn('CalculationNode', result.output)
-        self.assertIn(str(node.pk), result.output)
+        self.assertIn(str(node_01.pk), result.output)
 
-        # remove same node
-        result = self.cli_runner.invoke(group_removenodes, ['--force', '--group=dummygroup1', node.uuid])
+        # Remove same node
+        result = self.cli_runner.invoke(group_remove_nodes, ['--force', '--group=dummygroup1', node_01.uuid])
         self.assertIsNone(result.exception, result.output)
-        # check if node is added in group using group show command
+
+        # Check if node is added in group using group show command
         result = self.cli_runner.invoke(group_show, ['-r', 'dummygroup1'])
-        self.assertIsNone(result.exception, result.output)
+        self.assertClickResultNoException(result)
         self.assertNotIn('CalculationNode', result.output)
-        self.assertNotIn(str(node.pk), result.output)
+        self.assertNotIn(str(node_01.pk), result.output)
+
+        # Add all three nodes and then use `verdi group remove-nodes --clear` to remove them all
+        group = orm.load_group(label='dummygroup1')
+        group.add_nodes([node_01, node_02, node_03])
+        self.assertEqual(group.count(), 3)
+
+        result = self.cli_runner.invoke(group_remove_nodes, ['--force', '--clear', '--group=dummygroup1'])
+        self.assertClickResultNoException(result)
+        self.assertEqual(group.count(), 0)

--- a/aiida/backends/tests/orm/test_groups.py
+++ b/aiida/backends/tests/orm/test_groups.py
@@ -165,6 +165,21 @@ class TestGroups(AiidaTestCase):
         group.remove_nodes([node_01, node_02])
         self.assertEqual(set(_.pk for _ in nodes), set(_.pk for _ in group.nodes))
 
+    def test_clear(self):
+        """Test the `clear` method to remove all nodes."""
+        node_01 = orm.Data().store()
+        node_02 = orm.Data().store()
+        node_03 = orm.Data().store()
+        nodes = [node_01, node_02, node_03]
+        group = orm.Group(label='test_clear_nodes').store()
+
+        # Add initial nodes
+        group.add_nodes(nodes)
+        self.assertEqual(set(_.pk for _ in nodes), set(_.pk for _ in group.nodes))
+
+        group.clear()
+        self.assertEqual(list(group.nodes), [])
+
     def test_name_desc(self):
         """Test Group description."""
         group = orm.Group(label='testgroup2', description='some desc')

--- a/aiida/cmdline/commands/cmd_group.py
+++ b/aiida/cmdline/commands/cmd_group.py
@@ -27,50 +27,48 @@ def verdi_group():
     """Inspect, create and manage groups."""
 
 
-@verdi_group.command("removenodes")
+@verdi_group.command('add-nodes')
 @options.GROUP(required=True)
-@arguments.NODES()
-@options.FORCE(help="Force to remove the nodes from group.")
-@with_dbenv()
-def group_removenodes(group, nodes, force):
-    """Remove NODES from a given AiiDA group."""
-
-    if not force:
-        click.confirm(
-            "Are you sure to remove {} nodes from the group with PK = {} "
-            "({})?".format(len(nodes), group.id, group.label),
-            abort=True)
-
-    group.remove_nodes(nodes)
-
-
-@verdi_group.command("addnodes")
-@options.GROUP(required=True)
-@options.FORCE(help="Force to add nodes in the group.")
+@options.FORCE()
 @arguments.NODES()
 @with_dbenv()
-def group_addnodes(group, force, nodes):
-    """Add NODES to a given AiiDA group."""
-
+def group_add_nodes(group, force, nodes):
+    """Add NODES to the given GROUP."""
     if not force:
-        click.confirm(
-            "Are you sure to add {} nodes the group with PK = {} "
-            "({})?".format(len(nodes), group.id, group.label),
-            abort=True)
+        click.confirm('Do you really want to add {} nodes to Group<{}>?'.format(len(nodes), group.label), abort=True)
 
     group.add_nodes(nodes)
 
 
+@verdi_group.command('remove-nodes')
+@options.GROUP(required=True)
+@arguments.NODES()
+@options.GROUP_CLEAR()
+@options.FORCE()
+@with_dbenv()
+def group_remove_nodes(group, nodes, clear, force):
+    """Remove NODES from the given GROUP."""
+    if clear:
+        message = 'Do you really want to remove ALL the nodes from Group<{}>?'.format(group.label)
+    else:
+        message = 'Do you really want to remove {} nodes from Group<{}>?'.format(len(nodes), group.label)
+
+    if not force:
+        click.confirm(message, abort=True)
+
+    if clear:
+        group.clear()
+    else:
+        group.remove_nodes(nodes)
+
+
 @verdi_group.command("delete")
 @arguments.GROUP()
-@options.FORCE(help="Force deletion of the group even if it "
-               "is not empty. Note that this deletes only the "
+@options.FORCE(help="Force deletion of the group even if it is not empty. Note that this deletes only the "
                "group and not the nodes.")
 @with_dbenv()
 def group_delete(group, force):
-    """
-    Pass the GROUP to delete an existing group.
-    """
+    """Delete a GROUP"""
     from aiida import orm
     group_id = group.id
     group_label = group.label
@@ -88,35 +86,34 @@ def group_delete(group, force):
     echo.echo_success("Group '{}' (PK={}) deleted.".format(group_label, group_id))
 
 
-@verdi_group.command("rename")
+@verdi_group.command('rename')
 @arguments.GROUP()
-@click.argument("label", nargs=1, type=click.STRING)
+@click.argument('label', nargs=1, type=click.STRING)
 @with_dbenv()
 def group_rename(group, label):
     """Rename an existing group. Pass the GROUP which you want to rename and its new LABEL."""
     try:
         group.label = label
     except UniquenessError as exception:
-        echo.echo_critical("Error: {}.".format(exception))
+        echo.echo_critical('Error: {}.'.format(exception))
     else:
         echo.echo_success('Name successfully changed')
 
 
-@verdi_group.command("description")
+@verdi_group.command('description')
 @arguments.GROUP()
-@click.argument("description", type=click.STRING)
+@click.argument('description', type=click.STRING)
 @with_dbenv()
 def group_description(group, description):
     """
     Change the description of a given group.
     Pass the GROUP for which you want to edit the description and its
     new DESCRIPTION. If DESCRIPTION is not provided, just show the current description.
-
     """
     group.description = description
 
 
-@verdi_group.command("show")
+@verdi_group.command('show')
 @options.RAW(help="Show only a space-separated list of PKs of the calculations in the group")
 @click.option(
     '-u',
@@ -135,18 +132,18 @@ def group_show(group, raw, uuid):
 
     if raw:
         if uuid:
-            echo.echo(" ".join(str(_.uuid) for _ in group.nodes))
+            echo.echo(' '.join(str(_.uuid) for _ in group.nodes))
         else:
-            echo.echo(" ".join(str(_.pk) for _ in group.nodes))
+            echo.echo(' '.join(str(_.pk) for _ in group.nodes))
     else:
         type_string = group.type_string
         desc = group.description
         now = timezone.now()
 
         table = []
-        table.append(["Group label", group.label])
-        table.append(["Group type_string", type_string])
-        table.append(["Group description", desc if desc else "<no description>"])
+        table.append(['Group label', group.label])
+        table.append(['Group type_string', type_string])
+        table.append(['Group description', desc if desc else '<no description>'])
         echo.echo(tabulate(table))
 
         table = []
@@ -154,7 +151,7 @@ def group_show(group, raw, uuid):
         if uuid:
             header.append('UUID')
         header.extend(['PK', 'Type', 'Created'])
-        echo.echo("# Nodes:")
+        echo.echo('# Nodes:')
         for node in group.nodes:
             row = []
             if uuid:
@@ -178,9 +175,8 @@ def user_defined_group():
     return GroupTypeString.USER.value
 
 
-# pylint: disable=too-many-arguments, too-many-locals
-@verdi_group.command("list")
-@options.ALL_USERS(help="Show groups for all users, rather than only for the current user")
+@verdi_group.command('list')
+@options.ALL_USERS(help='Show groups for all users, rather than only for the current user')
 @click.option(
     '-u',
     '--user',
@@ -222,8 +218,8 @@ def user_defined_group():
 @with_dbenv()
 def group_list(all_users, user_email, all_types, group_type, with_description, count, past_days, startswith, endswith,
                contains, node):
-    # pylint: disable=too-many-branches
     """Show a list of groups."""
+    # pylint: disable=too-many-branches,too-many-arguments, too-many-locals
     import datetime
     from aiida.common.escaping import escape_for_sql_like
     from aiida.common import timezone
@@ -303,7 +299,7 @@ def group_list(all_users, user_email, all_types, group_type, with_description, c
     echo.echo(tabulate(table, headers=projection_header))
 
 
-@verdi_group.command("create")
+@verdi_group.command('create')
 @click.argument('group_label', nargs=1, type=click.STRING)
 @with_dbenv()
 def group_create(group_label):
@@ -319,7 +315,7 @@ def group_create(group_label):
         echo.echo_info("Group '{}' already exists, PK = {}".format(group.label, group.id))
 
 
-@verdi_group.command("copy")
+@verdi_group.command('copy')
 @arguments.GROUP('source_group')
 @click.argument('destination_group', nargs=1, type=click.STRING)
 @with_dbenv()
@@ -329,4 +325,4 @@ def group_copy(source_group, destination_group):
 
     dest_group = orm.Group.objects.get_or_create(label=destination_group, type_string=source_group.type_string)[0]
     dest_group.add_nodes(list(source_group.nodes))
-    echo.echo_success("Nodes copied from group<{}> to group<{}>".format(source_group, destination_group))
+    echo.echo_success('Nodes copied from group<{}> to group<{}>'.format(source_group, destination_group))

--- a/aiida/cmdline/commands/cmd_group.py
+++ b/aiida/cmdline/commands/cmd_group.py
@@ -7,12 +7,11 @@
 # For further information on the license, see the LICENSE.txt file        #
 # For further information please visit http://www.aiida.net               #
 ###########################################################################
-"""
-It defines subcommands for verdi group command.
-"""
+"""`verdi group` commands"""
 from __future__ import division
 from __future__ import print_function
 from __future__ import absolute_import
+
 import click
 
 from aiida.common.exceptions import UniquenessError
@@ -93,31 +92,34 @@ def group_delete(group, clear, force):
     echo.echo_success('Group<{}> deleted.'.format(label))
 
 
-@verdi_group.command('rename')
+@verdi_group.command('relabel')
 @arguments.GROUP()
-@click.argument('label', nargs=1, type=click.STRING)
+@click.argument('label', type=click.STRING)
 @with_dbenv()
-def group_rename(group, label):
-    """Rename an existing group. Pass the GROUP which you want to rename and its new LABEL."""
+def group_relabel(group, label):
+    """Change the label of the given GROUP to LABEL."""
     try:
         group.label = label
     except UniquenessError as exception:
         echo.echo_critical('Error: {}.'.format(exception))
     else:
-        echo.echo_success('Name successfully changed')
+        echo.echo_success('Label changed to {}'.format(label))
 
 
 @verdi_group.command('description')
 @arguments.GROUP()
-@click.argument('description', type=click.STRING)
+@click.argument('description', type=click.STRING, required=False)
 @with_dbenv()
 def group_description(group, description):
+    """Change the description of the given GROUP to DESCRIPTION.
+
+    If no DESCRIPTION is defined, the current description will simply be echoed.
     """
-    Change the description of a given group.
-    Pass the GROUP for which you want to edit the description and its
-    new DESCRIPTION. If DESCRIPTION is not provided, just show the current description.
-    """
-    group.description = description
+    if description:
+        group.description = description
+        echo.echo_success('Changed the description of Group<{}>'.format(group.label))
+    else:
+        echo.echo(group.description)
 
 
 @verdi_group.command('show')

--- a/aiida/cmdline/params/options/__init__.py
+++ b/aiida/cmdline/params/options/__init__.py
@@ -27,8 +27,8 @@ __all__ = (
     'BACKEND', 'DB_HOST', 'DB_PORT', 'DB_USERNAME', 'DB_PASSWORD', 'DB_NAME', 'REPOSITORY_PATH', 'PROFILE_ONLY_CONFIG',
     'PROFILE_SET_DEFAULT', 'PREPEND_TEXT', 'APPEND_TEXT', 'LABEL', 'DESCRIPTION', 'INPUT_PLUGIN', 'CALC_JOB_STATE',
     'PROCESS_STATE', 'EXIT_STATUS', 'FAILED', 'LIMIT', 'PROJECT', 'ORDER_BY', 'PAST_DAYS', 'OLDER_THAN', 'ALL',
-    'ALL_STATES', 'ALL_USERS', 'RAW', 'HOSTNAME', 'TRANSPORT', 'SCHEDULER', 'USER', 'PORT', 'FREQUENCY', 'VERBOSE',
-    'TIMEOUT', 'FORMULA_MODE', 'TRAJECTORY_INDEX', 'WITH_ELEMENTS', 'WITH_ELEMENTS_EXCLUSIVE'
+    'ALL_STATES', 'ALL_USERS', 'GROUP_CLEAR', 'RAW', 'HOSTNAME', 'TRANSPORT', 'SCHEDULER', 'USER', 'PORT', 'FREQUENCY',
+    'VERBOSE', 'TIMEOUT', 'FORMULA_MODE', 'TRAJECTORY_INDEX', 'WITH_ELEMENTS', 'WITH_ELEMENTS_EXCLUSIVE'
 )
 
 
@@ -102,12 +102,12 @@ DATA = OverridableOption(
 GROUP = OverridableOption(
     '-G', '--group', 'group',
     type=types.GroupParamType(),
-    help='A single group identified by its ID, UUID or name.')
+    help='A single group identified by its ID, UUID or label.')
 
 GROUPS = OverridableOption(
     '-G', '--groups', 'groups',
     type=types.GroupParamType(), cls=MultipleValueOption,
-    help='One or multiple groups identified by their ID, UUID or name.')
+    help='One or multiple groups identified by their ID, UUID or label.')
 
 NODE = OverridableOption(
     '-N', '--node', 'node',
@@ -298,6 +298,11 @@ ALL_USERS = OverridableOption(
     '-A', '--all-users', 'all_users',
     is_flag=True, default=False,
     help='Include all entries regardless of the owner.')
+
+GROUP_CLEAR = OverridableOption(
+    '-c', '--clear',
+    is_flag=True, default=False,
+    help='Remove all the nodes from the group.')
 
 RAW = OverridableOption(
     '-r', '--raw', 'raw',

--- a/aiida/orm/groups.py
+++ b/aiida/orm/groups.py
@@ -281,6 +281,10 @@ class Group(entities.Entity):
         else:
             return False
 
+    def clear(self):
+        """Remove all the nodes from this group."""
+        return self._backend_entity.clear()
+
     def add_nodes(self, nodes):
         """Add a node or a set of nodes to the group.
 

--- a/aiida/orm/implementation/django/groups.py
+++ b/aiida/orm/implementation/django/groups.py
@@ -116,6 +116,10 @@ class DjangoGroup(entities.DjangoModelEntity[models.DbGroup], BackendGroup):  # 
         """
         return self._dbmodel.dbnodes.count()
 
+    def clear(self):
+        """Remove all the nodes from this group."""
+        self._dbmodel.dbnodes.clear()
+
     @property
     def nodes(self):
         """Get an iterator to the nodes in the group"""

--- a/aiida/orm/implementation/groups.py
+++ b/aiida/orm/implementation/groups.py
@@ -128,8 +128,9 @@ class BackendGroup(backends.BackendEntity):
 
     @abc.abstractproperty
     def is_stored(self):
-        """
-        :return: True if the respective DbNode has been already saved in the DB, False otherwise
+        """Return whether the group is stored.
+
+        :return: boolean, True if the group is stored, False otherwise
         """
 
     @abc.abstractmethod
@@ -150,6 +151,10 @@ class BackendGroup(backends.BackendEntity):
 
         :return: integer number of entities contained within the group
         """
+
+    @abc.abstractmethod
+    def clear(self):
+        """Remove all the nodes from this group."""
 
     def add_nodes(self, nodes, **kwargs):  # pylint: disable=unused-argument
         """Add a set of nodes to the group.

--- a/aiida/orm/implementation/sqlalchemy/groups.py
+++ b/aiida/orm/implementation/sqlalchemy/groups.py
@@ -133,6 +133,14 @@ class SqlaGroup(entities.SqlaModelEntity[DbGroup], BackendGroup):  # pylint: dis
         session = get_scoped_session()
         return session.query(self.MODEL_CLASS).join(self.MODEL_CLASS.dbnodes).filter(DbGroup.id == self.pk).count()
 
+    def clear(self):
+        """Remove all the nodes from this group."""
+        from aiida.backends.sqlalchemy import get_scoped_session
+        session = get_scoped_session()
+        # Note we have to call `dbmodel` and `_dbmodel` to circumvent the `ModelWrapper`
+        self.dbmodel.dbnodes = []
+        session.commit()
+
     @property
     def nodes(self):
         """Get an iterator to all the nodes in the group"""

--- a/docs/source/verdi/verdi_user_guide.rst
+++ b/docs/source/verdi/verdi_user_guide.rst
@@ -457,7 +457,7 @@ Below is a list with all available subcommands.
 
     Usage:  [OPTIONS] COMMAND [ARGS]...
 
-      Inspect, create and manage groups.
+      Create, inspect and manage groups.
 
     Options:
       --help  Show this message and exit.
@@ -467,7 +467,7 @@ Below is a list with all available subcommands.
       copy          Add all nodes that belong to source group to the
                     destination...
       create        Create a new empty group with the name GROUP_NAME.
-      delete        Delete a GROUP
+      delete        Delete a GROUP.
       description   Change the description of a given group.
       list          Show a list of groups.
       remove-nodes  Remove NODES from the given GROUP.

--- a/docs/source/verdi/verdi_user_guide.rst
+++ b/docs/source/verdi/verdi_user_guide.rst
@@ -463,15 +463,16 @@ Below is a list with all available subcommands.
       --help  Show this message and exit.
 
     Commands:
-      addnodes     Add NODES to a given AiiDA group.
-      copy         Add all nodes that belong to source group to the destination...
-      create       Create a new empty group with the name GROUP_NAME.
-      delete       Pass the GROUP to delete an existing group.
-      description  Change the description of a given group.
-      list         Show a list of groups.
-      removenodes  Remove NODES from a given AiiDA group.
-      rename       Rename an existing group.
-      show         Show information on a given group.
+      add-nodes     Add NODES to the given GROUP.
+      copy          Add all nodes that belong to source group to the
+                    destination...
+      create        Create a new empty group with the name GROUP_NAME.
+      delete        Delete a GROUP
+      description   Change the description of a given group.
+      list          Show a list of groups.
+      remove-nodes  Remove NODES from the given GROUP.
+      rename        Rename an existing group.
+      show          Show information on a given group.
 
 
 .. _verdi_import:

--- a/docs/source/verdi/verdi_user_guide.rst
+++ b/docs/source/verdi/verdi_user_guide.rst
@@ -468,10 +468,10 @@ Below is a list with all available subcommands.
                     destination...
       create        Create a new empty group with the name GROUP_NAME.
       delete        Delete a GROUP.
-      description   Change the description of a given group.
+      description   Change the description of the given GROUP to DESCRIPTION.
       list          Show a list of groups.
+      relabel       Change the label of the given GROUP to LABEL.
       remove-nodes  Remove NODES from the given GROUP.
-      rename        Rename an existing group.
       show          Show information on a given group.
 
 

--- a/docs/source/working_with_aiida/index.rst
+++ b/docs/source/working_with_aiida/index.rst
@@ -21,7 +21,7 @@ This will make understanding and using ``verdi`` a lot easier!
 * :ref:`devel<verdi_devel>`:  Commands for developers.
 * :ref:`export<verdi_export>`:  Create and manage export archives.
 * :ref:`graph<verdi_graph>`:  Create visual representations of part of the provenance graph.
-* :ref:`group<verdi_group>`:  Inspect, create and manage groups.
+* :ref:`group<verdi_group>`:  Create, inspect and manage groups.
 * :ref:`import<verdi_import>`:  Import one or multiple exported AiiDA archives
 * :ref:`node<verdi_node>`:  Inspect, create and manage nodes.
 * :ref:`plugin<verdi_plugin>`:  Inspect installed plugins for various entry point categories.


### PR DESCRIPTION
Fixes #2677 

* Implement `Group.clear` to remove all the nodes

This is also now added as an option to `verdi group remove-nodes`.

* Add the `-c/--clear` option to `verdi group delete`

Before the `--force` flag was used to both disable asking for
confirmation as well as triggering to remove all nodes before deleting
the group. This bundling of two very different behaviors in a single
important flag is dangerous. Here we change `--force` to only deal with
asking for confirmation and add the `--clear` flag to allow the user to
confirm they are sure they want to delete a group that contains nodes.

* Fix bug in `verdi group description` and `verdi group rename`

The doc string of `verdi group description` said that the description
would be echoed if no argument was specified but the argument was
actually required. The argument is now optional and when not provided
will trigger the current description of the group to be echoed.

The command `verdi group rename` is renamed to `verdi group relabel`
since a while back the `name` property was renamed to `label`.