### PR TITLE
Make `Parser` an abstract class and `parse` abstract method

### DIFF
--- a/aiida/backends/tests/engine/test_calc_job.py
+++ b/aiida/backends/tests/engine/test_calc_job.py
@@ -16,6 +16,9 @@ from aiida import orm
 from aiida.backends.testbase import AiidaTestCase
 from aiida.common import exceptions
 from aiida.engine import launch, CalcJob, Process, CalcJobBuilder
+from aiida.plugins import CalculationFactory
+
+ArithmeticAddCalculation = CalculationFactory('arithmetic.add')  # pylint: disable=invalid-name
 
 
 class TestCalcJob(AiidaTestCase):
@@ -88,3 +91,23 @@ class TestCalcJob(AiidaTestCase):
         """ verify that `CalcJob.get_builder` returns CalcJobBuilder"""
         builder = CalcJob.get_builder()
         self.assertIsInstance(builder, CalcJobBuilder)
+
+    def test_invalid_parser_name(self):
+        """Passing an invalid parser name should already stop during input validation."""
+        inputs = {
+            'code': self.code,
+            'x': orm.Int(1),
+            'y': orm.Int(2),
+            'metadata': {
+                'options': {
+                    'resources': {
+                        'num_machines': 1,
+                        'num_mpiprocs_per_machine': 1
+                    },
+                    'parser_name': 'invalid_parser'
+                }
+            }
+        }
+
+        with self.assertRaises(exceptions.ValidationError):
+            ArithmeticAddCalculation(inputs=inputs)

--- a/aiida/orm/nodes/process/calculation/calcjob.py
+++ b/aiida/orm/nodes/process/calculation/calcjob.py
@@ -162,11 +162,16 @@ class CalcJobNode(CalculationNode):
             raise exceptions.ValidationError('invalid calculation state `{}`'.format(self.get_state()))
 
         try:
-            self.get_parser_class()
-        except exceptions.EntryPointError:
-            raise exceptions.ValidationError("No valid class/implementation found for the parser '{}'. "
-                                             "Set the parser to None if you do not need an automatic "
-                                             "parser.".format(self.get_option('parser_name')))
+            parser_class = self.get_parser_class()
+        except exceptions.EntryPointError as exception:
+            raise exceptions.ValidationError('invalid parser specified: {}'.format(exception))
+
+        try:
+            # Since a parser is not required to be set, so `get_parser_class` will return `None` in that case
+            if parser_class is not None:
+                parser_class(self)
+        except TypeError as exception:
+            raise exceptions.ValidationError('invalid parser specified: {}'.format(exception))
 
         computer = self.computer
         scheduler = computer.get_scheduler()

--- a/aiida/parsers/parser.py
+++ b/aiida/parsers/parser.py
@@ -15,6 +15,9 @@ from __future__ import division
 from __future__ import print_function
 from __future__ import absolute_import
 
+from abc import ABCMeta, abstractmethod
+import six
+
 from aiida.common import exceptions, extendeddicts
 from aiida.engine import calcfunction
 from aiida.engine.processes.ports import CalcJobOutputPort
@@ -22,8 +25,11 @@ from aiida.engine.processes.ports import CalcJobOutputPort
 __all__ = ('Parser',)
 
 
-class Parser(object):  # pylint: disable=useless-object-inheritance
+@six.add_metaclass(ABCMeta)
+class Parser(object):
     """Base class for a Parser that can parse the outputs produced by a CalcJob process."""
+
+    # pylint: disable=useless-object-inheritance
 
     def __init__(self, node):
         """Construct the Parser instance.
@@ -138,6 +144,7 @@ class Parser(object):  # pylint: disable=useless-object-inheritance
 
         return parse_calcfunction.run_get_node(**inputs)
 
+    @abstractmethod
     def parse(self, **kwargs):
         """Parse the contents of the output files retrieved in the `FolderData`.
 
@@ -147,4 +154,3 @@ class Parser(object):  # pylint: disable=useless-object-inheritance
         :param kwargs: output nodes attached to the `CalcJobNode` of the parser instance.
         :return: an instance of ExitCode or None
         """
-        raise NotImplementedError


### PR DESCRIPTION
Fixes #2673 

This prevents one from instantiating a parser that has not implemented
the `parse` method, without which it will be useless. This also makes
the validation of the `CalcJob.metadata.options.parser_name` easier as
it will now be able to verify that the specified parser entry point can
both be resolved and imported, as well as constructed, or the input
validation will fail. This will prevent users from accidentally
launching a calculation job only to find after it has finished that an
incorrect parser was specified.

Note that we cannot use the `validator` key of the input port for this
task, as the ports are overridable by sub classes of the `CalcJob` and
if they forget to reattach the validator, the validation will not be
performed.