### PR TITLE
Remove the `CalcJobNode.options` shortcut property

### DIFF
--- a/aiida/backends/tests/engine/test_process.py
+++ b/aiida/backends/tests/engine/test_process.py
@@ -20,6 +20,7 @@ from aiida.backends.testbase import AiidaTestCase
 from aiida.backends.tests.utils import processes as test_processes
 from aiida.common.lang import override
 from aiida.engine import Process, run, run_get_pk, run_get_node
+from aiida.engine.processes.ports import PortNamespace
 
 
 class NameSpacedProcess(Process):
@@ -101,6 +102,16 @@ class TestProcess(AiidaTestCase):
     def test_inputs(self):
         with self.assertRaises(ValueError):
             run(test_processes.BadOutput)
+
+    def test_spec_metadata_property(self):
+        """ `Process.spec_metadata` should return the metadata port namespace of its spec."""
+        self.assertIsInstance(Process.spec_metadata, PortNamespace)
+        self.assertEqual(Process.spec_metadata, Process.spec().inputs['metadata'])
+
+    def test_spec_options_property(self):
+        """ `Process.spec_options` should return the options port namespace of its spec."""
+        self.assertIsInstance(Process.spec_options, PortNamespace)
+        self.assertEqual(Process.spec_options, Process.spec().inputs['metadata']['options'])
 
     def test_input_link_creation(self):
         dummy_inputs = ['a', 'b', 'c', 'd']

--- a/aiida/engine/processes/process.py
+++ b/aiida/engine/processes/process.py
@@ -111,15 +111,31 @@ class Process(plumpy.Process):
             self.set_logger(self.node.logger)
 
     @classproperty
-    def exit_codes(self):
-        """
-        Return the namespace of exit codes defined for this WorkChain through its ProcessSpec.
+    def exit_codes(cls):  # pylint: disable=no-self-argument
+        """Return the namespace of exit codes defined for this WorkChain through its ProcessSpec.
+
         The namespace supports getitem and getattr operations with an ExitCode label to retrieve a specific code.
         Additionally, the namespace can also be called with either the exit code integer status to retrieve it.
 
         :returns: ExitCodesNamespace of ExitCode named tuples
         """
-        return self.spec().exit_codes
+        return cls.spec().exit_codes
+
+    @classproperty
+    def spec_metadata(cls):  # pylint: disable=no-self-argument
+        """Return the metadata port namespace of the process specification of this process.
+
+        :return: metadata dictionary
+        """
+        return cls.spec().inputs['metadata']
+
+    @classproperty
+    def spec_options(cls):  # pylint: disable=no-self-argument
+        """Return the metadata options port namespace of the process specification of this process.
+
+        :return: options dictionary
+        """
+        return cls.spec_metadata['options']  # pylint: disable=unsubscriptable-object
 
     @property
     def node(self):
@@ -139,7 +155,7 @@ class Process(plumpy.Process):
 
     @property
     def metadata(self):
-        """Return the metadata passed when launching this process.
+        """Return the metadata that were specified when this process instance was launched.
 
         :return: metadata dictionary
         """
@@ -150,7 +166,7 @@ class Process(plumpy.Process):
 
     @property
     def options(self):
-        """Return the options of the metadata passed when launching this process.
+        """Return the options of the metadata that were specified when this process instance was launched.
 
         :return: options dictionary
         """

--- a/aiida/orm/nodes/process/calculation/calcjob.py
+++ b/aiida/orm/nodes/process/calculation/calcjob.py
@@ -179,14 +179,6 @@ class CalcJobNode(CalculationNode):
 
         raise NotExistent('the `_raw_input_folder` has not yet been created')
 
-    @property
-    def options(self):
-        """Return the available process options for the process class that created this node."""
-        try:
-            return self.process_class.spec().inputs._ports['metadata']['options']  # pylint: disable=protected-access
-        except ValueError:
-            return {}
-
     def get_option(self, name):
         """
         Retun the value of an option that was set for this CalcJobNode
@@ -215,7 +207,7 @@ class CalcJobNode(CalculationNode):
         :return: dictionary of the options and their values
         """
         options = {}
-        for name in self.options.keys():
+        for name in self.process_class.spec_options.keys():
             value = self.get_option(name)
             if value is not None:
                 options[name] = value


### PR DESCRIPTION
Fixes #2735 

This can lead to confusion with the `get_option` method, which retrieves
actual option values set on the node, whereas `options` will return the
options of the process spec which created the node. By removing the
shortcut, one will have to do `self.process_class.inputs` instead, which
is not so bad but makes it very clear that you are accessing a property
of the process.