### PR TITLE
Capture `KeyboardInterrupt` in `Runner.run` and kill processes

### DIFF
--- a/aiida/common/escaping.py
+++ b/aiida/common/escaping.py
@@ -38,6 +38,9 @@ def escape_for_bash(str_to_escape):
     within triple quotes to make it work, getting finally: the complicated
     string found below.
     """
+    if str_to_escape is None:
+        return ''
+
     escaped_quotes = str_to_escape.replace("'", """'"'"'""")
     return "'{}'".format(escaped_quotes)
 

--- a/aiida/engine/processes/process.py
+++ b/aiida/engine/processes/process.py
@@ -22,6 +22,7 @@ import traceback
 import six
 from six.moves import filter, range
 from pika.exceptions import ConnectionClosed
+from kiwipy.communications import UnroutableError
 
 import plumpy
 from plumpy import ProcessState
@@ -239,6 +240,8 @@ class Process(plumpy.Process):
                         killing.append(result)
                 except ConnectionClosed:
                     self.logger.info('no connection available to kill child<%s>', child.pk)
+                except UnroutableError:
+                    self.logger.info('kill signal was unable to reach child<%s>', child.pk)
 
             if isinstance(result, plumpy.Future):
                 # We ourselves are waiting to be killed so add it to the list

--- a/aiida/schedulers/plugins/direct.py
+++ b/aiida/schedulers/plugins/direct.py
@@ -104,7 +104,7 @@ class DirectScheduler(aiida.schedulers.Scheduler):
                 command += ' {}'.format(escape_for_bash(jobs))
             else:
                 try:
-                    command += ' {}'.format(' '.join(escape_for_bash(j) for j in jobs))
+                    command += ' {}'.format(' '.join(escape_for_bash(job) for job in jobs if job))
                 except TypeError:
                     raise TypeError("If provided, the 'jobs' variable must be a string or a list of strings")
 


### PR DESCRIPTION
Addresses #2711 partially but does not fix it 

Currently, if a user runs a `Process` in a local interpreter and then
interrupts the interpreter the process will be lost. However, the node
will reflect the last active state. This can be confusing to new users,
who will still for example see a "process" in the `Waiting` state.

To prevent this situation, the `Runner._run` method is modified and
attaches listeners to the `SIGINT` and `SIGTERM` signals that when
emitted will trigger a clean function that will log the interrupt and
call `process.kill` on the process that is currently in the scope.
This should ensure that if a user runs a process in a local interpreter
and interrupts it, the process will be properly killed, which will cause
the node to properly reflect what has happened.

The current solution works for a single process being run, but has
issues for nested processes. Sometimes only the current process is
killed and the others in the chain are unaffected before the interpreter
shuts down.