### PR TITLE
Update dependency requirement `plumpy==0.14.0`

### DIFF
--- a/aiida/backends/tests/engine/test_process_spec.py
+++ b/aiida/backends/tests/engine/test_process_spec.py
@@ -35,19 +35,19 @@ class TestProcessSpec(AiidaTestCase):
         """Test a process spec with dynamic input enabled."""
         node = Node()
         data = Data()
-        self.assertIsNotNone(self.spec.validate_inputs({'key': 'foo'}))
-        self.assertIsNotNone(self.spec.validate_inputs({'key': 5}))
-        self.assertIsNotNone(self.spec.validate_inputs({'key': node}))
-        self.assertIsNone(self.spec.validate_inputs({'key': data}))
+        self.assertIsNotNone(self.spec.inputs.validate({'key': 'foo'}))
+        self.assertIsNotNone(self.spec.inputs.validate({'key': 5}))
+        self.assertIsNotNone(self.spec.inputs.validate({'key': node}))
+        self.assertIsNone(self.spec.inputs.validate({'key': data}))
 
     def test_dynamic_output(self):
         """Test a process spec with dynamic output enabled."""
         node = Node()
         data = Data()
-        self.assertIsNotNone(self.spec.validate_outputs({'key': 'foo'}))
-        self.assertIsNotNone(self.spec.validate_outputs({'key': 5}))
-        self.assertIsNotNone(self.spec.validate_outputs({'key': node}))
-        self.assertIsNone(self.spec.validate_outputs({'key': data}))
+        self.assertIsNotNone(self.spec.outputs.validate({'key': 'foo'}))
+        self.assertIsNotNone(self.spec.outputs.validate({'key': 5}))
+        self.assertIsNotNone(self.spec.outputs.validate({'key': node}))
+        self.assertIsNone(self.spec.outputs.validate({'key': data}))
 
     def test_exit_code(self):
         """Test the definition of error codes through the ProcessSpec."""

--- a/docs/requirements_for_rtd.txt
+++ b/docs/requirements_for_rtd.txt
@@ -41,7 +41,7 @@ passlib==1.7.1
 pg8000<1.13.0
 pgtest==1.2.0
 pika==1.0.0
-plumpy==0.13.1
+plumpy==0.14.0
 psutil==5.5.1
 pyblake2==1.1.2; python_version<'3.6'
 pymatgen<=2018.12.12

--- a/environment.yml
+++ b/environment.yml
@@ -31,7 +31,7 @@ dependencies:
 - psycopg2==2.8
 - paramiko==2.4.2
 - ipython>=4.0,<6.0
-- plumpy==0.13.1
+- plumpy==0.14.0
 - kiwipy[rmq]==0.5.0
 - pika==1.0.0
 - circus==0.15.0

--- a/setup.json
+++ b/setup.json
@@ -43,7 +43,7 @@
     "psycopg2-binary==2.8",
     "paramiko==2.4.2",
     "ipython>=4.0,<6.0",
-    "plumpy==0.13.1",
+    "plumpy==0.14.0",
     "kiwipy[rmq]==0.5.0",
     "pika==1.0.0",
     "circus==0.15.0",


### PR DESCRIPTION
Fixes #2839 

This version fixes two bugs in process port validation.