### PR TITLE
Remove hybrid properties from SqlaAlchemy and dummy models

### DIFF
--- a/aiida/backends/sqlalchemy/migrations/env.py
+++ b/aiida/backends/sqlalchemy/migrations/env.py
@@ -20,7 +20,8 @@ from aiida.backends.sqlalchemy.models.comment import DbComment
 from aiida.backends.sqlalchemy.models.computer import DbComputer
 from aiida.backends.sqlalchemy.models.group import DbGroup
 from aiida.backends.sqlalchemy.models.log import DbLog
-from aiida.backends.sqlalchemy.models.node import DbComputer, DbLink, DbNode
+from aiida.backends.sqlalchemy.models.node import DbLink, DbNode
+from aiida.backends.sqlalchemy.models.computer import DbComputer
 from aiida.backends.sqlalchemy.models.settings import DbSetting
 from aiida.backends.sqlalchemy.models.user import DbUser
 from aiida.common.exceptions import DbContentError

--- a/aiida/backends/sqlalchemy/models/node.py
+++ b/aiida/backends/sqlalchemy/models/node.py
@@ -13,7 +13,6 @@ from __future__ import print_function
 from __future__ import absolute_import
 from sqlalchemy import ForeignKey, select
 from sqlalchemy.orm import relationship, backref
-from sqlalchemy.ext.hybrid import hybrid_property
 from sqlalchemy.schema import Column
 from sqlalchemy.types import Integer, String, Boolean, DateTime, Text
 # Specific to PGSQL. If needed to be agnostic
@@ -25,8 +24,6 @@ from aiida.common import timezone
 from aiida.backends.sqlalchemy.models.base import Base
 from aiida.common.utils import get_new_uuid
 from aiida.backends.sqlalchemy.utils import flag_modified
-from aiida.backends.sqlalchemy.models.user import DbUser
-from aiida.backends.sqlalchemy.models.computer import DbComputer
 
 
 class DbNode(Base):
@@ -208,39 +205,6 @@ class DbNode(Base):
             return "{} node [{}]: {}".format(simplename, self.pk, self.label)
         else:
             return "{} node [{}]".format(simplename, self.pk)
-
-    # User email
-    @hybrid_property
-    def user_email(self):
-        """
-        Returns: the email of the user
-        """
-        return self.user.email
-
-    @user_email.expression
-    def user_email(cls):
-        """
-        Returns: the email of the user at a class level (i.e. in the database)
-        """
-        return select([DbUser.email]).where(DbUser.id == cls.user_id).label(
-            'user_email')
-
-    # Computer name
-    @hybrid_property
-    def computer_name(self):
-        """
-        Returns: the of the computer
-        """
-        return self.dbcomputer.name
-
-    @computer_name.expression
-    def computer_name(cls):
-        """
-        Returns: the name of the computer at a class level (i.e. in the database)
-        """
-        return select([DbComputer.name]).where(DbComputer.id ==
-                                               cls.dbcomputer_id).label(
-            'computer_name')
 
 
 class DbLink(Base):

--- a/aiida/orm/implementation/django/dummy_model.py
+++ b/aiida/orm/implementation/django/dummy_model.py
@@ -19,7 +19,7 @@ from __future__ import absolute_import
 
 # pylint: disable=no-name-in-module, import-error, invalid-name
 from sqlalchemy.ext.declarative import declarative_base
-from sqlalchemy import (Column, Table, ForeignKey, UniqueConstraint, select)
+from sqlalchemy import (Column, Table, ForeignKey, UniqueConstraint)
 
 from sqlalchemy.types import (
     Integer,
@@ -31,7 +31,6 @@ from sqlalchemy.types import (
 )
 from sqlalchemy.orm import (relationship, backref, sessionmaker)
 
-from sqlalchemy.ext.hybrid import hybrid_property
 from sqlalchemy.dialects.postgresql import UUID
 
 # MISC
@@ -175,35 +174,6 @@ class DbNode(Base):
         secondaryjoin="DbNode.id == DbLink.output_id",
         backref=backref("inputs", passive_deletes=True),
         passive_deletes=True)
-
-    @hybrid_property
-    def user_email(self):
-        """
-        Returns: the email of the user
-        """
-        return self.user.email
-
-    @user_email.expression
-    def user_email(self):
-        """
-        Returns: the email of the user at a class level (i.e. in the database)
-        """
-        return select([DbUser.email]).where(DbUser.id == self.user_id).label('user_email')
-
-    # Computer name
-    @hybrid_property
-    def computer_name(self):
-        """
-        Returns: the of the computer
-        """
-        return self.dbcomputer.name
-
-    @computer_name.expression
-    def computer_name(self):
-        """
-        Returns: the name of the computer at a class level (i.e. in the database)
-        """
-        return select([DbComputer.name]).where(DbComputer.id == self.dbcomputer_id).label('computer_name')
 
 
 class DbAuthInfo(Base):


### PR DESCRIPTION
Fixes #2765 

Soon the current hard-coded dummy model, to map the Django models on
SqlAlchemy models, which drives the `QueryBuilder` implementation, will
be replaced with dynamically generated Aldjemy models. However, these do
not support hybrid properties so they have to be removed.