### PR TITLE
Clean work directory in Jenkins

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -44,6 +44,11 @@ pipeline {
     stages {
         stage('Pre-build') {
             steps {
+                // Clean work dir (often runs reshare the same folder, and it might
+                // contain old data from previous runs - this is particularly 
+                // problematic when a folder is deleted from git but .pyc files
+                // are left in)
+                sh 'git clean -fdx'
                 sh 'sudo /etc/init.d/ssh restart'
                 sh 'sudo chown -R jenkins:jenkins /home/jenkins/.cache/'
                 // (re)start rabbitmq (both to start it or to reload the configuration)
@@ -160,6 +165,7 @@ pipeline {
         always {
             // Some debug stuff
             sh 'whoami ; pwd; echo $TEST_AIIDA_BACKEND'
+	    cleanWs()
         }
         success {
             echo 'The run finished successfully!'


### PR DESCRIPTION
In Jenkins the work directory was not being cleaned.
Besides keeping, in the long term, GBs of old files,
this was problematic for tests because the work
directories are often reused, and this is a problem
e.g. if a folder is deleted on git but .pyc files
are left in.

This commit both runs a clean command from git
before running (so it removes any file that is not
under git control) and also cleans the workspace
directory at the very end of the job to free up space.