### PR TITLE
Make the outputs of a live process nestable

### DIFF
--- a/aiida/backends/tests/engine/test_work_chain.py
+++ b/aiida/backends/tests/engine/test_work_chain.py
@@ -1168,10 +1168,16 @@ class TestWorkChainExpose(AiidaTestCase):
         self.assertEquals(
             res, {
                 'a': Float(2.2),
-                'sub_1.b': Float(2.3),
-                'sub_1.c': Bool(True),
-                'sub_2.b': Float(1.2),
-                'sub_2.sub_3.c': Bool(False)
+                'sub_1': {
+                    'b': Float(2.3),
+                    'c': Bool(True)
+                },
+                'sub_2': {
+                    'b': Float(1.2),
+                    'sub_3': {
+                        'c': Bool(False)
+                    }
+                }
             })
 
     @unittest.skip('Reenable when issue #2515 is solved: references to deleted ORM instances')
@@ -1194,11 +1200,21 @@ class TestWorkChainExpose(AiidaTestCase):
                 )))
         self.assertEquals(
             res, {
-                'sub.sub.a': Float(2.2),
-                'sub.sub.sub_1.b': Float(2.3),
-                'sub.sub.sub_1.c': Bool(True),
-                'sub.sub.sub_2.b': Float(1.2),
-                'sub.sub.sub_2.sub_3.c': Bool(False)
+                'sub': {
+                    'sub': {
+                        'a': Float(2.2),
+                        'sub_1': {
+                            'b': Float(2.3),
+                            'c': Bool(True)
+                        },
+                        'sub_2': {
+                            'b': Float(1.2),
+                            'sub_3': {
+                                'c': Bool(False)
+                            }
+                        }
+                    }
+                }
             })
 
     def test_issue_1741_expose_inputs(self):

--- a/aiida/engine/daemon/execmanager.py
+++ b/aiida/engine/daemon/execmanager.py
@@ -367,8 +367,12 @@ def parse_results(process, retrieved_temporary_folder=None):
             parser.logger.error('parser returned exit code<{}>: {}'.format(exit_code.status, exit_code.message))
 
         for link_label, node in parser.outputs.items():
-            node.add_incoming(process.node, link_type=LinkType.CREATE, link_label=link_label)
-            node.store()
+            try:
+                process.out(link_label, node)
+            except ValueError as exception:
+                parser.logger.error('invalid value {} specified with label {}: {}'.format(node, link_label, exception))
+                exit_code = process.exit_codes.ERROR_INVALID_OUTPUT
+                break
 
     return exit_code
 

--- a/aiida/engine/processes/calcjobs/calcjob.py
+++ b/aiida/engine/processes/calcjobs/calcjob.py
@@ -106,9 +106,6 @@ class CalcJob(Process):
             help='Files that are retrieved by the daemon will be stored in this node. By default the stdout and stderr '
                  'of the scheduler will be added, but one can add more by specifying them in `CalcInfo.retrieve_list`.')
 
-        spec.exit_code(10, 'ERROR_PARSING_FAILED', message='the parsing of the job failed')
-        spec.exit_code(20, 'ERROR_FAILED', message='the job failed for an unspecified reason')
-
     @classmethod
     def get_state_classes(cls):
         # Overwrite the waiting state

--- a/aiida/engine/processes/functions.py
+++ b/aiida/engine/processes/functions.py
@@ -224,8 +224,10 @@ class FunctionProcess(Process):
             # If the function support kwargs then allow dynamic inputs, otherwise disallow
             spec.inputs.dynamic = keywords is not None
 
-            # Function processes return data types
-            spec.outputs.valid_type = orm.Data
+            # Function processes must have a dynamic output namespace since we do not know beforehand what outputs
+            # will be returned and the valid types for the value should be `Data` nodes as well as a dictionary because
+            # the output namespace can be nested.
+            spec.outputs.valid_type = (orm.Data, dict)
 
         return type(
             func.__name__, (FunctionProcess,), {

--- a/aiida/engine/processes/ports.py
+++ b/aiida/engine/processes/ports.py
@@ -15,6 +15,10 @@ from __future__ import absolute_import
 from collections import Mapping
 from plumpy import ports
 
+__all__ = ('PortNamespace', 'InputPort', 'OutputPort', 'CalcJobOutputPort', 'WithNonDb', 'WithSerialize')
+
+OutputPort = ports.OutputPort  # pylint: disable=invalid-name
+
 
 class WithNonDb(object):  # pylint: disable=useless-object-inheritance
     """

--- a/docs/requirements_for_rtd.txt
+++ b/docs/requirements_for_rtd.txt
@@ -44,7 +44,7 @@ passlib==1.7.1
 pathlib2; python_version<'3.5'
 pg8000<1.13.0
 pgtest==1.2.0
-plumpy==0.13.0
+plumpy==0.13.1
 psutil==5.5.1
 pyblake2==1.1.2; python_version<'3.6'
 pymatgen<=2018.12.12

--- a/environment.yml
+++ b/environment.yml
@@ -36,7 +36,7 @@ dependencies:
 - paramiko==2.4.2
 - ecdsa==0.13
 - ipython>=4.0,<6.0
-- plumpy==0.13.0
+- plumpy==0.13.1
 - circus==0.15.0
 - tornado<5.0
 - simplejson==3.16.0

--- a/setup.json
+++ b/setup.json
@@ -47,7 +47,7 @@
     "paramiko==2.4.2",
     "ecdsa==0.13",
     "ipython>=4.0,<6.0",
-    "plumpy==0.13.0",
+    "plumpy==0.13.1",
     "circus==0.15.0",
     "tornado<5.0",
     "pyblake2==1.1.2; python_version<'3.6'",


### PR DESCRIPTION
Fixes #2680 and fixes #2666 

The outputs namespace of a process specification allows for arbitrary
nesting, just like the inputs. The inputs of a process, when passed,
will have to have a nesting structure that matches that of the inputs
process specification. However, the internal structure of outputs of a
process were not keeping the same nested structure as their process
specification counterpart. Of course when the processes finishes and the
outputs have to be linked up through links to the process node, the
support for nesting disappears and the mapping will have to be
flattened. However, while the process is "alive" the internal outputs
should keep the nesting structure of the process spec.