### PR TITLE
Properly unload database environment when swapping profiles

### DIFF
--- a/aiida/backends/sqlalchemy/__init__.py
+++ b/aiida/backends/sqlalchemy/__init__.py
@@ -7,27 +7,73 @@
 # For further information on the license, see the LICENSE.txt file        #
 # For further information please visit http://www.aiida.net               #
 ###########################################################################
-
-# The next two serve as 'global' variables, set in the load_dbenv
-# call. They are properly reset upon forking.
 from __future__ import division
 from __future__ import print_function
 from __future__ import absolute_import
-engine = None
-scopedsessionclass = None
+
+from sqlalchemy import create_engine
+from sqlalchemy.orm import scoped_session
+from sqlalchemy.orm import sessionmaker
+
+# The next two serve as global variables, set in the `load_dbenv` call and should be properly reset upon forking.
+ENGINE = None
+SCOPED_SESSION_CLASS = None
 
 
 def get_scoped_session():
-    """
-    Return a scoped session (according to SQLAlchemy docs, 
-    this returns always the same object within a thread, and
-    a different object in a different thread.
-    Moreover, since we update the scopedsessionclass upon
-    forking, also forks have different session objects.
-    """
-    if scopedsessionclass is None:
-        s = None
-    else:
-        s = scopedsessionclass()
+    """Return a scoped session
 
-    return s
+    According to SQLAlchemy docs, this returns always the same object within a thread, and a different object in a
+    different thread. Moreover, since we update the session class upon forking, different session objects will be used.
+    """
+    global SCOPED_SESSION_CLASS
+
+    if SCOPED_SESSION_CLASS is None:
+        reset_session()
+
+    return SCOPED_SESSION_CLASS()
+
+
+def recreate_after_fork(engine):
+    """Callback called after a fork.
+
+    Not only disposes the engine, but also recreates a new scoped session to use independent sessions in the fork.
+
+    :param engine: the engine that will be used by the sessionmaker
+    """
+    global ENGINE
+    global SCOPED_SESSION_CLASS
+
+    ENGINE.dispose()
+    SCOPED_SESSION_CLASS = scoped_session(sessionmaker(bind=ENGINE, expire_on_commit=True))
+
+
+def reset_session(profile=None):
+    """
+    Resets (global) engine and sessionmaker classes, to create a new one
+    (or creates a new one from scratch if not already available)
+
+    :param profile: the profile whose configuration to use to connect to the database
+    """
+    from multiprocessing.util import register_after_fork
+    from aiida.manage.configuration import get_profile
+    from .utils import loads_json, dumps_json
+
+    global ENGINE
+    global SCOPED_SESSION_CLASS
+
+    if profile is None:
+        profile = get_profile()
+
+    separator = ':' if profile.database_port else ''
+    engine_url = 'postgresql://{user}:{password}@{hostname}{separator}{port}/{name}'.format(
+        separator=separator,
+        user=profile.database_username,
+        password=profile.database_password,
+        hostname=profile.database_hostname,
+        port=profile.database_port,
+        name=profile.database_name)
+
+    ENGINE = create_engine(engine_url, json_serializer=dumps_json, json_deserializer=loads_json, encoding='utf-8')
+    SCOPED_SESSION_CLASS = scoped_session(sessionmaker(bind=ENGINE, expire_on_commit=True))
+    register_after_fork(ENGINE, recreate_after_fork)

--- a/aiida/backends/sqlalchemy/alembic_manage.py
+++ b/aiida/backends/sqlalchemy/alembic_manage.py
@@ -80,7 +80,7 @@ if __name__ == "__main__":
         command = getattr(alembic_command, args.command)
         alembic_cfg = get_alembic_conf()
 
-        with sa.engine.begin() as connection:
+        with sa.ENGINE.begin() as connection:
             alembic_cfg.attributes['connection'] = connection
             if command.__name__ == CURRENT_CMD:
                 command(alembic_cfg, verbose=args.verbose)

--- a/aiida/backends/sqlalchemy/tests/test_migrations.py
+++ b/aiida/backends/sqlalchemy/tests/test_migrations.py
@@ -84,7 +84,7 @@ class TestMigrationsSQLA(AiidaTestCase):
         :param destination: the name of the destination migration
         """
         # Undo all previous real migration of the database
-        with sa.engine.connect() as connection:
+        with sa.ENGINE.connect() as connection:
             self.alembic_cfg.attributes['connection'] = connection  # pylint: disable=unsupported-assignment-operation
             command.upgrade(self.alembic_cfg, destination)
 
@@ -94,7 +94,7 @@ class TestMigrationsSQLA(AiidaTestCase):
 
         :param destination: the name of the destination migration
         """
-        with sa.engine.connect() as connection:
+        with sa.ENGINE.connect() as connection:
             self.alembic_cfg.attributes['connection'] = connection  # pylint: disable=unsupported-assignment-operation
             command.downgrade(self.alembic_cfg, destination)
 
@@ -130,7 +130,7 @@ class TestMigrationsSQLA(AiidaTestCase):
         Utility method to get the current revision string
         """
         from alembic.migration import MigrationContext  # pylint: disable=import-error
-        with sa.engine.begin() as connection:
+        with sa.ENGINE.begin() as connection:
             context = MigrationContext.configure(connection)
             current_rev = context.get_current_revision()
         return current_rev
@@ -147,7 +147,7 @@ class TestMigrationsSQLA(AiidaTestCase):
         from alembic.migration import MigrationContext  # pylint: disable=import-error
         from sqlalchemy.ext.automap import automap_base  # pylint: disable=import-error,no-name-in-module
 
-        with sa.engine.begin() as connection:
+        with sa.ENGINE.begin() as connection:
             context = MigrationContext.configure(connection)
             bind = context.bind
 
@@ -165,7 +165,7 @@ class TestMigrationsSQLA(AiidaTestCase):
         """
         from sqlalchemy.orm import Session  # pylint: disable=import-error,no-name-in-module
 
-        with sa.engine.begin() as connection:
+        with sa.ENGINE.begin() as connection:
             session = Session(connection.engine)
             yield session
             session.close()
@@ -302,7 +302,7 @@ class TestMigrationSchemaVsModelsSchema(AiidaTestCase):
 
         # The correction URL to the SQLA database of the current
         # AiiDA connection
-        curr_db_url = sa.engine.url
+        curr_db_url = sa.ENGINE.url
 
         # Create new urls for the two new databases
         self.db_url_left = get_temporary_uri(str(curr_db_url))
@@ -356,7 +356,7 @@ class TestProvenanceRedesignMigration(TestMigrationsSQLA):
         DbNode = self.get_auto_base().classes.db_dbnode  # pylint: disable=invalid-name
         DbUser = self.get_auto_base().classes.db_dbuser  # pylint: disable=invalid-name
 
-        with sa.engine.begin() as connection:
+        with sa.ENGINE.begin() as connection:
             try:
                 session = Session(connection.engine)
 
@@ -402,7 +402,7 @@ class TestProvenanceRedesignMigration(TestMigrationsSQLA):
 
         DbNode = self.get_auto_base().classes.db_dbnode  # pylint: disable=invalid-name
 
-        with sa.engine.begin() as connection:
+        with sa.ENGINE.begin() as connection:
             try:
                 session = Session(connection.engine)
 
@@ -537,7 +537,7 @@ class TestCalcAttributeKeysMigration(TestMigrationsSQLA):
         DbNode = self.get_auto_base().classes.db_dbnode  # pylint: disable=invalid-name
         DbUser = self.get_auto_base().classes.db_dbuser  # pylint: disable=invalid-name
 
-        with sa.engine.begin() as connection:
+        with sa.ENGINE.begin() as connection:
             try:
                 session = Session(connection.engine)
 
@@ -578,7 +578,7 @@ class TestCalcAttributeKeysMigration(TestMigrationsSQLA):
 
         not_found = tuple([0])
 
-        with sa.engine.begin() as connection:
+        with sa.ENGINE.begin() as connection:
             try:
                 session = Session(connection.engine)
 
@@ -621,7 +621,7 @@ class TestDbLogMigrationRecordCleaning(TestMigrationsSQLA):
 
         DbWorkflow = self.get_auto_base().classes.db_dbworkflow  # pylint: disable=invalid-name
 
-        with sa.engine.begin() as connection:
+        with sa.ENGINE.begin() as connection:
             try:
                 session = Session(connection.engine)
                 session.query(DbWorkflow).delete()
@@ -645,7 +645,7 @@ class TestDbLogMigrationRecordCleaning(TestMigrationsSQLA):
         DbWorkflow = self.get_auto_base().classes.db_dbworkflow  # pylint: disable=invalid-name
         DbLog = self.get_auto_base().classes.db_dblog  # pylint: disable=invalid-name
 
-        with sa.engine.begin() as connection:
+        with sa.ENGINE.begin() as connection:
             try:
                 session = Session(connection.engine)
 
@@ -809,7 +809,7 @@ class TestDbLogMigrationRecordCleaning(TestMigrationsSQLA):
 
         DbLog = self.get_auto_base().classes.db_dblog  # pylint: disable=invalid-name
 
-        with sa.engine.begin() as connection:
+        with sa.ENGINE.begin() as connection:
             try:
                 session = Session(connection.engine)
 
@@ -853,7 +853,7 @@ class TestDbLogMigrationRecordCleaning(TestMigrationsSQLA):
 
         DbLog = self.get_auto_base().classes.db_dblog  # pylint: disable=invalid-name
 
-        with sa.engine.begin() as connection:
+        with sa.ENGINE.begin() as connection:
             try:
                 session = Session(connection.engine)
                 metadata = list(session.query(DbLog).with_entities(getattr(DbLog, 'metadata')).all())
@@ -881,7 +881,7 @@ class TestDbLogMigrationBackward(TestBackwardMigrationsSQLA):
         DbNode = self.get_auto_base().classes.db_dbnode  # pylint: disable=invalid-name
         DbLog = self.get_auto_base().classes.db_dblog  # pylint: disable=invalid-name
 
-        with sa.engine.begin() as connection:
+        with sa.ENGINE.begin() as connection:
             try:
                 session = Session(connection.engine)
 
@@ -944,7 +944,7 @@ class TestDbLogMigrationBackward(TestBackwardMigrationsSQLA):
 
         DbLog = self.get_auto_base().classes.db_dblog  # pylint: disable=invalid-name
 
-        with sa.engine.begin() as connection:
+        with sa.ENGINE.begin() as connection:
             try:
                 session = Session(connection.engine)
 
@@ -991,7 +991,7 @@ class TestDbLogUUIDAddition(TestMigrationsSQLA):
         DbNode = self.get_auto_base().classes.db_dbnode  # pylint: disable=invalid-name
         DbLog = self.get_auto_base().classes.db_dblog  # pylint: disable=invalid-name
 
-        with sa.engine.begin() as connection:
+        with sa.ENGINE.begin() as connection:
             try:
                 session = Session(connection.engine)
 
@@ -1027,7 +1027,7 @@ class TestDbLogUUIDAddition(TestMigrationsSQLA):
 
         DbLog = self.get_auto_base().classes.db_dblog  # pylint: disable=invalid-name
 
-        with sa.engine.begin() as connection:
+        with sa.ENGINE.begin() as connection:
             try:
                 session = Session(connection.engine)
                 l_uuids = list(session.query(DbLog).with_entities(getattr(DbLog, 'uuid')).all())
@@ -1049,7 +1049,7 @@ class TestDataMoveWithinNodeMigration(TestMigrationsSQLA):
         DbNode = self.get_auto_base().classes.db_dbnode  # pylint: disable=invalid-name
         DbUser = self.get_auto_base().classes.db_dbuser  # pylint: disable=invalid-name
 
-        with sa.engine.begin() as connection:
+        with sa.ENGINE.begin() as connection:
             try:
                 session = Session(connection.engine)
 
@@ -1078,7 +1078,7 @@ class TestDataMoveWithinNodeMigration(TestMigrationsSQLA):
 
         DbNode = self.get_auto_base().classes.db_dbnode  # pylint: disable=invalid-name
 
-        with sa.engine.begin() as connection:
+        with sa.ENGINE.begin() as connection:
             try:
                 session = Session(connection.engine)
 
@@ -1115,7 +1115,7 @@ class TestTrajectoryDataMigration(TestMigrationsSQLA):
         DbNode = self.get_auto_base().classes.db_dbnode  # pylint: disable=invalid-name
         DbUser = self.get_auto_base().classes.db_dbuser  # pylint: disable=invalid-name
 
-        with sa.engine.begin() as connection:
+        with sa.ENGINE.begin() as connection:
             try:
                 session = Session(connection.engine)
 
@@ -1147,7 +1147,7 @@ class TestTrajectoryDataMigration(TestMigrationsSQLA):
 
         DbNode = self.get_auto_base().classes.db_dbnode  # pylint: disable=invalid-name
 
-        with sa.engine.begin() as connection:
+        with sa.ENGINE.begin() as connection:
             try:
                 session = Session(connection.engine)
 
@@ -1175,7 +1175,7 @@ class TestNodePrefixRemovalMigration(TestMigrationsSQLA):
         DbNode = self.get_auto_base().classes.db_dbnode  # pylint: disable=invalid-name
         DbUser = self.get_auto_base().classes.db_dbuser  # pylint: disable=invalid-name
 
-        with sa.engine.begin() as connection:
+        with sa.ENGINE.begin() as connection:
             try:
                 session = Session(connection.engine)
 
@@ -1204,7 +1204,7 @@ class TestNodePrefixRemovalMigration(TestMigrationsSQLA):
 
         DbNode = self.get_auto_base().classes.db_dbnode  # pylint: disable=invalid-name
 
-        with sa.engine.begin() as connection:
+        with sa.ENGINE.begin() as connection:
             try:
                 session = Session(connection.engine)
 
@@ -1230,7 +1230,7 @@ class TestParameterDataToDictMigration(TestMigrationsSQLA):
         DbNode = self.get_auto_base().classes.db_dbnode  # pylint: disable=invalid-name
         DbUser = self.get_auto_base().classes.db_dbuser  # pylint: disable=invalid-name
 
-        with sa.engine.begin() as connection:
+        with sa.ENGINE.begin() as connection:
             try:
                 session = Session(connection.engine)
 
@@ -1256,7 +1256,7 @@ class TestParameterDataToDictMigration(TestMigrationsSQLA):
 
         DbNode = self.get_auto_base().classes.db_dbnode  # pylint: disable=invalid-name
 
-        with sa.engine.begin() as connection:
+        with sa.ENGINE.begin() as connection:
             try:
                 session = Session(connection.engine)
 

--- a/aiida/backends/sqlalchemy/tests/test_session.py
+++ b/aiida/backends/sqlalchemy/tests/test_session.py
@@ -169,7 +169,7 @@ class TestSessionSqla(AiidaTestCase):
         import aiida.backends.sqlalchemy as sa
         from sqlalchemy.orm import sessionmaker
 
-        Session = sessionmaker(bind=sa.engine)
+        Session = sessionmaker(bind=sa.ENGINE)
         custom_session = Session()
 
         user = self.backend.users.create(email='test@localhost').store()

--- a/aiida/backends/sqlalchemy/utils.py
+++ b/aiida/backends/sqlalchemy/utils.py
@@ -33,9 +33,6 @@ from alembic.config import Config
 from alembic.runtime.environment import EnvironmentContext
 from alembic.script import ScriptDirectory
 from dateutil import parser
-from sqlalchemy import create_engine
-from sqlalchemy.orm import scoped_session
-from sqlalchemy.orm import sessionmaker
 
 from aiida.backends import sqlalchemy as sa
 
@@ -60,56 +57,30 @@ def flag_modified(instance, key):
     flag_modified_sqla(instance, key)
 
 
-def recreate_after_fork(engine):
-    """
-    :param engine: the engine that will be used by the sessionmaker
-
-    Callback called after a fork. Not only disposes the engine, but also recreates a new scoped session
-    to use independent sessions in the forked process.
-    """
-    sa.engine.dispose()
-    sa.scopedsessionclass = scoped_session(sessionmaker(bind=sa.engine, expire_on_commit=True))
-
-
-def reset_session(profile):
-    """
-    :param profile: the profile whose configuration to use to connect to the database
-
-    Resets (global) engine and sessionmaker classes, to create a new one
-    (or creates a new one from scratch if not already available)
-    """
-    from multiprocessing.util import register_after_fork
-
-    separator = ':' if profile.database_port else ''
-    engine_url = 'postgresql://{user}:{password}@{hostname}{separator}{port}/{name}'.format(
-        separator=separator,
-        user=profile.database_username,
-        password=profile.database_password,
-        hostname=profile.database_hostname,
-        port=profile.database_port,
-        name=profile.database_name)
-
-    sa.engine = create_engine(engine_url, json_serializer=dumps_json, json_deserializer=loads_json, encoding='utf-8')
-    sa.scopedsessionclass = scoped_session(sessionmaker(bind=sa.engine, expire_on_commit=True))
-    register_after_fork(sa.engine, recreate_after_fork)
-
-
 def load_dbenv(profile):
-    """
-    Load the database environment (SQLAlchemy) and perform some checks.
+    """Load the database environment and ensure that the code and database schema versions are compatible.
 
     :param profile: the string with the profile to use
     """
     _load_dbenv_noschemacheck(profile)
-    # Check schema version and the existence of the needed tables
     check_schema_version(profile_name=profile.name)
 
 
 def _load_dbenv_noschemacheck(profile):
+    """Load the database environment without checking that code and database schema versions are compatible.
+
+    This should ONLY be used internally, inside load_dbenv, and for schema migrations. DO NOT USE OTHERWISE!
+
+    :param profile: instance of `Profile` whose database to load
     """
-    Load the SQLAlchemy database.
-    """
-    reset_session(profile)
+    sa.reset_session(profile)
+
+
+def unload_dbenv():
+    """Unload the database environment, which boils down to destroying the current engine and session."""
+    if sa.ENGINE is not None:
+        sa.ENGINE.dispose()
+    sa.SCOPED_SESSION_CLASS = None
 
 
 _aiida_autouser_cache = None
@@ -375,12 +346,12 @@ def migrate_database(alembic_cfg=None):
     if alembic_cfg is None:
         alembic_cfg = get_alembic_conf()
 
-    with sa.engine.connect() as connection:
+    with sa.ENGINE.connect() as connection:
         alembic_cfg.attributes['connection'] = connection
         command.upgrade(alembic_cfg, "head")
 
 
-def check_schema_version(profile_name=None):
+def check_schema_version(profile_name):
     """
     Check if the version stored in the database is the same of the version of the code.
 
@@ -392,15 +363,12 @@ def check_schema_version(profile_name=None):
     alembic_cfg = get_alembic_conf()
 
     # Getting the version of the code and the database, reusing the existing engine (initialized by AiiDA)
-    with sa.engine.begin() as connection:
+    with sa.ENGINE.begin() as connection:
         alembic_cfg.attributes['connection'] = connection
         code_schema_version = get_migration_head(alembic_cfg)
         db_schema_version = get_db_schema_version(alembic_cfg)
 
     if code_schema_version != db_schema_version:
-        from aiida.manage.manager import get_manager
-        manager = get_manager()
-        profile_name = manager.get_profile().name
         raise ConfigurationError('Database schema version {} is outdated compared to the code schema version {}\n'
                                  'To migrate the database to the current version, run the following commands:'
                                  '\n  verdi -p {} daemon stop\n  verdi -p {} database migrate'.format(

--- a/aiida/backends/testbase.py
+++ b/aiida/backends/testbase.py
@@ -22,7 +22,7 @@ from aiida.backends.tests import get_db_test_list
 from aiida.common.exceptions import ConfigurationError, TestsNotAllowedError, InternalError
 from aiida.common.lang import classproperty
 from aiida.manage import configuration
-from aiida.manage.manager import reset_manager
+from aiida.manage.manager import get_manager, reset_manager
 
 
 def check_if_tests_can_run():
@@ -78,6 +78,9 @@ class AiidaTestCase(unittest.TestCase):
         # to avoid that it is run
         check_if_tests_can_run()
 
+        # Force the loading of the backend which will load the required database environment
+        get_manager().get_backend()
+
         cls.__backend_instance = cls.get_backend_class()()
         cls.__backend_instance.setUpClass_method(*args, **kwargs)
         cls.backend = cls.__backend_instance.backend
@@ -128,7 +131,6 @@ class AiidaTestCase(unittest.TestCase):
 
         cls.__backend_instance.clean_db()
 
-        # Reset AiiDA manager cache
         reset_manager()
 
     @classmethod

--- a/aiida/backends/tests/cmdline/commands/test_setup.py
+++ b/aiida/backends/tests/cmdline/commands/test_setup.py
@@ -13,10 +13,12 @@ from __future__ import print_function
 from __future__ import absolute_import
 
 import traceback
+import unittest
 
 from click.testing import CliRunner
 
 from aiida import orm
+from aiida.backends import BACKEND_DJANGO
 from aiida.backends.testbase import AiidaPostgresTestCase
 from aiida.backends.tests.utils.configuration import with_temporary_config_instance
 from aiida.cmdline.commands import cmd_setup
@@ -24,6 +26,7 @@ from aiida.manage import configuration
 from aiida.manage.external.postgres import Postgres
 
 
+@unittest.skipIf(configuration.PROFILE.database_backend == BACKEND_DJANGO, 'Reenable when #2813 is addressed')
 class TestVerdiSetup(AiidaPostgresTestCase):
     """Tests for `verdi quicksetup`."""
 

--- a/aiida/backends/tests/cmdline/commands/test_setup.py
+++ b/aiida/backends/tests/cmdline/commands/test_setup.py
@@ -30,6 +30,7 @@ class TestVerdiSetup(AiidaPostgresTestCase):
     def setUp(self):
         """Create a CLI runner to invoke the CLI commands."""
         super(TestVerdiSetup, self).setUp()
+        self.backend = configuration.PROFILE.database_backend
         self.cli_runner = CliRunner()
 
     @with_temporary_config_instance
@@ -45,7 +46,8 @@ class TestVerdiSetup(AiidaPostgresTestCase):
 
         options = [
             '--non-interactive', '--profile', profile_name, '--email', user_email, '--first-name', user_first_name,
-            '--last-name', user_last_name, '--institution', user_institution, '--db-port', self.pg_test.dsn['port']
+            '--last-name', user_last_name, '--institution', user_institution, '--db-port', self.pg_test.dsn['port'],
+            '--db-backend', self.backend
         ]
 
         result = self.cli_runner.invoke(cmd_setup.quicksetup, options)
@@ -57,6 +59,9 @@ class TestVerdiSetup(AiidaPostgresTestCase):
 
         profile = config.get_profile(profile_name)
         profile.default_user = user_email
+
+        # Verify that the backend type of the created profile matches that of the profile for the current test session
+        self.assertEqual(self.backend, profile.database_backend)
 
         user = orm.User.objects.get(email=user_email)
         self.assertEqual(user.first_name, user_first_name)
@@ -104,7 +109,7 @@ class TestVerdiSetup(AiidaPostgresTestCase):
         options = [
             '--non-interactive', '--profile', profile_name, '--email', user_email, '--first-name', user_first_name,
             '--last-name', user_last_name, '--institution', user_institution, '--db-name', db_name, '--db-username',
-            db_user, '--db-password', db_pass
+            db_user, '--db-password', db_pass, '--db-port', self.pg_test.dsn['port'], '--db-backend', self.backend
         ]
 
         result = self.cli_runner.invoke(cmd_setup.setup, options)
@@ -116,6 +121,9 @@ class TestVerdiSetup(AiidaPostgresTestCase):
 
         profile = config.get_profile(profile_name)
         profile.default_user = user_email
+
+        # Verify that the backend type of the created profile matches that of the profile for the current test session
+        self.assertEqual(self.backend, profile.database_backend)
 
         user = orm.User.objects.get(email=user_email)
         self.assertEqual(user.first_name, user_first_name)

--- a/aiida/manage/configuration/__init__.py
+++ b/aiida/manage/configuration/__init__.py
@@ -38,7 +38,7 @@ def load_profile(profile=None):
     """
     from aiida.common import InvalidOperation
     from aiida.common.log import configure_logging
-    from aiida.manage.manager import reset_manager
+    from aiida.manage.manager import get_manager, reset_manager
 
     global PROFILE
     global BACKEND_UUID
@@ -60,6 +60,8 @@ def load_profile(profile=None):
     # Also set `with_orm=True` to make sure that the `DBLogHandler` is configured as well.
     configure_logging(with_orm=True)
 
+    manager = get_manager()
+    manager.unload_backend()
     reset_manager()
 
     return PROFILE

--- a/aiida/manage/manager.py
+++ b/aiida/manage/manager.py
@@ -45,6 +45,26 @@ class Manager(object):  # pylint: disable=useless-object-inheritance
         from .configuration import get_profile
         return get_profile()
 
+    def unload_backend(self):
+        """Unload the current backend and its corresponding database environment."""
+        from aiida.backends import BACKEND_DJANGO, BACKEND_SQLA
+        from aiida.common import ConfigurationError
+
+        profile = self.get_profile()
+        backend = profile.database_backend
+
+        if backend == BACKEND_DJANGO:
+            from aiida.backends.djsite.utils import unload_dbenv
+            unload_backend = unload_dbenv
+        elif backend == BACKEND_SQLA:
+            from aiida.backends.sqlalchemy.utils import unload_dbenv
+            unload_backend = unload_dbenv
+        else:
+            raise ConfigurationError('Invalid backend type {} in profile: {}'.format(backend, profile.name))
+
+        unload_backend()
+        self._backend = None
+
     def _load_backend(self, schema_check=True):
         """Load the backend for the currently configured profile and return it.
 

--- a/aiida/orm/implementation/sqlalchemy/backend.py
+++ b/aiida/orm/implementation/sqlalchemy/backend.py
@@ -119,7 +119,7 @@ class SqlaBackend(SqlBackend[base.Base]):
         """
         from aiida.backends import sqlalchemy as sa
         try:
-            connection = sa.engine.raw_connection()
+            connection = sa.ENGINE.raw_connection()
             yield connection.cursor()
         finally:
             self.get_connection().close()
@@ -143,4 +143,4 @@ class SqlaBackend(SqlBackend[base.Base]):
         :return: the SQLA database connection
         """
         from aiida.backends import sqlalchemy as sa
-        return sa.engine.raw_connection()
+        return sa.ENGINE.raw_connection()


### PR DESCRIPTION
Fixes #2810 and fixes #2811 

This tackles two problems that were brought to light by the changes made to bring JSONB to Django and use Aldjemy to dynamically generate SqlAlchemy models for the QueryBuilder. Essentially we discovered that when a profile is switched, the database environment is not properly reset. This experimental functionality was added recently and is only being used to make running unittests for `verdi quicksetup/setup` within the normal test framework possible. To do so, a new AiiDA instance has to be generated as well as swapping the profile from the generic test session one, to one that is created on the fly by the setup commands. We realized that the incorrect backend was used for the commands, which is handled by the first commit. But fixing this revealed the more serious problem. When swapping profiles, existing database connections are not properly reset, causing the supposedly isolated test to use the wrong (i.e. global test session connection). This is now fixed for SqlAlchemy, but the required functionality of `unload_dbenv` is not yet implemented for Django. This will be taken care of in issue #2813 .