### PR TITLE
Automatically set `CalcInfo.uuid` in `CalcJob.run`

### DIFF
--- a/aiida/calculations/plugins/arithmetic/add.py
+++ b/aiida/calculations/plugins/arithmetic/add.py
@@ -64,7 +64,6 @@ class ArithmeticAddCalculation(CalcJob):
         codeinfo.code_uuid = input_code.uuid
 
         calcinfo = CalcInfo()
-        calcinfo.uuid = str(self.node.uuid)
         calcinfo.codes_info = [codeinfo]
         calcinfo.retrieve_list = retrieve_list
         calcinfo.local_copy_list = local_copy_list

--- a/aiida/calculations/plugins/templatereplacer.py
+++ b/aiida/calculations/plugins/templatereplacer.py
@@ -167,7 +167,6 @@ class TemplatereplacerCalculation(CalcJob):
         calcinfo.retrieve_list = []
         calcinfo.retrieve_temporary_list = []
 
-        calcinfo.uuid = self.node.uuid
         calcinfo.local_copy_list = local_copy_list
         calcinfo.remote_copy_list = remote_copy_list
 

--- a/aiida/engine/processes/calcjobs/calcjob.py
+++ b/aiida/engine/processes/calcjobs/calcjob.py
@@ -145,6 +145,7 @@ class CalcJob(Process):
                 raise exceptions.InvalidOperation('calculation node has unstored links in cache')
 
             calc_info, script_filename = self.presubmit(folder)
+            calc_info.uuid = str(self.uuid)
             input_codes = [load_node(_.code_uuid, sub_classes=(Code,)) for _ in calc_info.codes_info]
 
             for code in input_codes:


### PR DESCRIPTION
Fixes #2872 

The `uuid` field in the `CalcInfo` data structure which is built and
returned by the `CalcJob.prepare_for_submission` implementation, is used
subsequently by the engine to create the remote working directory.
Previously, the implementer of `prepare_for_submission` was required to
set it, but this always boiled down to setting it to the UUID of the
process node. Since this is the only behavior that should happen anyway,
we might as well have the engine take care of this, making the
implementation of the `prepare_for_submission` for plugins simpler.