### PR TITLE
Include only input links in creating a process restart builder

### DIFF
--- a/aiida/backends/tests/engine/test_process_builder.py
+++ b/aiida/backends/tests/engine/test_process_builder.py
@@ -112,12 +112,15 @@ class TestProcessBuilder(AiidaTestCase):
 
     def test_builder_restart_work_chain(self):
         """Verify that nested namespaces imploded into flat link labels can be reconstructed into nested namespaces."""
+        caller = orm.WorkChainNode().store()
+
         node = orm.WorkChainNode(process_type=TestWorkChain.build_process_type())
         node.add_incoming(self.inputs['dynamic']['namespace']['alp'], LinkType.INPUT_WORK, 'dynamic__namespace__alp')
         node.add_incoming(self.inputs['name']['spaced'], LinkType.INPUT_WORK, 'name__spaced')
         node.add_incoming(self.inputs['name_spaced'], LinkType.INPUT_WORK, 'name_spaced')
         node.add_incoming(self.inputs['boolean'], LinkType.INPUT_WORK, 'boolean')
         node.add_incoming(orm.Int(DEFAULT_INT).store(), LinkType.INPUT_WORK, 'default')
+        node.add_incoming(caller, link_type=LinkType.CALL_WORK, link_label='CALL_WORK')
         node.store()
 
         builder = node.get_builder_restart()

--- a/aiida/orm/nodes/process/process.py
+++ b/aiida/orm/nodes/process/process.py
@@ -96,7 +96,7 @@ class ProcessNode(Sealable, Node):
         :return: `~aiida.engine.processes.builder.ProcessBuilder` instance
         """
         builder = self.process_class.get_builder()
-        builder._update(self.get_incoming().nested())  # pylint: disable=protected-access
+        builder._update(self.get_incoming(link_type=(LinkType.INPUT_CALC, LinkType.INPUT_WORK)).nested())  # pylint: disable=protected-access
 
         return builder
 


### PR DESCRIPTION
Fixes #2881  

The `Process.get_builder_restart` was populating the builder by getting
all the nodes with incoming links, including call links which of course
are not defined in the spec and so would cause an exception. Simply by
adding a link filter to only get input data nodes, this problem is fixed.