### PR TITLE
Raise `InvalidOperation` for global `submit` in nested process

### DIFF
--- a/aiida/backends/tests/engine/test_work_chain.py
+++ b/aiida/backends/tests/engine/test_work_chain.py
@@ -1270,22 +1270,40 @@ class TestWorkChainExpose(AiidaTestCase):
         run(Child)
 
 
-class TestWorkChainReturnDict(AiidaTestCase):
+class TestWorkChainMisc(AiidaTestCase):
 
     class PointlessWorkChain(WorkChain):
 
         @classmethod
         def define(cls, spec):
-            super(TestWorkChainReturnDict.PointlessWorkChain, cls).define(spec)
+            super(TestWorkChainMisc.PointlessWorkChain, cls).define(spec)
             spec.outline(cls.return_dict)
 
         def return_dict(self):
             """Only return a dictionary, which should be allowed, even though it accomplishes nothing."""
             return {}
 
+    class IllegalSubmitWorkChain(WorkChain):
+
+        @classmethod
+        def define(cls, spec):
+            super(TestWorkChainMisc.IllegalSubmitWorkChain, cls).define(spec)
+            spec.outline(cls.illegal_submit)
+
+        def illegal_submit(self):
+            """Only return a dictionary, which should be allowed, even though it accomplishes nothing."""
+            from aiida.engine import submit
+            submit(TestWorkChainMisc.PointlessWorkChain)
+
     def test_run_pointless_workchain(self):
         """Running the pointless workchain should not incur any exceptions"""
-        run(TestWorkChainReturnDict.PointlessWorkChain)
+        run(TestWorkChainMisc.PointlessWorkChain)
+
+    def test_global_submit_raises(self):
+        """Using top-level submit should raise."""
+        with self.assertRaises(exceptions.InvalidOperation):
+            run(TestWorkChainMisc.IllegalSubmitWorkChain)
+
 
 
 class TestDefaultUniqueness(AiidaTestCase):

--- a/aiida/engine/utils.py
+++ b/aiida/engine/utils.py
@@ -194,8 +194,7 @@ def exponential_backoff_retry(fct, initial_interval=10.0, max_attempts=5, logger
 
 
 def is_process_function(function):
-    """
-    Return whether the given function is a process function
+    """Return whether the given function is a process function
 
     :param function: a function
     :returns: True if the function is a wrapped process function, False otherwise
@@ -204,6 +203,15 @@ def is_process_function(function):
         return function.is_process_function
     except AttributeError:
         return False
+
+
+def is_process_scoped():
+    """Return whether the current scope is within a process.
+
+    :returns: True if the current scope is within a nested process, False otherwise
+    """
+    from .processes.process import Process
+    return Process.current() is not None
 
 
 @contextlib.contextmanager


### PR DESCRIPTION
Fixes #2780 

If one wants to submit another process from within a process, the
`submit` method of the parent process instance should be used instead of
the global launch function, which will guarantee the correct runner is
used.