### PR TITLE
Fix bug in process function interrupt handlers causing `verdi daemon stop` to timeout

### DIFF
--- a/aiida/engine/daemon/runner.py
+++ b/aiida/engine/daemon/runner.py
@@ -30,7 +30,9 @@ def start_daemon():
     configure_logging(daemon=True, daemon_log_file=daemon_client.daemon_log_file)
 
     try:
-        runner = get_manager().create_daemon_runner()
+        manager = get_manager()
+        runner = manager.create_daemon_runner()
+        manager.set_runner(runner)
     except Exception as exception:
         LOGGER.exception('daemon runner failed to start')
         raise

--- a/aiida/engine/processes/process.py
+++ b/aiida/engine/processes/process.py
@@ -293,7 +293,7 @@ class Process(plumpy.Process):
 
             if killing:
                 # We are waiting for things to be killed, so return the 'gathered' future
-                result = plumpy.gather(result)
+                result = plumpy.gather(killing)
 
         return result
 

--- a/aiida/engine/runners.py
+++ b/aiida/engine/runners.py
@@ -116,6 +116,15 @@ class Runner(object):  # pylint: disable=useless-object-inheritance
     def controller(self):
         return self._controller
 
+    @property
+    def is_daemon_runner(self):
+        """Return whether the runner is a daemon runner, which means it submits processes over RabbitMQ.
+
+        :return: True if the runner is a daemon runner
+        :rtype: bool
+        """
+        return self._rmq_submit
+
     def is_closed(self):
         return self._closed
 


### PR DESCRIPTION
Fixes #2693 

The issue is addressed in two separate commits, because the source of the issue was two-fold. Although this solves this particular issue and makes the handling of interrupts in local runners more robust, a more general problem was laid bare as documented in issue #2965 .
Unfortunately, I haven't found a way to add unit tests for the issue that this PR solves.