### PR TITLE
Allow a CI system to control the pip version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,6 @@
 
 # Files created by RPN tests
 .ci/polish/polish_workchains/polish*
+
+# Build files
+dist/

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ from __future__ import print_function
 from __future__ import absolute_import
 import sys
 import json
-from os import path
+from os import path, environ
 # pylint: disable=wrong-import-order
 # Note: This speeds up command line scripts (e.g. verdi)
 from utils import fastentrypoints  # pylint: disable=unused-import
@@ -37,8 +37,9 @@ if __name__ == '__main__':
     REQUIRED_VERSION_MIN = StrictVersion(PIP_REQUIRED_VERSION_MIN)
     REQUIRED_VERSION_MAX = StrictVersion(PIP_REQUIRED_VERSION_MAX)
     INSTALLED_VERSION = StrictVersion(pip.__version__)
+    CI = environ.get('CI', False)
 
-    if INSTALLED_VERSION < REQUIRED_VERSION_MIN or INSTALLED_VERSION >= REQUIRED_VERSION_MAX:
+    if (INSTALLED_VERSION < REQUIRED_VERSION_MIN or INSTALLED_VERSION >= REQUIRED_VERSION_MAX) and not CI:
         print('The installation requires {}<=pip<{}, whereas currently {} is installed'.format(
             REQUIRED_VERSION_MIN, REQUIRED_VERSION_MAX, INSTALLED_VERSION))
         sys.exit(1)


### PR DESCRIPTION
Only we that are familiar are going to see the error in this case.

Outside CI:
```
~/Code/aiida_core  fix-allow-any-pip-version-on-ci ✔
▶ python setup.py sdist   
The installation requires 10.0<=pip<19.0, whereas currently 19.0.3 is installed
```

Inside CI:
```
~/Code/aiida_core  fix-allow-any-pip-version-on-ci ✔
▶ CI=1 python setup.py sdist 
[ REENTRY ] registering entry points with reentry...
(....)
Writing aiida-core-1.0.0b2/setup.cfg
creating dist
Creating tar archive
removing 'aiida-core-1.0.0b2' (and everything under it)
```