### PR TITLE
Fix dependency requirements for `kiwipy` and `pika`

### DIFF
--- a/docs/requirements_for_rtd.txt
+++ b/docs/requirements_for_rtd.txt
@@ -35,6 +35,7 @@ flask-marshmallow==0.9.0
 futures; python_version=='2.7'
 ipython>=4.0,<6.0
 itsdangerous==1.1.0
+kiwipy[rmq]==0.5.0
 marshmallow-sqlalchemy==0.16.0
 meld3==1.0.2
 mock==2.0.0
@@ -44,6 +45,7 @@ passlib==1.7.1
 pathlib2; python_version<'3.5'
 pg8000<1.13.0
 pgtest==1.2.0
+pika==1.0.0
 plumpy==0.13.1
 psutil==5.5.1
 pyblake2==1.1.2; python_version<'3.6'

--- a/environment.yml
+++ b/environment.yml
@@ -37,6 +37,8 @@ dependencies:
 - ecdsa==0.13
 - ipython>=4.0,<6.0
 - plumpy==0.13.1
+- kiwipy[rmq]==0.5.0
+- pika==1.0.0
 - circus==0.15.0
 - tornado<5.0
 - simplejson==3.16.0

--- a/setup.json
+++ b/setup.json
@@ -48,6 +48,8 @@
     "ecdsa==0.13",
     "ipython>=4.0,<6.0",
     "plumpy==0.13.1",
+    "kiwipy[rmq]==0.5.0",
+    "pika==1.0.0",
     "circus==0.15.0",
     "tornado<5.0",
     "pyblake2==1.1.2; python_version<'3.6'",


### PR DESCRIPTION
Fixes #2674 

Even though these dependencies are already direct sub depencencies of
`plumpy`, they are referenced directly as well in the code. The safest
solution is to pin all three of them that are known to be compatible.