### PR TITLE
Remove usage of `aiida.cmdline.utils.echo` from non CLI code

### DIFF
--- a/aiida/cmdline/commands/cmd_graph.py
+++ b/aiida/cmdline/commands/cmd_graph.py
@@ -11,6 +11,7 @@
 from __future__ import division
 from __future__ import print_function
 from __future__ import absolute_import
+
 import click
 
 from aiida.cmdline.commands.cmd_verdi import verdi
@@ -31,36 +32,38 @@ def verdi_graph():
 @click.option(
     '-a',
     '--ancestor-depth',
-    help="The maximum depth when recursing upwards, if not set it will recurse to the end",
+    help='The maximum depth when recursing upwards, if not set it will recurse to the end.',
     type=click.IntRange(min=0))
 @click.option(
     '-d',
     '--descendant-depth',
-    help="The maximum depth when recursing through the descendants, if not set it will recurse to the end",
+    help='The maximum depth when recursing through the descendants, if not set it will recurse to the end',
     type=click.IntRange(min=0))
-@click.option('-o', '--outputs', is_flag=True, help="Always show all outputs of a calculation")
-@click.option('-i', '--inputs', is_flag=True, help="Always show all inputs of a calculation")
+@click.option('-o', '--outputs', is_flag=True, help='Always show all outputs of a calculation.')
+@click.option('-i', '--inputs', is_flag=True, help='Always show all inputs of a calculation.')
 @click.option(
     '-f',
     '--output-format',
-    help="The output format, something that can be recognized by graphviz"
-    "(see http://www.graphviz.org/doc/info/output.html)",
+    help='The output format, something that can be recognized by graphviz'
+    '(see http://www.graphviz.org/doc/info/output.html).',
     default='dot')
 @decorators.with_dbenv()
 def generate(root_node, ancestor_depth, descendant_depth, outputs, inputs, output_format):
-    """
-    Generate a graph from a given ROOT_NODE user-specified by its pk.
-    """
+    """Generate a graph for a given ROOT_NODE."""
     from aiida.tools.visualization.graphviz import draw_graph
 
-    exit_status, output_file_name = draw_graph(
-        root_node,
-        ancestor_depth=ancestor_depth,
-        descendant_depth=descendant_depth,
-        image_format=output_format,
-        include_calculation_inputs=inputs,
-        include_calculation_outputs=outputs)
+    try:
+        exit_status, output_file_name = draw_graph(
+            root_node,
+            ancestor_depth=ancestor_depth,
+            descendant_depth=descendant_depth,
+            image_format=output_format,
+            include_calculation_inputs=inputs,
+            include_calculation_outputs=outputs)
+    except OSError as exception:
+        echo.echo_critical(str(exception))
+
     if exit_status:
-        echo.echo_critical("Failed to generate graph")
+        echo.echo_critical('Failed to generate graph')
     else:
-        echo.echo_success("Output file is {}".format(output_file_name))
+        echo.echo_success('Output file is {}'.format(output_file_name))

--- a/aiida/orm/groups.py
+++ b/aiida/orm/groups.py
@@ -15,7 +15,6 @@ from __future__ import absolute_import
 from enum import Enum
 import six
 
-from aiida.cmdline.utils import echo
 from aiida.common import exceptions
 from aiida.common.lang import type_check
 from aiida.manage.manager import get_manager
@@ -67,7 +66,7 @@ class Group(entities.Entity):
                 kwargs['type_string'] = kwargs.pop('type')
                 warnings.warn('type is deprecated, use type_string instead', DeprecationWarning)  # pylint: disable=no-member
             if not label:
-                echo.echo_critical("Group label must be provided")
+                raise ValueError('Group label must be provided')
 
             filters = {'label': label}
 
@@ -131,7 +130,7 @@ class Group(entities.Entity):
             type_string = type
             warnings.warn('type is deprecated, use type_string instead', DeprecationWarning)  # pylint: disable=no-member
         if not label:
-            echo.echo_critical("Group label must be provided")
+            raise ValueError('Group label must be provided')
 
         # Check that chosen type_string is allowed
         if not isinstance(type_string, six.string_types):

--- a/aiida/tools/visualization/graphviz.py
+++ b/aiida/tools/visualization/graphviz.py
@@ -202,8 +202,9 @@ def draw_graph(origin_node,
     try:
         exit_code = subprocess.call(['dot', '-T', image_format, fname, '-o', output_file_name])
     except OSError:
-        from aiida.cmdline.utils import echo
-        echo.echo_critical('Operating system error - perhaps Graphviz is not installed?')
+        raise OSError('call to `dot` failed: perhaps graphviz is not installed?')
+
     # cleaning up by removing the temporary file
     os.remove(fname)
+
     return exit_code, output_file_name

--- a/docs/source/verdi/verdi_user_guide.rst
+++ b/docs/source/verdi/verdi_user_guide.rst
@@ -445,7 +445,7 @@ Below is a list with all available subcommands.
       --help  Show this message and exit.
 
     Commands:
-      generate  Generate a graph from a given ROOT_NODE user-specified by its...
+      generate  Generate a graph for a given ROOT_NODE.
 
 
 .. _verdi_group:


### PR DESCRIPTION
Fixes #2819 

The `echo` functions should only be used for code that is directly
called in command line interface utilities. Internal code should simply
communicate by throwing exceptions.