### PR TITLE
Remove default dynamicity of `WorkChain` port namespaces

### DIFF
--- a/.ci/workchains.py
+++ b/.ci/workchains.py
@@ -65,6 +65,7 @@ class SerializeWorkChain(WorkChain):
         )
 
         spec.outline(cls.echo)
+        spec.outputs.dynamic = True
 
     def echo(self):
         self.out('output', self.inputs.test)

--- a/aiida/backends/tests/engine/test_work_chain.py
+++ b/aiida/backends/tests/engine/test_work_chain.py
@@ -164,7 +164,7 @@ class PotentialFailureWorkChain(WorkChain):
         spec.input('through_exit_code', valid_type=Bool, default=Bool(False))
         spec.exit_code(cls.EXIT_STATUS, 'EXIT_STATUS', cls.EXIT_MESSAGE)
         spec.outline(if_(cls.should_return_out_of_outline)(return_(cls.EXIT_STATUS)), cls.failure, cls.success)
-        spec.output('optional', required=False)
+        spec.output(cls.OUTPUT_LABEL, required=False)
 
     def should_return_out_of_outline(self):
         return self.inputs.through_return.value
@@ -415,6 +415,7 @@ class TestWorkchain(AiidaTestCase):
             def define(cls, spec):
                 super(ReturnA, cls).define(spec)
                 spec.outline(cls.result)
+                spec.outputs.dynamic = True
 
             def result(self):
                 self.out('res', A)
@@ -425,6 +426,7 @@ class TestWorkchain(AiidaTestCase):
             def define(cls, spec):
                 super(ReturnB, cls).define(spec)
                 spec.outline(cls.result)
+                spec.outputs.dynamic = True
 
             def result(self):
                 self.out('res', B)
@@ -549,7 +551,6 @@ class TestWorkchain(AiidaTestCase):
                 return ToContext(subwc=self.submit(SubWorkChain))
 
             def check(self):
-                pass
                 assert self.ctx.subwc.outputs.value == Int(5)
 
         class SubWorkChain(WorkChain):
@@ -558,6 +559,7 @@ class TestWorkchain(AiidaTestCase):
             def define(cls, spec):
                 super(SubWorkChain, cls).define(spec)
                 spec.outline(cls.do_run)
+                spec.outputs.dynamic = True
 
             def do_run(self):
                 self.out("value", Int(5).store())
@@ -588,6 +590,7 @@ class TestWorkchain(AiidaTestCase):
             def define(cls, spec):
                 super(SubWorkChain, cls).define(spec)
                 spec.outline(cls.do_run)
+                spec.outputs.dynamic = True
 
             def do_run(self):
                 self.out('value', node)
@@ -666,6 +669,7 @@ class TestWorkchain(AiidaTestCase):
             def define(cls, spec):
                 super(SimpleWc, cls).define(spec)
                 spec.outline(cls.result)
+                spec.outputs.dynamic = True
 
             def result(self):
                 self.out('result', val)

--- a/aiida/backends/tests/test_query.py
+++ b/aiida/backends/tests/test_query.py
@@ -134,7 +134,7 @@ class TestQueryBuilder(AiidaTestCase):
                 spec.input('through_exit_code', valid_type=orm.Bool, default=orm.Bool(False))
                 spec.exit_code(cls.EXIT_STATUS, 'EXIT_STATUS', cls.EXIT_MESSAGE)
                 spec.outline(if_(cls.should_return_out_of_outline)(return_(cls.EXIT_STATUS)), cls.failure, cls.success)
-                spec.output('optional', required=False)
+                spec.output(cls.OUTPUT_LABEL, required=False)
 
             def should_return_out_of_outline(self):
                 return self.inputs.through_return.value

--- a/aiida/engine/processes/workchains/workchain.py
+++ b/aiida/engine/processes/workchains/workchain.py
@@ -48,14 +48,6 @@ class WorkChain(Process):
     _STEPPER_STATE = 'stepper_state'
     _CONTEXT = 'CONTEXT'
 
-    @classmethod
-    def define(cls, spec):
-        super(WorkChain, cls).define(spec)
-        # For now workchains can accept any input and emit any output
-        # If this changes in the future the spec should be updated here.
-        spec.inputs.dynamic = True
-        spec.outputs.dynamic = True
-
     def __init__(self, inputs=None, logger=None, runner=None, enable_persistence=True):
         """Construct the instance only if it is a sub class of `WorkChain` otherwise raise `InvalidOperation`."""
         if self.__class__ == WorkChain:

--- a/docs/source/concepts/workflows.rst
+++ b/docs/source/concepts/workflows.rst
@@ -125,7 +125,7 @@ If we were to reimplement our work function solution of the simple example probl
 
 Don't be intimidated by all the code in this snippet.
 The point of this example is not to explain the exact syntax, which will be done in greater detail in the :ref:`advanced workflows<working_workchains>` section, but to merely introduce the concept of the work chain.
-The core attributes of a work chain are defined by its :ref:`process specification<working_process_spec>` which is setup in the :py:meth:`~aiida.engine.processes.workchains.workchain.WorkChain.define` method.
+The core attributes of a work chain are defined by its :ref:`process specification<working_process_spec>` which is setup in the :py:meth:`~aiida.engine.processes.process.Process.define` method.
 The only thing you need to notice here is that it defines the *inputs* that the work chain takes, its logical *outline* and the *outputs* that it will produce.
 The steps of the outline are implemented as class methods of the work chain.
 The ``add`` step will add the first two integers and store the sum temporarily in the :ref:`context<working_workchain_context>`.


### PR DESCRIPTION
Fixes #2822 

This was already removed recently for the `Process` base class but was
overridden by the `WorkChain` class. Given that having the input and
output port namespace can lead to unexpected behavior for novice users,
it was decided to have them non-dynamic by default.