### PR TITLE
Make `verdi import` -G (group) option function as intended.

### DIFF
--- a/aiida/backends/tests/test_export_and_import.py
+++ b/aiida/backends/tests/test_export_and_import.py
@@ -665,6 +665,47 @@ class TestGroups(AiidaTestCase):
         builder.append(orm.Group, filters={'label': {'like': grouplabel + '%'}})
         self.assertEqual(builder.count(), 2)
 
+    @with_temp_dir
+    def test_import_to_group(self, temp_dir):
+        """Test `group` parameter
+        Make sure an unstored Group is stored by the import function, forwarding the Group object.
+        Make sure the Group is correctly handled and used for imported nodes.
+        """
+        from aiida.orm import load_group
+
+        # Create Nodes to export
+        data1 = orm.Data().store()
+        data2 = orm.Data().store()
+        node_uuids = [node.uuid for node in [data1, data2]]
+
+        # Export Nodes
+        filename = os.path.join(temp_dir, "export.aiida")
+        export([data1, data2], outfile=filename, silent=True)
+        self.reset_database()
+
+        # Create Group, do not store
+        group_label = "import_madness"
+        group = orm.Group(label=group_label)
+        group_uuid = group.uuid
+
+        # Try to import to this Group, providing only label - this should fail
+        with self.assertRaises(TypeError, msg="Labels should no longer be passable to `import_data`") as exc:
+            import_data(filename, group=group_label, silent=True)
+        exc = exc.exception
+        self.assertEqual(str(exc), "group must be a Group entity",
+            msg="The error message should be the same for both backends.")
+
+        # Import properly now, providing the Group object
+        import_data(filename, group=group, silent=True)
+
+        # Check Group for content
+        builder = orm.QueryBuilder().append(orm.Group, filters={'label': group_label}, project='uuid')
+        self.assertEqual(builder.count(), 1, msg="There should be exactly one Group with label {}. "
+                                                 "Instead {} was found.".format(group_label, builder.count()))
+        imported_group = load_group(builder.all()[0][0])
+        self.assertEqual(imported_group.uuid, group_uuid)
+        for node in imported_group.nodes:
+            self.assertIn(node.uuid, node_uuids)
 
 class TestCalculations(AiidaTestCase):
     """Test ex-/import cases related to Calculations"""

--- a/aiida/cmdline/commands/cmd_import.py
+++ b/aiida/cmdline/commands/cmd_import.py
@@ -143,9 +143,7 @@ def _migrate_archive(ctx, temp_folder, file_to_import, archive, non_interactive,
     cls=options.MultipleValueOption,
     help="Discover all URL targets pointing to files with the .aiida extension for these HTTP addresses. "
     "Automatically discovered archive URLs will be downloadeded and added to ARCHIVES for importing")
-@click.option(
-    '-G',
-    '--group',
+@options.GROUP(
     type=GroupParamType(create_if_not_exist=True),
     help='Specify group to which all the import nodes will be added. If such a group does not exist, it will be'
     ' created automatically.')


### PR DESCRIPTION
Fixes #2863.

Set `verdi import`'s `-G` (group) option to the general `options.GROUP()`, but allowing to create new `Group` if needed.
Only a `Group` label can be passed.
The handling of 'user_group' in `importexport.py` has been optimized.
Tests have been added for `verdi import` and for `importexport.py`.

**Note**: If one has created a `Group` to be used for the purpose of placing the imported `Node`s in, and has worked with it, but _not_ stored it and subsequently passes _its label_ to `import_data()`, the work will be overwritten. ~~Since the method `Group.objects.get_or_create(label="whatever_label")` is used.~~ However, if the `Group` object itself is passed to `import_data()`, the work will _not_ be overwritten. Instead, the `Group` will be stored and used.

**Edit**: The method `Group.objects.get_or_create(label="whatever_label")` is not used anymore, since there is need to specify a specific `type_string` if a new `Group` is created. However, the "quirk" described above is still valid.