### PR TITLE
Set default for `CalcJob.metadata.options.withmpi` to `False`

### DIFF
--- a/aiida/engine/processes/calcjobs/calcjob.py
+++ b/aiida/engine/processes/calcjobs/calcjob.py
@@ -78,7 +78,7 @@ class CalcJob(Process):
             help='Set the quality of service to use in for the queue on the remote computer')
         spec.input('metadata.options.computer', valid_type=orm.Computer, required=False,
             help='Set the computer to be used by the calculation')
-        spec.input('metadata.options.withmpi', valid_type=bool, default=True,
+        spec.input('metadata.options.withmpi', valid_type=bool, default=False,
             help='Set the calculation to use mpi',)
         spec.input('metadata.options.mpirun_extra_params', valid_type=(list, tuple), default=[],
             help='Set the extra params to pass to the mpirun (or equivalent) command after the one provided in '


### PR DESCRIPTION
Fixes #2689 

Running codes with MPI by accident that don't support it is worse than
accidentally not using MPI for those that can. The safer default for
`aiida-core` therefore is to set it to `False`. Plugins can override this
on a per calculation basis when defining the process specification.