### PR TITLE
Warn user when copying group to non-empty destination group

### DIFF
--- a/aiida/cmdline/commands/cmd_group.py
+++ b/aiida/cmdline/commands/cmd_group.py
@@ -332,6 +332,13 @@ def group_copy(source_group, destination_group):
     """Add all nodes that belong to source group to the destination group (which may or may not exist)."""
     from aiida import orm
 
-    dest_group = orm.Group.objects.get_or_create(label=destination_group, type_string=source_group.type_string)[0]
+    dest_group, created = orm.Group.objects.get_or_create(label=destination_group, type_string=source_group.type_string)
+
+    # Issue warning if destination group is not empty and get user confirmation to continue
+    if not created and not dest_group.is_empty:
+        echo.echo_warning('Destination group<{}> already exists and is not empty.'.format(dest_group.label))
+        click.confirm('Do you wish to continue anyway?', abort=True)
+
+    # Copy nodes
     dest_group.add_nodes(list(source_group.nodes))
-    echo.echo_success('Nodes copied from group<{}> to group<{}>'.format(source_group, destination_group))
+    echo.echo_success('Nodes copied from group<{}> to group<{}>'.format(source_group.label, dest_group.label))

--- a/aiida/orm/groups.py
+++ b/aiida/orm/groups.py
@@ -107,7 +107,7 @@ class Group(entities.Entity):
                  type=None):
         """
         Create a new group. Either pass a dbgroup parameter, to reload
-        ad group from the DB (and then, no further parameters are allowed),
+        a group from the DB (and then, no further parameters are allowed),
         or pass the parameters for the Group creation.
 
         :param dbgroup: the dbgroup object, if you want to reload the group


### PR DESCRIPTION
Fixes #2679

#### Logic:
If destination group was not created and is not empty, the user will be warned and asked to confirm the copy.

The copy will take place - or the user will have aborted.

#### Added test:
`test_copy_existing_group`: Creates source group with nodes.
First copies and creates destination group, checking all is well, then copies the same source group to the same destination group, checking an abort error is raised.

#### Minor things:
Corrected typo in doc-string for `__init__` of Group entity.