### PR TITLE
Move code endpoint under data, put node module as top hierarchy on top of data and process, remove hard coded type string from query help

### DIFF
--- a/aiida/restapi/api.py
+++ b/aiida/restapi/api.py
@@ -203,6 +203,7 @@ class AiidaApi(Api):
             '/codes/<id>/content/attributes/',
             '/codes/<id>/content/extras/',
             '/codes/<id>/content/visualization/',
+            '/codes/<id>/content/download/',
             endpoint='codes',
             strict_slashes=False,
             resource_class_kwargs=kwargs)

--- a/aiida/restapi/resources.py
+++ b/aiida/restapi/resources.py
@@ -187,7 +187,7 @@ class Node(Resource):
     def __init__(self, **kwargs):
 
         # Set translator
-        from aiida.restapi.translator.node import NodeTranslator
+        from aiida.restapi.translator.nodes.node import NodeTranslator
         self.trans = NodeTranslator(**kwargs)
 
         from aiida.orm import Node as tNode
@@ -380,24 +380,10 @@ class Calculation(Node):
     def __init__(self, **kwargs):
         super(Calculation, self).__init__(**kwargs)
 
-        from aiida.restapi.translator.calculation import CalculationTranslator
+        from aiida.restapi.translator.nodes.calculation import CalculationTranslator
         self.trans = CalculationTranslator(**kwargs)
         from aiida.orm import CalcJobNode as CalculationTclass
         self.tclass = CalculationTclass
-
-        self.parse_pk_uuid = 'uuid'
-
-
-class Code(Node):
-    """ Resource for Code """
-
-    def __init__(self, **kwargs):
-        super(Code, self).__init__(**kwargs)
-
-        from aiida.restapi.translator.code import CodeTranslator
-        self.trans = CodeTranslator(**kwargs)
-        from aiida.orm import Code as CodeTclass
-        self.tclass = CodeTclass
 
         self.parse_pk_uuid = 'uuid'
 
@@ -408,10 +394,24 @@ class Data(Node):
     def __init__(self, **kwargs):
         super(Data, self).__init__(**kwargs)
 
-        from aiida.restapi.translator.data import DataTranslator
+        from aiida.restapi.translator.nodes.data import DataTranslator
         self.trans = DataTranslator(**kwargs)
         from aiida.orm import Data as DataTclass
         self.tclass = DataTclass
+
+        self.parse_pk_uuid = 'uuid'
+
+
+class Code(Data):
+    """ Resource for Code """
+
+    def __init__(self, **kwargs):
+        super(Code, self).__init__(**kwargs)
+
+        from aiida.restapi.translator.nodes.data.code import CodeTranslator
+        self.trans = CodeTranslator(**kwargs)
+        from aiida.orm import Code as CodeTclass
+        self.tclass = CodeTclass
 
         self.parse_pk_uuid = 'uuid'
 
@@ -423,7 +423,7 @@ class StructureData(Data):
 
         super(StructureData, self).__init__(**kwargs)
 
-        from aiida.restapi.translator.data.structure import \
+        from aiida.restapi.translator.nodes.data.structure import \
             StructureDataTranslator
         self.trans = StructureDataTranslator(**kwargs)
         from aiida.orm import StructureData as StructureDataTclass
@@ -438,7 +438,7 @@ class KpointsData(Data):
     def __init__(self, **kwargs):
         super(KpointsData, self).__init__(**kwargs)
 
-        from aiida.restapi.translator.data.kpoints import KpointsDataTranslator
+        from aiida.restapi.translator.nodes.data.kpoints import KpointsDataTranslator
         self.trans = KpointsDataTranslator(**kwargs)
         from aiida.orm import KpointsData as KpointsDataTclass
         self.tclass = KpointsDataTclass
@@ -452,7 +452,7 @@ class BandsData(Data):
     def __init__(self, **kwargs):
         super(BandsData, self).__init__(**kwargs)
 
-        from aiida.restapi.translator.data.bands import \
+        from aiida.restapi.translator.nodes.data.bands import \
             BandsDataTranslator
         self.trans = BandsDataTranslator(**kwargs)
         from aiida.orm import BandsData as BandsDataTclass
@@ -468,7 +468,7 @@ class CifData(Data):
 
         super(CifData, self).__init__(**kwargs)
 
-        from aiida.restapi.translator.data.cif import \
+        from aiida.restapi.translator.nodes.data.cif import \
             CifDataTranslator
         self.trans = CifDataTranslator(**kwargs)
         from aiida.orm import CifData as CifDataTclass
@@ -484,7 +484,7 @@ class UpfData(Data):
 
         super(UpfData, self).__init__(**kwargs)
 
-        from aiida.restapi.translator.data.upf import \
+        from aiida.restapi.translator.nodes.data.upf import \
             UpfDataTranslator
         self.trans = UpfDataTranslator(**kwargs)
         from aiida.orm import UpfData as UpfDataTclass

--- a/aiida/restapi/translator/base.py
+++ b/aiida/restapi/translator/base.py
@@ -38,9 +38,6 @@ class BaseTranslator(object):
     # The string name of the AiiDA class
     _aiida_type = None
 
-    # The string associated to the AiiDA class in the query builder lexicon
-    _qb_type = None
-
     # If True (False) the corresponding AiiDA class has (no) uuid property
     _has_uuid = None
 
@@ -76,7 +73,6 @@ class BaseTranslator(object):
         self.__label__ = Class.__label__
         self._aiida_class = Class._aiida_class  # pylint: disable=protected-access
         self._aiida_type = Class._aiida_type  # pylint: disable=protected-access
-        self._qb_type = Class._qb_type  # pylint: disable=protected-access
         self._result_type = Class.__label__
 
         self._default = Class._default  # pylint: disable=protected-access
@@ -317,7 +313,8 @@ class BaseTranslator(object):
             :param columns: (list of strings)
             :return: a dictionary
             """
-            order_dict = {}
+            from collections import OrderedDict
+            order_dict = OrderedDict()
             for column in columns:
                 if column[0] == '-':
                     order_dict[column[1:]] = 'desc'

--- a/aiida/restapi/translator/computer.py
+++ b/aiida/restapi/translator/computer.py
@@ -28,8 +28,6 @@ class ComputerTranslator(BaseTranslator):
     _aiida_class = orm.Computer
     # The string name of the AiiDA class
     _aiida_type = "Computer"
-    # The string associated to the AiiDA class in the query builder lexicon
-    _qb_type = 'computer'
 
     # If True (False) the corresponding AiiDA class has (no) uuid property
     _has_uuid = True

--- a/aiida/restapi/translator/group.py
+++ b/aiida/restapi/translator/group.py
@@ -29,8 +29,6 @@ class GroupTranslator(BaseTranslator):
     _aiida_class = orm.Group
     # The string name of the AiiDA class
     _aiida_type = "groups.Group"
-    # The string associated to the AiiDA class in the query builder lexicon
-    _qb_type = 'group'
 
     # If True (False) the corresponding AiiDA class has (no) uuid property
     _has_uuid = True

--- a/aiida/restapi/translator/nodes/calculation/__init__.py
+++ b/aiida/restapi/translator/nodes/calculation/__init__.py
@@ -16,7 +16,7 @@ from __future__ import print_function
 from __future__ import absolute_import
 import os
 
-from aiida.restapi.translator.node import NodeTranslator
+from aiida.restapi.translator.nodes.node import NodeTranslator
 from aiida.restapi.common.exceptions import RestInputValidationError
 from aiida.orm.utils.repository import FileType
 
@@ -33,8 +33,6 @@ class CalculationTranslator(NodeTranslator):
     _aiida_class = CalculationNode
     # The string name of the AiiDA class
     _aiida_type = "process.calculation.calculation.CalculationNode"
-    # The string associated to the AiiDA class in the query builder lexicon
-    _qb_type = "process.calculation."
 
     _result_type = __label__
 

--- a/aiida/restapi/translator/nodes/data/__init__.py
+++ b/aiida/restapi/translator/nodes/data/__init__.py
@@ -14,8 +14,7 @@ Translator for data node
 from __future__ import division
 from __future__ import print_function
 from __future__ import absolute_import
-from aiida.restapi.translator.node import NodeTranslator
-import aiida
+from aiida.restapi.translator.nodes.node import NodeTranslator
 
 
 class DataTranslator(NodeTranslator):
@@ -26,11 +25,10 @@ class DataTranslator(NodeTranslator):
     # A label associated to the present class (coincides with the resource name)
     __label__ = "data"
     # The AiiDA class one-to-one associated to the present class
-    _aiida_class = aiida.orm.Data
+    from aiida.orm import Data
+    _aiida_class = Data
     # The string name of the AiiDA class
     _aiida_type = "data.Data"
-    # The string associated to the AiiDA class in the query builder lexicon
-    _qb_type = _aiida_type + '.'
 
     _result_type = __label__
 

--- a/aiida/restapi/translator/nodes/data/bands.py
+++ b/aiida/restapi/translator/nodes/data/bands.py
@@ -14,7 +14,7 @@ Translator for bands data
 from __future__ import division
 from __future__ import print_function
 from __future__ import absolute_import
-from aiida.restapi.translator.data import DataTranslator
+from aiida.restapi.translator.nodes.data import DataTranslator
 
 
 class BandsDataTranslator(DataTranslator):
@@ -29,8 +29,6 @@ class BandsDataTranslator(DataTranslator):
     _aiida_class = BandsData
     # The string name of the AiiDA class
     _aiida_type = "data.array.bands.BandsData"
-    # The string associated to the AiiDA class in the query builder lexicon
-    _qb_type = _aiida_type + '.'
 
     _result_type = __label__
 

--- a/aiida/restapi/translator/nodes/data/cif.py
+++ b/aiida/restapi/translator/nodes/data/cif.py
@@ -11,7 +11,7 @@
 from __future__ import division
 from __future__ import print_function
 from __future__ import absolute_import
-from aiida.restapi.translator.data import DataTranslator
+from aiida.restapi.translator.nodes.data import DataTranslator
 from aiida.common.exceptions import LicensingException
 
 
@@ -27,8 +27,6 @@ class CifDataTranslator(DataTranslator):
     _aiida_class = CifData
     # The string name of the AiiDA class
     _aiida_type = "data.cif.CifData"
-    # The string associated to the AiiDA class in the query builder lexicon
-    _qb_type = _aiida_type + '.'
 
     _result_type = __label__
 

--- a/aiida/restapi/translator/nodes/data/code.py
+++ b/aiida/restapi/translator/nodes/data/code.py
@@ -14,11 +14,10 @@ Translator for code
 from __future__ import division
 from __future__ import print_function
 from __future__ import absolute_import
-from aiida.restapi.translator.node import NodeTranslator
-from aiida.orm import Code
+from aiida.restapi.translator.nodes.data import DataTranslator
 
 
-class CodeTranslator(NodeTranslator):
+class CodeTranslator(DataTranslator):
     """
     Translator relative to resource 'codes' and aiida class Code
     """
@@ -26,11 +25,10 @@ class CodeTranslator(NodeTranslator):
     # A label associated to the present class (coincides with the resource name)
     __label__ = "codes"
     # The AiiDA class one-to-one associated to the present class
+    from aiida.orm import Code
     _aiida_class = Code
     # The string name of the AiiDA class
     _aiida_type = "data.code.Code"
-    # The string associated to the AiiDA class in the query builder lexicon
-    _qb_type = _aiida_type + '.'
 
     _result_type = __label__
 
@@ -40,3 +38,33 @@ class CodeTranslator(NodeTranslator):
         Create the basic query_help
         """
         super(CodeTranslator, self).__init__(Class=self.__class__, **kwargs)
+
+    @staticmethod
+    def get_visualization_data(node, visformat=None):
+        """
+        Generic function extented for codes data. Currently
+        it is not implemented.
+
+        :param node: node object that has to be visualized
+        :param visformat: visualization format
+        :returns: raise RestFeatureNotAvailable exception
+        """
+
+        from aiida.restapi.common.exceptions import RestFeatureNotAvailable
+
+        raise RestFeatureNotAvailable("This endpoint is not available for Codes.")
+
+    @staticmethod
+    def get_downloadable_data(node, download_format=None):
+        """
+        Generic function extented for codes data. Currently
+        it is not implemented.
+
+        :param node: node object that has to be downloaded
+        :param download_format: file extension format
+        :returns: raise RestFeatureNotAvailable exception
+        """
+
+        from aiida.restapi.common.exceptions import RestFeatureNotAvailable
+
+        raise RestFeatureNotAvailable("This endpoint is not available for Codes.")

--- a/aiida/restapi/translator/nodes/data/kpoints.py
+++ b/aiida/restapi/translator/nodes/data/kpoints.py
@@ -14,7 +14,7 @@ Translator for kpoints data
 from __future__ import division
 from __future__ import print_function
 from __future__ import absolute_import
-from aiida.restapi.translator.data import DataTranslator
+from aiida.restapi.translator.nodes.data import DataTranslator
 
 
 class KpointsDataTranslator(DataTranslator):
@@ -29,8 +29,6 @@ class KpointsDataTranslator(DataTranslator):
     _aiida_class = KpointsData
     # The string name of the AiiDA class
     _aiida_type = "data.array.kpoints.KpointsData"
-    # The string associated to the AiiDA class in the query builder lexicon
-    _qb_type = _aiida_type + '.'
 
     _result_type = __label__
 

--- a/aiida/restapi/translator/nodes/data/structure.py
+++ b/aiida/restapi/translator/nodes/data/structure.py
@@ -15,7 +15,7 @@ from __future__ import print_function
 from __future__ import absolute_import
 from __future__ import division
 
-from aiida.restapi.translator.data import DataTranslator
+from aiida.restapi.translator.nodes.data import DataTranslator
 from aiida.restapi.common.exceptions import RestInputValidationError
 from aiida.common.exceptions import LicensingException
 
@@ -32,8 +32,6 @@ class StructureDataTranslator(DataTranslator):
     _aiida_class = StructureData
     # The string name of the AiiDA class
     _aiida_type = "data.structure.StructureData"
-    # The string associated to the AiiDA class in the query builder lexicon
-    _qb_type = _aiida_type + '.'
 
     _result_type = __label__
 

--- a/aiida/restapi/translator/nodes/data/upf.py
+++ b/aiida/restapi/translator/nodes/data/upf.py
@@ -14,7 +14,7 @@ Translator for upf data
 from __future__ import division
 from __future__ import print_function
 from __future__ import absolute_import
-from aiida.restapi.translator.data import DataTranslator
+from aiida.restapi.translator.nodes.data import DataTranslator
 from aiida.restapi.common.exceptions import RestInputValidationError
 
 
@@ -30,8 +30,6 @@ class UpfDataTranslator(DataTranslator):
     _aiida_class = UpfData
     # The string name of the AiiDA class
     _aiida_type = "data.upf.UpfData"
-    # The string associated to the AiiDA class in the query builder lexicon
-    _qb_type = _aiida_type + '.'
 
     _result_type = __label__
 

--- a/aiida/restapi/translator/nodes/node.py
+++ b/aiida/restapi/translator/nodes/node.py
@@ -28,12 +28,12 @@ class NodeTranslator(BaseTranslator):
 
     # A label associated to the present class (coincides with the resource name)
     __label__ = "nodes"
+
     # The AiiDA class one-to-one associated to the present class
     _aiida_class = orm.Node
+
     # The string name of the AiiDA class
     _aiida_type = "node.Node"
-    # The string associated to the AiiDA class in the query builder lexicon
-    _qb_type = _aiida_type + '.'
 
     # If True (False) the corresponding AiiDA class has (no) uuid property
     _has_uuid = True
@@ -113,12 +113,15 @@ class NodeTranslator(BaseTranslator):
         # Inspect the subclasses of NodeTranslator, to avoid hard-coding
         # (should resemble the following tree)
         """
-                                          /- KpointsTranslator
-                                         /
-                         /- DataTranslator  -- SructureTranslator
-                        /                \
-                                          \- BandsTranslator
-        NodeTranslator  -- CodeTranslator
+                                              /- CodeTranslator
+                                             /
+                                            /- KpointsTranslator
+                                           /
+                           /- DataTranslator -- StructureTranslator
+                          /                \
+                         /                  \- BandsTranslator
+                        /
+        NodeTranslator
                         \
                          \- CalculationTranslator
         """
@@ -353,7 +356,7 @@ class NodeTranslator(BaseTranslator):
 
         :param parent: package/class.
             If package looks for the classes in submodules.
-            If class, first lookss for the package where it is contained
+            If class, first looks for the package where it is contained
         :param parent_class: class of which to look for subclasses
         :param recursive: True/False (go recursively into submodules)
         """
@@ -412,7 +415,6 @@ class NodeTranslator(BaseTranslator):
             # Look in submodules
             elif is_pkg and recursive:
                 results.update(self._get_subclasses(parent=app_module, parent_class=parent_class))
-
         return results
 
     def get_visualization_data(self, node, visformat=None):
@@ -428,7 +430,7 @@ class NodeTranslator(BaseTranslator):
         :returns: data selected and serialized for visualization
 
         If this method is called by Node resource it will look for the type
-        of object and invoke the correct method in the lowest-compatibel
+        of object and invoke the correct method in the lowest-compatible
         subclass
         """
 
@@ -456,14 +458,13 @@ class NodeTranslator(BaseTranslator):
         :returns: data in selected format to download
 
         If this method is called by Node resource it will look for the type
-        of object and invoke the correct method in the lowest-compatibel
+        of object and invoke the correct method in the lowest-compatible
         subclass
         """
 
         # Look for the translator associated to the class of which this node
         # is instance
         tclass = type(node)
-
         for subclass in self._subclasses.values():
             if subclass._aiida_type.split('.')[-1] == tclass.__name__:  # pylint: disable=protected-access
                 lowtrans = subclass
@@ -559,14 +560,13 @@ class NodeTranslator(BaseTranslator):
             """
 
             node_type = ntype.split(".")[0]
-
-            # default and data node shape
-            shape = "dot"
-
-            if node_type == "calculation":
+            if node_type == "process":
                 shape = "square"
-            elif node_type == "code":
+            elif ntype.split(".")[1] == "code":
                 shape = "triangle"
+            else:
+                # default and data node shape
+                shape = "dot"
 
             return shape
 

--- a/aiida/restapi/translator/user.py
+++ b/aiida/restapi/translator/user.py
@@ -27,8 +27,6 @@ class UserTranslator(BaseTranslator):
     _aiida_class = orm.User
     # The string name of the AiiDA class
     _aiida_type = "User"
-    # The string associated to the AiiDA class in the query builder lexicon
-    _qb_type = 'user'
 
     # If True (False) the corresponding AiiDA class has (no) uuid property
     _has_uuid = False


### PR DESCRIPTION
Fixes #3045 and fixes #3046.

Solved the following points of issue #2384: 
move code endpoint under data to match it with ORM hierarchy;
create node module as top hierarchy with calculation and data submodules;
remove hard coded type string from query help in translator classes and replace it with ORM class.
