### PR TITLE
Update dependency `kiwipy==0.5.1` with critical bug patch

### DIFF
--- a/docs/requirements_for_rtd.txt
+++ b/docs/requirements_for_rtd.txt
@@ -32,7 +32,7 @@ flask-marshmallow==0.9.0
 futures; python_version=='2.7'
 ipython>=4.0,<6.0
 itsdangerous==1.1.0
-kiwipy[rmq]==0.5.0
+kiwipy[rmq]==0.5.1
 marshmallow-sqlalchemy==0.16.0
 mock==2.0.0
 numpy==1.16.1

--- a/environment.yml
+++ b/environment.yml
@@ -32,7 +32,7 @@ dependencies:
 - paramiko==2.4.2
 - ipython>=4.0,<6.0
 - plumpy==0.14.0
-- kiwipy[rmq]==0.5.0
+- kiwipy[rmq]==0.5.1
 - pika==1.0.0
 - circus==0.15.0
 - tornado<5.0

--- a/setup.json
+++ b/setup.json
@@ -44,7 +44,7 @@
     "paramiko==2.4.2",
     "ipython>=4.0,<6.0",
     "plumpy==0.14.0",
-    "kiwipy[rmq]==0.5.0",
+    "kiwipy[rmq]==0.5.1",
     "pika==1.0.0",
     "circus==0.15.0",
     "tornado<5.0",


### PR DESCRIPTION
Fixes #2957 

The persistence of a task message, which represents a process that is to
be executed, is guaranteed by RabbitMQ, but only if the exchange, queue
and the task message itself are configured correctly. Up till now the
exchange and task queue were properly set to be durable, however, the
individual messages were sent with the default delivery mode, which
means non-persistent. This caused tasks to be lost on broker restart.
The patch release 0.5.1 of `kiwipy` fixes this by now always marking
task messages as persistent.