### PR TITLE
Fix verdi quicksetup on ubuntu 

### DIFF
--- a/aiida/backends/tests/utils/configuration.py
+++ b/aiida/backends/tests/utils/configuration.py
@@ -25,6 +25,7 @@ def create_mock_profile(name, repository_dirpath=None, **kwargs):
     :param repository_dirpath: optional absolute path to use as the base for the repository path
     """
     from aiida.manage.configuration import get_config, Profile
+    from aiida.manage.external.postgres import DEFAULT_DBINFO
 
     if repository_dirpath is None:
         config = get_config()
@@ -34,9 +35,9 @@ def create_mock_profile(name, repository_dirpath=None, **kwargs):
         'default_user': kwargs.pop('default_user', 'dummy@localhost'),
         'database_engine': kwargs.pop('database_engine', 'postgresql_psycopg2'),
         'database_backend': kwargs.pop('database_backend', 'django'),
+        'database_hostname': kwargs.pop('database_hostname', DEFAULT_DBINFO['host']),
+        'database_port': kwargs.pop('database_port', DEFAULT_DBINFO['port']),
         'database_name': kwargs.pop('database_name', name),
-        'database_port': kwargs.pop('database_port', '5432'),
-        'database_hostname': kwargs.pop('database_hostname', 'localhost'),
         'database_username': kwargs.pop('database_username', 'user'),
         'database_password': kwargs.pop('database_password', 'pass'),
         'repository_uri': 'file:///' + os.path.join(repository_dirpath, 'repository_' + name),

--- a/aiida/cmdline/commands/cmd_status.py
+++ b/aiida/cmdline/commands/cmd_status.py
@@ -82,10 +82,9 @@ def verdi_status():
         with Capturing(capture_stderr=True):
 
             postgres = Postgres.from_profile(profile)
-            pg_connected = postgres.try_connect()
 
-        dbinfo = postgres.get_dbinfo()
-        if pg_connected:
+        dbinfo = postgres.dbinfo.copy()
+        if postgres.is_connected:
             print_status(ServiceStatus.UP, 'postgres', "Connected to {}@{}:{}".format(
                 dbinfo['user'], dbinfo['host'], dbinfo['port']))
         else:

--- a/aiida/cmdline/params/options/commands/setup.py
+++ b/aiida/cmdline/params/options/commands/setup.py
@@ -226,10 +226,10 @@ QUICKSETUP_DATABASE_PORT = OverridableOption(
     '--db-port', help='Port to connect to the database.', default=DEFAULT_DBINFO['port'], type=click.INT)
 
 QUICKSETUP_DATABASE_NAME = OverridableOption(
-    '--db-name', help='Name of the database to connect to.', type=click.STRING, callback=get_quicksetup_database_name)
+    '--db-name', help='Name of the database to create.', type=click.STRING, callback=get_quicksetup_database_name)
 
 QUICKSETUP_DATABASE_USERNAME = OverridableOption(
-    '--db-username', help='User name to connect to the database.', type=click.STRING, callback=get_quicksetup_username)
+    '--db-username', help='Name of the database user to create.', type=click.STRING, callback=get_quicksetup_username)
 
 QUICKSETUP_DATABASE_PASSWORD = OverridableOption(
     '--db-password',
@@ -237,6 +237,22 @@ QUICKSETUP_DATABASE_PASSWORD = OverridableOption(
     type=click.STRING,
     hide_input=True,
     callback=get_quicksetup_password)
+
+QUICKSETUP_SUPERUSER_DATABASE_USERNAME = OverridableOption(
+    '--su-db-username', help='User name of the database super user.', type=click.STRING, default=DEFAULT_DBINFO['user'])
+
+QUICKSETUP_SUPERUSER_DATABASE_NAME = OverridableOption(
+    '--su-db-name',
+    help='Name of the template database to connect to as the database superuser.',
+    type=click.STRING,
+    default=DEFAULT_DBINFO['database'])
+
+QUICKSETUP_SUPERUSER_DATABASE_PASSWORD = OverridableOption(
+    '--su-db-password',
+    help='Password to connect as the database superuser.',
+    type=click.STRING,
+    hide_input=True,
+    default=DEFAULT_DBINFO['password'])
 
 QUICKSETUP_REPOSITORY_URI = OverridableOption(
     '--repository',

--- a/aiida/engine/processes/process.py
+++ b/aiida/engine/processes/process.py
@@ -33,7 +33,6 @@ from aiida.common.lang import classproperty, override, protected
 from aiida.common.links import LinkType
 from aiida.common.log import LOG_LEVEL_REPORT
 
-from .. import utils
 from .exit_code import ExitCode
 from .builder import ProcessBuilder
 from .ports import InputPort, OutputPort, PortNamespace, PORT_NAMESPACE_SEPARATOR
@@ -282,10 +281,12 @@ class Process(plumpy.Process):
         # Update the node attributes every time we enter a new state
 
     def on_entered(self, from_state):
+        # pylint: disable=cyclic-import
+        from aiida.engine.utils import set_process_state_change_timestamp
         self.update_node_state(self._state)
         self._save_checkpoint()
         # Update the latest process state change timestamp
-        utils.set_process_state_change_timestamp(self)
+        set_process_state_change_timestamp(self)
         super(Process, self).on_entered(from_state)
 
     @override

--- a/aiida/engine/utils.py
+++ b/aiida/engine/utils.py
@@ -240,9 +240,9 @@ def set_process_state_change_timestamp(process):
     :param process: the Process instance that changed its state
     """
     from aiida.backends.utils import set_global_setting
+    from aiida.common import timezone
     from aiida.common.exceptions import UniquenessError
     from aiida.orm import ProcessNode, CalculationNode, WorkflowNode
-    from aiida.common import timezone
 
     if isinstance(process.node, CalculationNode):
         process_type = 'calculation'

--- a/aiida/manage/configuration/__init__.py
+++ b/aiida/manage/configuration/__init__.py
@@ -82,6 +82,7 @@ def load_config(create=False):
     from .config import Config
     from .migrations import check_and_migrate_config
     from .settings import AIIDA_CONFIG_FOLDER, DEFAULT_CONFIG_FILE_NAME
+    from aiida.manage.external.postgres import DEFAULT_DBINFO
 
     if IN_RT_DOC_MODE:
         # The following is a dummy config.json configuration that it is used for the
@@ -92,10 +93,10 @@ def load_config(create=False):
                 'default': {
                     'AIIDADB_ENGINE': 'postgresql_psycopg2',
                     'AIIDADB_BACKEND': 'django',
-                    'AIIDADB_HOST': 'localhost',
+                    'AIIDADB_HOST': DEFAULT_DBINFO['host'],
+                    'AIIDADB_PORT': DEFAULT_DBINFO['port'],
                     'AIIDADB_NAME': 'aiidadb',
                     'AIIDADB_PASS': '123',
-                    'AIIDADB_PORT': '5432',
                     'default_user_email': 'aiida@epfl.ch',
                     'TIMEZONE': 'Europe/Zurich',
                     'AIIDADB_REPOSITORY_URI': 'file:///repository',

--- a/aiida/manage/configuration/setup.py
+++ b/aiida/manage/configuration/setup.py
@@ -64,11 +64,10 @@ def delete_db(profile, non_interactive=True, verbose=False):
     from aiida.common import json
 
     postgres = Postgres.from_profile(profile, interactive=not non_interactive, quiet=False)
-    postgres.determine_setup()
 
     if verbose:
         echo.echo_info("Parameters used to connect to postgres:")
-        echo.echo(json.dumps(postgres.get_dbinfo(), indent=4))
+        echo.echo(json.dumps(postgres.dbinfo, indent=4))
 
     database_name = profile.database_name
     if not postgres.db_exists(database_name):

--- a/aiida/manage/external/pgsu.py
+++ b/aiida/manage/external/pgsu.py
@@ -1,0 +1,348 @@
+# -*- coding: utf-8 -*-
+"""Connect to an existing PostgreSQL cluster as the `postgres` superuser and execute SQL commands.
+
+Note: Once the API of this functionality has converged, this module should be moved out of aiida-core and into a
+  separate package that can then be tested on multiple OS / postgres setups. Therefore, **please keep this
+  module entirely AiiDA-agnostic**.
+"""
+from __future__ import division
+from __future__ import print_function
+from __future__ import absolute_import
+
+try:
+    import subprocess32 as subprocess
+except ImportError:
+    import subprocess
+
+from enum import IntEnum
+import click
+
+DEFAULT_DBINFO = {
+    'host': 'localhost',
+    'port': 5432,
+    'user': 'postgres',
+    'password': None,
+    'database': 'template1',
+}
+
+
+class PostgresConnectionMode(IntEnum):
+    """Describe mode of connecting to postgres."""
+
+    DISCONNECTED = 0
+    PSYCOPG = 1
+    PSQL = 2
+
+
+class PGSU(object):  # pylint: disable=useless-object-inheritance
+    """
+    Connect to an existing PostgreSQL cluster as the `postgres` superuser and execute SQL commands.
+
+    Tries to use psycopg2 with a fallback to psql subcommands (using ``sudo su`` to run as postgres user).
+
+    Simple Example::
+
+        postgres = PGSU()
+        postgres.execute("CREATE USER testuser PASSWORD 'testpw'")
+
+    Complex Example::
+
+        postgres = PGSU(interactive=True, dbinfo={'port': 5433})
+        postgres.execute("CREATE USER testuser PASSWORD 'testpw'")
+
+    Note: In postgresql
+     * you cannot drop databases you are currently connected to
+     * 'template0' is the unmodifiable template database (which you cannot connect to)
+     * 'template1' is the modifiable template database (which you can connect to)
+    """
+
+    def __init__(self, interactive=False, quiet=True, dbinfo=None, determine_setup=True):
+        """Store postgres connection info.
+
+        :param interactive: use True for verdi commands
+        :param quiet: use False to show warnings/exceptions
+        :param dbinfo: psycopg dictionary containing keys like 'host', 'user', 'port', 'database'
+        :param determine_setup: Whether to determine setup upon instantiation.
+            You may set this to False and use the 'determine_setup()' method instead.
+        """
+        self.interactive = interactive
+        self.quiet = quiet
+        self.connection_mode = PostgresConnectionMode.DISCONNECTED
+
+        self.setup_fail_callback = prompt_db_info if interactive else None
+        self.setup_fail_counter = 0
+        self.setup_max_tries = 1
+
+        self.dbinfo = DEFAULT_DBINFO.copy()
+        if dbinfo is not None:
+            self.dbinfo.update(dbinfo)
+
+        if determine_setup:
+            self.determine_setup()
+
+    def execute(self, command, **kwargs):
+        """Execute postgres command using determined connection mode.
+
+        :param command: A psql command line as a str
+        :param kwargs: will be forwarded to _execute_... function
+        """
+        # Use self.dbinfo as default kwargs, update with provided kwargs
+        kw_copy = self.dbinfo.copy()
+        kw_copy.update(kwargs)
+
+        if self.connection_mode == PostgresConnectionMode.PSYCOPG:  # pylint: disable=no-else-return
+            return _execute_psyco(command, **kw_copy)
+        elif self.connection_mode == PostgresConnectionMode.PSQL:
+            return _execute_psql(command, **kw_copy)
+
+        raise ValueError('Could not connect to postgres.')
+
+    def set_setup_fail_callback(self, callback):
+        """
+        Set a callback to be called when setup cannot be determined automatically
+
+        :param callback: a callable with signature ``callback(interactive, dbinfo)``
+          that returns a ``dbinfo`` dictionary.
+        """
+        self.setup_fail_callback = callback
+
+    def determine_setup(self):
+        """Determine how to connect as the postgres superuser.
+
+        Depending on how postgres is set up, psycopg2 can be used to create dbs and db users,
+        otherwise a subprocess has to be used that executes psql as an os user with appropriate permissions.
+
+        Note: We aim to connect as a superuser (typically 'postgres') with privileges to manipulate (create/drop)
+          databases and database users.
+
+        :returns success: True, if connection could be established.
+        :rtype success: bool
+        """
+        # find out if we run as a postgres superuser or can connect as postgres
+        # This will work on OSX in some setups but not in the default Debian one
+        dbinfo = self.dbinfo.copy()
+
+        for pg_user in set([dbinfo.get('user'), None]):
+            dbinfo['user'] = pg_user
+            if _try_connect_psycopg(**dbinfo):
+                self.dbinfo = dbinfo
+                self.connection_mode = PostgresConnectionMode.PSYCOPG
+                return True
+
+        # This will work for the default Debian postgres setup, assuming that sudo is available to the user
+        # Check if the user can find the sudo command
+        if _sudo_exists():
+            if _try_subcmd(interactive=self.interactive, quiet=self.quiet, **dbinfo):
+                self.dbinfo = dbinfo
+                self.connection_mode = PostgresConnectionMode.PSQL
+                return True
+        elif not self.quiet:
+            click.echo('Warning: Could not find `sudo` for connecting to the database.')
+
+        self.setup_fail_counter += 1
+        return self._no_setup_detected()
+
+    def _no_setup_detected(self):
+        """Print a warning message and calls the failed setup callback
+
+        :returns: False, if no successful try.
+        """
+        message = '\n'.join([
+            'Warning: Unable to autodetect postgres setup - do you know how to access it?',
+        ])
+
+        if not self.quiet:
+            click.echo(message)
+
+        if self.setup_fail_callback and self.setup_fail_counter <= self.setup_max_tries:
+            self.dbinfo = self.setup_fail_callback(self.interactive, self.dbinfo)
+            return self.determine_setup()
+
+        return False
+
+    @property
+    def is_connected(self):
+        return self.connection_mode in (PostgresConnectionMode.PSYCOPG, PostgresConnectionMode.PSQL)
+
+
+def prompt_db_info(interactive, dbinfo):
+    """
+    Prompt interactively for postgres database connection details
+
+    Can be used as a setup fail callback for :py:class:`PGSU`
+
+    :return: dictionary with the following keys: host, port, database, user
+    """
+    if not interactive:
+        return DEFAULT_DBINFO
+
+    access = False
+    while not access:
+        dbinfo_new = {}
+        dbinfo_new['host'] = click.prompt('postgres host', default=dbinfo.get('host'), type=str)
+        dbinfo_new['port'] = click.prompt('postgres port', default=dbinfo.get('port'), type=int)
+        dbinfo_new['user'] = click.prompt('postgres super user', default=dbinfo.get('user'), type=str)
+        dbinfo_new['database'] = click.prompt('database', default=dbinfo.get('database'), type=str)
+        click.echo('')
+        click.echo('Trying to access postgres ...')
+        if _try_connect_psycopg(**dbinfo_new):
+            access = True
+        else:
+            dbinfo_new['password'] = click.prompt(
+                'postgres password of {}'.format(dbinfo_new['user']), hide_input=True, type=str, default='')
+            if not dbinfo_new.get('password'):
+                dbinfo_new.pop('password')
+    return dbinfo_new
+
+
+def _try_connect_psycopg(**kwargs):
+    """
+    try to start a psycopg2 connection.
+
+    :return: True if successful, False otherwise
+    """
+    from psycopg2 import connect
+    success = False
+    try:
+        conn = connect(**kwargs)
+        success = True
+        conn.close()
+    except Exception:  # pylint: disable=broad-except
+        pass
+    return success
+
+
+def _sudo_exists():
+    """
+    Check that the sudo command can be found
+
+    :return: True if successful, False otherwise
+    """
+    try:
+        subprocess.check_output(['sudo', '-V'])
+    except subprocess.CalledProcessError:
+        return False
+    except OSError:
+        return False
+
+    return True
+
+
+def _try_subcmd(**kwargs):
+    """
+    try to run psql in a subprocess.
+
+    :return: True if successful, False otherwise
+    """
+    success = False
+    try:
+        kwargs['stderr'] = subprocess.STDOUT
+        _execute_psql(r'\q', **kwargs)
+        success = True
+    except subprocess.CalledProcessError:
+        pass
+    return success
+
+
+def _execute_psyco(command, **kwargs):
+    """
+    executes a postgres commandline through psycopg2
+
+    :param command: A psql command line as a str
+    :param kwargs: will be forwarded to psycopg2.connect
+    """
+    import psycopg2
+
+    # Note: Ubuntu 18.04 uses "peer" as the default postgres configuration
+    # which allows connections only when the unix user matches the database user.
+    # This restriction no longer applies for IPv4/v6-based connection,
+    # when specifying host=localhost.
+    if kwargs.get('host') is None:
+        kwargs['host'] = 'localhost'
+
+    output = None
+    with psycopg2.connect(**kwargs) as conn:
+        conn.autocommit = True
+        with conn.cursor() as cursor:
+            cursor.execute(command)
+            if cursor.description is not None:
+                output = cursor.fetchall()
+
+    # see http://initd.org/psycopg/docs/usage.html#with-statement
+    conn.close()
+    return output
+
+
+def _execute_psql(command, user='postgres', quiet=True, interactive=False, **kwargs):
+    """
+    Executes an SQL command via ``psql`` as another system user in a subprocess.
+
+    Tries to "become" the user specified in ``kwargs`` (i.e. interpreted as UNIX system user)
+    and run psql in a subprocess.
+
+    :param command: A psql command line as a str
+    :param quiet: If True, don't print warnings.
+    :param interactive: If False, `sudo` won't ask for a password and fail if one is required.
+    :param kwargs: connection details to forward to psql, signature as in psycopg2.connect
+    """
+    option_str = ''
+
+    database = kwargs.pop('database', None)
+    if database:
+        option_str += '-d {}'.format(database)
+    # to do: Forward password to psql; ignore host only when the password is None.  # pylint: disable=fixme
+    kwargs.pop('password', None)
+
+    host = kwargs.pop('host', 'localhost')
+    if host and host != 'localhost':
+        option_str += ' -h {}'.format(host)
+    elif not quiet:
+        click.echo("Warning: Found host 'localhost' but dropping '-h localhost' option for psql " +
+                   "since this may cause psql to switch to password-based authentication.")
+
+    port = kwargs.pop('port', None)
+    if port:
+        option_str += ' -p {}'.format(port)
+
+    user = kwargs.pop('user', 'postgres')
+
+    # Build command line
+    sudo_cmd = ['sudo']
+    if not interactive:
+        sudo_cmd += ['-n']
+    su_cmd = ['su', user, '-c']
+
+    psql_cmd = ['psql {opt} -tc {cmd}'.format(cmd=escape_for_bash(command), opt=option_str)]
+    sudo_su_psql = sudo_cmd + su_cmd + psql_cmd
+    result = subprocess.check_output(sudo_su_psql, **kwargs)
+    result = result.decode('utf-8').strip().split('\n')
+    result = [i for i in result if i]
+
+    return result
+
+
+def escape_for_bash(str_to_escape):
+    """
+    This function takes any string and escapes it in a way that
+    bash will interpret it as a single string.
+
+    Explanation:
+
+    At the end, in the return statement, the string is put within single
+    quotes. Therefore, the only thing that I have to escape in bash is the
+    single quote character. To do this, I substitute every single
+    quote ' with '"'"' which means:
+
+    First single quote: exit from the enclosing single quotes
+
+    Second, third and fourth character: "'" is a single quote character,
+    escaped by double quotes
+
+    Last single quote: reopen the single quote to continue the string
+
+    Finally, note that for python I have to enclose the string '"'"'
+    within triple quotes to make it work, getting finally: the complicated
+    string found below.
+    """
+    escaped_quotes = str_to_escape.replace("'", """'"'"'""")
+    return "'{}'".format(escaped_quotes)

--- a/aiida/manage/fixtures.py
+++ b/aiida/manage/fixtures.py
@@ -158,10 +158,7 @@ class FixtureManager(object):  # pylint: disable=too-many-public-methods,useless
         if not self.db_params:
             self.create_db_cluster()
         self.postgres = Postgres(interactive=False, quiet=True, dbinfo=self.db_params)
-        self.postgres.determine_setup()
-        self.db_params = self.postgres.get_dbinfo()
-        if not self.postgres.pg_execute:
-            raise FixtureError('Could not connect to the test postgres instance')
+        self.db_params = self.postgres.dbinfo.copy()
         self.postgres.create_dbuser(self.db_user, self.db_pass)
         self.postgres.create_db(self.db_user, self.db_name)
         self.__is_running_on_test_db = True

--- a/docs/source/verdi/verdi_user_guide.rst
+++ b/docs/source/verdi/verdi_user_guide.rst
@@ -639,9 +639,14 @@ Below is a list with all available subcommands.
                                       Backend type to use to map the database.
       --db-host TEXT                  Hostname to connect to the database.
       --db-port INTEGER               Port to connect to the database.
-      --db-name TEXT                  Name of the database to connect to.
-      --db-username TEXT              User name to connect to the database.
+      --db-name TEXT                  Name of the database to create.
+      --db-username TEXT              Name of the database user to create.
       --db-password TEXT              Password to connect to the database.
+      --su-db-name TEXT               Name of the template database to connect to
+                                      as the database superuser.
+      --su-db-username TEXT           User name of the database super user.
+      --su-db-password TEXT           Password to connect as the database
+                                      superuser.
       --repository DIRECTORY          Absolute path for the file system
                                       repository.
       --config FILE                   Load option values from configuration file
@@ -742,9 +747,8 @@ Below is a list with all available subcommands.
                                       Backend type to use to map the database.
       --db-host TEXT                  Hostname to connect to the database.
       --db-port INTEGER               Port to connect to the database.
-      --db-name TEXT                  Name of the database to connect to.
-                                      [required]
-      --db-username TEXT              User name to connect to the database.
+      --db-name TEXT                  Name of the database to create.  [required]
+      --db-username TEXT              Name of the database user to create.
                                       [required]
       --db-password TEXT              Password to connect to the database.
                                       [required]


### PR DESCRIPTION
fix #2836 
prepare #2837  

On the default postgres configuration for ubuntu 18.04, both the local IPv4 and IPv6 connections are configured to require a password, while the connection over sockets doesn't (on MacOS 10.14 with postgresql 9.6 both work without password).
We were passing the `-h localhost` flag, which switched to IPv4/IPv6 and thus required the password of the `postgres` user (in addition to the sudo password). We are now no longer doing this when going via the `psql` shell.
Note: When going via `psycopg2`,  you *do* need `host='localhost'` on Ubuntu. `pgsu` is now handling this correctly.

This issue demonstrates how dependent the `verdi quicksetup` functionality is on the details of the postgres setup of the OS. This PR therefore also extracts the core of the `aiida.manage.external.postgres.Postgres` class into into a separate class in the `pgsu.py` module (PGSU for postgres superuser), which only has the purpose to connect to a given DB as the postgres superuser and execute SQL commands. Once the API has converged, this should enable extracting pgsu from aiida-core into a separate package and test this package for a number of OS/postgres-setup combinations.
Work in this has started in https://github.com/ltalirz/pgsu

Further changes:
 * add three new command line options to `verdi quicksetup` in order to allow to configure the `superuser`: 
   - `--su-db-username`
   - `--su-db-name`
   - `--su-db-password`

To decide
 - [ ] whether to change the `DEFAULT_DBINFO` to some explicitly constant construct
 - [ ] tests for the new superuser options?