### PR TITLE
Add config file option

### DIFF
--- a/aiida/backends/tests/cmdline/commands/test_code.py
+++ b/aiida/backends/tests/cmdline/commands/test_code.py
@@ -96,6 +96,27 @@ class TestVerdiCodeSetup(AiidaTestCase):
         self.assertClickResultNoException(result)
         self.assertIsInstance(Code.get_from_string('{}'.format(label)), Code)
 
+    def test_from_config(self):
+        """Test setting up a code from a config file"""
+        from aiida.orm import Code
+        import tempfile
+        import os
+
+        label = 'noninteractive_config'
+
+        with tempfile.NamedTemporaryFile('w') as handle:
+            handle.write("""---
+label: {l}
+input_plugin: arithmetic.add
+computer: {c}
+remote_abs_path: /remote/abs/path
+""".format(l=label, c=self.comp.name))
+            handle.flush()
+            result = self.cli_runner.invoke(setup_code, ['--non-interactive', '--config', os.path.realpath(handle.name)])
+
+        self.assertClickResultNoException(result)
+        self.assertIsInstance(Code.get_from_string('{}'.format(label)), Code)
+
     def test_mixed(self):
         from aiida.orm import Code
         label = 'mixed_remote'

--- a/aiida/backends/tests/cmdline/commands/test_computer.py
+++ b/aiida/backends/tests/cmdline/commands/test_computer.py
@@ -299,6 +299,28 @@ class TestVerdiComputerSetup(AiidaTestCase):
         self.assertIsInstance(result.exception, SystemExit)
         self.assertIn("unknown replacement field 'unknown_key'", str(result.output))
 
+    def test_noninteractive_from_config(self):
+        """Test setting up a computer from a config file"""
+        from aiida.orm import Computer
+        import tempfile
+        import os
+
+        label = 'noninteractive_config'
+
+        with tempfile.NamedTemporaryFile('w') as handle:
+            handle.write("""---
+label: {l}
+hostname: {l}
+transport: local
+scheduler: direct
+""".format(l=label))
+            handle.flush()
+            result = self.cli_runner.invoke(computer_setup,
+                                            ['--non-interactive', '--config', os.path.realpath(handle.name)])
+
+        self.assertClickResultNoException(result)
+        self.assertIsInstance(Computer.objects.get(name=label), Computer)
+
 
 class TestVerdiComputerConfigure(AiidaTestCase):
 

--- a/aiida/backends/tests/cmdline/commands/test_setup.py
+++ b/aiida/backends/tests/cmdline/commands/test_setup.py
@@ -72,12 +72,12 @@ class TestVerdiSetup(AiidaPostgresTestCase):
         self.assertEqual(user.institution, user_institution)
 
     @with_temporary_config_instance
-    def test_user_setup_from_config_file(self):
-        """Test `verdi quicksetup` non-interactively."""
+    def test_quicksetup_from_config_file(self):
+        """Test `verdi quicksetup` from configuration file."""
         import tempfile
         import os
 
-        with tempfile.NamedTemporaryFile('w', delete=False) as handle:
+        with tempfile.NamedTemporaryFile('w') as handle:
             handle.write("""---
 profile: testing
 first_name: Leopold

--- a/aiida/backends/tests/cmdline/commands/test_setup.py
+++ b/aiida/backends/tests/cmdline/commands/test_setup.py
@@ -72,6 +72,24 @@ class TestVerdiSetup(AiidaPostgresTestCase):
         self.assertEqual(user.institution, user_institution)
 
     @with_temporary_config_instance
+    def test_user_setup_from_config_file(self):
+        """Test `verdi quicksetup` non-interactively."""
+        import tempfile
+        import os
+
+        with tempfile.NamedTemporaryFile('w', delete=False) as handle:
+            handle.write("""---
+profile: testing
+first_name: Leopold
+last_name: Talirz
+institution: EPFL
+backend: django
+email: 123@234.de""")
+            handle.flush()
+            result = self.cli_runner.invoke(cmd_setup.quicksetup, ['--config', os.path.realpath(handle.name)])
+        self.assertClickResultNoException(result)
+
+    @with_temporary_config_instance
     def test_quicksetup_wrong_port(self):
         """Test `verdi quicksetup` exits if port is wrong."""
         configuration.reset_profile()

--- a/aiida/cmdline/commands/cmd_code.py
+++ b/aiida/cmdline/commands/cmd_code.py
@@ -74,6 +74,7 @@ def set_code_builder(ctx, param, value):
 @options.PREPEND_TEXT()
 @options.APPEND_TEXT()
 @options.NON_INTERACTIVE()
+@options.CONFIG_FILE()
 @with_dbenv()
 def setup_code(non_interactive, **kwargs):
     """Setup a new Code."""

--- a/aiida/cmdline/commands/cmd_computer.py
+++ b/aiida/cmdline/commands/cmd_computer.py
@@ -234,6 +234,7 @@ def set_computer_builder(ctx, param, value):
 @options.PREPEND_TEXT()
 @options.APPEND_TEXT()
 @options.NON_INTERACTIVE()
+@options.CONFIG_FILE()
 @click.pass_context
 @with_dbenv()
 def computer_setup(ctx, non_interactive, **kwargs):

--- a/aiida/cmdline/commands/cmd_setup.py
+++ b/aiida/cmdline/commands/cmd_setup.py
@@ -38,6 +38,7 @@ from aiida.manage.manager import get_manager
 @options_setup.SETUP_DATABASE_USERNAME()
 @options_setup.SETUP_DATABASE_PASSWORD()
 @options_setup.SETUP_REPOSITORY_URI()
+@options.CONFIG_FILE()
 def setup(non_interactive, profile, email, first_name, last_name, institution, password, db_engine, db_backend, db_host,
           db_port, db_name, db_username, db_password, repository):
     """Setup a new profile."""
@@ -111,6 +112,7 @@ def setup(non_interactive, profile, email, first_name, last_name, institution, p
 @options_setup.QUICKSETUP_DATABASE_USERNAME()
 @options_setup.QUICKSETUP_DATABASE_PASSWORD()
 @options_setup.QUICKSETUP_REPOSITORY_URI()
+@options.CONFIG_FILE()
 @click.pass_context
 def quicksetup(ctx, non_interactive, profile, email, first_name, last_name, institution, password, db_engine,
                db_backend, db_host, db_port, db_name, db_username, db_password, repository):

--- a/aiida/cmdline/params/options/__init__.py
+++ b/aiida/cmdline/params/options/__init__.py
@@ -19,6 +19,7 @@ from aiida.backends import BACKEND_DJANGO, BACKEND_SQLA
 from .. import types
 from .multivalue import MultipleValueOption
 from .overridable import OverridableOption
+from .config import ConfigFileOption
 
 __all__ = (
     'PROFILE', 'CALCULATION', 'CALCULATIONS', 'CODE', 'CODES', 'COMPUTER', 'COMPUTERS', 'DATUM', 'DATA', 'GROUP',
@@ -377,3 +378,6 @@ WITH_ELEMENTS_EXCLUSIVE = OverridableOption(
     cls=MultipleValueOption,
     default=None,
     help='Only select objects containing only these and no other elements.')
+
+CONFIG_FILE = ConfigFileOption(
+    '--config', help='Load option values from configuration file in yaml format.')

--- a/aiida/cmdline/params/options/config.py
+++ b/aiida/cmdline/params/options/config.py
@@ -24,41 +24,42 @@ from .overridable import OverridableOption
 
 def yaml_config_file_provider(file_path, cmd_name):  # pylint: disable=unused-argument
     """Read yaml config file."""
-    try:
-        with open(file_path, 'r') as handle:
-            return yaml.load(handle)
-    except IOError:
-        return {}
+    with open(file_path, 'r') as handle:
+        return yaml.load(handle)
 
 
 class ConfigFileOption(OverridableOption):
     """
-    Wrapper around click_config_file.configuration_option that increases reusability
+    Wrapper around click_config_file.configuration_option that increases reusability.
 
     Example::
 
         CONFIG_FILE = ConfigFileOption('--config', help='A configuration file')
 
         @click.command()
-        @click.option('my_option')
-        @CONFIG_FILE(help='Configuration file for this cmd')
-        def ls_or_create(my_option):
-            click.echo(os.listdir(folder))
+        @click.option('computer_name')
+        @CONFIG_FILE(help='Configuration file for computer_setup')
+        def computer_setup(computer_name):
+            click.echo("Setting up computer {}".format(computername))
 
-        ls_or_create --config myconfig.yml
+        computer_setup --config config.yml
+
+    with config.yml::
+
+        ---
+        computer_name: computer1
 
     """
 
-    def __init__(self, *args, **kwargs):  # pylint: disable=super-init-not-called
+    def __init__(self, *args, **kwargs):
         """
         Store the default args and kwargs.
 
         :param args: default arguments to be used for the option
         :param kwargs: default keyword arguments to be used that can be overridden in the call
         """
-        self.args = args
-        self.kwargs = {'provider': yaml_config_file_provider}
-        self.kwargs.update(kwargs)
+        kwargs.update({'provider': yaml_config_file_provider, 'implicit': False})
+        super(ConfigFileOption, self).__init__(*args, **kwargs)
 
     def __call__(self, **kwargs):
         """

--- a/aiida/cmdline/params/options/config.py
+++ b/aiida/cmdline/params/options/config.py
@@ -1,0 +1,74 @@
+# -*- coding: utf-8 -*-
+###########################################################################
+# Copyright (c), The AiiDA team. All rights reserved.                     #
+# This file is part of the AiiDA code.                                    #
+#                                                                         #
+# The code is hosted on GitHub at https://github.com/aiidateam/aiida_core #
+# For further information on the license, see the LICENSE.txt file        #
+# For further information please visit http://www.aiida.net               #
+###########################################################################
+# pylint: disable=cyclic-import
+"""
+.. py:module::config
+    :synopsis: Convenience class for configuration file option
+"""
+from __future__ import division
+from __future__ import print_function
+from __future__ import absolute_import
+
+import yaml
+import click_config_file
+
+from .overridable import OverridableOption
+
+
+def yaml_config_file_provider(file_path, cmd_name):  # pylint: disable=unused-argument
+    """Read yaml config file."""
+    try:
+        with open(file_path, 'r') as handle:
+            return yaml.load(handle)
+    except IOError:
+        return {}
+
+
+class ConfigFileOption(OverridableOption):
+    """
+    Wrapper around click_config_file.configuration_option that increases reusability
+
+    Example::
+
+        CONFIG_FILE = ConfigFileOption('--config', help='A configuration file')
+
+        @click.command()
+        @click.option('my_option')
+        @CONFIG_FILE(help='Configuration file for this cmd')
+        def ls_or_create(my_option):
+            click.echo(os.listdir(folder))
+
+        ls_or_create --config myconfig.yml
+
+    """
+
+    def __init__(self, *args, **kwargs):  # pylint: disable=super-init-not-called
+        """
+        Store the default args and kwargs.
+
+        :param args: default arguments to be used for the option
+        :param kwargs: default keyword arguments to be used that can be overridden in the call
+        """
+        self.args = args
+        self.kwargs = {'provider': yaml_config_file_provider}
+        self.kwargs.update(kwargs)
+
+    def __call__(self, **kwargs):
+        """
+        Override the stored kwargs, (ignoring args as we do not allow option name changes) and return the option.
+
+        :param kwargs: keyword arguments that will override those set in the construction
+        :return: click_config_file.configuration_option constructed with args and kwargs defined during construction
+            and call of this instance
+        """
+        kw_copy = self.kwargs.copy()
+        kw_copy.update(kwargs)
+
+        return click_config_file.configuration_option(*self.args, **kw_copy)

--- a/docs/requirements_for_rtd.txt
+++ b/docs/requirements_for_rtd.txt
@@ -21,6 +21,7 @@ ase==3.17.0
 chainmap; python_version<'3.5'
 circus==0.15.0
 click-completion==0.5.1
+click-config-file==0.4.3
 click-plugins==1.0.4
 click-spinner==0.1.8
 click==7.0

--- a/docs/requirements_for_rtd.txt
+++ b/docs/requirements_for_rtd.txt
@@ -21,7 +21,7 @@ ase==3.17.0
 chainmap; python_version<'3.5'
 circus==0.15.0
 click-completion==0.5.1
-click-config-file==0.4.3
+click-config-file==0.5.0
 click-plugins==1.0.4
 click-spinner==0.1.8
 click==7.0

--- a/docs/source/verdi/verdi_user_guide.rst
+++ b/docs/source/verdi/verdi_user_guide.rst
@@ -644,6 +644,8 @@ Below is a list with all available subcommands.
       --db-password TEXT              Password to connect to the database.
       --repository DIRECTORY          Absolute path for the file system
                                       repository.
+      --config FILE                   Load option values from configuration file
+                                      in yaml format.
       --help                          Show this message and exit.
 
 
@@ -748,6 +750,8 @@ Below is a list with all available subcommands.
                                       [required]
       --repository DIRECTORY          Absolute path for the file system
                                       repository.
+      --config FILE                   Load option values from configuration file
+                                      in yaml format.
       --help                          Show this message and exit.
 
 

--- a/environment.yml
+++ b/environment.yml
@@ -27,7 +27,7 @@ dependencies:
 - passlib==1.7.1
 - click==7.0
 - click-completion==0.5.1
-- click-config-file==0.4.3
+- click-config-file==0.5.0
 - click-plugins==1.0.4
 - click-spinner==0.1.8
 - tabulate==0.8.3

--- a/environment.yml
+++ b/environment.yml
@@ -27,6 +27,7 @@ dependencies:
 - passlib==1.7.1
 - click==7.0
 - click-completion==0.5.1
+- click-config-file==0.4.3
 - click-plugins==1.0.4
 - click-spinner==0.1.8
 - tabulate==0.8.3

--- a/setup.json
+++ b/setup.json
@@ -39,6 +39,7 @@
     "passlib==1.7.1",
     "click==7.0",
     "click-completion==0.5.1",
+    "click-config-file==0.4.3",
     "click-plugins==1.0.4",
     "click-spinner==0.1.8",
     "tabulate==0.8.3",

--- a/setup.json
+++ b/setup.json
@@ -39,7 +39,7 @@
     "passlib==1.7.1",
     "click==7.0",
     "click-completion==0.5.1",
-    "click-config-file==0.4.3",
+    "click-config-file==0.5.0",
     "click-plugins==1.0.4",
     "click-spinner==0.1.8",
     "tabulate==0.8.3",


### PR DESCRIPTION
This PR adds a `--config` option to

 * `verdi quicksetup`
 * `verdi setup`
 * `verdi code setup`
 * `verdi computer setup`

that allows to simply read parameters from a config file in yaml format.

E.g. create a file `config.yaml`:
```yaml
---
first_name: Leopold
last_name: Talirz
institution: EPFL
profile_name: testing
backend: django
email: 123@234.de
```

And run
`verdi quicksetup --config config.yaml`


To do:
 - [x] use `functools.partial` (or similar) to use the yaml config file provider by default so that one can use it simply as `options.CONFIG_FILE`. I played a bit around with this but somehow didn't manage to get it to work - would appreciate help on this (should not be too hard)
 - [x] to decide: it adds a dependency on `click_config_file`, which is a very minimal (1 file). we could also decide to include it inside AiiDA but I'd be fine with adding the dependency.
 - [x] once decisions have been made, extend this to other commands
    - [x] computer setup
    - [x] code setup