### PR TITLE
Reinstate the test submit functionality for `CalcJob`

### DIFF
--- a/aiida/backends/tests/engine/test_calc_job.py
+++ b/aiida/backends/tests/engine/test_calc_job.py
@@ -15,7 +15,7 @@ from __future__ import absolute_import
 from aiida import orm
 from aiida.backends.testbase import AiidaTestCase
 from aiida.common import exceptions
-from aiida.engine import launch, CalcJob, Process, CalcJobBuilder
+from aiida.engine import launch, CalcJob, Process
 from aiida.plugins import CalculationFactory
 
 ArithmeticAddCalculation = CalculationFactory('arithmetic.add')  # pylint: disable=invalid-name
@@ -86,11 +86,6 @@ class TestCalcJob(AiidaTestCase):
         # The `metadata.options` input expects a plain dict and not a node `Dict`
         with self.assertRaises(TypeError):
             launch.run(SimpleCalcJob, code=self.code, metadata={'options': orm.Dict(dict={'a': 1})})
-
-    def test_return_builder(self):
-        """ verify that `CalcJob.get_builder` returns CalcJobBuilder"""
-        builder = CalcJob.get_builder()
-        self.assertIsInstance(builder, CalcJobBuilder)
 
     def test_invalid_parser_name(self):
         """Passing an invalid parser name should already stop during input validation."""

--- a/aiida/engine/processes/builder.py
+++ b/aiida/engine/processes/builder.py
@@ -17,7 +17,7 @@ import collections
 
 from aiida.engine.processes.ports import PortNamespace
 
-__all__ = ('ProcessBuilder', 'CalcJobBuilder', 'ProcessBuilderNamespace')
+__all__ = ('ProcessBuilder', 'ProcessBuilderNamespace')
 
 
 class ProcessBuilderNamespace(collections.MutableMapping):
@@ -147,28 +147,3 @@ class ProcessBuilder(ProcessBuilderNamespace):
     @property
     def process_class(self):
         return self._process_class
-
-
-class CalcJobBuilder(ProcessBuilder):
-    """A process builder specific to CalcJob implementations that provides also the `submit_test` functionality."""
-
-    def __dir__(self):
-        return super(CalcJobBuilder, self).__dir__() + ['submit_test']
-
-    def submit_test(self, folder=None, subfolder_name=None):
-        """
-        Run a test submission by creating the files that would be generated for the real calculation in a local folder,
-        without actually storing the calculation nor the input nodes. This functionality therefore also does not
-        require any of the inputs nodes to be stored yet.
-
-        :param folder: a Folder object, within which to create the calculation files. By default a folder
-            will be created in the current working directory
-        :param subfolder_name: the name of the subfolder to use within the directory of the ``folder`` object. By
-            default a unique string will be generated based on the current datetime with the format ``yymmdd-``
-            followed by an auto incrementing index
-        """
-        inputs = {'store_provenance': False}
-        inputs.update(**self)
-        process = self._process_class(inputs=inputs)
-
-        return process.node.submit_test(folder, subfolder_name)

--- a/aiida/engine/processes/process.py
+++ b/aiida/engine/processes/process.py
@@ -462,6 +462,9 @@ class Process(plumpy.Process):
             except exceptions.ModificationNotAllowed:
                 # The calculation was already stored
                 pass
+        else:
+            # Cannot persist the process if were not storing provenance because that would require a stored node
+            self._enable_persistence = False
 
         if self.node.pk is not None:
             return self.node.pk
@@ -555,7 +558,7 @@ class Process(plumpy.Process):
     def _setup_metadata(self):
         """Store the metadata on the ProcessNode."""
         for name, metadata in self.metadata.items():
-            if name == 'store_provenance':
+            if name in ['store_provenance', 'dry_run']:
                 continue
             elif name == 'label':
                 self.node.label = metadata

--- a/aiida/orm/nodes/process/calculation/calcjob.py
+++ b/aiida/orm/nodes/process/calculation/calcjob.py
@@ -107,7 +107,7 @@ class CalcJobNode(CalculationNode):
             ignore_errors=ignore_errors, ignored_folder_content=ignored_folder_content, **kwargs)
 
     def get_builder_restart(self):
-        """Return a `CalcJobBuilder` that is ready to relaunch the same `CalcJob` that created this node.
+        """Return a `ProcessBuilder` that is ready to relaunch the same `CalcJob` that created this node.
 
         The process class will be set based on the `process_type` of this node and the inputs of the builder will be
         prepopulated with the inputs registered for this node. This functionality is very useful if a process has
@@ -116,7 +116,7 @@ class CalcJobNode(CalculationNode):
         In addition to prepopulating the input nodes, which is implemented by the base `ProcessNode` class, here we
         also add the `options` that were passed in the `metadata` input of the `CalcJob` process.
 
-        :return: `~aiida.engine.processes.builder.CalcJobBuilder` instance
+        :return: `~aiida.engine.processes.builder.ProcessBuilder` instance
         """
         builder = super(CalcJobNode, self).get_builder_restart()
         builder.metadata.options = self.get_options()


### PR DESCRIPTION
The old `JobCalculation` had a method `submit_test` which would perform
a test submission, by mocking the remote working directory that would be
created in a real submission in a local sandbox folder. This method was
removed because the replacement class `CalcJobNode` no longer provided
methods to actually run anything. Instead this is now the responsability
of the `CalcJob` process class.

To provide similar functionality a new metadata input `dry_run` is
introduced for the `CalcJob` class. When passed in the inputs when the
process is ran, the same procedure as a normal submission is started but
the `upload_calculation` step will the local transport instead of the
targeted remote computer and will write the files to a local sandbox
folder instead of a remote working directory. After the upload task is
completed, the process is stopped instead of going to the submission
step.

This new approach has the advantage over the old implementation that the
pathway that is followed in the test submission is alsmost identical to
the code that would be executed in an actual submission. Additionally,
by using a metadata option, instead of a special launcher function or a
specific method on the `ProcessBuilder` ensures that the user does not
have to import and call a separate function, nor does the method on the
builder have to block a name in the input namespace.