### PR TITLE
Implement generic list print function for command line

### DIFF
--- a/aiida/cmdline/commands/cmd_profile.py
+++ b/aiida/cmdline/commands/cmd_profile.py
@@ -46,14 +46,9 @@ def profile_list():
     if not config.profiles:
         echo.echo_info('no profiles configured')
     else:
-
-        default_profile = config.default_profile_name
-
-        for profile in sorted(config.profiles, key=lambda p: p.name):
-            if profile.name == default_profile:
-                click.secho('{} {}'.format('*', profile.name), fg='green')
-            else:
-                click.secho('{} {}'.format(' ', profile.name))
+        sort = lambda profile: profile.name
+        highlight = lambda profile: profile.name == config.default_profile_name
+        echo.echo_formatted_list(config.profiles, ['name'], sort=sort, highlight=highlight)
 
 
 @verdi_profile.command('show')

--- a/aiida/cmdline/commands/cmd_status.py
+++ b/aiida/cmdline/commands/cmd_status.py
@@ -7,7 +7,7 @@
 # For further information on the license, see the LICENSE.txt file        #
 # For further information please visit http://www.aiida.net               #
 ###########################################################################
-"""`verdi profile` command."""
+"""`verdi status` command."""
 from __future__ import division
 from __future__ import print_function
 from __future__ import absolute_import

--- a/aiida/cmdline/commands/cmd_user.py
+++ b/aiida/cmdline/commands/cmd_user.py
@@ -7,19 +7,19 @@
 # For further information on the license, see the LICENSE.txt file        #
 # For further information please visit http://www.aiida.net               #
 ###########################################################################
-"""
-This allows to setup and configure a user from command line.
-"""
+"""`verdi user` command."""
 from __future__ import division
 from __future__ import print_function
 from __future__ import absolute_import
+
 from functools import partial
 import click
 
 from aiida.cmdline.commands.cmd_verdi import verdi
-from aiida.cmdline.params.types.user import UserParamType
-from aiida.cmdline.utils.decorators import with_dbenv
-from aiida.cmdline.params import options
+from aiida.cmdline.params import options, types
+from aiida.cmdline.utils import decorators, echo
+
+PASSWORD_UNCHANGED = '***'  # noqa
 
 
 @verdi.group('user')
@@ -27,61 +27,72 @@ def verdi_user():
     """Inspect and manage users."""
 
 
-def get_default(value, ctx):
+def get_user_attribute_default(attribute, ctx):
+    """Return the default value for the given attribute of the user passed in the context.
+
+    :param attribute: attribute for which to get the current value
+    :param ctx: click context which should contain the selected user
+    :return: user attribute default value if set, or None
     """
-    Get the default argument using a user instance property
-    :param value: The name of the property to use
-    :param ctx: The click context (which will be used to get the user)
-    :return: The default value, or None
-    """
-    user = ctx.params['user']
-    value = getattr(user, value)
-    # In our case the empty string means there is no default
-    if value == "":
+    default = getattr(ctx.params['user'], attribute)
+
+    # None or empty string means there is no default
+    if not default:
         return None
-    return value
+
+    return default
 
 
-PASSWORD_UNCHANGED = '***'  # noqa
+@verdi_user.command('list')
+@decorators.with_dbenv()
+def user_list():
+    """Displays list of all users."""
+    from aiida.orm import User
+
+    default_user = User.objects.get_default()
+
+    if default_user is None:
+        echo.echo_warning('no default user has been configured')
+
+    attributes = ['email', 'first_name', 'last_name']
+    sort = lambda user: user.email
+    highlight = lambda x: x.email == default_user.email if default_user else None
+    echo.echo_formatted_list(User.objects.all(), attributes, sort=sort, highlight=highlight)
 
 
 @verdi_user.command()
-@click.argument('user', metavar='USER', type=UserParamType(create=True))
+@click.argument('user', metavar='USER', type=types.UserParamType(create=True))
 @options.NON_INTERACTIVE()
 @click.option(
     '--first-name',
     prompt='First name',
-    type=str,
-    contextual_default=partial(get_default, 'first_name'),
+    type=click.STRING,
+    contextual_default=partial(get_user_attribute_default, 'first_name'),
     cls=options.interactive.InteractiveOption)
 @click.option(
     '--last-name',
     prompt='Last name',
-    type=str,
-    contextual_default=partial(get_default, 'last_name'),
+    type=click.STRING,
+    contextual_default=partial(get_user_attribute_default, 'last_name'),
     cls=options.interactive.InteractiveOption)
 @click.option(
     '--institution',
     prompt='Institution',
-    type=str,
-    contextual_default=partial(get_default, 'institution'),
+    type=click.STRING,
+    contextual_default=partial(get_user_attribute_default, 'institution'),
     cls=options.interactive.InteractiveOption)
 @click.option(
     '--password',
     prompt='Password',
     hide_input=True,
     required=False,
-    type=str,
+    type=click.STRING,
     default=PASSWORD_UNCHANGED,
     confirmation_prompt=True,
     cls=options.interactive.InteractiveOption)
-@with_dbenv()
-def configure(user, first_name, last_name, institution, password, non_interactive):
-    """
-    Create or update a user.  Email address us taken as the user identiier.
-    """
-    # pylint: disable=unused-argument,unused-variable
-
+@decorators.with_dbenv()
+def configure(user, first_name, last_name, institution, password, non_interactive):  # pylint: disable=unused-argument
+    """Create or update a USER."""
     if first_name is not None:
         user.first_name = first_name
     if last_name is not None:
@@ -91,69 +102,11 @@ def configure(user, first_name, last_name, institution, password, non_interactiv
     if password != PASSWORD_UNCHANGED:
         user.password = password
 
-    if user.is_stored:
-        action = 'updated'
-    else:
-        action = 'created'
+    action = 'updated' if user.is_stored else 'created'
+
     user.store()
-    click.echo(">> User {} {} ({}) {}. <<".format(user.first_name, user.last_name, user.email, action))
+
+    echo.echo_success('{} successfully {}'.format(user.email, action))
+
     if not user.has_usable_password():
-        click.echo("** NOTE: no password set for this user, ")
-        click.echo("         so they will not be able to login")
-        click.echo("         via the REST API and the Web Interface.")
-
-
-# pylint: disable=too-many-branches
-@verdi_user.command('list')
-@click.option('--color', is_flag=True, help='Show results with colors', default=False)
-@with_dbenv()
-def user_list(color):
-    """
-    List all the users.
-    :param color: Show the list using colors
-    """
-    from aiida.manage.manager import get_manager
-    from aiida import orm
-
-    manager = get_manager()
-
-    current_user = manager.get_profile().default_user_email
-
-    if current_user is not None:
-        pass
-    else:
-        click.echo("### No default user configured yet, run 'verdi install'! ###", err=True)
-
-    for user in orm.User.objects.all():
-        name_pieces = []
-        if user.first_name:
-            name_pieces.append(user.first_name)
-        if user.last_name:
-            name_pieces.append(user.last_name)
-        full_name = ' '.join(name_pieces)
-        if full_name:
-            full_name = " {}".format(full_name)
-
-        institution_str = " ({})".format(user.institution) if user.institution else ""
-
-        permissions_list = []
-        if not user.has_usable_password():
-            permissions_list.append("NO_PWD")
-            color_id = 'black'  # Dark gray
-        else:
-            color_id = 'blue'  # Blue
-        permissions_str = ",".join(permissions_list)
-        if permissions_str:
-            permissions_str = " [{}]".format(permissions_str)
-
-        if user.email == current_user:
-            symbol = ">"
-            color_id = 'red'
-        else:
-            symbol = "*"
-
-        if not color:
-            color_id = None
-
-        click.secho("{}{}".format(symbol, user.email), fg=color_id, bold=True, nl=False)
-        click.secho(":{}{}{}".format(full_name, institution_str, permissions_str), fg=color_id)
+        echo.echo_warning('no password set, so authentication for the REST API will be disabled')

--- a/aiida/cmdline/utils/echo.py
+++ b/aiida/cmdline/utils/echo.py
@@ -135,6 +135,33 @@ def echo_deprecated(message, bold=False, nl=True, err=True, exit=False):
         sys.exit(ExitCode.DEPRECATED)
 
 
+def echo_formatted_list(collection, attributes, sort=None, highlight=None, hide=None):
+    """Print a collection of entries as a formatted list, one entry per line.
+
+    :param collection: a list of objects
+    :param attributes: a list of attributes to print for each entry in the collection
+    :param sort: optional lambda to sort the collection
+    :param highlight: optional lambda to highlight an entry in the collection if it returns True
+    :param hide: optional lambda to skip an entry if it returns True
+    """
+    if sort:
+        entries = sorted(collection, key=sort)
+    else:
+        entries = collection
+
+    template = '{symbol}' + ' {}' * len(attributes)
+
+    for entry in entries:
+        if hide and hide(entry):
+            continue
+
+        values = [getattr(entry, attribute) for attribute in attributes]
+        if highlight and highlight(entry):
+            click.secho(template.format(symbol='*', *values), fg='green')
+        else:
+            click.secho(template.format(symbol=' ', *values))
+
+
 def echo_dictionary(dictionary, fmt='json+date'):
     """
     Print the given dictionary to stdout in the given format

--- a/docs/source/verdi/verdi_user_guide.rst
+++ b/docs/source/verdi/verdi_user_guide.rst
@@ -792,8 +792,8 @@ Below is a list with all available subcommands.
       --help  Show this message and exit.
 
     Commands:
-      configure  Create or update a user.
-      list       List all the users.
+      configure  Create or update a USER.
+      list       Displays list of all users.
 
 
 


### PR DESCRIPTION
Fixes #2408 

Multiple `verdi` commands will print a simple list of entries in a
collection where optionally some entries are highlighted. This concept
is abstracted in `aiida.cmdline.utils.echo.echo_formatted_list` to make
the output across the commands more homogeneous. The command that
implement it for now:

 * `verdi computer list`
 * `verdi profile list`
 * `verdi user list`

The function provides optional lambdas that can help sort the
collection, determine highlighting and which entries should be hidden.