### PR TITLE
Formalize the mapping of port namespaces to link labels

### DIFF
--- a/aiida/backends/tests/cmdline/utils/test_common.py
+++ b/aiida/backends/tests/cmdline/utils/test_common.py
@@ -26,13 +26,11 @@ class TestCommonUtilities(AiidaTestCase):
         from aiida.cmdline.utils.common import get_node_summary
 
         computer_label = self.computer.name  # pylint: disable=no-member
-        code_label = 'test_code'
 
         code = Code(
             input_plugin_name='arithmetic.add',
             remote_computer_exec=[self.computer, '/remote/abs/path'],
         )
-        code.label = code_label
         code.store()
 
         node = CalculationNode()
@@ -42,7 +40,6 @@ class TestCommonUtilities(AiidaTestCase):
 
         summary = get_node_summary(node)
         self.assertIn(node.uuid, summary)
-        self.assertIn(code_label, summary)
         self.assertIn(computer_label, summary)
 
     def test_get_process_function_report(self):

--- a/aiida/backends/tests/engine/test_ports.py
+++ b/aiida/backends/tests/engine/test_ports.py
@@ -64,3 +64,24 @@ class TestPortNamespace(AiidaTestCase):
         port = InputPort('not_storable')
         port_namespace['not_storable'] = port
         self.assertEqual(port.non_db, namespace_non_db)
+
+    def test_validate_port_name(self):
+        """This test will ensure that illegal port names will raise a `ValueError` when trying to add it."""
+        port = InputPort('port')
+        port_namespace = PortNamespace('namespace')
+
+        illegal_port_names = [
+            'two__underscores',
+            'three___underscores',
+            '_leading_underscore',
+            'trailing_underscore_',
+            'non_numeric_%',
+            'including.period',
+            'disallowed👻unicodecharacters',
+            'white space',
+            'das-hes',
+        ]
+
+        for port_name in illegal_port_names:
+            with self.assertRaises(ValueError):
+                port_namespace[port_name] = port

--- a/aiida/backends/tests/engine/test_process.py
+++ b/aiida/backends/tests/engine/test_process.py
@@ -61,8 +61,8 @@ class TestProcessNamespace(AiidaTestCase):
         self.assertEquals(input_node.value, 5)
 
         # Check that the link of the process node has the correct link name
-        self.assertTrue('some_name_space_a' in proc.node.get_incoming().all_link_labels())
-        self.assertEquals(proc.node.get_incoming().get_node_by_label('some_name_space_a'), 5)
+        self.assertTrue('some__name__space__a' in proc.node.get_incoming().all_link_labels())
+        self.assertEquals(proc.node.get_incoming().get_node_by_label('some__name__space__a'), 5)
 
 class ProcessStackTest(Process):
 

--- a/aiida/backends/tests/engine/test_process_builder.py
+++ b/aiida/backends/tests/engine/test_process_builder.py
@@ -11,9 +11,12 @@ from __future__ import division
 from __future__ import print_function
 from __future__ import absolute_import
 
+from collections import MutableMapping
+
+from aiida import orm
 from aiida.backends.testbase import AiidaTestCase
+from aiida.common import LinkType
 from aiida.engine import WorkChain, Process
-from aiida.orm import Dict, Bool, Float, Int
 from aiida.plugins import CalculationFactory
 
 DEFAULT_INT = 256
@@ -24,10 +27,12 @@ class TestWorkChain(WorkChain):
     @classmethod
     def define(cls, spec):
         super(TestWorkChain, cls).define(spec)
-        spec.input('a', valid_type=Int, help='A pointless integer')
-        spec.input('b', valid_type=Float, help='A pointless float')
-        spec.input('c.d', valid_type=Bool, help='A pointless boolean')
-        spec.input('e', valid_type=Int, default=Int(DEFAULT_INT))
+        spec.input_namespace('dynamic.namespace', dynamic=True)
+        spec.input('values', valid_type=orm.Int, help='Port name that overlaps with method of mutable mapping')
+        spec.input('name.spaced', valid_type=orm.Int, help='Namespaced port')
+        spec.input('name_spaced', valid_type=orm.Str, help='Not actually a namespaced port')
+        spec.input('boolean', valid_type=orm.Bool, help='A pointless boolean')
+        spec.input('default', valid_type=orm.Int, default=orm.Int(DEFAULT_INT))
 
 
 class TestProcessBuilder(AiidaTestCase):
@@ -37,22 +42,32 @@ class TestProcessBuilder(AiidaTestCase):
         self.assertIsNone(Process.current())
         self.process_class = CalculationFactory('templatereplacer')
         self.builder = self.process_class.get_builder()
+        self.builder_workchain = TestWorkChain.get_builder()
+        self.inputs = {
+            'dynamic': {
+                'namespace': {
+                    'alp': orm.Int(1)
+                }
+            },
+            'name': {
+                'spaced': orm.Int(1),
+            },
+            'name_spaced': orm.Str('underscored'),
+            'boolean': orm.Bool(True),
+            'metadata': {'options': {}}
+        }
 
     def tearDown(self):
         super(TestProcessBuilder, self).tearDown()
         self.assertIsNone(Process.current())
 
     def test_process_builder_attributes(self):
-        """
-        Check that the builder has all the input ports of the process class as attributes
-        """
+        """Check that the builder has all the input ports of the process class as attributes."""
         for name, port in self.process_class.spec().inputs.items():
             self.assertTrue(hasattr(self.builder, name))
 
     def test_process_builder_set_attributes(self):
-        """
-        Verify that setting attributes in builder works
-        """
+        """Verify that setting attributes in builder works."""
         label = 'Test label'
         description = 'Test description'
 
@@ -62,99 +77,138 @@ class TestProcessBuilder(AiidaTestCase):
         self.assertEquals(self.builder.metadata.label, label)
         self.assertEquals(self.builder.metadata.description, description)
 
-    def test_workchain(self):
-        """
-        Verify that the attributes of the TestWorkChain can be set but defaults are not there
-        """
-        builder = TestWorkChain.get_builder()
-        builder.a = Int(2)
-        builder.b = Float(2.3)
-        builder.c.d = Bool(True)
-        self.assertEquals(builder, {'a': Int(2), 'b': Float(2.3), 'c': {'d': Bool(True)}, 'metadata': {'options': {}}})
-
-    def test_invalid_setattr_raises(self):
-        """
-        Verify that __setattr__ cannot be called on a terminal Port
-        """
-        builder = TestWorkChain.get_builder()
-        with self.assertRaises(AttributeError):
-            builder.a.b = 3
+    def test_dynamic_setters(self):
+        """Verify that the attributes of the TestWorkChain can be set but defaults are not there."""
+        self.builder_workchain.dynamic.namespace = self.inputs['dynamic']['namespace']
+        self.builder_workchain.name.spaced = self.inputs['name']['spaced']
+        self.builder_workchain.name_spaced = self.inputs['name_spaced']
+        self.builder_workchain.boolean = self.inputs['boolean']
+        self.assertEquals(self.builder_workchain, self.inputs)
 
     def test_dynamic_getters_value(self):
-        """
-        Verify that getters will return the actual value
-        """
-        builder = TestWorkChain.get_builder()
-        builder.a = Int(2)
-        builder.b = Float(2.3)
-        builder.c.d = Bool(True)
+        """Verify that getters will return the actual value."""
+        self.builder_workchain.dynamic.namespace = self.inputs['dynamic']['namespace']
+        self.builder_workchain.name.spaced = self.inputs['name']['spaced']
+        self.builder_workchain.name_spaced = self.inputs['name_spaced']
+        self.builder_workchain.boolean = self.inputs['boolean']
 
         # Verify that the correct type is returned by the getter
-        self.assertTrue(isinstance(builder.a, Int))
-        self.assertTrue(isinstance(builder.b, Float))
-        self.assertTrue(isinstance(builder.c.d, Bool))
+        self.assertTrue(isinstance(self.builder_workchain.dynamic.namespace, dict))
+        self.assertTrue(isinstance(self.builder_workchain.name.spaced, orm.Int))
+        self.assertTrue(isinstance(self.builder_workchain.name_spaced, orm.Str))
+        self.assertTrue(isinstance(self.builder_workchain.boolean, orm.Bool))
 
         # Verify that the correct value is returned by the getter
-        self.assertEquals(builder.a, Int(2))
-        self.assertEquals(builder.b, Float(2.3))
-        self.assertEquals(builder.c.d, Bool(True))
+        self.assertEquals(self.builder_workchain.dynamic.namespace, self.inputs['dynamic']['namespace'])
+        self.assertEquals(self.builder_workchain.name.spaced, self.inputs['name']['spaced'])
+        self.assertEquals(self.builder_workchain.name_spaced, self.inputs['name_spaced'])
+        self.assertEquals(self.builder_workchain.boolean, self.inputs['boolean'])
 
     def test_dynamic_getters_doc_string(self):
-        """
-        Verify that getters have the correct docstring
+        """Verify that getters have the correct docstring."""
+        builder = TestWorkChain.get_builder()
+        self.assertEquals(builder.__class__.name_spaced.__doc__, str(TestWorkChain.spec().inputs['name_spaced']))
+        self.assertEquals(builder.__class__.boolean.__doc__, str(TestWorkChain.spec().inputs['boolean']))
+
+    def test_builder_restart_work_chain(self):
+        """Verify that nested namespaces imploded into flat link labels can be reconstructed into nested namespaces."""
+        node = orm.WorkChainNode(process_type=TestWorkChain.build_process_type()).store()
+        node.add_incoming(self.inputs['dynamic']['namespace']['alp'], LinkType.INPUT_WORK, 'dynamic__namespace__alp')
+        node.add_incoming(self.inputs['name']['spaced'], LinkType.INPUT_WORK, 'name__spaced')
+        node.add_incoming(self.inputs['name_spaced'], LinkType.INPUT_WORK, 'name_spaced')
+        node.add_incoming(self.inputs['boolean'], LinkType.INPUT_WORK, 'boolean')
+        node.add_incoming(orm.Int(DEFAULT_INT), LinkType.INPUT_WORK, 'default')
+
+        builder = node.get_builder_restart()
+        self.assertIn('dynamic', builder)
+        self.assertIn('namespace', builder.dynamic)
+        self.assertIn('alp', builder.dynamic.namespace)
+        self.assertIn('name', builder)
+        self.assertIn('spaced', builder.name)
+        self.assertIn('name_spaced', builder)
+        self.assertIn('boolean', builder)
+        self.assertIn('default', builder)
+        self.assertEquals(builder.dynamic.namespace['alp'], self.inputs['dynamic']['namespace']['alp'])
+        self.assertEquals(builder.name.spaced, self.inputs['name']['spaced'])
+        self.assertEquals(builder.name_spaced, self.inputs['name_spaced'])
+        self.assertEquals(builder.boolean, self.inputs['boolean'])
+        self.assertEquals(builder.default, orm.Int(DEFAULT_INT))
+
+    def test_port_names_overlapping_mutable_mapping_methods(self):
+        """Check that port names take precedence over `collections.MutableMapping` methods.
+
+        The `ProcessBuilderNamespace` is a `collections.MutableMapping` but since the port names are made accessible
+        as attributes, they can overlap with some of the mappings builtin methods, e.g. `values()`, `items()` etc.
+        The port names should take precendence in this case and if one wants to access the mapping methods one needs to
+        cast the builder to a dictionary first.
         """
         builder = TestWorkChain.get_builder()
-        self.assertEquals(builder.__class__.a.__doc__, str(TestWorkChain.spec().inputs['a']))
-        self.assertEquals(builder.__class__.b.__doc__, str(TestWorkChain.spec().inputs['b']))
-        self.assertEquals(builder.__class__.c.__doc__, str(TestWorkChain.spec().inputs['c']))
-        self.assertEquals(builder.c.__class__.d.__doc__, str(TestWorkChain.spec().inputs['c']['d']))
 
-    def test_job_calculation_get_builder_restart(self):
-        """
-        Test the get_builder_restart method of CalcJobNode class
-        """
-        from aiida.orm import CalcJobNode
+        # The `values` method is obscured by a port that also happens to be called `values`, so calling it should raise
+        with self.assertRaises(TypeError):
+            builder.values()
 
-        # Have to set the process type manually, because usually this will be done automatically when the node is
-        # instantiated by the process itself. Since we hack it here and instantiate the node directly ourselves we
-        # have to set the process type for the restart builder to be able to recreate the process class.
-        original = CalcJobNode(
-            computer=self.computer, process_type='aiida.calculations:templatereplacer', label='original')
+        # However, we can assign a node to it
+        builder.values = orm.Int(2)
+
+        # Calling the attribute `values` will then actually try to call the node, which should raise
+        with self.assertRaises(TypeError):
+            builder.values()
+
+        # Casting the builder to a dict, *should* then make `values` callable again
+        self.assertIn(orm.Int(2), dict(builder).values())
+
+        # The mapping methods should not be auto-completed, i.e. not in the values returned by calling `dir`
+        for method in [method for method in dir(MutableMapping) if method != 'values']:
+            self.assertNotIn(method, dir(builder))
+
+        # On the other hand, all the port names *should* be present
+        for port_name in TestWorkChain.spec().inputs.keys():
+            self.assertIn(port_name, dir(builder))
+
+        # The `update` method is implemented, but prefixed with an underscore to not block the name for a port
+        builder.update({'boolean': orm.Bool(False)})
+        self.assertEqual(builder.boolean, orm.Bool(False))
+
+    def test_calc_job_node_get_builder_restart(self):
+        """Test the `CalcJobNode.get_builder_restart` method."""
+        original = orm.CalcJobNode(computer=self.computer, process_type='aiida.calculations:arithmetic.add', label='original')
         original.set_option('resources', {'num_machines': 1, 'num_mpiprocs_per_machine': 1})
         original.set_option('max_wallclock_seconds', 1800)
         original.store()
 
+        original.add_incoming(orm.Int(1), link_type=LinkType.INPUT_CALC, link_label='x')
+        original.add_incoming(orm.Int(2), link_type=LinkType.INPUT_CALC, link_label='y')
+
         builder = original.get_builder_restart()
 
+        self.assertIn('x', builder)
+        self.assertIn('y', builder)
+        self.assertIn('metadata', builder)
+        self.assertIn('options', builder.metadata)
+        self.assertEquals(builder.x, orm.Int(1))
+        self.assertEquals(builder.y, orm.Int(2))
         self.assertDictEqual(builder.metadata.options, original.get_options())
 
     def test_code_get_builder(self):
-        """
-        Test that the get_builder method of Code returns a builder
-        where the code is already set.
-        """
-        from aiida.orm import Code
-
-        code1 = Code()
-        # This also sets the code as a remote code
-        code1.set_remote_computer_exec((self.computer, '/bin/true'))
-        code1.label = 'test_code1'
-        code1.set_input_plugin_name('templatereplacer')
-        code1.store()
+        """Test that the `Code.get_builder` method returns a builder where the code is already set."""
+        code = orm.Code()
+        code.set_remote_computer_exec((self.computer, '/bin/true'))
+        code.label = 'test_code'
+        code.set_input_plugin_name('templatereplacer')
+        code.store()
 
         # Check that I can get a builder
-        builder = code1.get_builder()
-        self.assertEquals(builder.code.pk, code1.pk)
+        builder = code.get_builder()
+        self.assertEquals(builder.code.pk, code.pk)
 
         # Check that I can set the parameters
-        builder.parameters = Dict(dict={})
+        builder.parameters = orm.Dict(dict={})
 
         # Check that it complains for an unknown input
         with self.assertRaises(AttributeError):
             builder.unknown_parameter = 3
 
-        # Check that it complains if the type is not the correct one
-        # (for the templatereplacer, it should be a
-        # Dict)
+        # Check that it complains if the type is not the correct one (for the templatereplacer, it should be a Dict)
         with self.assertRaises(ValueError):
-            builder.parameters = Int(3)
+            builder.parameters = orm.Int(3)

--- a/aiida/backends/tests/engine/test_work_chain.py
+++ b/aiida/backends/tests/engine/test_work_chain.py
@@ -1312,6 +1312,6 @@ class TestDefaultUniqueness(AiidaTestCase):
 
         # Trying to load one of the inputs through the UUID should fail,
         # as both `child_one.a` and `child_two.a` should have the same UUID.
-        node = load_node(uuid=node.get_incoming().get_node_by_label('child_one_a').uuid)
+        node = load_node(uuid=node.get_incoming().get_node_by_label('child_one__a').uuid)
         self.assertEquals(
             len(uuids), len(nodes), 'Only {} unique UUIDS for {} input nodes'.format(len(uuids), len(nodes)))

--- a/aiida/backends/tests/parsers/test_parser.py
+++ b/aiida/backends/tests/parsers/test_parser.py
@@ -19,7 +19,7 @@ class CustomCalcJob(CalcJob):
     @classmethod
     def define(cls, spec):
         super(CustomCalcJob, cls).define(spec)
-        spec.input('in', valid_type=orm.Data)
+        spec.input('inp', valid_type=orm.Data)
         spec.output('output', pass_to_parser=True)
         spec.output_namespace('out.space', dynamic=True)
 

--- a/aiida/cmdline/utils/common.py
+++ b/aiida/cmdline/utils/common.py
@@ -86,7 +86,7 @@ def get_node_summary(node):
     :return: a string summary of the node
     """
     from plumpy import ProcessState
-    from aiida.orm import Code, ProcessNode
+    from aiida.orm import ProcessNode
 
     table_headers = ['Property', 'Value']
     table = []
@@ -105,7 +105,7 @@ def get_node_summary(node):
             process_state = None
 
         try:
-            table.append(['process state', ProcessState(process_state)])
+            table.append(['process state', ProcessState(process_state).value.capitalize()])
         except ValueError:
             table.append(['process state', process_state])
 
@@ -122,22 +122,13 @@ def get_node_summary(node):
         if computer is not None:
             table.append(['computer', '[{}] {}'.format(node.computer.pk, node.computer.name)])
 
-    try:
-        code = node.get_incoming(node_class=Code).first()
-    except ValueError:
-        pass
-    else:
-        table.append(['code', code.node.label])
-
     return tabulate(table, headers=table_headers)
 
 
 def get_node_info(node, include_summary=True):
-    # pylint: disable=too-many-branches
-    """
-    Return a multi line string of information about the given node, such as the incoming and outcoming links
+    """Return a multi line string of information about the given node, such as the incoming and outcoming links.
 
-    :param include_summary: also include a summary of node properties
+    :param include_summary: boolean, if True, also include a summary of node properties
     :return: a string summary of the node including a description of all its links and log messages
     """
     from aiida.common.links import LinkType
@@ -148,44 +139,22 @@ def get_node_info(node, include_summary=True):
     else:
         result = ''
 
-    nodes_input_calc = node.get_incoming(link_type=LinkType.INPUT_CALC).all()
-    nodes_input_work = node.get_incoming(link_type=LinkType.INPUT_WORK).all()
-    nodes_caller = node.get_incoming(link_type=(LinkType.CALL_CALC, LinkType.CALL_WORK)).all()
-    nodes_create = node.get_outgoing(link_type=LinkType.CREATE).all()
-    nodes_return = node.get_outgoing(link_type=LinkType.RETURN).all()
-    nodes_called = node.get_outgoing(link_type=(LinkType.CALL_CALC, LinkType.CALL_WORK)).all()
-    nodes_input = nodes_input_calc + nodes_input_work
-    nodes_output = nodes_create + nodes_return
+    nodes_caller = node.get_incoming(link_type=(LinkType.CALL_CALC, LinkType.CALL_WORK))
+    nodes_called = node.get_outgoing(link_type=(LinkType.CALL_CALC, LinkType.CALL_WORK))
+    nodes_input = node.get_incoming(link_type=(LinkType.INPUT_CALC, LinkType.INPUT_WORK))
+    nodes_output = node.get_outgoing(link_type=(LinkType.CREATE, LinkType.RETURN))
 
     if nodes_caller:
-        table = []
-        table_headers = ['Called by', 'PK', 'Type']
-        for entry in nodes_caller:
-            table.append([entry.link_label, entry.node.pk, entry.node.__class__.__name__])
-        result += '\n{}'.format(tabulate(table, headers=table_headers))
+        result += '\n' + format_nested_links(nodes_caller.nested(), headers=['Called by', 'PK', 'Type'])
 
     if nodes_input:
-        table = []
-        table_headers = ['Inputs', 'PK', 'Type']
-        for entry in nodes_input:
-            if entry.link_label == 'code':
-                continue
-            table.append([entry.link_label, entry.node.pk, entry.node.__class__.__name__])
-        result += '\n{}'.format(tabulate(table, headers=table_headers))
+        result += '\n' + format_nested_links(nodes_input.nested(), headers=['Inputs', 'PK', 'Type'])
 
     if nodes_output:
-        table = []
-        table_headers = ['Outputs', 'PK', 'Type']
-        for entry in nodes_output:
-            table.append([entry.link_label, entry.node.pk, entry.node.__class__.__name__])
-        result += '\n{}'.format(tabulate(table, headers=table_headers))
+        result += '\n' + format_nested_links(nodes_output.nested(), headers=['Outputs', 'PK', 'Type'])
 
     if nodes_called:
-        table = []
-        table_headers = ['Called', 'PK', 'Type']
-        for entry in nodes_called:
-            table.append([entry.link_label, entry.node.pk, entry.node.__class__.__name__])
-        result += '\n{}'.format(tabulate(table, headers=table_headers))
+        result += '\n' + format_nested_links(nodes_called.nested(), headers=['Called', 'PK', 'Type'])
 
     log_messages = orm.Log.objects.get_logs_for(node)
 
@@ -194,7 +163,43 @@ def get_node_info(node, include_summary=True):
         table_headers = ['Log messages']
         table.append(['There are {} log messages for this calculation'.format(len(log_messages))])
         table.append(["Run 'verdi process report {}' to see them".format(node.pk)])
-        result += '\n{}'.format(tabulate(table, headers=table_headers))
+        result += '\n\n{}'.format(tabulate(table, headers=table_headers))
+
+    return result
+
+
+def format_nested_links(links, headers):
+    """Given a nested dictionary of nodes, return a nested string representation.
+
+    :param links: a nested dictionary of nodes
+    :param headers: headers to use
+    :return: nested formatted string
+    """
+    import collections
+    import tabulate as tb
+
+    tb.PRESERVE_WHITESPACE = True
+
+    indent_size = 4
+
+    def format_recursive(links, depth=0):
+        """Recursively format a dictionary of nodes into indented strings."""
+        rows = []
+        for label, value in links.items():
+            if isinstance(value, collections.Mapping):
+                rows.append([depth, label, '', ''])
+                rows.extend(format_recursive(value, depth=depth + 1))
+            else:
+                rows.append([depth, label, value.pk, value.__class__.__name__])
+        return rows
+
+    table = []
+
+    for depth, label, pk, class_name in format_recursive(links):
+        table.append(['{indent}{label}'.format(indent=' ' * (depth * indent_size), label=label), pk, class_name])
+
+    result = '\n{}'.format(tabulate(table, headers=headers))
+    tb.PRESERVE_WHITESPACE = False
 
     return result
 

--- a/aiida/common/lang.py
+++ b/aiida/common/lang.py
@@ -14,6 +14,50 @@ from __future__ import absolute_import
 
 import functools
 import inspect
+import keyword
+import six
+
+# Python 3 has a nice built-in solution, but while we support python 2 we need this ugly switch
+# Note that there is a difference between the PY2 and PY3 implementations as the latter allows unicode characters
+if six.PY2:
+
+    def isidentifier(identifier):
+        """Return whether the given string is a valid python identifier.
+
+        :return: boolean, True if identifier is valid, False otherwise
+        :raises TypeError: if identifier is not string type
+        """
+        import string
+
+        type_check(identifier, six.string_types)
+
+        if not identifier:
+            return False
+
+        if keyword.iskeyword(identifier):
+            return False
+
+        first = '_' + string.lowercase + string.uppercase  # pylint: disable=no-member
+        if identifier[0] not in first:
+            return False
+
+        other = first + string.digits
+        for character in identifier[1:]:
+            if character not in other:
+                return False
+
+        return True
+
+else:
+
+    def isidentifier(identifier):
+        """Return whether the given string is a valid python identifier.
+
+        :return: boolean, True if identifier is valid, False otherwise
+        :raises TypeError: if identifier is not string type
+        """
+        type_check(identifier, six.string_types)
+        return identifier.isidentifier() and not keyword.iskeyword(identifier)
 
 
 def type_check(what, of_type, msg=None, allow_none=False):

--- a/aiida/engine/processes/ports.py
+++ b/aiida/engine/processes/ports.py
@@ -12,11 +12,18 @@ from __future__ import division
 from __future__ import print_function
 from __future__ import absolute_import
 
-from collections import Mapping
+import collections
+import re
+import six
+
 from plumpy import ports
 
-__all__ = ('PortNamespace', 'InputPort', 'OutputPort', 'CalcJobOutputPort', 'WithNonDb', 'WithSerialize')
+from aiida.common.lang import isidentifier, type_check
 
+__all__ = ('PortNamespace', 'InputPort', 'OutputPort', 'CalcJobOutputPort', 'WithNonDb', 'WithSerialize',
+           'PORT_NAMESPACE_SEPARATOR')
+
+PORT_NAMESPACE_SEPARATOR = '__'  # The character sequence to represent a nested port namespace in a flat link label
 OutputPort = ports.OutputPort  # pylint: disable=invalid-name
 
 
@@ -136,10 +143,50 @@ class PortNamespace(WithNonDb, ports.PortNamespace):
         if not isinstance(port, ports.Port):
             raise TypeError('port needs to be an instance of Port')
 
+        self.validate_port_name(key)
+
         if hasattr(port, 'non_db_explicitly_set') and not port.non_db_explicitly_set:
             port.non_db = self.non_db
 
         super(PortNamespace, self).__setitem__(key, port)
+
+    @staticmethod
+    def validate_port_name(port_name):
+        """Validate the name of a port.
+
+        A valid port name obeys the following rules:
+
+            * Does not containe two or more consecutive underscores
+            * Does not start *or* end with a single underscore
+
+        :param port_name: the proposed name of the port to be added
+        :raise TypeError: if the port name is not a string type
+        :raise ValueError: if the port name is illegal
+        """
+        max_consecutive_underscores = 1
+        allowed_character_set = '[a-zA-Z0-9_]'
+
+        message = 'invalid port name `{}`: should be string type but is instead: {}'.format(port_name, type(port_name))
+        type_check(port_name, six.string_types, message)
+
+        # Following regexes will match all groups of consecutive underscores where each group will be of the form
+        # `('___', '_')`, where the first element is the matched group of consecutive underscores.
+        consecutive_underscores = [match[0] for match in re.findall(r'((_)\2+)', port_name)]
+
+        if any([len(entry) > max_consecutive_underscores for entry in consecutive_underscores]):
+            raise ValueError('invalid port name `{}`: more than two consecutive underscores'.format(port_name))
+
+        if port_name.startswith('_'):
+            raise ValueError('invalid port name `{}`: cannot start with an underscore'.format(port_name))
+
+        if port_name.endswith('_'):
+            raise ValueError('invalid port name `{}`: cannot end with an underscore'.format(port_name))
+
+        if re.sub(allowed_character_set, '', port_name):
+            raise ValueError('invalid port name `{}`: can only use alphanumeric characters'.format(port_name))
+
+        if not isidentifier(port_name):
+            raise ValueError('invalid port name `{}`: not a valid python identifier'.format(port_name))
 
     def serialize(self, mapping):
         """
@@ -149,12 +196,10 @@ class PortNamespace(WithNonDb, ports.PortNamespace):
         :param mapping: a mapping of values to be serialized
         :returns: the serialized mapping
         """
-        from aiida.common.lang import type_check
-
         if mapping is None:
             return None
 
-        type_check(mapping, Mapping)
+        type_check(mapping, collections.Mapping)
 
         result = {}
 

--- a/aiida/engine/processes/process.py
+++ b/aiida/engine/processes/process.py
@@ -38,7 +38,7 @@ from aiida.orm.utils import serialize
 from .. import utils
 from .exit_code import ExitCode
 from .builder import ProcessBuilder
-from .ports import InputPort, OutputPort, PortNamespace
+from .ports import InputPort, OutputPort, PortNamespace, PORT_NAMESPACE_SEPARATOR
 from .process_spec import ProcessSpec
 
 __all__ = ('Process', 'ProcessState')
@@ -597,7 +597,7 @@ class Process(plumpy.Process):
         """
         return dict(self._flatten_outputs(self.spec().outputs, self.outputs))
 
-    def _flatten_inputs(self, port, port_value, parent_name='', separator='_'):
+    def _flatten_inputs(self, port, port_value, parent_name='', separator=PORT_NAMESPACE_SEPARATOR):
         """
         Function that will recursively flatten the inputs dictionary, omitting inputs for ports that
         are marked as being non database storable
@@ -630,7 +630,7 @@ class Process(plumpy.Process):
         assert (port is None) or (isinstance(port, InputPort) and port.non_db)
         return []
 
-    def _flatten_outputs(self, port, port_value, parent_name='', separator='_'):
+    def _flatten_outputs(self, port, port_value, parent_name='', separator=PORT_NAMESPACE_SEPARATOR):
         """
         Function that will recursively flatten the outputs dictionary.
 

--- a/aiida/orm/nodes/process/process.py
+++ b/aiida/orm/nodes/process/process.py
@@ -86,6 +86,20 @@ class ProcessNode(Sealable, Node):
         from aiida.orm.utils.log import create_logger_adapter
         return create_logger_adapter(self._logger, self)
 
+    def get_builder_restart(self):
+        """Return a `ProcessBuilder` that is ready to relaunch the process that created this node.
+
+        The process class will be set based on the `process_type` of this node and the inputs of the builder will be
+        prepopulated with the inputs registered for this node. This functionality is very useful if a process has
+        completed and you want to relaunch it with slightly different inputs.
+
+        :return: `~aiida.engine.processes.builder.ProcessBuilder` instance
+        """
+        builder = self.process_class.get_builder()
+        builder._update(self.get_incoming().nested())  # pylint: disable=protected-access
+
+        return builder
+
     @property
     def process_class(self):
         """Return the process class that was used to create this node.


### PR DESCRIPTION
Fixes #2688 

The `Process` and `ProcessNode` duality forces us to define a mapping
between the nested port namespaces of the process and the flat link
label hierarchy of the corresponding node in the provenance graph.

Originally the nested namespace were imploded into a single string,
using a single underscore to concatenate the various port names. This
made it however impossible to distinguish a link label that came from a
nested namespace or simply from a single port that contained an
underscore. Given that underscores are allowed in valid python
identifiers we don't want to forbid the use of those. Instead, we
change the nesting character to be a double underscore and forbid a port
name if it satisfies any of the following rules:

 * Contains more than one consecutive underscore
 * Starts with an underscore
 * Ends with an underscore
 * Is otherwise not a valid python identifier

With these restrictions, mapping the flattened link labels back onto a
nested namespaced dictionary becomes an injective function.