### PR TITLE
Change the heuristics of the `AIIDA_PATH` environment variable

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -112,8 +112,6 @@ pipeline {
                         environment name: 'RUN_ALSO_DJANGO', value: 'true'
                     }
                     steps {
-                        // An empty .aiida folder must be present in the AIIDA_PATH
-                        sh 'mkdir -p "$AIIDA_PATH/.aiida"'
                         sh '.ci/setup_profiles.sh'
                         sh '.ci/before_script.sh'
                         sh '.ci/test_script.sh'
@@ -131,8 +129,6 @@ pipeline {
                         environment name: 'RUN_ALSO_SQLALCHEMY', value: 'true'
                     }
                     steps {
-                        // An empty .aiida folder must be present in the AIIDA_PATH
-                        sh 'mkdir -p "$AIIDA_PATH/.aiida"'
                         sh '.ci/setup_profiles.sh'
                         sh '.ci/before_script.sh'
                         sh '.ci/test_script.sh'

--- a/aiida/backends/tests/cmdline/commands/test_profile.py
+++ b/aiida/backends/tests/cmdline/commands/test_profile.py
@@ -76,7 +76,7 @@ class TestVerdiProfileSetup(AiidaTestCase):
 
         result = self.cli_runner.invoke(cmd_profile.profile_list)
         self.assertClickSuccess(result)
-        self.assertIn('configuration folder: ' + self.config.dirpath, result.output)
+        self.assertIn('Info: configuration folder: ' + self.config.dirpath, result.output)
         self.assertIn('* {}'.format(self.profile_list[0]), result.output)
         self.assertIn(self.profile_list[1], result.output)
 
@@ -91,7 +91,7 @@ class TestVerdiProfileSetup(AiidaTestCase):
         result = self.cli_runner.invoke(cmd_profile.profile_list)
 
         self.assertClickSuccess(result)
-        self.assertIn('configuration folder: ' + self.config.dirpath, result.output)
+        self.assertIn('Info: configuration folder: ' + self.config.dirpath, result.output)
         self.assertIn('* {}'.format(self.profile_list[1]), result.output)
         self.assertClickSuccess(result)
 

--- a/aiida/cmdline/commands/cmd_profile.py
+++ b/aiida/cmdline/commands/cmd_profile.py
@@ -30,12 +30,18 @@ def verdi_profile():
 @verdi_profile.command('list')
 def profile_list():
     """Displays list of all available profiles."""
+
     try:
         config = get_config()
     except (exceptions.MissingConfigurationError, exceptions.ConfigurationError) as exception:
+        # This can happen for a fresh install and the `verdi setup` has not yet been run. In this case it is still nice
+        # to be able to see the configuration directory, for instance for those who have set `AIIDA_PATH`. This way
+        # they can at least verify that it is correctly set.
+        from aiida.manage.configuration.settings import AIIDA_CONFIG_FOLDER
+        echo.echo_info('configuration folder: {}'.format(AIIDA_CONFIG_FOLDER))
         echo.echo_critical(str(exception))
-
-    echo.echo_info('configuration folder: {}'.format(config.dirpath))
+    else:
+        echo.echo_info('configuration folder: {}'.format(config.dirpath))
 
     if not config.profiles:
         echo.echo_info('no profiles configured')

--- a/aiida/common/folders.py
+++ b/aiida/common/folders.py
@@ -14,15 +14,9 @@ from __future__ import absolute_import
 
 import fnmatch
 import io
-import itertools
 import os
 import shutil
 import tempfile
-
-try:
-    from pathlib import Path
-except ImportError:
-    from pathlib2 import Path
 
 import six
 
@@ -33,22 +27,6 @@ from aiida.common.utils import get_repository_folder
 GROUP_WRITABLE = True
 
 VALID_SECTIONS = ['node']
-
-
-def find_path(root, dir_name):
-    """Iteratively recurse uopwards from a root folder to try and find a given directory.
-
-    :param root: path to start from
-    :param dir_name: name of the directory to try and find
-    :return: path of the directory if found
-    :raises OSError: if directory could not be found
-    """
-    path = Path(os.path.abspath(root))
-    for parent in itertools.chain([path], path.parents):
-        directory = parent / dir_name
-        if directory.is_dir():
-            return directory
-    raise OSError('No directory found')
 
 
 class Folder(object):  # pylint: disable=useless-object-inheritance

--- a/aiida/manage/configuration/settings.py
+++ b/aiida/manage/configuration/settings.py
@@ -12,32 +12,86 @@ from __future__ import division
 from __future__ import print_function
 from __future__ import absolute_import
 
+import errno
 import os
 
-from aiida.common.folders import find_path
+from aiida.common import ConfigurationError
 
 DEFAULT_UMASK = 0o0077
 DEFAULT_AIIDA_PATH_VARIABLE = 'AIIDA_PATH'
+DEFAULT_AIIDA_PATH = '~'
 DEFAULT_AIIDA_USER = 'aiida@localhost'
-DEFAULT_CONFIG_DIR_BASE = '~'
 DEFAULT_CONFIG_DIR_NAME = '.aiida'
 DEFAULT_CONFIG_FILE_NAME = 'config.json'
 DEFAULT_CONFIG_INDENT_SIZE = 4
 DEFAULT_DAEMON_DIR_NAME = 'daemon'
 DEFAULT_DAEMON_LOG_DIR_NAME = 'log'
 
-AIIDA_PATH = [os.path.expanduser(path) for path in os.environ.get(DEFAULT_AIIDA_PATH_VARIABLE, '').split(':') if path]
-AIIDA_PATH.append(os.path.expanduser('~'))
+AIIDA_CONFIG_FOLDER = None
+DAEMON_DIR = None
+DAEMON_LOG_DIR = None
 
-for path in AIIDA_PATH:
+
+def create_configuration_directory(path):
+    """Attempt to create the configuration folder at the given path skipping if it already exists
+
+    :param path: an absolute path to create a directory at
+    """
     try:
-        AIIDA_CONFIG_FOLDER = os.path.expanduser(str(find_path(root=path, dir_name=DEFAULT_CONFIG_DIR_NAME)))
-        break
-    except OSError:
-        pass
-else:
-    default_folder = os.path.join(DEFAULT_CONFIG_DIR_BASE, DEFAULT_CONFIG_DIR_NAME)
-    AIIDA_CONFIG_FOLDER = os.path.expanduser(default_folder)
+        os.makedirs(path)
+    except OSError as exception:
+        if exception.errno != errno.EEXIST:
+            raise ConfigurationError("could not create the '{}' configuration folder in '{}'".format(
+                DEFAULT_CONFIG_DIR_NAME, DEFAULT_AIIDA_PATH))
 
-DAEMON_DIR = os.path.join(AIIDA_CONFIG_FOLDER, DEFAULT_DAEMON_DIR_NAME)
-DAEMON_LOG_DIR = os.path.join(DAEMON_DIR, DEFAULT_DAEMON_LOG_DIR_NAME)
+
+def set_configuration_directory():
+    """Determine the location of the configuration directory and set the related global variables.
+
+    The location of the configuration folder will be determined and optionally created following these heuristics:
+
+        * If the `AIIDA_PATH` variable is set, all the paths will be checked to see if they contain a configuration
+          folder. The first one to be encountered will be set as `AIIDA_CONFIG_FOLDER`. If none of them contain one,
+          a configuration folder will be created in the last path considered.
+        * If the `AIIDA_PATH` variable is not set the `DEFAULT_AIIDA_PATH` value will be used as base path and if it
+          does not yet contain a configuration folder, one will be created.
+
+    In principle then, a configuration folder should always be found or automatically created.
+    """
+    # pylint: disable = global-statement
+    global AIIDA_CONFIG_FOLDER
+    global DAEMON_DIR
+    global DAEMON_LOG_DIR
+
+    environment_variable = os.environ.get(DEFAULT_AIIDA_PATH_VARIABLE, None)
+
+    if environment_variable:
+
+        # Loop over all the paths in the `AIIDA_PATH` variable to see if any of them contain a configuration folder
+        for base_dir_path in [os.path.expanduser(path) for path in environment_variable.split(':') if path]:
+
+            AIIDA_CONFIG_FOLDER = os.path.expanduser(os.path.join(base_dir_path))
+
+            # Only add the base config directory name to the base path if it does not already do so
+            # Someone might already include it in the environment variable. e.g.: AIIDA_PATH=/home/some/path/.aiida
+            if not AIIDA_CONFIG_FOLDER.endswith(DEFAULT_CONFIG_DIR_NAME):
+                AIIDA_CONFIG_FOLDER = os.path.join(AIIDA_CONFIG_FOLDER, DEFAULT_CONFIG_DIR_NAME)
+
+            # If the directory exists, we leave it set and break the loop
+            if os.path.isdir(AIIDA_CONFIG_FOLDER):
+                break
+        else:
+            # Simply create the folder at the last considered path
+            create_configuration_directory(AIIDA_CONFIG_FOLDER)
+
+    else:
+        # The `AIIDA_PATH` variable is not set, so default to the default path and try to create it if it does not exist
+        AIIDA_CONFIG_FOLDER = os.path.expanduser(os.path.join(DEFAULT_AIIDA_PATH, DEFAULT_CONFIG_DIR_NAME))
+        create_configuration_directory(AIIDA_CONFIG_FOLDER)
+
+    DAEMON_DIR = os.path.join(AIIDA_CONFIG_FOLDER, DEFAULT_DAEMON_DIR_NAME)
+    DAEMON_LOG_DIR = os.path.join(DAEMON_DIR, DEFAULT_DAEMON_LOG_DIR_NAME)
+
+
+# Initialize the configuration directory settings
+set_configuration_directory()

--- a/docs/requirements_for_rtd.txt
+++ b/docs/requirements_for_rtd.txt
@@ -42,7 +42,6 @@ mock==2.0.0
 numpy==1.16.1
 paramiko==2.4.2
 passlib==1.7.1
-pathlib2; python_version<'3.5'
 pg8000<1.13.0
 pgtest==1.2.0
 pika==1.0.0

--- a/docs/source/install/installation.rst
+++ b/docs/source/install/installation.rst
@@ -41,30 +41,29 @@ To leave or deactivate the environment, simply run::
 
 .. _aiida_path_in_virtualenv:
 
-Creating an ``.aiida`` folder in your virtualenvironment
---------------------------------------------------------
+Isolating the configuration folder in your virtual environment
+--------------------------------------------------------------
 
-When you run AiiDA in multiple virtual environments, it can be convenient to use a separate ``.aiida`` folder for each virtualenv. To do this, you can use the :ref:`AIIDA_PATH mechanism <directory_location>` as follows:
+When you run AiiDA in multiple virtual environments, it can be convenient to use a separate ``.aiida`` configuration folder for each environment.
+To do this, you can use the :ref:```AIIDA_PATH`` mechanism <directory_location>` as follows:
 
-1. Create your virtualenv, as described above
-2. Create a ``.aiida`` directory in your virtualenv directory::
-
-    mkdir ~/.virtualenvs/my_env/.aiida
-3. At the end of ``~/.virtualenvs/my_env/bin/activate``, add the following line::
+1. Create your virtual environment, as described above
+2. At the end of ``~/.virtualenvs/my_env/bin/activate``, add the following line, which will set the ``AIIDA_PATH`` environment variable::
 
     export AIIDA_PATH='~/.virtualenvs/my_env'
-4. Deactivate and re-activate the virtualenv
-5. You can test that everything is set up correctly if you can reproduce the following::
+
+3. Deactivate and re-activate the virtual environment
+4. You can test that everything is set up correctly if you can reproduce the following::
 
     (my_env)$ echo $AIIDA_PATH
     >>> ~/.virtualenvs/my_env
 
     (my_env)$ verdi profile list
-    >>> Configuration folder: /home/my_username/.virtualenvs/my_env/.aiida
-    >>> Stopping: No configuration file found
-    >>> Note: if no configuration file was found, it means that you have not run
-    >>> 'verdi setup' yet to configure at least one AiiDA profile.
-6. Continue setting up AiiDA with ``verdi setup`` or ``verdi quicksetup``.
+    >>> Info: configuration folder: /home/my_username/.virtualenvs/my_env/.aiida
+    >>> Critical: configuration file /home/my_username/.virtualenvs/my_env/.aiida/config.json does not exist
+
+   Note: if you get the 'Critical' message, it simply means that you have not yet run `verdi setup` to configure at least one AiiDA profile.
+5. Continue setting up AiiDA with ``verdi setup`` or ``verdi quicksetup``.
 
 Aiida python package
 ====================
@@ -80,7 +79,7 @@ Install the ``aiida`` python package from `PyPI`_ using:
 
     pip install --pre aiida
 
-.. note:: 
+.. note::
     If you are installing AiiDA in your system environment,
     consider adding the ``--user`` flag to avoid the need for
     administrator privileges.
@@ -134,7 +133,7 @@ Most users should use the interactive quicksetup:
 .. code-block:: bash
 
     verdi quicksetup <profile_name>
-    
+
 which leads through the installation process and takes care of creating the corresponding AiiDA database.
 
 For maximum control and customizability, one can use ``verdi setup``
@@ -208,9 +207,9 @@ If you uses the same names used in the example commands above, during the ``verd
 Database setup using Unix sockets
 +++++++++++++++++++++++++++++++++
 
-Instead of using passwords to protect access to the database 
+Instead of using passwords to protect access to the database
 (which could be used by other users on the same machine),
-PostgreSQL allows password-less logins via Unix sockets. 
+PostgreSQL allows password-less logins via Unix sockets.
 
 In this scenario PostgreSQL compares the user connecting to the socket with its
 own database of users and will allow a connection if a matching user exists.
@@ -317,7 +316,7 @@ Place this command in your startup file, i.e. one of
 * the `activate script <https://virtualenv.pypa.io/en/latest/userguide/#activate-script>`_ of your virtual environment
 * a `startup file <https://conda.io/docs/user-guide/tasks/manage-environments.html#saving-environment-variables>`_ for your conda environment
 
-In order to enable tab completion in your current shell, 
+In order to enable tab completion in your current shell,
 make sure to source the startup file once.
 
 .. note::
@@ -356,31 +355,36 @@ After updating your ``PATH`` you can check if it worked in the following way:
 
 .. _directory_location:
 
+
 Customizing the configuration directory location
 ------------------------------------------------
 
-By default, the AiiDA configuration is stored in the directory ``~/.aiida``. This can be changed by setting the ``AIIDA_PATH`` environment variable. The value of ``AIIDA_PATH`` can be a colon-separated list of paths. For each of the paths in the list, AiiDA will look for a ``.aiida`` directory in the given path and all of its parent folders. If no ``.aiida`` directory is found, ``~/.aiida`` will be used.
+By default, the AiiDA configuration is stored in the directory ``~/.aiida``.
+This can be changed by setting the ``AIIDA_PATH`` environment variable.
+The value of ``AIIDA_PATH`` can be a colon-separated list of paths.
+For each of the paths in the list, AiiDA will look for a ``.aiida`` directory in the given path.
+The first configuration folder that is encountered will be used
+If no ``.aiida`` directory is found in any of the paths found in the environment variable, one will be created automatically in the last path that was considered.
 
 For example, the directory structure in your home might look like this ::
 
     .
     ├── .aiida
-    ├── project_a
-    │   ├── .aiida
-    │   └── subfolder
-    └── project_b
-        └── .aiida
+    └── project_a
+        ├── .aiida
+        └── subfolder
 
-If you set ::
 
-    export AIIDA_PATH='~/project_a:~/project_b'
+If you leave the ``AIIDA_PATH`` variable unset, the default location in your home will be used.
+However, if you set ::
 
-the configuration directory used will be ``~/project_a/.aiida``. The same is true if you set ``AIIDA_PATH='~/project_a/subdir'``, because ``subdir`` itself does not contain a ``.aiida`` folder, so AiiDA will first check its parent directories.
+    export AIIDA_PATH='~/project_a:'
 
-If you set ``AIIDA_PATH='.'``, the configuration directory used depends on the current working directory. Inside the ``project_a`` and ``project_b`` directories, their respective ``.aiida`` directory will be used. Outside of these directories, ``~/.aiida`` is used.
+The configuration directory used will be ``~/project_a/.aiida``.
 
-An example for when this option might be used is when two different AiiDA versions are used simultaneously. Using two different ``.aiida`` directories also allows running two daemon concurrently.
-Note however that this option does **not** change the database cluster that is being used. This means that by default you still need to take care that the database names do not clash.
+.. warning::
+    Note that even if the sub directory ``.aiida`` would not yet have existed in ``~/project_a``, AiiDA will automatically create it for you.
+    Be careful therefore to check that the path you set for ``AIIDA_PATH`` is correct.
 
 Using AiiDA in Jupyter
 ----------------------
@@ -414,7 +418,7 @@ add the following code to a ``.py`` file (create one if there isn't any) in ``<h
 
       # Get the current Ipython session
       ipython = IPython.get_ipython()
-  
+
       # Register the line magic
       load_ipython_extension(ipython)
 

--- a/setup.json
+++ b/setup.json
@@ -54,7 +54,6 @@
     "tornado<5.0",
     "pyblake2==1.1.2; python_version<'3.6'",
     "chainmap; python_version<'3.5'",
-    "pathlib2; python_version<'3.5'",
     "singledispatch>=3.4.0.3; python_version<'3.5'",
     "enum34==1.1.6; python_version<'3.5'",
     "simplejson==3.16.0",


### PR DESCRIPTION
Fixes #2337 

The location of the configuration folder will be determined and
optionally created following these heuristics:

 * If the `AIIDA_PATH` variable is set, all the paths will be checked
   to see if they contain a configuration folder. The first one to be
   encountered will be set as `AIIDA_CONFIG_FOLDER`. If none of them
   contain one, a configuration folder will be created in the last
   path considered.

 * If the `AIIDA_PATH` variable is not set the `DEFAULT_AIIDA_PATH`
   value will be used as base path and if it does not yet contain a
   configuration folder, one will be created.

This new approach will guarantee that a configuration folder will
always be set and created if necessary. The one downside is that if
someone sets the environment variable to the wrong value, a config
folder will be created without a warning.