### PR TITLE
Fix for reversibleness of Django migration `0035_simplify_user_model`

### DIFF
--- a/aiida/backends/djsite/db/migrations/0035_simplify_user_model.py
+++ b/aiida/backends/djsite/db/migrations/0035_simplify_user_model.py
@@ -16,7 +16,7 @@ from __future__ import absolute_import
 
 # Remove when https://github.com/PyCQA/pylint/issues/1931 is fixed
 # pylint: disable=no-name-in-module,import-error,no-member
-from django.db import migrations
+from django.db import migrations, models
 
 from aiida.backends.djsite.db.migrations import upgrade_schema_version
 
@@ -32,6 +32,11 @@ class Migration(migrations.Migration):
     ]
 
     operations = [
+        migrations.AlterField(
+            model_name='dbuser',
+            name='password',
+            field=models.CharField(max_length=128, default='pass', verbose_name='password'),
+        ),
         migrations.RemoveField(
             model_name='dbuser',
             name='password',
@@ -51,6 +56,11 @@ class Migration(migrations.Migration):
         migrations.RemoveField(
             model_name='dbuser',
             name='is_staff',
+        ),
+        migrations.AlterField(
+            model_name='dbuser',
+            name='is_superuser',
+            field=models.BooleanField(default=False, blank=True),
         ),
         migrations.RemoveField(
             model_name='dbuser',

--- a/aiida/backends/tests/__init__.py
+++ b/aiida/backends/tests/__init__.py
@@ -21,7 +21,7 @@ DB_TEST_LIST = {
     BACKEND_DJANGO: {
         'generic': ['aiida.backends.djsite.db.subtests.test_generic'],
         'nodes': ['aiida.backends.djsite.db.subtests.test_nodes'],
-        # 'migrations': ['aiida.backends.djsite.db.subtests.test_migrations'],
+        'migrations': ['aiida.backends.djsite.db.subtests.test_migrations'],
         'query': ['aiida.backends.djsite.db.subtests.test_query'],
     },
     BACKEND_SQLA: {

--- a/aiida/orm/users.py
+++ b/aiida/orm/users.py
@@ -24,9 +24,8 @@ class User(entities.Entity):
     """AiiDA User"""
 
     class Collection(entities.Collection):
-        """
-            The collection of users stored in a backend
-            """
+        """The collection of users stored in a backend."""
+
         UNDEFINED = 'UNDEFINED'
         _default_user = None  # type: aiida.orm.User
 
@@ -165,52 +164,34 @@ class User(entities.Entity):
         :return: schema of the user
         """
         return {
-            "date_joined": {
-                "display_name": "User since",
-                "help_text": "Date and time of registration",
-                "is_foreign_key": False,
-                "type": "datetime.datetime"
+            'id': {
+                'display_name': 'Id',
+                'help_text': 'Id of the object',
+                'is_foreign_key': False,
+                'type': 'int'
             },
-            "email": {
-                "display_name": "email",
-                "help_text": "e-mail of the user",
-                "is_foreign_key": False,
-                "type": "str"
+            'email': {
+                'display_name': 'email',
+                'help_text': 'e-mail of the user',
+                'is_foreign_key': False,
+                'type': 'str'
             },
-            "first_name": {
-                "display_name": "First name",
-                "help_text": "First name of the user",
-                "is_foreign_key": False,
-                "type": "str"
+            'first_name': {
+                'display_name': 'First name',
+                'help_text': 'First name of the user',
+                'is_foreign_key': False,
+                'type': 'str'
             },
-            "id": {
-                "display_name": "Id",
-                "help_text": "Id of the object",
-                "is_foreign_key": False,
-                "type": "int"
+            'institution': {
+                'display_name': 'Institution',
+                'help_text': 'Affiliation of the user',
+                'is_foreign_key': False,
+                'type': 'str'
             },
-            "institution": {
-                "display_name": "Institution",
-                "help_text": "Affiliation of the user",
-                "is_foreign_key": False,
-                "type": "str"
-            },
-            "is_active": {
-                "display_name": "Active",
-                "help_text": "True(False) if the user is active(not)",
-                "is_foreign_key": False,
-                "type": "bool"
-            },
-            "last_login": {
-                "display_name": "Last login",
-                "help_text": "Date and time of the last login",
-                "is_foreign_key": False,
-                "type": "datetime.datetime"
-            },
-            "last_name": {
-                "display_name": "Last name",
-                "help_text": "Last name of the user",
-                "is_foreign_key": False,
-                "type": "str"
+            'last_name': {
+                'display_name': 'Last name',
+                'help_text': 'Last name of the user',
+                'is_foreign_key': False,
+                'type': 'str'
             }
         }

--- a/aiida/restapi/translator/user.py
+++ b/aiida/restapi/translator/user.py
@@ -35,38 +35,28 @@ class UserTranslator(BaseTranslator):
 
     _result_type = __label__
 
-    _default_projections = ['id', 'first_name', "last_name", 'institution', 'date_joined']
+    _default_projections = ['id', 'first_name', 'last_name', 'institution']
 
     ## user schema
     # All the values from column_order must present in additional info dict
     # Note: final schema will contain details for only the fields present in column order
     _schema_projections = {
-        "column_order":
-        ["id", "first_name", "last_name", "email", "institution", "date_joined", "last_login", "is_active"],
-        "additional_info": {
-            "id": {
-                "is_display": True
+        'column_order': ['id', 'first_name', 'last_name', 'email', 'institution'],
+        'additional_info': {
+            'id': {
+                'is_display': True
             },
-            "first_name": {
-                "is_display": True
+            'first_name': {
+                'is_display': True
             },
-            "last_name": {
-                "is_display": True
+            'last_name': {
+                'is_display': True
             },
-            "email": {
-                "is_display": True
+            'email': {
+                'is_display': True
             },
-            "institution": {
-                "is_display": True
-            },
-            "date_joined": {
-                "is_display": False
-            },
-            "last_login": {
-                "is_display": False
-            },
-            "is_active": {
-                "is_display": False
+            'institution': {
+                'is_display': True
             }
         }
     }


### PR DESCRIPTION
The migration dropped the columns `password` and `is_superuser` of the
`User` model, both of which used to be non-nullable. The migration did
not provide for a default value, causing the migration tests to fail
when the reverse operation was applied and rows with null values were
encountered.