### PR TITLE
Forward `submit` to `run` for `dry_run=True`

### DIFF
--- a/aiida/backends/tests/engine/test_launch.py
+++ b/aiida/backends/tests/engine/test_launch.py
@@ -11,10 +11,10 @@ from __future__ import division
 from __future__ import print_function
 from __future__ import absolute_import
 
+from aiida import orm
 from aiida.backends.testbase import AiidaTestCase
 from aiida.common import exceptions
-from aiida.engine import launch, run, run_get_node, run_get_pk, Process, WorkChain, calcfunction
-from aiida.orm import Int, WorkChainNode, CalcFunctionNode
+from aiida.engine import launch, Process, WorkChain, calcfunction
 
 
 @calcfunction
@@ -27,13 +27,13 @@ class AddWorkChain(WorkChain):
     @classmethod
     def define(cls, spec):
         super(AddWorkChain, cls).define(spec)
-        spec.input('a', valid_type=Int)
-        spec.input('b', valid_type=Int)
+        spec.input('a', valid_type=orm.Int)
+        spec.input('b', valid_type=orm.Int)
         spec.outline(cls.add)
-        spec.output('result', valid_type=Int)
+        spec.output('result', valid_type=orm.Int)
 
     def add(self):
-        self.out('result', Int(self.inputs.a + self.inputs.b).store())
+        self.out('result', orm.Int(self.inputs.a + self.inputs.b).store())
 
 
 class TestLaunchers(AiidaTestCase):
@@ -41,8 +41,8 @@ class TestLaunchers(AiidaTestCase):
     def setUp(self):
         super(TestLaunchers, self).setUp()
         self.assertIsNone(Process.current())
-        self.a = Int(1)
-        self.b = Int(2)
+        self.a = orm.Int(1)
+        self.b = orm.Int(2)
         self.result = 3
 
     def tearDown(self):
@@ -50,30 +50,30 @@ class TestLaunchers(AiidaTestCase):
         self.assertIsNone(Process.current())
 
     def test_calcfunction_run(self):
-        result = run(add, a=self.a, b=self.b)
+        result = launch.run(add, a=self.a, b=self.b)
         self.assertEquals(result, self.result)
 
     def test_calcfunction_run_get_node(self):
-        result, node = run_get_node(add, a=self.a, b=self.b)
+        result, node = launch.run_get_node(add, a=self.a, b=self.b)
         self.assertEquals(result, self.result)
-        self.assertTrue(isinstance(node, CalcFunctionNode))
+        self.assertTrue(isinstance(node, orm.CalcFunctionNode))
 
     def test_calcfunction_run_get_pk(self):
-        result, pk = run_get_pk(add, a=self.a, b=self.b)
+        result, pk = launch.run_get_pk(add, a=self.a, b=self.b)
         self.assertEquals(result, self.result)
         self.assertTrue(isinstance(pk, int))
 
     def test_workchain_run(self):
-        result = run(AddWorkChain, a=self.a, b=self.b)
+        result = launch.run(AddWorkChain, a=self.a, b=self.b)
         self.assertEquals(result['result'], self.result)
 
     def test_workchain_run_get_node(self):
-        result, node = run_get_node(AddWorkChain, a=self.a, b=self.b)
+        result, node = launch.run_get_node(AddWorkChain, a=self.a, b=self.b)
         self.assertEquals(result['result'], self.result)
-        self.assertTrue(isinstance(node, WorkChainNode))
+        self.assertTrue(isinstance(node, orm.WorkChainNode))
 
     def test_workchain_run_get_pk(self):
-        result, pk = run_get_pk(AddWorkChain, a=self.a, b=self.b)
+        result, pk = launch.run_get_pk(AddWorkChain, a=self.a, b=self.b)
         self.assertEquals(result['result'], self.result)
         self.assertTrue(isinstance(pk, int))
 
@@ -81,22 +81,22 @@ class TestLaunchers(AiidaTestCase):
         builder = AddWorkChain.get_builder()
         builder.a = self.a
         builder.b = self.b
-        result = run(builder)
+        result = launch.run(builder)
         self.assertEquals(result['result'], self.result)
 
     def test_workchain_builder_run_get_node(self):
         builder = AddWorkChain.get_builder()
         builder.a = self.a
         builder.b = self.b
-        result, node = run_get_node(builder)
+        result, node = launch.run_get_node(builder)
         self.assertEquals(result['result'], self.result)
-        self.assertTrue(isinstance(node, WorkChainNode))
+        self.assertTrue(isinstance(node, orm.WorkChainNode))
 
     def test_workchain_builder_run_get_pk(self):
         builder = AddWorkChain.get_builder()
         builder.a = self.a
         builder.b = self.b
-        result, pk = run_get_pk(builder)
+        result, pk = launch.run_get_pk(builder)
         self.assertEquals(result['result'], self.result)
         self.assertTrue(isinstance(pk, int))
 
@@ -104,3 +104,39 @@ class TestLaunchers(AiidaTestCase):
         """Verify that submitting with `store_provenance=False` raises."""
         with self.assertRaises(exceptions.InvalidOperation):
             launch.submit(AddWorkChain, a=self.a, b=self.b, metadata={'store_provenance': False})
+
+    def test_launchers_dry_run(self):
+        """All launchers should work with `dry_run=True`, even `submit` which forwards to `run`."""
+        from aiida.plugins import CalculationFactory
+
+        ArithmeticAddCalculation = CalculationFactory('arithmetic.add')
+
+        code = orm.Code(
+            input_plugin_name='arithmetic.add',
+            remote_computer_exec=[self.computer, '/bin/true'])
+
+        inputs = {
+            'code': code,
+            'x': orm.Int(1),
+            'y': orm.Int(1),
+            'metadata': {
+                'dry_run': True,
+                'options': {
+                    'resources': {'num_machines': 1, 'num_mpiprocs_per_machine': 1}
+                }
+            }
+        }
+
+        result = launch.run(ArithmeticAddCalculation, **inputs)
+        self.assertEqual(result, {})
+
+        result, pk = launch.run_get_pk(ArithmeticAddCalculation, **inputs)
+        self.assertEqual(result, {})
+        self.assertIsInstance(pk, int)
+
+        result, node = launch.run_get_node(ArithmeticAddCalculation, **inputs)
+        self.assertEqual(result, {})
+        self.assertIsInstance(node, orm.CalcJobNode)
+
+        node = launch.submit(ArithmeticAddCalculation, **inputs)
+        self.assertIsInstance(node, orm.CalcJobNode)

--- a/aiida/engine/launch.py
+++ b/aiida/engine/launch.py
@@ -87,6 +87,12 @@ def submit(process, **inputs):
 
     process = instantiate_process(runner, process, **inputs)
 
+    # If a dry run is requested, simply forward to `run`, because it is not compatible with `submit`. We choose for this
+    # instead of raising, because in this way the user does not have to change the launcher when testing.
+    if process.metadata.get('dry_run', False):
+        _, node = run_get_node(process)
+        return node
+
     if not process.metadata.store_provenance:
         raise InvalidOperation('cannot submit a process with `store_provenance=False`')
 

--- a/aiida/engine/runners.py
+++ b/aiida/engine/runners.py
@@ -154,6 +154,9 @@ class Runner(object):  # pylint: disable=useless-object-inheritance
         if not process.metadata.store_provenance:
             raise exceptions.InvalidOperation('cannot submit a process with `store_provenance=False`')
 
+        if process.metadata.get('dry_run', False):
+            raise exceptions.InvalidOperation('cannot submit a process from within another with `dry_run=True`')
+
         if self._rmq_submit:
             self.persister.save_checkpoint(process)
             process.close()


### PR DESCRIPTION
Fixes #2823 

Typically one will run `dry_run=True` in combination with
`store_provenance=False`, however, that is required for `submit` to work
as it needs to keep a record in the database to communicate it to other
workers. Instead of forbidding `submit` to be used with a dry run, we
simply forward internally to `run`. This way the user does not have to
switch the launcher between testing with dry runs and actual submissions.