### PR TITLE
Fix bugs in migrations of calculation job node attribute keys

### DIFF
--- a/aiida/backends/djsite/db/migrations/0023_calc_job_option_attribute_keys.py
+++ b/aiida/backends/djsite/db/migrations/0023_calc_job_option_attribute_keys.py
@@ -8,7 +8,7 @@
 # For further information please visit http://www.aiida.net               #
 ###########################################################################
 # pylint: disable=invalid-name,too-few-public-methods
-"""Migration of CalcJobNode attributes for metadata options whose key changed."""
+"""Migration of ProcessNode attributes for metadata options whose key changed."""
 from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
@@ -25,14 +25,14 @@ DOWN_REVISION = '1.0.22'
 
 
 class Migration(migrations.Migration):
-    """Migration of CalcJobNode attributes for metadata options whose key changed.
+    """Migration of ProcessNode attributes for metadata options whose key changed.
 
     Renamed attribute keys:
 
-      * `custom_environment_variables` -> `environment_variables`
-      * `jobresource_params` -> `resources`
-      * `_process_label` -> `process_label`
-      * `parser` -> `parser_name`
+      * `custom_environment_variables` -> `environment_variables` (CalcJobNode)
+      * `jobresource_params` -> `resources` (CalcJobNode)
+      * `_process_label` -> `process_label` (ProcessNode)
+      * `parser` -> `parser_name` (CalcJobNode)
 
     Deleted attributes:
       * `linkname_retrieved` (We do not actually delete it just in case some relies on it)
@@ -54,7 +54,8 @@ class Migration(migrations.Migration):
                     attribute.key = 'custom_environment_variables' OR
                     attribute.key LIKE 'custom\_environment\_variables.%'
                 ) AND
-                node.type = 'node.process.calculation.calcjob.CalcJobNode.';
+                node.type = 'node.process.calculation.calcjob.CalcJobNode.' AND
+                node.id = attribute.dbnode_id;
             -- custom_environment_variables -> environment_variables
 
             UPDATE db_dbattribute AS attribute
@@ -65,7 +66,8 @@ class Migration(migrations.Migration):
                     attribute.key = 'jobresource_params' OR
                     attribute.key LIKE 'jobresource\_params.%'
                 ) AND
-                node.type = 'node.process.calculation.calcjob.CalcJobNode.';
+                node.type = 'node.process.calculation.calcjob.CalcJobNode.' AND
+                node.id = attribute.dbnode_id;
             -- jobresource_params -> resources
 
             UPDATE db_dbattribute AS attribute
@@ -73,7 +75,8 @@ class Migration(migrations.Migration):
             FROM db_dbnode AS node
             WHERE
                 attribute.key = '_process_label' AND
-                node.type LIKE 'node.process.%';
+                node.type LIKE 'node.process.%' AND
+                node.id = attribute.dbnode_id;
             -- _process_label -> process_label
 
             UPDATE db_dbattribute AS attribute
@@ -81,7 +84,8 @@ class Migration(migrations.Migration):
             FROM db_dbnode AS node
             WHERE
                 attribute.key = 'parser' AND
-                node.type = 'node.process.calculation.calcjob.CalcJobNode.';
+                node.type = 'node.process.calculation.calcjob.CalcJobNode.' AND
+                node.id = attribute.dbnode_id;
             -- parser -> parser_name
             """,
             reverse_sql=r"""
@@ -93,7 +97,8 @@ class Migration(migrations.Migration):
                     attribute.key = 'environment_variables' OR
                     attribute.key LIKE 'environment\_variables.%'
                 ) AND
-                node.type = 'node.process.calculation.calcjob.CalcJobNode.';
+                node.type = 'node.process.calculation.calcjob.CalcJobNode.' AND
+                node.id = attribute.dbnode_id;
             -- environment_variables -> custom_environment_variables
 
             UPDATE db_dbattribute AS attribute
@@ -104,7 +109,8 @@ class Migration(migrations.Migration):
                     attribute.key = 'resources' OR
                     attribute.key LIKE 'resources.%'
                 ) AND
-                node.type = 'node.process.calculation.calcjob.CalcJobNode.';
+                node.type = 'node.process.calculation.calcjob.CalcJobNode.' AND
+                node.id = attribute.dbnode_id;
             -- resources -> jobresource_params
 
             UPDATE db_dbattribute AS attribute
@@ -112,7 +118,8 @@ class Migration(migrations.Migration):
             FROM db_dbnode AS node
             WHERE
                 attribute.key = 'process_label' AND
-                node.type LIKE 'node.process.%';
+                node.type LIKE 'node.process.%' AND
+                node.id = attribute.dbnode_id;
             -- process_label -> _process_label
 
             UPDATE db_dbattribute AS attribute
@@ -120,7 +127,8 @@ class Migration(migrations.Migration):
             FROM db_dbnode AS node
             WHERE
                 attribute.key = 'parser_name' AND
-                node.type = 'node.process.calculation.calcjob.CalcJobNode.';
+                node.type = 'node.process.calculation.calcjob.CalcJobNode.' AND
+                node.id = attribute.dbnode_id;
             -- parser_name -> parser
             """),
         upgrade_schema_version(REVISION, DOWN_REVISION)

--- a/aiida/backends/djsite/db/subtests/test_migrations.py
+++ b/aiida/backends/djsite/db/subtests/test_migrations.py
@@ -293,6 +293,14 @@ class TestCalcAttributeKeysMigration(TestMigrationsModelModifierV0025):
         self.set_attribute(self.node_calc, self.KEY_ENVIRONMENT_VARIABLES_OLD, self.environment_variables)
         self.set_attribute(self.node_calc, self.KEY_PARSER_NAME_OLD, self.parser_name)
 
+        # Create a node of a different type to ensure that its attributes are not updated
+        self.node_other = self.DbNode(type='node.othernode.', user_id=self.default_user.id)
+        self.node_other.save()
+        self.set_attribute(self.node_other, self.KEY_PROCESS_LABEL_OLD, self.process_label)
+        self.set_attribute(self.node_other, self.KEY_RESOURCES_OLD, self.resources)
+        self.set_attribute(self.node_other, self.KEY_ENVIRONMENT_VARIABLES_OLD, self.environment_variables)
+        self.set_attribute(self.node_other, self.KEY_PARSER_NAME_OLD, self.parser_name)
+
     def test_attribute_key_changes(self):
         """Verify that the keys are successfully changed of the affected attributes."""
         NOT_FOUND = tuple([0])
@@ -308,6 +316,17 @@ class TestCalcAttributeKeysMigration(TestMigrationsModelModifierV0025):
         self.assertEqual(self.get_attribute(self.node_calc, self.KEY_RESOURCES_OLD, default=NOT_FOUND), NOT_FOUND)
         self.assertEqual(self.get_attribute(self.node_calc, self.KEY_ENVIRONMENT_VARIABLES_OLD, default=NOT_FOUND), NOT_FOUND)
         self.assertEqual(self.get_attribute(self.node_calc, self.KEY_PARSER_NAME_OLD, default=NOT_FOUND), NOT_FOUND)
+
+        # The following node should not be migrated even if its attributes have the matching keys because
+        # the node is not a ProcessNode
+        self.assertEqual(self.get_attribute(self.node_other, self.KEY_PROCESS_LABEL_OLD), self.process_label)
+        self.assertEqual(self.get_attribute(self.node_other, self.KEY_RESOURCES_OLD), self.resources)
+        self.assertEqual(self.get_attribute(self.node_other, self.KEY_ENVIRONMENT_VARIABLES_OLD), self.environment_variables)
+        self.assertEqual(self.get_attribute(self.node_other, self.KEY_PARSER_NAME_OLD), self.parser_name)
+        self.assertEqual(self.get_attribute(self.node_other, self.KEY_PROCESS_LABEL_NEW, default=NOT_FOUND), NOT_FOUND)
+        self.assertEqual(self.get_attribute(self.node_other, self.KEY_RESOURCES_NEW, default=NOT_FOUND), NOT_FOUND)
+        self.assertEqual(self.get_attribute(self.node_other, self.KEY_ENVIRONMENT_VARIABLES_NEW, default=NOT_FOUND), NOT_FOUND)
+        self.assertEqual(self.get_attribute(self.node_other, self.KEY_PARSER_NAME_NEW, default=NOT_FOUND), NOT_FOUND)
 
 
 class TestDbLogMigrationRecordCleaning(TestMigrations):

--- a/aiida/backends/sqlalchemy/migrations/versions/7ca08c391c49_calc_job_option_attribute_keys.py
+++ b/aiida/backends/sqlalchemy/migrations/versions/7ca08c391c49_calc_job_option_attribute_keys.py
@@ -8,7 +8,7 @@
 # For further information please visit http://www.aiida.net               #
 ###########################################################################
 # pylint: disable=invalid-name,no-member
-"""Migration of CalcJobNode attributes for metadata options whose key changed.
+"""Migration of ProcessNode attributes for metadata options whose key changed.
 
 Revision ID: 7ca08c391c49
 Revises: e72ad251bcdb
@@ -32,14 +32,14 @@ depends_on = None
 
 
 def upgrade():
-    """Migration of CalcJobNode attributes for metadata options whose key changed.
+    """Migration of ProcessNode attributes for metadata options whose key changed.
 
     Renamed attribute keys:
 
-      * `custom_environment_variables` -> `environment_variables`
-      * `jobresource_params` -> `resources`
-      * `_process_label` -> `process_label`
-      * `parser` -> `parser_name`
+      * `custom_environment_variables` -> `environment_variables` (CalcJobNode)
+      * `jobresource_params` -> `resources` (CalcJobNode)
+      * `_process_label` -> `process_label` (ProcessNode)
+      * `parser` -> `parser_name` (CalcJobNode)
 
     Deleted attributes:
       * `linkname_retrieved` (We do not actually delete it just in case some relies on it)

--- a/aiida/backends/sqlalchemy/migrations/versions/7ca08c391c49_calc_job_option_attribute_keys.py
+++ b/aiida/backends/sqlalchemy/migrations/versions/7ca08c391c49_calc_job_option_attribute_keys.py
@@ -49,7 +49,7 @@ def upgrade():
 
     statement = text("""
         UPDATE db_dbnode
-        SET attributes = jsonb_set(attributes, '{environment_variables}', to_jsonb(attributes->>'custom_environment_variables'))
+        SET attributes = jsonb_set(attributes, '{environment_variables}', attributes->'custom_environment_variables')
         WHERE
             attributes ? 'custom_environment_variables' AND
             type = 'node.process.calculation.calcjob.CalcJobNode.';
@@ -60,7 +60,7 @@ def upgrade():
         -- custom_environment_variables -> environment_variables
 
         UPDATE db_dbnode
-        SET attributes = jsonb_set(attributes, '{resources}', to_jsonb(attributes->>'jobresource_params'))
+        SET attributes = jsonb_set(attributes, '{resources}', attributes->'jobresource_params')
         WHERE
             attributes ? 'jobresource_params' AND
             type = 'node.process.calculation.calcjob.CalcJobNode.';
@@ -71,7 +71,7 @@ def upgrade():
         -- jobresource_params -> resources
 
         UPDATE db_dbnode
-        SET attributes = jsonb_set(attributes, '{process_label}', to_jsonb(attributes->>'_process_label'))
+        SET attributes = jsonb_set(attributes, '{process_label}', attributes->'_process_label')
         WHERE
             attributes ? '_process_label' AND
             type like 'node.process.%';
@@ -82,7 +82,7 @@ def upgrade():
         -- _process_label -> process_label
 
         UPDATE db_dbnode
-        SET attributes = jsonb_set(attributes, '{parser_name}', to_jsonb(attributes->>'parser'))
+        SET attributes = jsonb_set(attributes, '{parser_name}', attributes->'parser')
         WHERE
             attributes ? 'parser' AND
             type = 'node.process.calculation.calcjob.CalcJobNode.';

--- a/aiida/backends/sqlalchemy/tests/test_migrations.py
+++ b/aiida/backends/sqlalchemy/tests/test_migrations.py
@@ -559,13 +559,17 @@ class TestCalcAttributeKeysMigration(TestMigrationsSQLA):
                 node_work = DbNode(type='node.process.workflow.WorkflowNode.', attributes=attributes, user_id=user.id)
                 node_calc = DbNode(
                     type='node.process.calculation.calcjob.CalcJobNode.', attributes=attributes, user_id=user.id)
+                # Create a node of a different type to ensure that its attributes are not updated
+                node_other = DbNode(type='node.othernode.', attributes=attributes, user_id=user.id)
 
                 session.add(node_work)
                 session.add(node_calc)
+                session.add(node_other)
                 session.commit()
 
                 self.node_work_id = node_work.id
                 self.node_calc_id = node_calc.id
+                self.node_other_id = node_other.id
             finally:
                 session.close()
 
@@ -586,10 +590,9 @@ class TestCalcAttributeKeysMigration(TestMigrationsSQLA):
                 self.assertEqual(node_work.attributes.get(self.KEY_PROCESS_LABEL_NEW), self.process_label)
                 self.assertEqual(node_work.attributes.get(self.KEY_PROCESS_LABEL_OLD, not_found), not_found)
 
-                node_calc = session.query(DbNode).filter(DbNode.id == self.node_calc_id).one()
-
                 # The dictionaries need to be cast with ast.literal_eval, because the `get` will return a string
                 # representation of the dictionary that the attribute contains
+                node_calc = session.query(DbNode).filter(DbNode.id == self.node_calc_id).one()
                 self.assertEqual(node_calc.attributes.get(self.KEY_PROCESS_LABEL_NEW), self.process_label)
                 self.assertEqual(node_calc.attributes.get(self.KEY_PARSER_NAME_NEW), self.parser_name)
                 self.assertEqual(ast.literal_eval(node_calc.attributes.get(self.KEY_RESOURCES_NEW)), self.resources)
@@ -600,6 +603,19 @@ class TestCalcAttributeKeysMigration(TestMigrationsSQLA):
                 self.assertEqual(node_calc.attributes.get(self.KEY_PARSER_NAME_OLD, not_found), not_found)
                 self.assertEqual(node_calc.attributes.get(self.KEY_RESOURCES_OLD, not_found), not_found)
                 self.assertEqual(node_calc.attributes.get(self.KEY_ENVIRONMENT_VARIABLES_OLD, not_found), not_found)
+
+                # The following node should not be migrated even if its attributes have the matching keys because
+                # the node is not a ProcessNode
+                node_other = session.query(DbNode).filter(DbNode.id == self.node_other_id).one()
+                self.assertEqual(node_other.attributes.get(self.KEY_PROCESS_LABEL_OLD), self.process_label)
+                self.assertEqual(node_other.attributes.get(self.KEY_PARSER_NAME_OLD), self.parser_name)
+                self.assertEqual(node_other.attributes.get(self.KEY_RESOURCES_OLD), self.resources)
+                self.assertEqual(
+                    node_other.attributes.get(self.KEY_ENVIRONMENT_VARIABLES_OLD), self.environment_variables)
+                self.assertEqual(node_other.attributes.get(self.KEY_PROCESS_LABEL_NEW, not_found), not_found)
+                self.assertEqual(node_other.attributes.get(self.KEY_PARSER_NAME_NEW, not_found), not_found)
+                self.assertEqual(node_other.attributes.get(self.KEY_RESOURCES_NEW, not_found), not_found)
+                self.assertEqual(node_other.attributes.get(self.KEY_ENVIRONMENT_VARIABLES_NEW, not_found), not_found)
             finally:
                 session.close()
 

--- a/aiida/backends/sqlalchemy/tests/test_migrations.py
+++ b/aiida/backends/sqlalchemy/tests/test_migrations.py
@@ -575,7 +575,6 @@ class TestCalcAttributeKeysMigration(TestMigrationsSQLA):
 
     def test_attribute_key_changes(self):
         """Verify that the keys are successfully changed of the affected attributes."""
-        import ast
         from sqlalchemy.orm import Session  # pylint: disable=import-error,no-name-in-module
 
         DbNode = self.get_auto_base().classes.db_dbnode  # pylint: disable=invalid-name
@@ -590,15 +589,12 @@ class TestCalcAttributeKeysMigration(TestMigrationsSQLA):
                 self.assertEqual(node_work.attributes.get(self.KEY_PROCESS_LABEL_NEW), self.process_label)
                 self.assertEqual(node_work.attributes.get(self.KEY_PROCESS_LABEL_OLD, not_found), not_found)
 
-                # The dictionaries need to be cast with ast.literal_eval, because the `get` will return a string
-                # representation of the dictionary that the attribute contains
                 node_calc = session.query(DbNode).filter(DbNode.id == self.node_calc_id).one()
                 self.assertEqual(node_calc.attributes.get(self.KEY_PROCESS_LABEL_NEW), self.process_label)
                 self.assertEqual(node_calc.attributes.get(self.KEY_PARSER_NAME_NEW), self.parser_name)
-                self.assertEqual(ast.literal_eval(node_calc.attributes.get(self.KEY_RESOURCES_NEW)), self.resources)
+                self.assertEqual(node_calc.attributes.get(self.KEY_RESOURCES_NEW), self.resources)
                 self.assertEqual(
-                    ast.literal_eval(node_calc.attributes.get(self.KEY_ENVIRONMENT_VARIABLES_NEW)),
-                    self.environment_variables)
+                    node_calc.attributes.get(self.KEY_ENVIRONMENT_VARIABLES_NEW), self.environment_variables)
                 self.assertEqual(node_calc.attributes.get(self.KEY_PROCESS_LABEL_OLD, not_found), not_found)
                 self.assertEqual(node_calc.attributes.get(self.KEY_PARSER_NAME_OLD, not_found), not_found)
                 self.assertEqual(node_calc.attributes.get(self.KEY_RESOURCES_OLD, not_found), not_found)


### PR DESCRIPTION
Fixes #2797 and fixes #2831 

This PR fixes two distinct bugs in the migrations for key name changes in the attributes of calculation job nodes.

The faulty migration has been added in commit [2c961cbbb89aa8f2a2ab257dcb34322f7cc98bb9](https://github.com/aiidateam/aiida_core/commit/2c961cbbb89aa8f2a2ab257dcb34322f7cc98bb9#diff-f712699834f2257f35791ed0de4c788e) and so was present between version `v1.0.0b1 - v1.0.0b3`.

The Django migration `0023_calc_job_option_attribute_keys` failed to properly join the attributes on the filtered nodes, potentially causing attribute keys of non `CalcJobNode` to erroneously be updated. The chances of this having to occurred while the bug was present are negligible.

The bug in the SqlAlchemy migration `7ca08c391c49_calc_job_option_attribute_keys` is more serious. The used JSONB operator was wrong and erroneously converted the dictionaries for the attributes `resources` and `environment_variables` to text. All SqlAlchemy databases that have activated the migration between `v1.0.0b1 - v1.0.0b3` will now have values with type text instead of dictionaries for the attributes `resources` and `environment_variables`.