### PR TITLE
Ensure that stacktrace is included in transport task exceptions

### DIFF
--- a/aiida/engine/processes/process.py
+++ b/aiida/engine/processes/process.py
@@ -22,10 +22,10 @@ import traceback
 import six
 from six.moves import filter, range
 from pika.exceptions import ConnectionClosed
-from kiwipy.communications import UnroutableError
 
 import plumpy
 from plumpy import ProcessState
+from kiwipy.communications import UnroutableError
 
 from aiida import orm
 from aiida.common import exceptions
@@ -268,7 +268,7 @@ class Process(plumpy.Process):
 
         :rtype: bool
         """
-        self.node.logger.debug('Request to kill Process<{}>'.format(self.node.pk))
+        self.node.logger.info('Request to kill Process<{}>'.format(self.node.pk))
 
         had_been_terminated = self.has_terminated()
 

--- a/aiida/engine/utils.py
+++ b/aiida/engine/utils.py
@@ -161,6 +161,7 @@ def exponential_backoff_retry(fct, initial_interval=10.0, max_attempts=5, logger
     :param fct: the function to call, which will be turned into a coroutine first if it is not already
     :param initial_interval: the time to wait after the first caught exception before calling the coroutine again
     :param max_attempts: the maximum number of times to call the coroutine before re-raising the exception
+    :param ignore_exceptions: list or tuple of exceptions to ignore, i.e. when caught do nothing and simply re-raise
     :raises: ``tornado.gen.Result`` if the ``coro`` call completes within ``max_attempts`` retries without raising
     """
     if logger is None:
@@ -181,14 +182,14 @@ def exponential_backoff_retry(fct, initial_interval=10.0, max_attempts=5, logger
                 raise
 
             count = iteration + 1
-            core_name = coro.__name__
+            coro_name = coro.__name__
 
             if iteration == max_attempts - 1:
-                logger.exception('iteration %d of %s excepted', count, core_name)
-                logger.warning('maximum attempts %d of calling %s, exceeded', max_attempts, core_name)
+                logger.exception('iteration %d of %s excepted', count, coro_name)
+                logger.warning('maximum attempts %d of calling %s, exceeded', max_attempts, coro_name)
                 raise
             else:
-                logger.exception('iteration %d of %s excepted, retrying after %d seconds', count, core_name, interval)
+                logger.exception('iteration %d of %s excepted, retrying after %d seconds', count, coro_name, interval)
                 yield gen.sleep(interval)
                 interval *= 2
 

--- a/aiida/engine/utils.py
+++ b/aiida/engine/utils.py
@@ -180,13 +180,15 @@ def exponential_backoff_retry(fct, initial_interval=10.0, max_attempts=5, logger
             if ignore_exceptions is not None and isinstance(exception, ignore_exceptions):
                 raise
 
+            count = iteration + 1
+            core_name = coro.__name__
+
             if iteration == max_attempts - 1:
-                logger.warning('maximum attempts %d of calling %s, exceeded', max_attempts, coro.__name__)
+                logger.exception('iteration %d of %s excepted', count, core_name)
+                logger.warning('maximum attempts %d of calling %s, exceeded', max_attempts, core_name)
                 raise
             else:
-                logger.exception('iteration %d of %s excepted, retrying after %d seconds', iteration + 1, coro.__name__,
-                                 interval)
-
+                logger.exception('iteration %d of %s excepted, retrying after %d seconds', count, core_name, interval)
                 yield gen.sleep(interval)
                 interval *= 2
 

--- a/aiida/manage/external/rmq.py
+++ b/aiida/manage/external/rmq.py
@@ -16,8 +16,8 @@ import collections
 import logging
 
 from tornado import gen
-from kiwipy import communications
 import plumpy
+from kiwipy import communications, Future
 
 __all__ = ('RemoteException', 'CommunicationTimeout', 'DeliveryFailed', 'ProcessLauncher')
 
@@ -157,7 +157,7 @@ class ProcessLauncher(plumpy.ProcessLauncher):
 
             LOGGER.info('not continuing process<%d> which is already terminated with state %s', pid, node.process_state)
 
-            future = communicator.create_future()
+            future = Future()
 
             if node.is_finished:
                 future.set_result({entry.link_label: entry.node for entry in node.get_outgoing(node_class=Data)})

--- a/aiida/orm/logs.py
+++ b/aiida/orm/logs.py
@@ -58,8 +58,16 @@ class Log(entities.Entity):
 
             metadata = dict(record.__dict__)
 
-            # Stringify the content of `exc_info` and `args` if they exist in the metadata to ensure serializability
-            for key in ['exc_info', 'args']:
+            # If an `exc_info` is present, the log message was an exception, so format the full traceback
+            try:
+                import traceback
+                exc_info = metadata.pop('exc_info')
+                message = ''.join(traceback.format_exception(*exc_info))
+            except (TypeError, KeyError):
+                message = record.getMessage()
+
+            # Stringify the content of `args` if they exist in the metadata to ensure serializability
+            for key in ['args']:
                 if key in metadata:
                     metadata[key] = str(metadata[key])
 
@@ -68,7 +76,7 @@ class Log(entities.Entity):
                 loggername=record.name,
                 levelname=record.levelname,
                 dbnode_id=dbnode_id,
-                message=record.getMessage(),
+                message=message,
                 metadata=metadata)
 
         def get_logs_for(self, entity, order_by=None):


### PR DESCRIPTION
Fixes #2898 and fixes #2984 

When a transport task of a calculation job excepts, the exponential
back off retry wrapper calls the logger of the process node with the
exception. This will trigger the `DbLogHandler` such that the log
message is entered into the database with a link to the process node.
However, only the message was included and not the stack trace which
made it difficult to determine the cause from `verdi process report`.
To fix this, in the `Log.objects.create_from_record` we attempt to
format a traceback from the `exc_info` if it is included in the record
which will be the case for an exception log.

This commit also fixes a bug in the `ProcessLauncher._continue` method
that was calling the `create_future` method of the communicator, which
has long been removed. Instead a normal future should just be created.