### PR TITLE
Make backend type for `verdi quicksetup --config` test dynamic

### DIFF
--- a/aiida/backends/tests/cmdline/commands/test_setup.py
+++ b/aiida/backends/tests/cmdline/commands/test_setup.py
@@ -83,8 +83,8 @@ profile: testing
 first_name: Leopold
 last_name: Talirz
 institution: EPFL
-backend: django
-email: 123@234.de""")
+backend: {}
+email: 123@234.de""".format(self.backend))
             handle.flush()
             result = self.cli_runner.invoke(cmd_setup.quicksetup, ['--config', os.path.realpath(handle.name)])
         self.assertClickResultNoException(result)


### PR DESCRIPTION
Fixes #2931 

It was hardcoded to `django` causing the SqlAlchemy tests to fail.