### PR TITLE
Hide `verdi daemon start-circus` from auto-completion and help

### DIFF
--- a/aiida/cmdline/commands/cmd_daemon.py
+++ b/aiida/cmdline/commands/cmd_daemon.py
@@ -207,7 +207,7 @@ def restart(ctx, reset, no_wait):
             print_client_response_status(response)
 
 
-@verdi_daemon.command()
+@verdi_daemon.command(hidden=True)
 @click.option('--foreground', is_flag=True, help='Run in foreground.')
 @decorators.with_dbenv()
 @decorators.check_circus_zmq_version

--- a/docs/requirements_for_rtd.txt
+++ b/docs/requirements_for_rtd.txt
@@ -20,7 +20,7 @@ anyjson==0.3.3
 ase==3.17.0
 chainmap; python_version<'3.5'
 circus==0.15.0
-click-completion==0.5.0
+click-completion==0.5.1
 click-plugins==1.0.4
 click-spinner==0.1.8
 click==7.0

--- a/docs/source/verdi/verdi_user_guide.rst
+++ b/docs/source/verdi/verdi_user_guide.rst
@@ -334,14 +334,13 @@ Below is a list with all available subcommands.
       --help  Show this message and exit.
 
     Commands:
-      decr          Remove NUMBER [default=1] workers from the running daemon
-      incr          Add NUMBER [default=1] workers to the running daemon
-      logshow       Show the log of the daemon, press CTRL+C to quit
-      restart       Restart the daemon.
-      start         Start the daemon
-      start-circus  This will actually launch the circus daemon, either...
-      status        Print the status of the current daemon or all daemons
-      stop          Stop the daemon
+      decr     Remove NUMBER [default=1] workers from the running daemon
+      incr     Add NUMBER [default=1] workers to the running daemon
+      logshow  Show the log of the daemon, press CTRL+C to quit
+      restart  Restart the daemon.
+      start    Start the daemon
+      status   Print the status of the current daemon or all daemons
+      stop     Stop the daemon
 
 
 .. _verdi_data:

--- a/environment.yml
+++ b/environment.yml
@@ -26,7 +26,7 @@ dependencies:
 - aldjemy==0.9.1
 - passlib==1.7.1
 - click==7.0
-- click-completion==0.5.0
+- click-completion==0.5.1
 - click-plugins==1.0.4
 - click-spinner==0.1.8
 - tabulate==0.8.3

--- a/setup.json
+++ b/setup.json
@@ -38,7 +38,7 @@
     "aldjemy==0.9.1",
     "passlib==1.7.1",
     "click==7.0",
-    "click-completion==0.5.0",
+    "click-completion==0.5.1",
     "click-plugins==1.0.4",
     "click-spinner==0.1.8",
     "tabulate==0.8.3",


### PR DESCRIPTION
Fixes #2537 

This command should not be called directly by users but will rather be
invoked by `verdi daemon start`. This is accomplished by marking the
command as `hidden=True` which was implemented in `click==7.0`. However,
the attribute was being ignored by the `click-completion` package, which
was fixed in `click-completion==0.5.1` which is now added as dependency.