### PR TITLE
Require `store_provenance=True` in `submit` or raise

### DIFF
--- a/aiida/backends/tests/engine/test_launch.py
+++ b/aiida/backends/tests/engine/test_launch.py
@@ -12,7 +12,8 @@ from __future__ import print_function
 from __future__ import absolute_import
 
 from aiida.backends.testbase import AiidaTestCase
-from aiida.engine import run, run_get_node, run_get_pk, Process, WorkChain, calcfunction
+from aiida.common import exceptions
+from aiida.engine import launch, run, run_get_node, run_get_pk, Process, WorkChain, calcfunction
 from aiida.orm import Int, WorkChainNode, CalcFunctionNode
 
 
@@ -98,3 +99,8 @@ class TestLaunchers(AiidaTestCase):
         result, pk = run_get_pk(builder)
         self.assertEquals(result['result'], self.result)
         self.assertTrue(isinstance(pk, int))
+
+    def test_submit_store_provenance_false(self):
+        """Verify that submitting with `store_provenance=False` raises."""
+        with self.assertRaises(exceptions.InvalidOperation):
+            launch.submit(AddWorkChain, a=self.a, b=self.b, metadata={'store_provenance': False})

--- a/aiida/engine/launch.py
+++ b/aiida/engine/launch.py
@@ -71,6 +71,8 @@ def submit(process, **inputs):
     .. warning: this should not be used within another process. Instead, there one should use the `submit` method of
         the wrapping process itself, i.e. use `self.submit`.
 
+    .. warning: submission of processes requires `store_provenance=True`
+
     :param process: the process class to submit
     :param inputs: the inputs to be passed to the process
     :return: the calculation node of the process
@@ -84,6 +86,10 @@ def submit(process, **inputs):
     controller = manager.get_manager().get_process_controller()
 
     process = instantiate_process(runner, process, **inputs)
+
+    if not process.metadata.store_provenance:
+        raise InvalidOperation('cannot submit a process with `store_provenance=False`')
+
     runner.persister.save_checkpoint(process)
     process.close()
 

--- a/aiida/engine/runners.py
+++ b/aiida/engine/runners.py
@@ -19,6 +19,7 @@ import tornado.ioloop
 
 import plumpy
 
+from aiida.common import exceptions
 from aiida.orm import load_node
 from .processes import futures
 from .processes.calcjobs import manager
@@ -149,6 +150,9 @@ class Runner(object):  # pylint: disable=useless-object-inheritance
         assert not self._closed
 
         process = instantiate_process(self, process, *args, **inputs)
+
+        if not process.metadata.store_provenance:
+            raise exceptions.InvalidOperation('cannot submit a process with `store_provenance=False`')
 
         if self._rmq_submit:
             self.persister.save_checkpoint(process)


### PR DESCRIPTION
Fixes #2826 

The current design of submitting processes, requires them to be stored
in the database as the state is stored as a checkpoint on the node. This
means that allowing `store_provenance=False` is non-sensical and will
lead to unexpected and cryptic errors. Instead we check for this value
and raise when set to False in combination with `submit`.