### PR TITLE
Improve `safe_interval` validation `verdi computer configure`

### DIFF
--- a/aiida/backends/tests/cmdline/commands/test_setup.py
+++ b/aiida/backends/tests/cmdline/commands/test_setup.py
@@ -132,8 +132,7 @@ email: 123@234.de""".format(self.backend))
         options = [
             '--non-interactive', '--email', user_email, '--first-name', user_first_name, '--last-name', user_last_name,
             '--institution', user_institution, '--db-name', db_name, '--db-username', db_user, '--db-password', db_pass,
-            '--db-port', self.pg_test.dsn['port'], '--db-backend', self.backend, '--repository',
-            '/project/aiida_repository', '--profile', profile_name
+            '--db-port', self.pg_test.dsn['port'], '--db-backend', self.backend, '--profile', profile_name
         ]
 
         result = self.cli_runner.invoke(cmd_setup.setup, options)

--- a/aiida/cmdline/commands/cmd_computer.py
+++ b/aiida/cmdline/commands/cmd_computer.py
@@ -592,7 +592,7 @@ def computer_config_show(computer, user, defaults, as_option_string):
                         option.name, computer)
                     option_value = option.opts[-1] if is_default else ''
                 else:
-                    option_value = '{}={}'.format(option.opts[-1], config[option.name])
+                    option_value = '{}={}'.format(option.opts[-1], option.type(config[option.name]))
                 option_items.append(option_value)
         opt_string = ' '.join(option_items)
         echo.echo(escape_for_bash(opt_string))

--- a/aiida/transports/plugins/local.py
+++ b/aiida/transports/plugins/local.py
@@ -22,6 +22,7 @@ Local transport
 from __future__ import division
 from __future__ import print_function
 from __future__ import absolute_import
+
 import errno
 import os
 import shutil
@@ -46,22 +47,21 @@ class LocalTransport(Transport):
     with a ``prepend_text``. For example, the AiiDA daemon sets a ``PYTHONPATH``, so you might want to add
     ``unset PYTHONPATH`` if you plan on running calculations that use Python.
     """
+
     # There are no valid parameters for the local transport
     _valid_auth_options = []
 
-    # There is no real limit on how fast you can connect to localhost
-    # you should not be banned (as instead it is the case in SSH).
-    # So I set the (default) limit to zero.
-    _DEFAULT_SAFE_OPEN_INTERVAL = 2.
+    # There is no real limit on how fast you can safely connect to a localhost, unlike often the case with SSH transport
+    # where the remote computer will rate limit the number of connections.
+    _DEFAULT_SAFE_OPEN_INTERVAL = 0.0
 
     def __init__(self, **kwargs):
         super(LocalTransport, self).__init__()
-
-        # _internal_dir will emulate the concept of working directory
-        # The real current working directory is not to be changed
-        # self._internal_dir = None
+        # The `_internal_dir` will emulate the concept of working directory, as the real current working directory is
+        # not to be changed to prevent bug-prone situations
         self._is_open = False
         self._internal_dir = None
+
         # Just to avoid errors
         self._machine = kwargs.pop('machine', None)
         if self._machine and self._machine != 'localhost':
@@ -102,7 +102,6 @@ class LocalTransport(Transport):
         """
         Return a description as a string.
         """
-
         return "local [{}]".format("OPEN" if self._is_open else "CLOSED")
 
     @property

--- a/aiida/transports/transport.py
+++ b/aiida/transports/transport.py
@@ -28,6 +28,19 @@ DEFAULT_TRANSPORT_INTERVAL = 30.
 __all__ = ('Transport',)
 
 
+def validate_positive_number(ctx, param, value):  # pylint: disable=unused-argument
+    """Validate that the number passed to this parameter is a positive number.
+
+    :param ctx: the `click.Context`
+    :param param: the parameter
+    :param value: the value passed for the parameter
+    :raises `click.BadParameter`: if the value is not a positive number
+    """
+    if value is not None and value < 0:
+        from click import BadParameter
+        raise BadParameter('value needs to be a positive number')
+
+
 @six.add_metaclass(ABCMeta)
 class Transport(object):
     """
@@ -42,10 +55,11 @@ class Transport(object):
     _MAGIC_CHECK = re.compile('[*?[]')
     _valid_auth_options = []
     _common_auth_options = [('safe_interval', {
-        'type': int,
-        'prompt': 'Connection cooldown time (sec)',
-        'help': 'Minimum time between connections in sec',
-        'non_interactive_default': True
+        'type': float,
+        'prompt': 'Connection cooldown time (s)',
+        'help': 'Minimum time interval in seconds between consecutive connection openings',
+        'non_interactive_default': True,
+        'callback': validate_positive_number
     })]
 
     def __init__(self, *args, **kwargs):  # pylint: disable=unused-argument


### PR DESCRIPTION
Addresses #2880 partially

The computer configuration command for the transport specified that
an integer was required. However, a float value makes more sense. In
addition to this change, an additional validation callback was added to
make sure that the interval is positive.

The addition of the validation through the default option callback
mechanism required a small adaptation to the `InteractiveOption`.
The behavior of error handling was different if the option was
explicitly defined on the command line but without an explicit
`--non-interactive` flag. If a string value was passed, the type
validation would fail and prompt loop was never entered. However, if a
negative number was passed, the type validation would pass, but then the
normal callback would fail and in this case the prompt would start.
However, this was with the context improperly configured and so
exceptions would occur in the contextual defaults.