### PR TITLE
Upgrade reentry dependency

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -234,7 +234,8 @@
     language: system
     files: >-
       (?x)^(
-        setup_requirements.py|
+        setup.json|
+        setup.py|
         utils/validate_consistency.py|
         environment.yml|
       )$

--- a/.travis.yml
+++ b/.travis.yml
@@ -50,9 +50,12 @@ before_install:
 
 install:
     # Upgrade pip setuptools and wheel to be able to run the next command
-    - pip install -U pip==18.1 wheel setuptools coveralls
+    - pip install --upgrade pip wheel setuptools coveralls
     # Install AiiDA with some optional dependencies
     - if [ "$TEST_TYPE" == "docs" ]; then pip install . && pip install -r docs/requirements_for_rtd.txt; else pip install --no-cache-dir .[all]; fi
+    - reentry map
+    - reentry scan
+    - reentry map
 
 env:
     ## Build matrix to test both backends, and the docs

--- a/.travis.yml
+++ b/.travis.yml
@@ -53,9 +53,6 @@ install:
     - pip install --upgrade pip wheel setuptools coveralls
     # Install AiiDA with some optional dependencies
     - if [ "$TEST_TYPE" == "docs" ]; then pip install . && pip install -r docs/requirements_for_rtd.txt; else pip install --no-cache-dir .[all]; fi
-    - reentry map
-    - reentry scan
-    - reentry map
 
 env:
     ## Build matrix to test both backends, and the docs

--- a/docs/requirements_for_rtd.txt
+++ b/docs/requirements_for_rtd.txt
@@ -57,7 +57,7 @@ python-memcached==1.59
 python-mimeparse==1.6.0
 pytz==2018.9
 qe-tools==1.1.2
-reentry==1.3.0a1
+reentry>=1.3.0
 seekpath==1.8.4
 simplejson==3.16.0
 singledispatch>=3.4.0.3; python_version<'3.5'

--- a/docs/requirements_for_rtd.txt
+++ b/docs/requirements_for_rtd.txt
@@ -57,7 +57,7 @@ python-memcached==1.59
 python-mimeparse==1.6.0
 pytz==2018.9
 qe-tools==1.1.2
-reentry==1.2.2
+reentry==1.3.0a1
 seekpath==1.8.4
 simplejson==3.16.0
 singledispatch>=3.4.0.3; python_version<'3.5'

--- a/environment.yml
+++ b/environment.yml
@@ -6,7 +6,7 @@ channels:
 - conda-forge
 - etetoolkit
 dependencies:
-- reentry==1.3.0a1
+- reentry>=1.3.0
 - python-dateutil==2.8.0
 - python-mimeparse==1.6.0
 - django==1.11.20

--- a/environment.yml
+++ b/environment.yml
@@ -6,7 +6,7 @@ channels:
 - conda-forge
 - etetoolkit
 dependencies:
-- reentry==1.2.2
+- reentry==1.3.0a1
 - python-dateutil==2.8.0
 - python-mimeparse==1.6.0
 - django==1.11.20

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,3 @@
 [build-system]
 # Minimum requirements for the build system to execute.
-requires = ["setuptools", "wheel", "reentry==1.3.0a1"]
+requires = ["setuptools", "wheel", "reentry>=1.3.0"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,3 @@
 [build-system]
 # Minimum requirements for the build system to execute.
-requires = ["pip==18.1", "setuptools", "wheel", "reentry==1.2.2"]
+requires = ["pip==18.1", "setuptools", "wheel", "reentry==1.3.0a1"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,3 @@
 [build-system]
 # Minimum requirements for the build system to execute.
-requires = ["pip==18.1", "setuptools", "wheel", "reentry==1.3.0a1"]
+requires = ["setuptools", "wheel", "reentry==1.3.0a1"]

--- a/setup.json
+++ b/setup.json
@@ -18,7 +18,7 @@
     "Topic :: Scientific/Engineering"
   ],
   "install_requires": [
-    "reentry==1.3.0a1",
+    "reentry>=1.3.0",
     "python-dateutil==2.8.0",
     "python-mimeparse==1.6.0",
     "django==1.11.20",

--- a/setup.json
+++ b/setup.json
@@ -18,7 +18,7 @@
     "Topic :: Scientific/Engineering"
   ],
   "install_requires": [
-    "reentry==1.2.2",
+    "reentry==1.3.0a1",
     "python-dateutil==2.8.0",
     "python-mimeparse==1.6.0",
     "django==1.11.20",

--- a/setup.json
+++ b/setup.json
@@ -130,9 +130,6 @@
     ]
   },
   "reentry_register": true,
-  "reentry_scan": [
-    "aiida"
-  ],
   "entry_points": {
     "console_scripts": [
       "verdi=aiida.cmdline.commands.cmd_verdi:verdi"

--- a/setup.py
+++ b/setup.py
@@ -25,24 +25,12 @@ from setuptools import setup, find_packages
 if __name__ == '__main__':
     THIS_FOLDER = path.split(path.abspath(__file__))[0]
 
-    # Ensure that pip is installed and the version is between the required limits
-    try:
-        import pip
-    except ImportError:
-        print('Could not import pip, which is required for installation')
-        sys.exit(1)
-
-    PIP_REQUIRED_VERSION_MIN = '10.0.0'
-    PIP_REQUIRED_VERSION_MAX = '19.0.0'
-    REQUIRED_VERSION_MIN = StrictVersion(PIP_REQUIRED_VERSION_MIN)
-    REQUIRED_VERSION_MAX = StrictVersion(PIP_REQUIRED_VERSION_MAX)
-    INSTALLED_VERSION = StrictVersion(pip.__version__)
-    CI = environ.get('CI', False)
-
-    if (INSTALLED_VERSION < REQUIRED_VERSION_MIN or INSTALLED_VERSION >= REQUIRED_VERSION_MAX) and not CI:
-        print('The installation requires {}<=pip<{}, whereas currently {} is installed'.format(
-            REQUIRED_VERSION_MIN, REQUIRED_VERSION_MAX, INSTALLED_VERSION))
-        sys.exit(1)
+    ## Ensure that pip is installed and the version is between the required limits
+    #try:
+    #    import pip
+    #except ImportError:
+    #    print('Could not import pip, which is required for installation')
+    #    sys.exit(1)
 
     with open(path.join(THIS_FOLDER, 'setup.json'), 'r') as info:
         SETUP_JSON = json.load(info)

--- a/setup.py
+++ b/setup.py
@@ -13,13 +13,11 @@ from __future__ import division
 from __future__ import print_function
 
 from __future__ import absolute_import
-import sys
 import json
-from os import path, environ
+from os import path
 # pylint: disable=wrong-import-order
 # Note: This speeds up command line scripts (e.g. verdi)
 from utils import fastentrypoints  # pylint: disable=unused-import
-from distutils.version import StrictVersion
 from setuptools import setup, find_packages
 
 if __name__ == '__main__':

--- a/setup.py
+++ b/setup.py
@@ -25,13 +25,6 @@ from setuptools import setup, find_packages
 if __name__ == '__main__':
     THIS_FOLDER = path.split(path.abspath(__file__))[0]
 
-    ## Ensure that pip is installed and the version is between the required limits
-    #try:
-    #    import pip
-    #except ImportError:
-    #    print('Could not import pip, which is required for installation')
-    #    sys.exit(1)
-
     with open(path.join(THIS_FOLDER, 'setup.json'), 'r') as info:
         SETUP_JSON = json.load(info)
 


### PR DESCRIPTION
I've just released a new alpha version of reentry, which should work with pip 19 (and before).

 * upgrade reentry dependency to 1.3.0a1
 * remove `reentry_scan` from setup.py. The hook has been deprecated, see [reentry changelog](https://github.com/DropD/reentry/blob/develop/CHANGELOG.md) for details
 * remove pip dependency from build system (should not be needed)
 * remove check for pip version in setup.py
 * remove check for pip from setup.py
 * remove pinning of pip version from travis
