### PR TITLE
Update requirement for dependency `psycopg==2.8`

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -32,7 +32,7 @@ dependencies:
 - tabulate==0.8.3
 - ete3==3.1.1
 - uritools==2.2.0
-- psycopg2==2.7.6
+- psycopg2==2.8
 - paramiko==2.4.2
 - ecdsa==0.13
 - ipython>=4.0,<6.0

--- a/setup.json
+++ b/setup.json
@@ -44,7 +44,7 @@
     "tabulate==0.8.3",
     "ete3==3.1.1",
     "uritools==2.2.0",
-    "psycopg2==2.7.6",
+    "psycopg2-binary==2.8",
     "paramiko==2.4.2",
     "ecdsa==0.13",
     "ipython>=4.0,<6.0",


### PR DESCRIPTION
Fixes #2710 

This should get rid of the warning about the package moving the binary
builds to a the separate package `psycopg2-binary`. Whether we want to
use the binary build remains to be decided.