### PR TITLE
Do not treat `None` like values as `None` in `Config.option_set`

### DIFF
--- a/aiida/backends/tests/manage/configuration/test_config.py
+++ b/aiida/backends/tests/manage/configuration/test_config.py
@@ -306,6 +306,11 @@ class TestConfig(AiidaTestCase):
         self.assertEqual(config.option_get(option_name, scope=None, default=False), None)
         self.assertEqual(config.option_get(option_name, scope=None, default=True), option.default)
 
+        # Setting a `None` like option
+        option_value = 0
+        config.option_set(option_name, option_value)
+        self.assertEqual(config.option_get(option_name, scope=None, default=False), option_value)
+
     def test_store(self):
         """Test that the store method writes the configuration properly to disk."""
         config = Config(self.config_filepath, self.config_dictionary)

--- a/aiida/cmdline/commands/cmd_config.py
+++ b/aiida/cmdline/commands/cmd_config.py
@@ -31,8 +31,8 @@ def verdi_config(ctx, option, value, globally, unset):
     profile = ctx.obj.profile
 
     # Define the string that determines the scope: for specific profile or globally
-    scope = profile.name if not globally else None
-    scope_text = 'for {}'.format(profile.name) if not globally else 'globally'
+    scope = profile.name if (not globally and profile) else None
+    scope_text = 'for {}'.format(profile.name) if (not globally and profile) else 'globally'
 
     # Unset the specified option
     if unset:

--- a/aiida/manage/configuration/config.py
+++ b/aiida/manage/configuration/config.py
@@ -246,7 +246,7 @@ class Config(object):  # pylint: disable=useless-object-inheritance
         else:
             dictionary = self.dictionary
 
-        if parsed_value:
+        if parsed_value is not None:
             dictionary[option.key] = parsed_value
         elif option.default is not NO_DEFAULT:
             dictionary[option.key] = option.default


### PR DESCRIPTION
Fixes #2730 

An option that takes an integer for example, was ignoring values of `0`
since it was being treated as `None`.