### PR TITLE
Replace `TextField` stored for storing JSON with proper `JSONField`

### DIFF
--- a/aiida/backends/djsite/db/migrations/0033_replace_text_field_with_json_field.py
+++ b/aiida/backends/djsite/db/migrations/0033_replace_text_field_with_json_field.py
@@ -1,0 +1,52 @@
+# -*- coding: utf-8 -*-
+# pylint: disable=invalid-name,too-few-public-methods
+"""Replace use of text fields to store JSON data with builtin JSONField."""
+from __future__ import unicode_literals
+from __future__ import absolute_import
+
+# Remove when https://github.com/PyCQA/pylint/issues/1931 is fixed
+# pylint: disable=no-name-in-module,import-error,no-member
+import django.contrib.postgres.fields.jsonb
+from django.db import migrations
+
+from aiida.backends.djsite.db.migrations import upgrade_schema_version
+
+REVISION = '1.0.33'
+DOWN_REVISION = '1.0.32'
+
+
+class Migration(migrations.Migration):
+    """Replace use of text fields to store JSON data with builtin JSONField."""
+
+    dependencies = [
+        ('db', '0032_remove_legacy_workflows'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='dbauthinfo',
+            name='auth_params',
+            field=django.contrib.postgres.fields.jsonb.JSONField(default=dict),
+        ),
+        migrations.AlterField(
+            model_name='dbauthinfo',
+            name='metadata',
+            field=django.contrib.postgres.fields.jsonb.JSONField(default=dict),
+        ),
+        migrations.AlterField(
+            model_name='dbcomputer',
+            name='metadata',
+            field=django.contrib.postgres.fields.jsonb.JSONField(default=dict),
+        ),
+        migrations.AlterField(
+            model_name='dbcomputer',
+            name='transport_params',
+            field=django.contrib.postgres.fields.jsonb.JSONField(default=dict),
+        ),
+        migrations.AlterField(
+            model_name='dblog',
+            name='metadata',
+            field=django.contrib.postgres.fields.jsonb.JSONField(default=dict),
+        ),
+        upgrade_schema_version(REVISION, DOWN_REVISION)
+    ]

--- a/aiida/backends/djsite/db/migrations/__init__.py
+++ b/aiida/backends/djsite/db/migrations/__init__.py
@@ -22,7 +22,7 @@ class DeserializationException(AiidaException):
     pass
 
 
-LATEST_MIGRATION = '0032_remove_legacy_workflows'
+LATEST_MIGRATION = '0033_replace_text_field_with_json_field'
 
 
 def _update_schema_version(version, apps, schema_editor):

--- a/aiida/orm/authinfos.py
+++ b/aiida/orm/authinfos.py
@@ -7,7 +7,7 @@
 # For further information on the license, see the LICENSE.txt file        #
 # For further information please visit http://www.aiida.net               #
 ###########################################################################
-"""Authinfo objects and functions"""
+"""Module for the `AuthInfo` ORM class."""
 from __future__ import division
 from __future__ import print_function
 from __future__ import absolute_import
@@ -22,31 +22,26 @@ __all__ = ('AuthInfo',)
 
 
 class AuthInfo(entities.Entity):
-    """
-    Base class to map a DbAuthInfo, that contains computer configuration
-    specific to a given user (authorization info and other metadata, like
-    how often to check on a given computer etc.)
-    """
+    """ORM class that models the authorization information that allows a `User` to connect to a `Computer`."""
 
     class Collection(entities.Collection):
-        """The collection of AuthInfo entries."""
+        """The collection of `AuthInfo` entries."""
 
-        def delete(self, authinfo_id):
+        def delete(self, pk):
+            """Delete an entry from the collection.
+
+            :param pk: the pk of the entry to delete
             """
-            Remove an AuthInfo from the collection with the given id
-            :param authinfo_id: The ID of the authinfo to delete
-            """
-            self._backend.authinfos.delete(authinfo_id)
+            self._backend.authinfos.delete(pk)
 
     PROPERTY_WORKDIR = 'workdir'
 
     def __init__(self, computer, user, backend=None):
-        """
-        Create a AuthInfo given a computer and a user
+        """Create an `AuthInfo` instance for the given computer and user.
 
-        :param computer: a Computer instance
-        :param user: a User instance
-        :return: an AuthInfo object associated with the given computer and user
+        :param computer: a `Computer` instance
+        :param user: a `User` instance
+        :return: :class:`aiida.orm.authinfos.AuthInfo`
         """
         backend = backend or get_manager().get_backend()
         model = backend.authinfos.create(computer=computer.backend_entity, user=user.backend_entity)
@@ -54,99 +49,99 @@ class AuthInfo(entities.Entity):
 
     def __str__(self):
         if self.enabled:
-            return "AuthInfo for {} on {}".format(self.user.email, self.computer.name)
+            return 'AuthInfo for {} on {}'.format(self.user.email, self.computer.name)
 
-        return "AuthInfo for {} on {} [DISABLED]".format(self.user.email, self.computer.name)
+        return 'AuthInfo for {} on {} [DISABLED]'.format(self.user.email, self.computer.name)
 
     @property
     def enabled(self):
-        """
-        Is the computer enabled for this user?
+        """Return whether this instance is enabled.
 
-        :rtype: bool
+        :return: boolean, True if enabled, False otherwise
         """
         return self._backend_entity.enabled
 
     @enabled.setter
     def enabled(self, enabled):
-        """
-        Set the enabled state for the computer
+        """Set the enabled state
+
+        :param enabled: boolean, True to enable the instance, False to disable it
         """
         self._backend_entity.enabled = enabled
 
     @property
     def computer(self):
+        """Return the computer associated with this instance.
+
+        :return: :class:`aiida.orm.computers.Computer`
+        """
         from . import computers  # pylint: disable=cyclic-import
         return computers.Computer.from_backend_entity(self._backend_entity.computer)
 
     @property
     def user(self):
+        """Return the user associated with this instance.
+
+        :return: :class:`aiida.orm.users.User`
+        """
         return users.User.from_backend_entity(self._backend_entity.user)
 
-    def is_stored(self):
-        """
-        Is it already stored or not?
-
-        :return: Boolean
-        """
-        return self._backend_entity.is_stored()
-
     def get_auth_params(self):
-        """
-        Get the dictionary of auth_params
+        """Return the dictionary of authentication parameters
 
-        :return: a dictionary
+        :return: a dictionary with authentication parameters
         """
         return self._backend_entity.get_auth_params()
 
     def set_auth_params(self, auth_params):
-        """
-        Set the dictionary of auth_params
+        """Set the dictionary of authentication parameters
 
-        :param auth_params: a dictionary with the new auth_params
+        :param auth_params: a dictionary with authentication parameters
         """
         self._backend_entity.set_auth_params(auth_params)
 
-    def get_property(self, name):
-        """
-        Get an authinfo property
+    def get_metadata(self):
+        """Return the dictionary of metadata
 
-        :param name: the property name
-        :return: the property value
+        :return: a dictionary with metadata
         """
-        return self._backend_entity.get_property(name)
+        return self._backend_entity.get_metadata()
 
-    def set_property(self, name, value):
-        """
-        Set an authinfo property
+    def set_metadata(self, metadata):
+        """Set the dictionary of metadata
 
-        :param name: the property name
-        :param value: the property value
+        :param metadata: a dictionary with metadata
         """
-        self._backend_entity.set_property(name, value)
+        self._backend_entity.set_metadata(metadata)
 
     def get_workdir(self):
-        """
-        Get the workdir; defaults to the value of the corresponding computer, if not explicitly set
+        """Return the working directory.
 
-        :return: the workdir
+        If no explicit work directory is set for this instance, the working directory of the computer will be returned.
+
+        :return: the working directory
         :rtype: str
         """
         try:
-            return self.get_property(self.PROPERTY_WORKDIR)
-        except ValueError:
+            return self.get_metadata()[self.PROPERTY_WORKDIR]
+        except KeyError:
             return self.computer.get_workdir()
 
     def get_transport(self):
-        """
-        Return a configured transport to connect to the computer.
+        """Return a fully configured transport that can be used to connect to the computer set for this instance.
+
+        :return: :class:`aiida.transports.Transport`
         """
         computer = self.computer
-        try:
-            this_transport_class = TransportFactory(computer.get_transport_type())
-        except exceptions.EntryPointError as exception:
-            raise exceptions.ConfigurationError('No transport found for {} [type {}], message: {}'.format(
-                computer.hostname, computer.get_transport_type(), exception))
+        transport_type = computer.get_transport_type()
+        transport_params = computer.get_transport_params()
 
-        params = dict(list(computer.get_transport_params().items()) + list(self.get_auth_params().items()))
-        return this_transport_class(machine=computer.hostname, **params)
+        try:
+            transport_class = TransportFactory(transport_type)
+        except exceptions.EntryPointError as exception:
+            raise exceptions.ConfigurationError('transport type `{}` could not be loaded: {}'.format(
+                transport_type, exception))
+
+        parameters = dict(list(transport_params.items()) + list(self.get_auth_params().items()))
+
+        return transport_class(machine=computer.hostname, **parameters)

--- a/aiida/orm/computers.py
+++ b/aiida/orm/computers.py
@@ -660,7 +660,7 @@ class Computer(entities.Entity):
 
         if not set(kwargs.keys()).issubset(valid_keys):
             invalid_keys = [key for key in kwargs if key not in valid_keys]
-            raise ValueError('{transport}: recieved invalid authentication parameter(s) "{invalid}"'.format(
+            raise ValueError('{transport}: received invalid authentication parameter(s) "{invalid}"'.format(
                 transport=transport_cls, invalid=invalid_keys))
 
         try:

--- a/aiida/orm/computers.py
+++ b/aiida/orm/computers.py
@@ -318,7 +318,7 @@ class Computer(entities.Entity):
     def get_metadata(self):
         return self._backend_entity.get_metadata()
 
-    def set_metadata(self, metadata_dict):
+    def set_metadata(self, metadata):
         """
         Set the metadata.
 
@@ -326,7 +326,7 @@ class Computer(entities.Entity):
            data to the database! (The store method can be called multiple
            times, differently from AiiDA Node objects).
         """
-        self._backend_entity.set_metadata(metadata_dict)
+        self._backend_entity.set_metadata(metadata)
 
     def delete_property(self, name, raise_exception=True):
         """
@@ -350,9 +350,9 @@ class Computer(entities.Entity):
         :param name: the property name
         :param value: the new value
         """
-        olddata = self.get_metadata()
-        olddata[name] = value
-        self.set_metadata(olddata)
+        metadata = self.get_metadata() or {}
+        metadata[name] = value
+        self.set_metadata(metadata)
 
     def get_property(self, name, *args):
         """

--- a/aiida/orm/entities.py
+++ b/aiida/orm/entities.py
@@ -197,31 +197,30 @@ class Entity(object):  # pylint: disable=useless-object-inheritance
 
     @property
     def id(self):
-        """
-        Get the id for this entity.  This is unique only amongst entities of this type
-        for a particular backend
+        """Return the id for this entity.
 
-        :return: the entity id
+        This identifier is guaranteed to be unique amongst entities of the same type for a single backend instance.
+
+        :return: the entity's id
         """
         # pylint: disable=redefined-builtin, invalid-name
         return self._backend_entity.id
 
     @property
     def pk(self):
-        """
-        Get the primary key for this entity
+        """Return the primary key for this entity.
 
-        .. note:: Deprecated because the backend need not be a database and so principle key doesn't
-            always make sense.  Use `id()` instead.
+        This identifier is guaranteed to be unique amongst entities of the same type for a single backend instance.
 
-        :return: the principal key
+        :return: the entity's principal key
         """
         return self.id
 
     @property
     def uuid(self):
-        """
-        Get the UUID for this entity.  This is unique across all entities types and backends
+        """Return the UUID for this entity.
+
+        This identifier is unique across all entities types and backend instances.
 
         :return: the entity uuid
         :rtype: :class:`uuid.UUID`
@@ -229,18 +228,15 @@ class Entity(object):  # pylint: disable=useless-object-inheritance
         return self._backend_entity.uuid
 
     def store(self):
-        """
-        Store the entity.
-        """
+        """Store the entity."""
         self._backend_entity.store()
         return self
 
     @property
     def is_stored(self):
-        """
-        Is the computer stored?
+        """Return whether the entity is stored.
 
-        :return: True if stored, False otherwise
+        :return: boolean, True if stored, False otherwise
         :rtype: bool
         """
         return self._backend_entity.is_stored

--- a/aiida/orm/implementation/authinfos.py
+++ b/aiida/orm/implementation/authinfos.py
@@ -7,7 +7,7 @@
 # For further information on the license, see the LICENSE.txt file        #
 # For further information please visit http://www.aiida.net               #
 ###########################################################################
-"""Module for authinfo backend classes."""
+"""Module for the backend implementation of the `AuthInfo` ORM class."""
 from __future__ import division
 from __future__ import print_function
 from __future__ import absolute_import
@@ -22,133 +22,87 @@ __all__ = ('BackendAuthInfo', 'BackendAuthInfoCollection')
 
 @six.add_metaclass(abc.ABCMeta)
 class BackendAuthInfo(backends.BackendEntity):
-    """
-    Base class for backend authorization information which contains computer configuration
-    specific to a given user (authorization info and other metadata, like
-    how often to check on a given computer etc.)
-    """
+    """Backend implementation for the `AuthInfo` ORM class."""
 
     METADATA_WORKDIR = 'workdir'
 
-    def pk(self):
-        """
-        Return the principal key in the DB.
-        """
-        return self.id
-
-    @abc.abstractproperty
-    def id(self):  # pylint: disable=invalid-name
-        """
-        Return the ID in the DB.
-        """
-
     @abc.abstractproperty
     def enabled(self):
-        """
-        Is the computer enabled for this user?
+        """Return whether this instance is enabled.
 
-        :rtype: bool
+        :return: boolean, True if enabled, False otherwise
         """
 
     @enabled.setter
     def enabled(self, value):
-        """
-        Set the enabled state for the computer
+        """Set the enabled state
 
-        :return: Boolean
+        :param enabled: boolean, True to enable the instance, False to disable it
         """
 
     @abc.abstractproperty
     def computer(self):
-        """
-        The computer that this authinfo relates to
+        """Return the computer associated with this instance.
 
-        :return: The corresponding computer
-        :rtype: :class:`aiida.orm.Computer`
+        :return: :class:`aiida.orm.implementation.computers.BackendComputer`
         """
 
     @abc.abstractproperty
     def user(self):
-        """
-        The user that this authinfo relates to
+        """Return the user associated with this instance.
 
-        :return: The corresponding user
-        :rtype: :class:`aiida.orm.User`
-        """
-
-    @abc.abstractproperty
-    def is_stored(self):
-        """
-        Is it already stored or not?
-
-        :return: Boolean
-        :rtype: bool
+        :return: :class:`aiida.orm.implementation.users.BackendUser`
         """
 
     @abc.abstractmethod
     def get_auth_params(self):
-        """
-        Get the dictionary of auth_params
+        """Return the dictionary of authentication parameters
 
-        :return: a dictionary
+        :return: a dictionary with authentication parameters
         """
 
     @abc.abstractmethod
     def set_auth_params(self, auth_params):
-        """
-        Set the dictionary of auth_params
+        """Set the dictionary of authentication parameters
 
-        :param auth_params: a dictionary with the new auth_params
+        :param auth_params: a dictionary with authentication parameters
         """
 
     @abc.abstractmethod
     def get_metadata(self):
-        """
-        Get the metadata dictionary
+        """Return the dictionary of metadata
 
-        :return: a dictionary
+        :return: a dictionary with metadata
         """
 
     @abc.abstractmethod
     def set_metadata(self, metadata):
-        """
-        Replace the metadata dictionary in the DB with the provided dictionary
-        """
+        """Set the dictionary of metadata
 
-    def get_property(self, name):
-        try:
-            return self.get_metadata()[name]
-        except KeyError:
-            raise ValueError('Unknown property: {}'.format(name))
-
-    def set_property(self, name, value):
-        metadata = self.get_metadata()
-        metadata[name] = value
-        self.set_metadata(metadata)
+        :param metadata: a dictionary with metadata
+        """
 
 
 @six.add_metaclass(abc.ABCMeta)
 class BackendAuthInfoCollection(backends.BackendCollection[BackendAuthInfo]):
-    """The collection of AuthInfo entries."""
+    """The collection of backend `AuthInfo` entries."""
 
     ENTITY_CLASS = BackendAuthInfo
 
     @abc.abstractmethod
-    def delete(self, authinfo_id):
-        """
-        Remove an AuthInfo from the collection with the given id
-        :param authinfo_id: The ID of the authinfo to delete
+    def delete(self, pk):
+        """Delete an entry from the collection.
+
+        :param pk: the pk of the entry to delete
         """
 
     @abc.abstractmethod
     def get(self, computer, user):
-        """
-        Return a AuthInfo given a computer and a user
+        """Return an entry from the collection that is configured for the given computer and user
 
-        :param computer: a Computer instance
-        :param user: a User instance
-        :return: a AuthInfo object associated to the given computer and user
-        :raise aiida.common.NotExistent: if the user is not configured to use computer
-        :raise sqlalchemy.orm.exc.MultipleResultsFound: if the user is configured
-            more than once to use the computer! Should never happen
+        :param computer: a :class:`aiida.orm.implementation.computers.BackendComputer` instance
+        :param user: a :class:`aiida.orm.implementation.users.BackendUser` instance
+        :return: :class:`aiida.orm.implementation.authinfos.BackendAuthInfo`
+        :raise aiida.common.exceptions.NotExistent: if no entry exists for the computer/user pair
+        :raise aiida.common.exceptions.MultipleObjectsError: if multiple entries exist for the computer/user pair
         """

--- a/aiida/orm/implementation/computers.py
+++ b/aiida/orm/implementation/computers.py
@@ -66,7 +66,7 @@ class BackendComputer(backends.BackendEntity):
         pass
 
     @abc.abstractmethod
-    def set_metadata(self, metadata_dict):
+    def set_metadata(self, metadata):
         """
         Set the metadata.
 

--- a/aiida/orm/implementation/django/authinfos.py
+++ b/aiida/orm/implementation/django/authinfos.py
@@ -7,7 +7,7 @@
 # For further information on the license, see the LICENSE.txt file        #
 # For further information please visit http://www.aiida.net               #
 ###########################################################################
-"""Django implementations for the `AuthInfo` entity and collection."""
+"""Module for the Django backend implementation of the `AuthInfo` ORM class."""
 from __future__ import division
 from __future__ import print_function
 from __future__ import absolute_import
@@ -22,30 +22,16 @@ from . import utils
 
 
 class DjangoAuthInfo(entities.DjangoModelEntity[DbAuthInfo], BackendAuthInfo):
-    """AuthInfo implementation for Django."""
+    """Django backend implementation for the `AuthInfo` ORM class."""
 
     MODEL_CLASS = DbAuthInfo
 
-    @classmethod
-    def get_dbmodel_attribute_name(cls, attr_name):
-        """Return the name of the auth info attribute as it is known to the database model.
-
-        This is essentially a mapping because the `type_string` attribute is called `type` on the database model class.
-
-        :return: name of the backend `attribute` as defined on the database model class
-        """
-        if attr_name == 'type_string':
-            return 'type'
-
-        return super(DjangoAuthInfo, cls).get_dbmodel_attribute_name(attr_name)
-
     def __init__(self, backend, computer, user):
-        """
-        Construct a DjangoAuthInfo.
+        """Construct a new instance.
 
-        :param computer: a Computer instance
-        :param user: a User instance
-        :return: an AuthInfo object associated with the given computer and user
+        :param computer: a :class:`aiida.orm.implementation.computers.BackendComputer` instance
+        :param user: a :class:`aiida.orm.implementation.users.BackendUser` instance
+        :return: an :class:`aiida.orm.implementation.authinfos.BackendAuthInfo` instance
         """
         from . import computers
         from . import users
@@ -55,109 +41,123 @@ class DjangoAuthInfo(entities.DjangoModelEntity[DbAuthInfo], BackendAuthInfo):
         self._dbmodel = utils.ModelWrapper(DbAuthInfo(dbcomputer=computer.dbmodel, aiidauser=user.dbmodel))
 
     @property
-    def is_stored(self):
-        """Return whether the `AuthInfo` is stored
-
-        :return: True if stored, False otherwise
-        """
-        return self._dbmodel.is_saved()
-
-    @property
-    def id(self):
+    def id(self):  # pylint: disable=invalid-name
         return self._dbmodel.id
 
     @property
-    def enabled(self):
-        return self._dbmodel.enabled
+    def is_stored(self):
+        """Return whether the entity is stored.
 
-    @enabled.setter
-    def enabled(self, enabled):
-        self._dbmodel.enabled = enabled
-
-    @property
-    def computer(self):
-        return self.backend.computers.from_dbmodel(self._dbmodel.dbcomputer)
-
-    @property
-    def user(self):
-        return self._backend.users.from_dbmodel(self._dbmodel.aiidauser)
-
-    def get_auth_params(self):
+        :return: True if stored, False otherwise
+        :rtype: bool
         """
-        Get the auth_params dictionary from the DB
-
-        :return: a dictionary
-        """
-        return self._dbmodel.auth_params
-
-    def set_auth_params(self, auth_params):
-        """
-        Replace the auth_params dictionary in the DB with the provided dictionary
-        """
-        self._dbmodel.auth_params = auth_params
-
-    def get_metadata(self):
-        """
-        Get the metadata dictionary from the DB
-
-        :return: a dictionary
-        """
-        return self._dbmodel.metadata
-
-    def set_metadata(self, metadata):
-        """
-        Replace the metadata dictionary in the DB with the provided dictionary
-        """
-        self._dbmodel.metadata = metadata
+        return self._dbmodel.is_saved()
 
     def store(self):
-        """
-        Store the AuthInfo (possibly updating values if changed)
+        """Store and return the instance.
 
-        :return: the AuthInfo instance
+        :return: :class:`aiida.orm.implementation.authinfos.BackendAuthInfo`
         """
         self._dbmodel.save()
         return self
 
+    @property
+    def enabled(self):
+        """Return whether this instance is enabled.
+
+        :return: boolean, True if enabled, False otherwise
+        """
+        return self._dbmodel.enabled
+
+    @enabled.setter
+    def enabled(self, enabled):
+        """Set the enabled state
+
+        :param enabled: boolean, True to enable the instance, False to disable it
+        """
+        self._dbmodel.enabled = enabled
+
+    @property
+    def computer(self):
+        """Return the computer associated with this instance.
+
+        :return: :class:`aiida.orm.implementation.computers.BackendComputer`
+        """
+        return self.backend.computers.from_dbmodel(self._dbmodel.dbcomputer)
+
+    @property
+    def user(self):
+        """Return the user associated with this instance.
+
+        :return: :class:`aiida.orm.implementation.users.BackendUser`
+        """
+        return self._backend.users.from_dbmodel(self._dbmodel.aiidauser)
+
+    def get_auth_params(self):
+        """Return the dictionary of authentication parameters
+
+        :return: a dictionary with authentication parameters
+        """
+        return self._dbmodel.auth_params
+
+    def set_auth_params(self, auth_params):
+        """Set the dictionary of authentication parameters
+
+        :param auth_params: a dictionary with authentication parameters
+        """
+        self._dbmodel.auth_params = auth_params
+
+    def get_metadata(self):
+        """Return the dictionary of metadata
+
+        :return: a dictionary with metadata
+        """
+        return self._dbmodel.metadata
+
+    def set_metadata(self, metadata):
+        """Set the dictionary of metadata
+
+        :param metadata: a dictionary with metadata
+        """
+        self._dbmodel.metadata = metadata
+
 
 class DjangoAuthInfoCollection(BackendAuthInfoCollection):
-    """Collection of AuthInfo instances."""
+    """The collection of Django backend `AuthInfo` entries."""
 
     ENTITY_CLASS = DjangoAuthInfo
 
-    def get(self, computer, user):
-        """
-        Return a AuthInfo given a computer and a user
+    def delete(self, pk):
+        """Delete an entry from the collection.
 
-        :param computer: a Computer instance
-        :param user: a User instance
-        :return: an AuthInfo object associated with the given computer and user
-        :raise aiida.common.NotExistent: if the user is not configured to use computer
-        :raise sqlalchemy.orm.exc.MultipleResultsFound: if the user is configured
-            more than once to use the computer! Should never happen
+        :param pk: the pk of the entry to delete
+        """
+        # pylint: disable=import-error,no-name-in-module
+        from django.core.exceptions import ObjectDoesNotExist
+        try:
+            DbAuthInfo.objects.get(pk=pk).delete()
+        except ObjectDoesNotExist:
+            raise exceptions.NotExistent('AuthInfo<{}> does not exist'.format(pk))
+
+    def get(self, computer, user):
+        """Return an entry from the collection that is configured for the given computer and user
+
+        :param computer: a :class:`aiida.orm.implementation.computers.BackendComputer` instance
+        :param user: a :class:`aiida.orm.implementation.users.BackendUser` instance
+        :return: :class:`aiida.orm.implementation.authinfos.BackendAuthInfo`
+        :raise aiida.common.exceptions.NotExistent: if no entry exists for the computer/user pair
+        :raise aiida.common.exceptions.MultipleObjectsError: if multiple entries exist for the computer/user pair
         """
         # pylint: disable=import-error,no-name-in-module
         from django.core.exceptions import ObjectDoesNotExist, MultipleObjectsReturned
 
         try:
             authinfo = DbAuthInfo.objects.get(dbcomputer=computer.id, aiidauser=user.id)
-            return self.from_dbmodel(authinfo)
         except ObjectDoesNotExist:
-            raise exceptions.NotExistent("The aiida user {} is not configured to use computer {}".format(
+            raise exceptions.NotExistent('User<{}> has no configuration for Computer<{}>'.format(
                 user.email, computer.name))
         except MultipleObjectsReturned:
-            raise exceptions.ConfigurationError("The aiida user {} is configured more than once to use "
-                                                "computer {}! Only one configuration is allowed".format(
-                                                    user.email, computer.name))
-
-    def delete(self, authinfo_id):
-        """Delete an `AuthInfo` entry from the collection and database.
-
-        :param authinfo_id: the id of the entity
-        """
-        # pylint: disable=import-error,no-name-in-module
-        from django.core.exceptions import ObjectDoesNotExist
-        try:
-            DbAuthInfo.objects.get(pk=authinfo_id).delete()
-        except ObjectDoesNotExist:
-            raise exceptions.NotExistent("AuthInfo with id '{}' not found".format(authinfo_id))
+            raise exceptions.MultipleObjectsError('User<{}> has multiple configurations for Computer<{}>'.format(
+                user.email, computer.name))
+        else:
+            return self.from_dbmodel(authinfo)

--- a/aiida/orm/implementation/django/authinfos.py
+++ b/aiida/orm/implementation/django/authinfos.py
@@ -14,7 +14,6 @@ from __future__ import absolute_import
 
 from aiida.backends.djsite.db.models import DbAuthInfo
 from aiida.common import exceptions
-from aiida.common import json
 from aiida.common.lang import type_check
 
 from ..authinfos import BackendAuthInfo, BackendAuthInfoCollection
@@ -89,20 +88,13 @@ class DjangoAuthInfo(entities.DjangoModelEntity[DbAuthInfo], BackendAuthInfo):
 
         :return: a dictionary
         """
-        try:
-            return json.loads(self._dbmodel.auth_params)
-        except ValueError:
-            email = self._dbmodel.aiidauser.email
-            hostname = self._dbmodel.dbcomputer.hostname
-            raise exceptions.DbContentError(
-                "Error while reading auth_params for dbauthinfo, aiidauser={}, computer={}".format(email, hostname))
+        return self._dbmodel.auth_params
 
     def set_auth_params(self, auth_params):
         """
         Replace the auth_params dictionary in the DB with the provided dictionary
         """
-        # Raises ValueError if data is not JSON-serializable
-        self._dbmodel.auth_params = json.dumps(auth_params)
+        self._dbmodel.auth_params = auth_params
 
     def get_metadata(self):
         """
@@ -110,19 +102,13 @@ class DjangoAuthInfo(entities.DjangoModelEntity[DbAuthInfo], BackendAuthInfo):
 
         :return: a dictionary
         """
-        try:
-            return json.loads(self._dbmodel.metadata)
-        except ValueError:
-            raise exceptions.DbContentError(
-                "Error while reading metadata for dbauthinfo, aiidauser={}, computer={}".format(
-                    self.aiidauser.email, self.dbcomputer.hostname))
+        return self._dbmodel.metadata
 
     def set_metadata(self, metadata):
         """
         Replace the metadata dictionary in the DB with the provided dictionary
         """
-        # Raises ValueError if data is not JSON-serializable
-        self._dbmodel.metadata = json.dumps(metadata)
+        self._dbmodel.metadata = metadata
 
     def store(self):
         """

--- a/aiida/orm/implementation/django/computers.py
+++ b/aiida/orm/implementation/django/computers.py
@@ -18,7 +18,7 @@ import six
 from django.db import IntegrityError, transaction
 
 from aiida.backends.djsite.db import models
-from aiida.common import exceptions, json
+from aiida.common import exceptions
 
 from ..computers import BackendComputerCollection, BackendComputer
 from . import entities
@@ -84,23 +84,16 @@ class DjangoComputer(entities.DjangoModelEntity[models.DbComputer], BackendCompu
         return self._dbmodel.hostname
 
     def get_metadata(self):
-        return json.loads(self._dbmodel.metadata)
+        return self._dbmodel.metadata
 
-    def set_metadata(self, metadata_dict):
-        self._dbmodel.metadata = json.dumps(metadata_dict)
+    def set_metadata(self, metadata):
+        self._dbmodel.metadata = metadata
 
     def get_transport_params(self):
-        try:
-            return json.loads(self._dbmodel.transport_params)
-        except ValueError:
-            raise exceptions.DbContentError('Error while reading transport params for Computer<{}>'.format(
-                self.hostname))
+        return self._dbmodel.transport_params
 
     def set_transport_params(self, val):
-        try:
-            self._dbmodel.transport_params = json.dumps(val)
-        except ValueError:
-            raise ValueError('The set of transport_params are not JSON-able')
+        self._dbmodel.transport_params = val
 
     def get_name(self):
         return self._dbmodel.name

--- a/aiida/orm/implementation/django/logs.py
+++ b/aiida/orm/implementation/django/logs.py
@@ -15,7 +15,6 @@ from __future__ import absolute_import
 # pylint: disable=import-error,no-name-in-module,fixme
 from aiida.backends.djsite.db import models
 from aiida.common import exceptions
-from aiida.common import json
 
 from . import entities
 from .. import BackendLog, BackendLogCollection
@@ -35,7 +34,7 @@ class DjangoLog(entities.DjangoModelEntity[models.DbLog], BackendLog):
             levelname=levelname,
             dbnode_id=dbnode_id,
             message=message,
-            metadata=json.dumps(metadata) if metadata else "{}")  # Make sure a json-serializable dict is created
+            metadata=metadata or {})
 
     @property
     def uuid(self):
@@ -84,7 +83,7 @@ class DjangoLog(entities.DjangoModelEntity[models.DbLog], BackendLog):
         """
         Get the metadata corresponding to the entry
         """
-        return json.loads(self._dbmodel.metadata)
+        return self._dbmodel.metadata
 
 
 class DjangoLogCollection(BackendLogCollection):

--- a/aiida/orm/implementation/django/querybuilder.py
+++ b/aiida/orm/implementation/django/querybuilder.py
@@ -12,8 +12,8 @@
 from __future__ import division
 from __future__ import print_function
 from __future__ import absolute_import
+
 from datetime import datetime
-from json import loads as json_loads
 import uuid
 import six
 
@@ -390,9 +390,6 @@ class DjangoQueryBuilder(BackendQueryBuilder):
         elif key == 'extras':
             # same as attributes
             return DbExtra.get_all_values_for_nodepk(res)
-        elif key in ('_metadata', 'transport_params') and res is not None:
-            # Metadata and transport_params are stored as json strings in the DB:
-            return json_loads(res)
         elif isinstance(res, uuid.UUID):
             returnval = six.text_type(res)
         else:

--- a/aiida/orm/implementation/sqlalchemy/computers.py
+++ b/aiida/orm/implementation/sqlalchemy/computers.py
@@ -94,8 +94,8 @@ class SqlaComputer(entities.SqlaModelEntity[DbComputer], BackendComputer):
     def get_metadata(self):
         return self._dbmodel._metadata  # pylint: disable=protected-access
 
-    def set_metadata(self, metadata_dict):
-        self._dbmodel._metadata = metadata_dict  # pylint: disable=protected-access
+    def set_metadata(self, metadata):
+        self._dbmodel._metadata = metadata  # pylint: disable=protected-access
 
     def get_transport_params(self):
         """

--- a/aiida/orm/importexport.py
+++ b/aiida/orm/importexport.py
@@ -895,21 +895,7 @@ def import_data_dj(in_path, user_group=None, ignore_unknown_nodes=False,
                                 raise exceptions.UniquenessError("A computer of that name ( {} ) already exists"
                                     " and I could not create a new one".format(orig_name))
 
-                        # The following is done for compatibility reasons
-                        # In case the export file was generate with the SQLA
-                        # export method
-                        if isinstance(import_data['metadata'], dict):
-                            import_data['metadata'] = json.dumps(import_data['metadata'])
-                        if isinstance(import_data['transport_params'], dict):
-                            import_data['transport_params'] = json.dumps(import_data['transport_params'])
-
                         imported_comp_names.add(import_data['name'])
-
-                    elif Model is models.DbLog:
-                        # Django requires metadata as a string.
-                        # A JSON-serializable string.
-                        if isinstance(import_data['metadata'], dict):
-                            import_data['metadata'] = json.dumps(import_data['metadata'])
 
                     objects_to_create.append(Model(**import_data))
                     import_entry_ids[unique_id] = import_entry_id

--- a/aiida/transports/plugins/local.py
+++ b/aiida/transports/plugins/local.py
@@ -67,8 +67,9 @@ class LocalTransport(Transport):
         if self._machine and self._machine != 'localhost':
             self.logger.debug('machine was passed, but it is not localhost')
         self._safe_open_interval = kwargs.pop('safe_interval', self._DEFAULT_SAFE_OPEN_INTERVAL)
+
         if kwargs:
-            raise ValueError("Input parameters to LocalTransport are not recognized")
+            raise ValueError('the following keywords are not recognized: {}'.format(kwargs))
 
     def open(self):
         """


### PR DESCRIPTION
Fixes #2699 

The following model fields were using a text field to store JSON:

 * `DbComputer.metadata`
 * `DbComputer.transport_params`
 * `DbAuthInfo.auth_params`
 * `DbAuthInfo.metadata`
 * `DbLog.metadata`

Now that Django supports a JSON field for the Postgres JSONB field it is
better to replace the old implementation such that these columns become
properly queryable and we are no longer responsible for proper
serialization and deserialization