### PR TITLE
allow singlefiledata to be constructed from string

### DIFF
--- a/aiida/backends/tests/orm/data/test_singlefile.py
+++ b/aiida/backends/tests/orm/data/test_singlefile.py
@@ -64,7 +64,7 @@ class TestSinglefileData(AiidaTestCase):
 
     def test_construct_from_filelike(self):
         """Test constructing an instance from filelike instead of filepath."""
-        content_original = 'some testing text\nwith a newline'
+        content_original = u'some testing text\nwith a newline'
 
         with tempfile.NamedTemporaryFile(mode='w+') as handle:
             basename = os.path.basename(handle.name)
@@ -89,7 +89,7 @@ class TestSinglefileData(AiidaTestCase):
 
     def test_construct_from_string(self):
         """Test constructing an instance from a string."""
-        content_original = 'some testing text\nwith a newline'
+        content_original = u'some testing text\nwith a newline'
 
         with io.StringIO(content_original) as handle:
             node = SinglefileData(file=handle)

--- a/aiida/backends/tests/orm/data/test_singlefile.py
+++ b/aiida/backends/tests/orm/data/test_singlefile.py
@@ -14,6 +14,7 @@ from __future__ import absolute_import
 
 import os
 import tempfile
+import io
 
 from aiida.backends.testbase import AiidaTestCase
 from aiida.orm import SinglefileData, load_node
@@ -85,3 +86,24 @@ class TestSinglefileData(AiidaTestCase):
 
         self.assertEqual(content_stored, content_original)
         self.assertEqual(node.list_object_names(), [basename])
+
+    def test_construct_from_string(self):
+        """Test constructing an instance from a string."""
+        content_original = 'some testing text\nwith a newline'
+
+        with io.StringIO(content_original) as handle:
+            node = SinglefileData(file=handle)
+
+        with node.open() as handle:
+            content_stored = handle.read()
+
+        self.assertEqual(content_stored, content_original)
+        self.assertEqual(node.list_object_names(), [SinglefileData.DEFAULT_FILENAME])
+
+        node.store()
+
+        with node.open() as handle:
+            content_stored = handle.read()
+
+        self.assertEqual(content_stored, content_original)
+        self.assertEqual(node.list_object_names(), [SinglefileData.DEFAULT_FILENAME])

--- a/aiida/orm/nodes/data/singlefile.py
+++ b/aiida/orm/nodes/data/singlefile.py
@@ -24,6 +24,8 @@ __all__ = ('SinglefileData',)
 class SinglefileData(Data):
     """Data class that can be used to store a single file in its repository."""
 
+    DEFAULT_FILENAME = 'file.txt'
+
     def __init__(self, file, **kwargs):
         """Construct a new instance and set the contents to that of the file.
 
@@ -80,7 +82,10 @@ class SinglefileData(Data):
                 raise ValueError('path `{}` does not correspond to an existing file'.format(file))
         else:
             is_filelike = True
-            key = os.path.basename(file.name)
+            try:
+                key = os.path.basename(file.name)
+            except AttributeError:
+                key = self.DEFAULT_FILENAME
 
         existing_object_names = self.list_object_names()
 

--- a/aiida/orm/nodes/data/singlefile.py
+++ b/aiida/orm/nodes/data/singlefile.py
@@ -48,8 +48,8 @@ class SinglefileData(Data):
         """Return an open file handle to the content of this data node.
 
         :param key: optional key within the repository, by default is the `filename` set in the attributes
-        :param mode: the mode with which to open the file handle
-        :return: a file handle in read mode
+        :param mode: the mode with which to open the file handle (default: read mode)
+        :return: a file handle
         """
         if key is None:
             key = self.filename
@@ -59,7 +59,7 @@ class SinglefileData(Data):
     def get_content(self):
         """Return the content of the single file stored for this data node.
 
-        :return: the string content of the file
+        :return: the content of the file as a string
         """
         with self.open() as handle:
             return handle.read()
@@ -68,6 +68,7 @@ class SinglefileData(Data):
         """Store the content of the file in the node's repository, deleting any other existing objects.
 
         :param file: an absolute filepath or filelike object whose contents to copy
+            Hint: Pass io.StringIO("my string") to construct the file directly from a string.
         """
         # pylint: disable=redefined-builtin
 


### PR DESCRIPTION
fix #2709 

it was already possible to construct a SinglefileData from a file
handle. However, it was calling `handle.name`, which probited using
io.StringIO(string) in order to construct a SinglefileData directly from
a string.

 * allow SinglefileData to be constructed from a StringIO
   (default filename: file.txt)
 * add test