### PR TITLE
update documentation using systemd unit template

### DIFF
--- a/docs/source/working_with_aiida/scripting.rst
+++ b/docs/source/working_with_aiida/scripting.rst
@@ -106,47 +106,52 @@ executable that is run using AiiDA. A simple example could be::
 
 Daemon as system service
 ------------------------
+
 If you would like the AiiDA daemon to run at startup of your linux system,
 you can set up a 
 `systemd service <https://www.freedesktop.org/software/systemd/man/systemd.service.html>`_
 for it.
 
-Create a file ``aiida-daemon.service`` using the template below, replacing
+Create a file ``aiida-daemon@.service`` using the template below, replacing
 ``{{ venv_dir }}``, ``{{ home_dir }}`` and  ``{{ user }}`` by appropriate
 values::
 
   [Unit]
-  Description=AiiDA daemon service
-  After=network.target
+  Description=AiiDA daemon service for profile %I
+  After=network.target postgresql.service rabbitmq-server.service
   
   [Service]
   Type=forking
-  ExecStart={{ venv_dir }}/bin/verdi daemon start
-  PIDFile={{ home_dir }}/.aiida/daemon/log/celery.pid
+  ExecStart={{ venv_dir }}/bin/verdi -p %i daemon start
+  PIDFile={{ home_dir }}/.aiida/daemon/circus-%i.pid
   # 2s delay to prevent read error on PID file
   ExecStartPost=/bin/sleep 2
   
-  ExecStop={{ venv_dir }}/bin/verdi daemon stop
-  ExecReload={{ venv_dir }}/bin/verdi daemon restart
+  ExecStop={{ venv_dir }}/bin/verdi -p %i daemon stop
+  ExecReload={{ venv_dir }}/bin/verdi -p %i daemon restart
   
   User={{ user }}
   Group={{ user }}
   Restart=on-failure
-  RestartSec=60       # Restart daemon after 1 min if crashes
+  # Restart daemon after 1 min if crashes
+  RestartSec=60
   StandardOutput=syslog
   StandardError=syslog
-  SyslogIdentifier=aiida-daemon
+  SyslogIdentifier=aiida-daemon-%i
   
   [Install]
   WantedBy=multi-user.target
 
-Enable the service like so::
+Install the service like so::
 
-  sudo cp aiida-daemon.service /etc/systemd/system/
+  sudo cp aiida-daemon@.service /etc/systemd/system/
   sudo systemctl daemon-reload
-  sudo systemctl start aiida-daemon.service
+
+Start the AiiDA daemon service for a profile ``profile``::
+
+  sudo systemctl start aiida-daemon@profile.service
 
 After this, the AiiDA daemon should start together with your system. 
 To remove the service again::
 
-  sudo systemctl disable aiida-daemon.service
+  sudo systemctl disable aiida-daemon@profile.service


### PR DESCRIPTION
fix #1434

update systemd service, switching to a systemd unit template that allows
to easily add daemon services per profile.

This template is tested on ubuntu 16.04 and 18.04 in
https://github.com/marvel-nccr/ansible-role-aiida/tree/develop