### PR TITLE
Documentation: add section on calculation functions

### DIFF
--- a/docs/source/working/include/snippets/calculations/calcfunctions/add_calcfunction_load_node.py
+++ b/docs/source/working/include/snippets/calculations/calcfunctions/add_calcfunction_load_node.py
@@ -1,0 +1,9 @@
+from aiida.engine import calcfunction
+from aiida.orm import Int
+
+@calcfunction
+def add(x, y):
+    result = load_node(100)
+    return result
+
+result = add(Int(1), Int(2))

--- a/docs/source/working/include/snippets/calculations/calcfunctions/add_calcfunction_store.py
+++ b/docs/source/working/include/snippets/calculations/calcfunctions/add_calcfunction_store.py
@@ -1,0 +1,9 @@
+from aiida.engine import calcfunction
+from aiida.orm import Int
+
+@calcfunction
+def add(x, y):
+    result = Int(x + y).store()
+    return result
+
+result = add(Int(1), Int(2))


### PR DESCRIPTION
Fixes #2627 

The section explains the specific intended usage and limitations of calc
functions. The generic rules of implementation are already described in
the process function section, since these also apply to work functions.