### PR TITLE
Ensure `mtime` update is triggered for Django

### DIFF
--- a/aiida/backends/tests/orm/implementation/test_nodes.py
+++ b/aiida/backends/tests/orm/implementation/test_nodes.py
@@ -126,6 +126,14 @@ class TestBackendNode(AiidaTestCase):
         self.assertEqual(node.ctime, ctime)
         self.assertEqual(node.mtime, mtime)
 
+    def test_mtime(self):
+        """Test the `mtime` is automatically updated when a database field is updated."""
+        node = self.node.store()
+        node_mtime = node.mtime
+
+        node.label = 'changed label'
+        self.assertTrue(node.mtime > node_mtime)
+
     def test_clone(self):
         """Test the `clone` method."""
         node = self.node.store()

--- a/aiida/orm/implementation/django/utils.py
+++ b/aiida/orm/implementation/django/utils.py
@@ -77,6 +77,10 @@ class ModelWrapper(object):
         """ If the user is stored then save the current value """
         if self.is_saved():
             try:
+                # Manually append the `mtime` to fields to update, because when using the `update_fields` keyword of the
+                # `save` method, the `auto_now` property of `mtime` column is not triggered
+                if self._is_model_field('mtime'):
+                    fields.add('mtime')
                 self._model.save(update_fields=fields)
             except django.db.IntegrityError as e:
                 # Convert to one of our exceptions


### PR DESCRIPTION
Fixes #2934 

The `ModelWrapper` utility class ensures that a database model instance
is automatically saved if a model field is updated and the instance is
already stored. This prevents the implementation from having to call
`save` manually every time a field is updated. The Django implementation
uses the `update_fields` keyword of the `save` method, to update only
the field affected. However, this circumvents the `auto_now` of the
`mtime` field. This bug is currently not visible, because in the model
wrapper currently also always updates the node version after a model
field is updated of a stored instance. This, however, uses a normal
`save` and so does properly update the `mtime`. Once this updating of
the node version would have been removed, this bug will be revealed.