### PR TITLE
Fix bug in creation of `SinglefileData` in `retrieve_calculation`

### DIFF
--- a/aiida/engine/daemon/execmanager.py
+++ b/aiida/engine/daemon/execmanager.py
@@ -403,8 +403,7 @@ def _retrieve_singlefiles(job, transport, folder, retrieve_file_list, logger_ext
     singlefiles = []
     for (linkname, subclassname, filename) in singlefile_list:
         SinglefileSubclass = DataFactory(subclassname)
-        singlefile = SinglefileSubclass()
-        singlefile.put_object_from_file(filename)
+        singlefile = SinglefileSubclass(file=filename)
         singlefile.add_incoming(job, link_type=LinkType.CREATE, link_label=linkname)
         singlefiles.append(singlefile)
 


### PR DESCRIPTION
Fixes #2858 

This functionality in the `retrieve_calculation` function of the
calculation job execmanager automatically creates `SinglefileData` nodes
based on the `retrieve_singlefile_list` set on the `CalcJobNode`. The
constructor requires the `file` argument which was not passed. The
constructor will automatically place the file in the repository so the
following call to `put_object_from_file` is superfluous.

P.S.: since we are keeping the feature for now and will just deprecate it, I think it is better to fix the bug now. The documentation where I will need to place the suggested method is not yet there. So I will do the actual deprecation and documentation adaptation at a later point in time