### PR TITLE
Allow global submit from within work functions

### DIFF
--- a/aiida/engine/launch.py
+++ b/aiida/engine/launch.py
@@ -14,6 +14,7 @@ from __future__ import absolute_import
 
 from aiida.common import InvalidOperation
 from aiida.manage import manager
+from .processes.functions import FunctionProcess
 from .processes.process import Process
 from .utils import is_process_function, is_process_scoped, instantiate_process
 
@@ -79,7 +80,9 @@ def submit(process, **inputs):
     """
     assert not is_process_function(process), 'Cannot submit a process function'
 
-    if is_process_scoped():
+    # Submitting from within another process requires `self.submit` unless it is a work function, in which case the
+    # current process in the scope should be an instance of `FunctionProcess`
+    if is_process_scoped() and not isinstance(Process.current(), FunctionProcess):
         raise InvalidOperation('Cannot use top-level `submit` from within another process, use `self.submit` instead')
 
     runner = manager.get_manager().get_runner()


### PR DESCRIPTION
Fixes #2864 

Recently, a limitation was placed on the global `submit` launcher
function and an exception would be raised if it was called from within
the scope of another process, because for this the `self.submit` method
of the process should be used instead. Note that this only applies to
workflow-like processes, since calculation-like processes *cannot* not
even call other processes. So this applies to work functions and work
chains. However, the process instance is not available within the body
of a work function implementation, so one *cannot* do `self.submit` and
in fact the global submitter should be used. Here we update the guard
to exclude work functions from this limitation.