### PR TITLE
Update dependencies `Jinja2` and `SqlAlchemy` for vulnerabilities

### DIFF
--- a/aiida/backends/sqlalchemy/migrations/versions/1b8ed3425af9_remove_legacy_workflows.py
+++ b/aiida/backends/sqlalchemy/migrations/versions/1b8ed3425af9_remove_legacy_workflows.py
@@ -178,8 +178,7 @@ def downgrade():
         sa.ForeignKeyConstraint(['dbworkflowstep_id'], [u'db_dbworkflowstep.id'],
                                 name=u'db_dbworkflowstep_calculations_dbworkflowstep_id_fkey'),
         sa.PrimaryKeyConstraint('id', name=u'db_dbworkflowstep_calculations_pkey'),
-        sa.UniqueConstraint(
-            'dbworkflowstep_id', 'dbnode_id', name=u'db_dbworkflowstep_calculations_dbworkflowstep_id_dbnode_id_key'))
+        sa.UniqueConstraint('dbworkflowstep_id', 'dbnode_id', name=u'db_dbworkflowstep_calculations_id_dbnode_id_key'))
     op.create_table(
         'db_dbworkflowstep_sub_workflows', sa.Column('id', sa.INTEGER(), autoincrement=True, nullable=False),
         sa.Column('dbworkflowstep_id', sa.INTEGER(), autoincrement=False, nullable=True),
@@ -190,6 +189,4 @@ def downgrade():
                                 name=u'db_dbworkflowstep_sub_workflows_dbworkflowstep_id_fkey'),
         sa.PrimaryKeyConstraint('id', name=u'db_dbworkflowstep_sub_workflows_pkey'),
         sa.UniqueConstraint(
-            'dbworkflowstep_id',
-            'dbworkflow_id',
-            name=u'db_dbworkflowstep_sub_workflows_dbworkflowstep_id_dbworkflow__key'))
+            'dbworkflowstep_id', 'dbworkflow_id', name=u'db_dbworkflowstep_sub_workflows_id_dbworkflow__key'))

--- a/aiida/backends/sqlalchemy/migrations/versions/e15ef2630a1b_initial_schema.py
+++ b/aiida/backends/sqlalchemy/migrations/versions/e15ef2630a1b_initial_schema.py
@@ -10,7 +10,7 @@
 """Initial schema
 
 Revision ID: e15ef2630a1b
-Revises: 
+Revises:
 Create Date: 2017-06-28 17:12:23.327195
 
 """
@@ -189,7 +189,7 @@ def upgrade():
     sa.ForeignKeyConstraint(['dbnode_id'], [u'db_dbnode.id'], name=u'db_dbworkflowstep_calculations_dbnode_id_fkey'),
     sa.ForeignKeyConstraint(['dbworkflowstep_id'], [u'db_dbworkflowstep.id'], name=u'db_dbworkflowstep_calculations_dbworkflowstep_id_fkey'),
     sa.PrimaryKeyConstraint('id', name=u'db_dbworkflowstep_calculations_pkey'),
-    sa.UniqueConstraint('dbworkflowstep_id', 'dbnode_id', name=u'db_dbworkflowstep_calculations_dbworkflowstep_id_dbnode_id_key')
+    sa.UniqueConstraint('dbworkflowstep_id', 'dbnode_id', name=u'db_dbworkflowstep_calculations_id_dbnode_id_key')
     )
     op.create_table('db_dbpath',
     sa.Column('id', sa.INTEGER(), nullable=False),
@@ -257,7 +257,7 @@ def upgrade():
     sa.ForeignKeyConstraint(['dbworkflow_id'], [u'db_dbworkflow.id'], name=u'db_dbworkflowstep_sub_workflows_dbworkflow_id_fkey'),
     sa.ForeignKeyConstraint(['dbworkflowstep_id'], [u'db_dbworkflowstep.id'], name=u'db_dbworkflowstep_sub_workflows_dbworkflowstep_id_fkey'),
     sa.PrimaryKeyConstraint('id', name=u'db_dbworkflowstep_sub_workflows_pkey'),
-    sa.UniqueConstraint('dbworkflowstep_id', 'dbworkflow_id', name=u'db_dbworkflowstep_sub_workflo_dbworkflowstep_id_dbworkflow__key')
+    sa.UniqueConstraint('dbworkflowstep_id', 'dbworkflow_id', name=u'db_dbworkflowstep_sub_workflows_id_dbworkflow__key')
     )
     # I get the session using the alembic connection
     # (Keep in mind that alembic uses the AiiDA SQLA

--- a/docs/requirements_for_rtd.txt
+++ b/docs/requirements_for_rtd.txt
@@ -4,7 +4,7 @@ Flask-HTTPAuth==3.2.4
 Flask-RESTful==0.3.7
 Flask-SQLAlchemy==2.3.2
 Flask==1.0.2
-Jinja2==2.10
+Jinja2==2.10.1
 MarkupSafe==1.1.1
 PyCifRW==4.2.1; python_version < '3'
 PyCifRW==4.4; python_version >= '3'
@@ -12,7 +12,7 @@ PyMySQL==0.9.3
 PyYAML==3.13
 Pygments==2.3.1
 SQLAlchemy-Utils==0.33.11
-SQLAlchemy==1.2.18
+SQLAlchemy==1.3.3
 Sphinx==1.8.4
 aldjemy==0.9.1
 alembic==1.0.7

--- a/environment.yml
+++ b/environment.yml
@@ -16,7 +16,7 @@ dependencies:
 - psutil==5.5.1
 - mock==2.0.0
 - numpy==1.16.1
-- SQLAlchemy==1.2.18
+- SQLAlchemy==1.3.3
 - SQLAlchemy-Utils==0.33.11
 - alembic==1.0.7
 - aldjemy==0.9.1

--- a/setup.json
+++ b/setup.json
@@ -28,7 +28,7 @@
     "psutil==5.5.1",
     "mock==2.0.0",
     "numpy==1.16.1",
-    "SQLAlchemy==1.2.18",
+    "SQLAlchemy==1.3.3",
     "SQLAlchemy-Utils==0.33.11",
     "alembic==1.0.7",
     "aldjemy==0.9.1",
@@ -77,7 +77,7 @@
       "Sphinx==1.8.4",
       "Pygments==2.3.1",
       "docutils==0.14",
-      "Jinja2==2.10",
+      "Jinja2==2.10.1",
       "MarkupSafe==1.1.1",
       "sphinx-rtd-theme==0.4.3",
       "sphinxcontrib-contentui==0.2.2"


### PR DESCRIPTION
Fixes #2842 

When upgrading `SqlAlchemy` the migration tests started failing because
the migration that drops the legacy workflow tables in the downgrade
reinstates a uniqueness constraint that exceeds the 63 maximum character
limit. Since these tables are dropped anyway and only created in the
downgrade for migration testing purposes, we should be safe in changing
the name of the identifier.