### PR TITLE
Clean up the entry point related exceptions

### DIFF
--- a/aiida/cmdline/commands/cmd_plugin.py
+++ b/aiida/cmdline/commands/cmd_plugin.py
@@ -29,7 +29,7 @@ def verdi_plugin():
 @decorators.with_dbenv()
 def plugin_list(entry_point_group, entry_point):
     """Display a list of all available plugins."""
-    from aiida.common.exceptions import LoadingPluginFailed, MissingPluginError
+    from aiida.common import EntryPointError
     from aiida.plugins.entry_point import get_entry_point_names, load_entry_point
 
     if entry_point_group is None:
@@ -44,7 +44,7 @@ def plugin_list(entry_point_group, entry_point):
     if entry_point:
         try:
             plugin = load_entry_point(entry_point_group, entry_point)
-        except (LoadingPluginFailed, MissingPluginError) as exception:
+        except EntryPointError as exception:
             echo.echo_critical(exception)
         else:
             echo.echo_info(entry_point)

--- a/aiida/cmdline/params/types/identifier.py
+++ b/aiida/cmdline/params/types/identifier.py
@@ -49,7 +49,7 @@ class IdentifierParamType(click.ParamType):
             will be mapped upon. These classes have to be strict sub classes of the base orm class defined
             by the orm class loader
         """
-        from aiida.common.exceptions import MissingEntryPointError, MultipleEntryPointError
+        from aiida.common import exceptions
 
         self._sub_classes = None
         self._entry_points = []
@@ -63,7 +63,7 @@ class IdentifierParamType(click.ParamType):
 
                 try:
                     entry_point = get_entry_point_from_string(entry_point_string)
-                except (ValueError, MissingEntryPointError, MultipleEntryPointError) as exception:
+                except (ValueError, exceptions.EntryPointError) as exception:
                     raise ValueError('{} is not a valid entry point string: {}'.format(entry_point_string, exception))
                 else:
                     self._entry_points.append(entry_point)
@@ -88,7 +88,7 @@ class IdentifierParamType(click.ParamType):
         :raises click.BadParameter: if the value cannot be mapped onto any existing instance
         :raises RuntimeError: if the defined orm class loader is not a subclass of the OrmEntityLoader class
         """
-        from aiida.common.exceptions import MultipleObjectsError, NotExistent
+        from aiida.common import exceptions
         from aiida.orm.utils.loaders import OrmEntityLoader
 
         if not value:
@@ -122,7 +122,7 @@ class IdentifierParamType(click.ParamType):
 
         try:
             entity = loader.load_entity(value, sub_classes=self._sub_classes)
-        except (MultipleObjectsError, NotExistent, ValueError) as exception:
+        except (exceptions.MultipleObjectsError, exceptions.NotExistent, ValueError) as exception:
             raise click.BadParameter(str(exception))
 
         return entity

--- a/aiida/cmdline/params/types/plugin.py
+++ b/aiida/cmdline/params/types/plugin.py
@@ -16,7 +16,7 @@ import six
 import click
 
 from aiida.cmdline.utils import decorators
-from aiida.common.exceptions import MissingEntryPointError, MultipleEntryPointError, LoadingEntryPointError
+from aiida.common import exceptions
 from aiida.plugins.entry_point import ENTRY_POINT_STRING_SEPARATOR, ENTRY_POINT_GROUP_PREFIX, EntryPointFormat
 from aiida.plugins.entry_point import format_entry_point_string, get_entry_point_string_format
 from aiida.plugins.entry_point import get_entry_point, get_entry_points, get_entry_point_groups
@@ -192,7 +192,7 @@ class PluginParamType(click.ParamType):
 
         try:
             entry_point = get_entry_point(group, name)
-        except (MissingEntryPointError, MultipleEntryPointError) as exception:
+        except exceptions.EntryPointError as exception:
             raise ValueError(exception)
 
         return entry_point
@@ -214,7 +214,7 @@ class PluginParamType(click.ParamType):
         if self.load:
             try:
                 return entry_point.load()
-            except LoadingEntryPointError as exception:
+            except exceptions.LoadingEntryPointError as exception:
                 raise click.BadParameter(str(exception))
         else:
             return entry_point

--- a/aiida/cmdline/utils/pluginable.py
+++ b/aiida/cmdline/utils/pluginable.py
@@ -13,7 +13,8 @@ from __future__ import print_function
 from __future__ import absolute_import
 import click
 
-from aiida.plugins.entry_point import load_entry_point, get_entry_point_names, MissingEntryPointError
+from aiida.common import exceptions
+from aiida.plugins.entry_point import load_entry_point, get_entry_point_names
 
 
 class Pluginable(click.Group):
@@ -35,6 +36,6 @@ class Pluginable(click.Group):
         command = None
         try:
             command = load_entry_point(self._entry_point_group, name)
-        except MissingEntryPointError:
+        except exceptions.EntryPointError:
             command = super(Pluginable, self).get_command(ctx, name)
         return command

--- a/aiida/common/exceptions.py
+++ b/aiida/common/exceptions.py
@@ -14,12 +14,12 @@ from __future__ import absolute_import
 
 __all__ = ('AiidaException', 'NotExistent', 'MultipleObjectsError', 'RemoteOperationError', 'ContentNotExistent',
            'FailedError', 'StoringNotAllowed', 'ModificationNotAllowed', 'IntegrityError', 'UniquenessError',
-           'MissingEntryPointError', 'MultipleEntryPointError', 'LoadingEntryPointError', 'MissingPluginError',
-           'LoadingPluginFailed', 'InvalidOperation', 'ParsingError', 'InternalError', 'PluginInternalError',
-           'ValidationError', 'ConfigurationError', 'ProfileConfigurationError', 'MissingConfigurationError',
-           'ConfigurationVersionError', 'DbContentError', 'InputValidationError', 'FeatureNotAvailable',
-           'FeatureDisabled', 'LicensingException', 'TestsNotAllowedError', 'UnsupportedSpeciesError',
-           'DanglingLinkError', 'TransportTaskException', 'IncompatibleArchiveVersionError', 'OutputParsingError')
+           'EntryPointError', 'MissingEntryPointError', 'MultipleEntryPointError', 'LoadingEntryPointError',
+           'InvalidOperation', 'ParsingError', 'InternalError', 'PluginInternalError', 'ValidationError',
+           'ConfigurationError', 'ProfileConfigurationError', 'MissingConfigurationError', 'ConfigurationVersionError',
+           'DbContentError', 'InputValidationError', 'FeatureNotAvailable', 'FeatureDisabled', 'LicensingException',
+           'TestsNotAllowedError', 'UnsupportedSpeciesError', 'DanglingLinkError', 'TransportTaskException',
+           'IncompatibleArchiveVersionError', 'OutputParsingError')
 
 
 class AiidaException(Exception):
@@ -92,34 +92,20 @@ class UniquenessError(AiidaException):
     """
 
 
-class MissingEntryPointError(AiidaException):
-    """
-    Raised when the requested entry point is not registered with the entry point manager
-    """
+class EntryPointError(AiidaException):
+    """Raised when an entry point cannot be uniquely resolved and imported."""
 
 
-class MultipleEntryPointError(AiidaException):
-    """
-    Raised when the requested entry point cannot uniquely be resolved by the entry point manager
-    """
+class MissingEntryPointError(EntryPointError):
+    """Raised when the requested entry point is not registered with the entry point manager."""
 
 
-class LoadingEntryPointError(AiidaException):
-    """
-    Raised when the class corresponding to requested entry point cannot be loaded
-    """
+class MultipleEntryPointError(EntryPointError):
+    """Raised when the requested entry point cannot uniquely be resolved by the entry point manager."""
 
 
-class MissingPluginError(AiidaException):
-    """
-    Raised when the user tries to use a plugin that is not available or does not exist.
-    """
-
-
-class LoadingPluginFailed(AiidaException):
-    """
-    Raised when loading a plugin through the plugin loader fails
-    """
+class LoadingEntryPointError(EntryPointError):
+    """Raised when the resource corresponding to requested entry point cannot be imported."""
 
 
 class InvalidOperation(AiidaException):

--- a/aiida/orm/authinfos.py
+++ b/aiida/orm/authinfos.py
@@ -12,7 +12,7 @@ from __future__ import division
 from __future__ import print_function
 from __future__ import absolute_import
 
-from aiida.common.exceptions import (ConfigurationError, MissingPluginError)
+from aiida.common import exceptions
 from aiida.plugins import TransportFactory
 from aiida.manage.manager import get_manager
 from . import entities
@@ -144,9 +144,9 @@ class AuthInfo(entities.Entity):
         computer = self.computer
         try:
             this_transport_class = TransportFactory(computer.get_transport_type())
-        except MissingPluginError as exc:
-            raise ConfigurationError('No transport found for {} [type {}], message: {}'.format(
-                computer.hostname, computer.get_transport_type(), exc))
+        except exceptions.EntryPointError as exception:
+            raise exceptions.ConfigurationError('No transport found for {} [type {}], message: {}'.format(
+                computer.hostname, computer.get_transport_type(), exception))
 
         params = dict(list(computer.get_transport_params().items()) + list(self.get_auth_params().items()))
         return this_transport_class(machine=computer.hostname, **params)

--- a/aiida/orm/autogroup.py
+++ b/aiida/orm/autogroup.py
@@ -13,8 +13,7 @@ from __future__ import absolute_import
 
 import six
 
-from aiida.common import timezone
-from aiida.common.exceptions import ValidationError, MissingPluginError
+from aiida.common import exceptions, timezone
 from aiida.orm import GroupTypeString
 
 
@@ -49,7 +48,7 @@ class Autogroup(object):
                         i.startswith('data'),
                         i == 'all',
             ]):
-                raise ValidationError("Module not recognized, allow prefixes "
+                raise exceptions.ValidationError("Module not recognized, allow prefixes "
                                       " are: calculation, code or data")
         the_param = [i + '.' for i in param]
 
@@ -60,15 +59,15 @@ class Autogroup(object):
             base, module = i.split('.', 1)
             if base == 'code':
                 if module:
-                    raise ValidationError("Cannot have subclasses for codes")
+                    raise exceptions.ValidationError("Cannot have subclasses for codes")
             elif base == 'all':
                 continue
             else:
                 if is_exact:
                     try:
                         factorydict[base](module.rstrip('.'))
-                    except MissingPluginError:
-                        raise ValidationError("Cannot find the class to be excluded")
+                    except exceptions.EntryPointError:
+                        raise exceptions.ValidationError("Cannot find the class to be excluded")
         return the_param
 
     def get_exclude(self):
@@ -120,7 +119,7 @@ class Autogroup(object):
         if self.get_include() is not None:
             if 'all.' in self.get_include():
                 if 'all.' in the_exclude_classes:
-                    raise ValidationError("Cannot exclude and include all classes")
+                    raise exceptions.ValidationError("Cannot exclude and include all classes")
         self.exclude = the_exclude_classes
 
     def set_exclude_with_subclasses(self, exclude):
@@ -139,7 +138,7 @@ class Autogroup(object):
         if self.get_exclude() is not None:
             if 'all.' in self.get_exclude():
                 if 'all.' in the_include_classes:
-                    raise ValidationError("Cannot exclude and include all classes")
+                    raise exceptions.ValidationError("Cannot exclude and include all classes")
 
         self.include = the_include_classes
 
@@ -156,7 +155,7 @@ class Autogroup(object):
         Set the name of the group to be created
         """
         if not isinstance(gname, six.string_types):
-            raise ValidationError("group name must be a string")
+            raise exceptions.ValidationError("group name must be a string")
         self.group_name = gname
 
     def is_to_be_grouped(self, the_class):

--- a/aiida/orm/computers.py
+++ b/aiida/orm/computers.py
@@ -232,7 +232,7 @@ class Computer(entities.Entity):
 
         try:
             job_resource_keys = self.get_scheduler().job_resource_class.get_valid_keys()
-        except exceptions.MissingPluginError:
+        except exceptions.EntryPointError:
             raise exceptions.ValidationError("Unable to load the scheduler for this computer")
 
         subst = {i: 'value' for i in job_resource_keys}
@@ -658,11 +658,10 @@ class Computer(entities.Entity):
         :return: the transport class
         """
         try:
-            # I return the class, not an instance
             return TransportFactory(self.get_transport_type())
-        except exceptions.MissingPluginError as exc:
+        except exceptions.EntryPointError as exception:
             raise exceptions.ConfigurationError('No transport found for {} [type {}], message: {}'.format(
-                self.name, self.get_transport_type(), exc))
+                self.name, self.get_transport_type(), exception))
 
     def get_scheduler(self):
         """
@@ -675,9 +674,9 @@ class Computer(entities.Entity):
             scheduler_class = SchedulerFactory(self.get_scheduler_type())
             # I call the init without any parameter
             return scheduler_class()
-        except exceptions.MissingPluginError as exc:
+        except exceptions.EntryPointError as exception:
             raise exceptions.ConfigurationError('No scheduler found for {} [type {}], message: {}'.format(
-                self.name, self.get_scheduler_type(), exc))
+                self.name, self.get_scheduler_type(), exception))
 
     def configure(self, user=None, **kwargs):
         """

--- a/aiida/orm/nodes/data/code.py
+++ b/aiida/orm/nodes/data/code.py
@@ -15,7 +15,7 @@ import io
 import os
 import six
 
-from aiida.common.exceptions import (ValidationError, MissingPluginError, InputValidationError)
+from aiida.common.exceptions import ValidationError, EntryPointError, InputValidationError
 
 from .data import Data
 
@@ -459,7 +459,7 @@ class Code(Data):
 
         :note: it also sets the ``builder.code`` value.
 
-        :raise aiida.common.MissingPluginError: if the specified plugin does not exist.
+        :raise aiida.common.EntryPointError: if the specified plugin does not exist.
         :raise ValueError: if no default plugin was specified.
 
         :return:
@@ -470,10 +470,8 @@ class Code(Data):
             raise ValueError("You did not specify a default input plugin for this code")
         try:
             C = CalculationFactory(plugin_name)
-        except MissingPluginError:
-            raise MissingPluginError("The input_plugin name for this code is "
-                                     "'{}', but it is not an existing plugin"
-                                     "name".format(plugin_name))
+        except EntryPointError:
+            raise EntryPointError('the calculation entry point `{}` could not be loaded'.format(plugin_name))
 
         builder = C.get_builder()
         # Setup the code already

--- a/aiida/orm/nodes/process/calculation/calcjob.py
+++ b/aiida/orm/nodes/process/calculation/calcjob.py
@@ -58,7 +58,6 @@ class CalcJobNode(CalculationNode):
 
         :return: CalculationTools instance
         """
-        from aiida.common.exceptions import MultipleEntryPointError, MissingEntryPointError, LoadingEntryPointError
         from aiida.plugins.entry_point import is_valid_entry_point_string, get_entry_point_from_string, load_entry_point
         from aiida.tools.calculations import CalculationTools
 
@@ -71,7 +70,7 @@ class CalcJobNode(CalculationNode):
                 try:
                     tools_class = load_entry_point('aiida.tools.calculations', entry_point.name)
                     self._tools = tools_class(self)
-                except (MultipleEntryPointError, MissingEntryPointError, LoadingEntryPointError) as exception:
+                except exceptions.EntryPointError as exception:
                     self._tools = CalculationTools(self)
                     self.logger.warning('could not load the calculation tools entry point {}: {}'.format(
                         entry_point.name, exception))
@@ -164,7 +163,7 @@ class CalcJobNode(CalculationNode):
 
         try:
             self.get_parser_class()
-        except exceptions.MissingPluginError:
+        except exceptions.EntryPointError:
             raise exceptions.ValidationError("No valid class/implementation found for the parser '{}'. "
                                              "Set the parser to None if you do not need an automatic "
                                              "parser.".format(self.get_option('parser_name')))
@@ -489,7 +488,7 @@ class CalcJobNode(CalculationNode):
         """Return the output parser object for this calculation or None if no parser is set.
 
         :return: a `Parser` class.
-        :raise: MissingPluginError from ParserFactory no plugin is found.
+        :raises `aiida.common.exceptions.EntryPointError`: if the parser entry point can not be resolved.
         """
         from aiida.plugins import ParserFactory
 

--- a/aiida/orm/nodes/process/process.py
+++ b/aiida/orm/nodes/process/process.py
@@ -94,7 +94,7 @@ class ProcessNode(Sealable, Node):
         :raises ValueError: if no process type is defined, it is an invalid process type string or cannot be resolved
             to load the corresponding class
         """
-        from aiida.common.exceptions import MultipleEntryPointError, MissingEntryPointError, LoadingEntryPointError
+        from aiida.common import exceptions
         from aiida.plugins.entry_point import load_entry_point_from_string
 
         if not self.process_type:
@@ -102,7 +102,7 @@ class ProcessNode(Sealable, Node):
 
         try:
             process_class = load_entry_point_from_string(self.process_type)
-        except (MissingEntryPointError, MultipleEntryPointError, LoadingEntryPointError) as exception:
+        except exceptions.EntryPointError as exception:
             raise ValueError('could not load process class for entry point {} for CalcJobNode<{}>: {}'.format(
                 self.pk, self.process_type, exception))
         except ValueError:

--- a/aiida/orm/utils/node.py
+++ b/aiida/orm/utils/node.py
@@ -49,7 +49,7 @@ def load_node_class(type_string):
     try:
         base_path = type_string.rsplit('.', 2)[0]
     except ValueError:
-        raise exceptions.MissingPluginError
+        raise exceptions.EntryPointError
 
     # This exception needs to be there to make migrations work that rely on the old type string starting with `node.`
     # Since now the type strings no longer have that prefix, we simply strip it and continue with the normal logic.
@@ -69,7 +69,7 @@ def load_node_class(type_string):
         entry_point_name = strip_prefix(base_path, 'nodes.')
         return load_entry_point('aiida.node', entry_point_name)
 
-    raise exceptions.MissingPluginError('unknown type string {}'.format(type_string))
+    raise exceptions.EntryPointError('unknown type string {}'.format(type_string))
 
 
 def get_type_string_from_class(class_module, class_name):

--- a/aiida/tools/data/orbital/orbital.py
+++ b/aiida/tools/data/orbital/orbital.py
@@ -17,7 +17,7 @@ from __future__ import division
 from __future__ import print_function
 from __future__ import absolute_import
 
-from aiida.common.exceptions import ValidationError, MissingPluginError
+from aiida.common.exceptions import ValidationError, EntryPointError
 from aiida.plugins import OrbitalFactory
 
 
@@ -81,7 +81,7 @@ class Orbital(object):
                     raise TypeError
                 try:
                     OrbitalFactory(v)
-                except (MissingPluginError, TypeError):
+                except (EntryPointError, TypeError):
                     raise ValidationError("The module name {} was found to "
                                           "be invalid".format(v))
             if k == "position":


### PR DESCRIPTION
Fixes #2692 

A new base exception is introduced `EntryPointError` which now forms the
new basis for the existing entry point exceptions:

 * `MissingEntryPointError`
 * `MultipleEntryPointError`
 * `LoadingEntryPointError`

This cleans code that often want to catch any three of these as they can
now simply catch the parent `EntryPointError`.

Furthermore, the following exceptions have been removed as they were
duplicating the functionality of those listed above:

 * `MissingPluginError`
 * `LoadingPluginFailed`