### PR TITLE
Add test to make sure `Process.out` accepts dictionaries

### DIFF
--- a/aiida/backends/tests/engine/test_process.py
+++ b/aiida/backends/tests/engine/test_process.py
@@ -217,6 +217,28 @@ class TestProcess(AiidaTestCase):
         recovered_process = process.node.process_class
         self.assertEqual(recovered_process, process.__class__)
 
+    def test_output_dictionary(self):
+        """Verify that a dictionary can be passed as an output for a namespace."""
+
+        class TestProcess(Process):
+
+            _node_class = orm.WorkflowNode
+            
+            @classmethod
+            def define(cls, spec):
+                super(TestProcess, cls).define(spec)
+                spec.input_namespace('namespace', valid_type=orm.Int, dynamic=True)
+                spec.output_namespace('namespace', valid_type=orm.Int, dynamic=True)
+
+            def run(self):
+                self.out('namespace', self.inputs.namespace)
+
+        results, node = run_get_node(TestProcess, namespace={'alpha': orm.Int(1), 'beta': orm.Int(2)})
+
+        self.assertTrue(node.is_finished_ok)
+        self.assertEqual(results['namespace']['alpha'], orm.Int(1))
+        self.assertEqual(results['namespace']['beta'], orm.Int(2))
+
     def test_output_validation_error(self):
         """Test that a process is marked as failed if its output namespace validation fails."""
 


### PR DESCRIPTION
Fixes #1571 

The recent commit `e5abcd9b114efe` already ensured that output port
namespaces are properly nested and so it took care of the issue that
`Process.out` could not accept a dictionary to be automatically mapped
onto a nested namespace. Here we add an explicit tests for this.