### PR TITLE
Implement an isolated mode for the `Pluginable` sub of `click.Group`

### DIFF
--- a/aiida/cmdline/utils/pluginable.py
+++ b/aiida/cmdline/utils/pluginable.py
@@ -22,20 +22,38 @@ class Pluginable(click.Group):
 
     def __init__(self, *args, **kwargs):
         """Initialize with entry point group."""
+        self._exclude_external_plugins = False  # Default behavior is of course to include external plugins
         self._entry_point_group = kwargs.pop('entry_point_group')
         super(Pluginable, self).__init__(*args, **kwargs)
 
     def list_commands(self, ctx):
         """Add entry point names of available plugins to the command list."""
         subcommands = super(Pluginable, self).list_commands(ctx)
-        subcommands.extend(get_entry_point_names(self._entry_point_group))
+
+        if not self._exclude_external_plugins:
+            subcommands.extend(get_entry_point_names(self._entry_point_group))
+
         return subcommands
 
     def get_command(self, ctx, name):  # pylint: disable=arguments-differ
         """Try to load a subcommand from entry points, else defer to super."""
         command = None
-        try:
-            command = load_entry_point(self._entry_point_group, name)
-        except exceptions.EntryPointError:
+        if not self._exclude_external_plugins:
+            try:
+                command = load_entry_point(self._entry_point_group, name)
+            except exceptions.EntryPointError:
+                command = super(Pluginable, self).get_command(ctx, name)
+        else:
             command = super(Pluginable, self).get_command(ctx, name)
         return command
+
+    def set_exclude_external_plugins(self, exclude_external_plugins):
+        """Set whether external plugins should be excluded.
+
+        If `exclude_external_plugins` is set to `True`, the plugins that belong to the `entry_point_group` defined
+        for this `click.Group` will not be discoverable. This is useful to limit the available commands to only those
+        provided by `aiida-core` (excluding those provided by plugins).
+
+        :param exclude_external_plugins: bool, when True, external plugins will not be discoverable
+        """
+        self._exclude_external_plugins = exclude_external_plugins

--- a/utils/validate_consistency.py
+++ b/utils/validate_consistency.py
@@ -119,7 +119,13 @@ def cli():
 @cli.command('verdi-autodocs')
 def validate_verdi_documentation():
     """Auto-generate the documentation for `verdi` through `click`."""
+    from click import Context
     from aiida.cmdline.commands.cmd_verdi import verdi
+
+    # Set the `verdi data` command to isolated mode such that external plugin commands are not discovered
+    ctx = Context(verdi)
+    command = verdi.get_command(ctx, 'data')
+    command.set_exclude_external_plugins(True)
 
     # Replacing the block with the overview of `verdi`
     filepath_verdi_overview = os.path.join(ROOT_DIR, 'docs', 'source', 'working_with_aiida', 'index.rst')


### PR DESCRIPTION
Fixes #2877 

The `Pluginable` sub class of `click.Group` allows sub commands to be
added to it dynamically from external plugins through entry points.
However, this gave problems for the auto-docs generator in the
pre-commit script `utils/validate_consistency.py` which would include
these external commands, even though it shouldn't. To solve this, we
implement the isolation mode for the `Pluginable` class which the
pre-commit script will enable before generating the documentation.