### PR TITLE
Add validation of the link label in `Node.add_incoming`

### DIFF
--- a/aiida/backends/tests/__init__.py
+++ b/aiida/backends/tests/__init__.py
@@ -122,6 +122,7 @@ db_test_list = {
         'orm.node': ['aiida.backends.tests.orm.node.test_node'],
         'orm.utils.calcjob': ['aiida.backends.tests.orm.utils.test_calcjob'],
         'orm.utils.node': ['aiida.backends.tests.orm.utils.test_node'],
+        'orm.utils.links': ['aiida.backends.tests.orm.utils.test_links'],
         'orm.utils.loaders': ['aiida.backends.tests.orm.utils.test_loaders'],
         'orm.utils.repository': ['aiida.backends.tests.orm.utils.test_repository'],
         'parsers.parser': ['aiida.backends.tests.parsers.test_parser'],

--- a/aiida/backends/tests/engine/test_process.py
+++ b/aiida/backends/tests/engine/test_process.py
@@ -103,15 +103,15 @@ class TestProcess(AiidaTestCase):
             run(test_processes.BadOutput)
 
     def test_input_link_creation(self):
-        dummy_inputs = ["1", "2", "3", "4"]
+        dummy_inputs = ['a', 'b', 'c', 'd']
 
-        inputs = {l: orm.Int(l) for l in dummy_inputs}
+        inputs = {string: orm.Str(string) for string in dummy_inputs}
         inputs['metadata'] = {'store_provenance': True}
         process = test_processes.DummyProcess(inputs)
 
         for entry in process.node.get_incoming().all():
             self.assertTrue(entry.link_label in inputs)
-            self.assertEqual(int(entry.link_label), int(entry.node.value))
+            self.assertEqual(entry.link_label, entry.node.value)
             dummy_inputs.remove(entry.link_label)
 
         # Make sure there are no other inputs

--- a/aiida/backends/tests/engine/test_work_chain.py
+++ b/aiida/backends/tests/engine/test_work_chain.py
@@ -647,7 +647,7 @@ class TestWorkchain(AiidaTestCase):
                 spec.outline(cls.result)
 
             def result(self):
-                self.out('_return', val)
+                self.out('result', val)
 
         class Workchain(WorkChain):
 
@@ -661,8 +661,8 @@ class TestWorkchain(AiidaTestCase):
                 return ToContext(result_b=self.submit(SimpleWc))
 
             def result(self):
-                test_case.assertEquals(self.ctx.result_a.outputs._return, val)
-                test_case.assertEquals(self.ctx.result_b.outputs._return, val)
+                test_case.assertEquals(self.ctx.result_a.outputs.result, val)
+                test_case.assertEquals(self.ctx.result_b.outputs.result, val)
 
         run_and_check_success(Workchain)
 

--- a/aiida/backends/tests/orm/node/test_node.py
+++ b/aiida/backends/tests/orm/node/test_node.py
@@ -256,8 +256,8 @@ class TestNodeLinks(AiidaTestCase):
         data = Data()
 
         # Verify that adding two return links with the same link label but from different source is allowed
-        data.add_incoming(return_one, link_type=LinkType.RETURN, link_label='return')
-        data.add_incoming(return_two, link_type=LinkType.RETURN, link_label='return')
+        data.add_incoming(return_one, link_type=LinkType.RETURN, link_label='returned')
+        data.add_incoming(return_two, link_type=LinkType.RETURN, link_label='returned')
         data.store()
 
         uuids_incoming = set(node.uuid for node in data.get_incoming().all_nodes())

--- a/aiida/backends/tests/orm/utils/test_links.py
+++ b/aiida/backends/tests/orm/utils/test_links.py
@@ -1,0 +1,37 @@
+# -*- coding: utf-8 -*-
+###########################################################################
+# Copyright (c), The AiiDA team. All rights reserved.                     #
+# This file is part of the AiiDA code.                                    #
+#                                                                         #
+# The code is hosted on GitHub at https://github.com/aiidateam/aiida_core #
+# For further information on the license, see the LICENSE.txt file        #
+# For further information please visit http://www.aiida.net               #
+###########################################################################
+"""Tests for the links utilities."""
+from __future__ import division
+from __future__ import print_function
+from __future__ import absolute_import
+
+from aiida.backends.testbase import AiidaTestCase
+from aiida.orm.utils.links import validate_link_label
+
+
+class TestValidateLinkLabel(AiidaTestCase):
+    """Tests for `validate_link_label` function."""
+
+    def test_validate_link_label(self):
+        """Test that illegal link labels will raise a `ValueError`."""
+
+        illegal_link_labels = [
+            '_leading_underscore',
+            'trailing_underscore_',
+            'non_numeric_%',
+            'including.period',
+            'disallowed👻unicodecharacters',
+            'white space',
+            'das-hes',
+        ]
+
+        for link_label in illegal_link_labels:
+            with self.assertRaises(ValueError):
+                validate_link_label(link_label)

--- a/aiida/backends/tests/test_export_and_import.py
+++ b/aiida/backends/tests/test_export_and_import.py
@@ -1708,9 +1708,9 @@ class TestLinks(AiidaTestCase):
         i1 = orm.Int(1).store()
         o1 = orm.Int(2).store()
 
-        w1.add_incoming(i1, LinkType.INPUT_WORK, 'input-i1')
+        w1.add_incoming(i1, LinkType.INPUT_WORK, 'input_i1')
         w1.add_incoming(w2, LinkType.CALL_WORK, 'call')
-        o1.add_incoming(w1, LinkType.RETURN, 'return')
+        o1.add_incoming(w1, LinkType.RETURN, 'returned')
 
         links_count_wanted = 2  # All 3 links, except CALL links (the CALL_WORK)
         links_wanted = [l for l in self.get_all_node_links() if l[3] not in
@@ -1751,7 +1751,7 @@ class TestLinks(AiidaTestCase):
         i1 = orm.Int(1).store()
         o1 = orm.Int(2).store()
 
-        w1.add_incoming(i1, LinkType.INPUT_WORK, 'input-i1')
+        w1.add_incoming(i1, LinkType.INPUT_WORK, 'input_i1')
         w1.add_incoming(w2, LinkType.CALL_WORK, 'call')
         o1.add_incoming(w1, LinkType.RETURN, 'return1')
         o1.add_incoming(w2, LinkType.RETURN, 'return2')

--- a/aiida/backends/tests/test_query.py
+++ b/aiida/backends/tests/test_query.py
@@ -1143,7 +1143,7 @@ class TestConsistency(AiidaTestCase):
         # adding 5 links going out:
         for inode in range(5):
             output_node = orm.Data().store()
-            output_node.add_incoming(parent, link_type=LinkType.CREATE, link_label='link-{}'.format(inode))
+            output_node.add_incoming(parent, link_type=LinkType.CREATE, link_label='link_{}'.format(inode))
         for projection in ('id', '*'):
             qb = orm.QueryBuilder()
             qb.append(orm.CalculationNode, filters={'id': parent.id}, tag='parent', project=projection)


### PR DESCRIPTION
Fixes #2568 

Because the link label is often used as a python identifier, for example
in the graph traversal tools, it is important that they are in fact
valid python identifiers. To guarantee this validation is added to the
`Node.add_incoming` method on the link label value. Valid link labels
adhere to the following restrictions:

 * Has to be a valid python identifier
 * Can only contain alphanumeric characters and underscores
 * Can not start or end with an underscore

Validation of port names will call the same validation function, since
the port name will become (part) of the eventual link name. An
additional constraint for port names is that they cannot contain more
than one consecutive underscores, since a double underscore is used to
indicate a nested namespacing.