### PR TITLE
fix typo in the serializer for `dict`

### DIFF
--- a/aiida/orm/nodes/data/dict.py
+++ b/aiida/orm/nodes/data/dict.py
@@ -101,4 +101,4 @@ class Dict(Data):
 
 @to_aiida_type.register(dict)
 def _(value):
-    return Dict(dictionary=value)
+    return Dict(dict=value)


### PR DESCRIPTION
The `to_aiida_type` serializer for `dict` was not working because of a typo. This is a quick patch to make it work.
PS: It seems `to_aiida_type` does not have any tests written as the bug is not caught.