### PR TITLE
Respect option `-p/--profile` in `verdi profile show`

### DIFF
--- a/aiida/backends/tests/cmdline/commands/test_profile.py
+++ b/aiida/backends/tests/cmdline/commands/test_profile.py
@@ -17,7 +17,7 @@ import six
 from click.testing import CliRunner
 
 from aiida.backends.testbase import AiidaPostgresTestCase
-from aiida.cmdline.commands import cmd_profile
+from aiida.cmdline.commands import cmd_profile, cmd_verdi
 from aiida.backends.tests.utils.configuration import create_mock_profile, with_temporary_config_instance
 from aiida.manage import configuration
 
@@ -112,6 +112,23 @@ class TestVerdiProfileSetup(AiidaPostgresTestCase):
             if isinstance(value, six.string_types):
                 self.assertIn(key.lower(), result.output)
                 self.assertIn(value, result.output)
+
+    @with_temporary_config_instance
+    def test_show_with_profile_option(self):
+        """Test the `verdi profile show` command in combination with `-p/--profile."""
+        self.mock_profiles()
+
+        profile_name_non_default = self.profile_list[1]
+
+        # Specifying the non-default profile as argument should override the default
+        result = self.cli_runner.invoke(cmd_profile.profile_show, [profile_name_non_default])
+        self.assertClickSuccess(result)
+        self.assertTrue(profile_name_non_default in result.output)
+
+        # Specifying `-p/--profile` should override the configured default
+        result = self.cli_runner.invoke(cmd_verdi.verdi, ['-p', profile_name_non_default, 'profile', 'show'])
+        self.assertClickSuccess(result)
+        self.assertTrue(profile_name_non_default in result.output)
 
     @with_temporary_config_instance
     def test_delete_partial(self):

--- a/aiida/cmdline/commands/cmd_verdi.py
+++ b/aiida/cmdline/commands/cmd_verdi.py
@@ -21,7 +21,7 @@ from aiida.common import exceptions
 
 @click.group(context_settings={'help_option_names': ['-h', '--help']})
 @options.PROFILE()
-@click.version_option(None, "-v", "--version", message="AiiDA version %(version)s")
+@click.version_option(None, '-v', '--version', message="AiiDA version %(version)s")
 @click.pass_context
 def verdi(ctx, profile):
     """The command line interface of AiiDA."""
@@ -31,6 +31,10 @@ def verdi(ctx, profile):
         ctx.obj = AttributeDict()
 
     config = get_config(create=True)
+
+    # This flag will be useful for commands that need to know if the current `ctx.obj.profile` is simply the default
+    # or is set because the user specified an explicit profile through `-p/--profile`
+    ctx.obj.profile_option_used = profile is not None
 
     if not profile:
         try:

--- a/aiida/cmdline/utils/defaults.py
+++ b/aiida/cmdline/utils/defaults.py
@@ -22,13 +22,20 @@ def get_default_profile(ctx, param, value):  # pylint: disable=unused-argument
 
     This should be used if the default profile should be returned lazily, at a point for example when the config
     is not created at import time. Otherwise, the preference should go to calling `get_config` to load the actual
-    config and using `config.default_profile_name` to get the default profile name
+    config and using `config.default_profile_name` to get the default profile name.
+
+    This all of course unless the `-p/--profile` option was used by the user which trumps everything, in which case the
+    `profile_option_used` attribute on the `ctx.obj` object will have been set and we simply return the profile that
+    was already loaded by `verdi` itself and set in `ctx.obj.profile`.
 
     :raises click.UsageError: if the config could not be loaded or no default profile exists
     :return: the default profile
     """
     if value:
         return value
+
+    if ctx.obj.profile_option_used:
+        return ctx.obj.profile
 
     try:
         config = get_config()


### PR DESCRIPTION
Fixes #2875 

Even when a non-default option was specified with `verdi profile show`
the default specified in the configuration was taken. The order of
precedence for profile in verdi commands should be:

 * Configuration default
 * Profile option `-p/--profile`
 * Command specific profile parameter

By setting an attribute `profile_option_used` in the `ctx.obj` of the
`verdi` command, other commands can see whether the user specified an
explicit profile that should potentially be respected.