### PR TITLE
Fix false negative of postgres connection in `verdi status`

### DIFF
--- a/aiida/backends/tests/cmdline/commands/test_status.py
+++ b/aiida/backends/tests/cmdline/commands/test_status.py
@@ -19,7 +19,7 @@ from aiida.backends.tests.utils.configuration import with_temporary_config_insta
 
 
 class TestVerdiStatus(AiidaTestCase):
-    """Tests for `verdi rehash`."""
+    """Tests for `verdi status`."""
 
     def setUp(self):
         self.cli_runner = CliRunner()
@@ -29,11 +29,13 @@ class TestVerdiStatus(AiidaTestCase):
         """Test running verdi status.
 
         Note: The exit status may differ depending on the environment in which the tests are run.
+            Also cannot check for the exit status to see if connecting to all services worked, because
+            the profile might not be properly setup in this temporary config instance unittest.
         """
         options = []
         result = self.cli_runner.invoke(cmd_status.verdi_status, options)
         self.assertIsInstance(result.exception, SystemExit)
-        self.assertIn("profile", result.output)
-        self.assertIn("postgres", result.output)
-        self.assertIn("rabbitmq", result.output)
-        self.assertIn("daemon", result.output)
+        self.assertIn('profile', result.output)
+        self.assertIn('postgres', result.output)
+        self.assertIn('rabbitmq', result.output)
+        self.assertIn('daemon', result.output)

--- a/aiida/manage/external/postgres.py
+++ b/aiida/manage/external/postgres.py
@@ -69,13 +69,11 @@ class Postgres(PGSU):
         :returns: Postgres instance pre-populated with data from AiiDA profile
         """
         dbinfo = DEFAULT_DBINFO.copy()
-
-        get = profile.dictionary.get
         dbinfo.update(
             dict(
-                host=get('AIIDADB_HOST', DEFAULT_DBINFO['host']),
-                port=get('AIIDADB_PORT', DEFAULT_DBINFO['port']),
-            ))
+                host=profile.database_hostname or DEFAULT_DBINFO['host'],
+                port=profile.database_port or DEFAULT_DBINFO['port']))
+
         return Postgres(dbinfo=dbinfo, **kwargs)
 
     def check_db_name(self, dbname):


### PR DESCRIPTION
Fixes #2911 

The output of `verdi status` was reporting a problem in connecting to
the postgres database even though all other commands seemed to work. The
problem was with the `Postgres.from_profile` used to perform the check
that did not correctly use the database connection details from the
profile but just the defaults.