### PR TITLE
Automatically add optional endopts marker to `verdi` commands

### DIFF
--- a/aiida/cmdline/params/options/multivalue.py
+++ b/aiida/cmdline/params/options/multivalue.py
@@ -19,6 +19,25 @@ import click
 from .. import types
 
 
+def collect_usage_pieces(self, ctx):
+    """Returns all the pieces that go into the usage line and returns it as a list of strings."""
+    result = [self.options_metavar]
+
+    # If the command contains a `MultipleValueOption` make sure to add `[--]` to the help string before the
+    # arguments, which hints the use of the optional `endopts` marker
+    if any([isinstance(param, MultipleValueOption) for param in self.get_params(ctx)]):
+        result.append('[--]')
+
+    for param in self.get_params(ctx):
+        result.extend(param.get_usage_pieces(ctx))
+
+    return result
+
+
+# Override the `collect_usage_pieces` method of the `click.Command` class to automatically affect all commands
+click.Command.collect_usage_pieces = collect_usage_pieces
+
+
 class MultipleValueOption(click.Option):
     """
     An option that can handle multiple values with a single flag. For example::

--- a/docs/source/verdi/verdi_user_guide.rst
+++ b/docs/source/verdi/verdi_user_guide.rst
@@ -140,7 +140,7 @@ This is fairly typical for command line arguments, but slightly more unorthodox 
 However, ``verdi`` has multiple commands where an option needs to be able to support options that take more than one value.
 Take for example the ``verdi export create`` command, with part of its help string::
 
-  Usage: verdi export create [OPTIONS] OUTPUT_FILE
+  Usage: verdi export create [OPTIONS] [--] OUTPUT_FILE
 
     Export various entities, such as Codes, Computers, Groups and Nodes, to an
     archive file for backup or sharing purposes.
@@ -169,6 +169,7 @@ Unfortunately, this leads to an ambiguity, as the 'greedy' multi value option ``
 This will cause the command to abort if the validation fails, but even worse it might be silently accepted.
 The root of the problem is that the multi value option needs to necessarily be greedy and cannot distinguish which value belongs to it and which value is just another argument.
 The typical solution for this problem is to use the so called 'endopts' marker, which is defined as two dashes ``--``, which can be used to mark the end of the options and clearly distinguish them from the arguments.
+Note that this is also indicated by the usage string of the command where it shows ``[--]`` between the ``[OPTIONS]`` and ``OUTPUT_FILE`` parameters, meaning that the ``--`` endopts marker can optionally be used.
 The previous command can therefore be made unambiguous as follows::
 
   verdi export create -N 10 11 12 -- archive.aiida
@@ -482,7 +483,7 @@ Below is a list with all available subcommands.
 
 ::
 
-    Usage:  [OPTIONS] [ARCHIVES]...
+    Usage:  [OPTIONS] [--] [ARCHIVES]...
 
       Import one or multiple exported AiiDA archives
 
@@ -691,7 +692,7 @@ Below is a list with all available subcommands.
 
 ::
 
-    Usage:  [OPTIONS] SCRIPTNAME [VARARGS]...
+    Usage:  [OPTIONS] [--] SCRIPTNAME [VARARGS]...
 
       Execute an AiiDA script.
 


### PR DESCRIPTION
Fixes #2076 

Some `verdi` commands have options with the `MultipleValueOption` class
which allow to pass multi values to an option without repeating the flag.
However, this introduces the traditional ambiguity about when the option
values stop and become for example a positional argument, since the
option matching is greedy. The endopts marker `--` is traditionally used
to signal to the parser that the options have ended and everything that
follows should be interpreted as positional arguments.

To reduce the confusion of this feature, it would help if the usage
string of command with multi value options would include the endopts
marker. Here we override the `collect_usage_pieces` of the
`click.Command` class, which will ensure a usage string like e.g.:

    verdi export create [OPTIONS] [--] OUTPUT_FILE

The added `[--]` indicate that the endopts can optionally be used.