### PR TITLE
set correct backend for quicksetup test

### DIFF
--- a/aiida/backends/tests/cmdline/commands/test_setup.py
+++ b/aiida/backends/tests/cmdline/commands/test_setup.py
@@ -83,7 +83,7 @@ profile: testing
 first_name: Leopold
 last_name: Talirz
 institution: EPFL
-backend: {}
+db_backend: {}
 email: 123@234.de""".format(self.backend))
             handle.flush()
             result = self.cli_runner.invoke(cmd_setup.quicksetup, ['--config', os.path.realpath(handle.name)])


### PR DESCRIPTION
hopefully fix #2950 

Also opened a feature request for introducing key validation in click-config-file https://github.com/phha/click_config_file/issues/11 