### PR TITLE
Fix problem in validation of `InteractiveOption` CLI option type

### DIFF
--- a/.ci/before_script.sh
+++ b/.ci/before_script.sh
@@ -23,7 +23,7 @@ then
         verdi -p $TEST_AIIDA_BACKEND computer setup --non-interactive --label=torquessh --hostname=localhost --transport=ssh --scheduler=torque --mpiprocs-per-machine=1 --prepend-text="" --append-text=""
 
         # Configure the torquessh computer
-        verdi -p $TEST_AIIDA_BACKEND computer configure ssh torquessh --non-interactive --username=app --port=10022 --key-filename=~/.ssh/id_rsa --timeout=60 --compress --gss-host=localhost --load-system-host-keys --key-policy=RejectPolicy
+        verdi -p $TEST_AIIDA_BACKEND computer configure ssh torquessh --non-interactive --safe-interval=1 --username=app --port=10022 --key-filename=~/.ssh/id_rsa --timeout=60 --compress --gss-host=localhost --load-system-host-keys --key-policy=RejectPolicy
 
         # Configure the 'doubler' code inside torquessh
         verdi -p $TEST_AIIDA_BACKEND code setup -n -L doubler \
@@ -50,7 +50,7 @@ then
         verdi -p $TEST_AIIDA_BACKEND computer setup --non-interactive --label=torquessh --hostname=localhost --transport=ssh --scheduler=direct --mpiprocs-per-machine=1 --prepend-text="" --append-text=""
 
         # Configure the torquessh computer - this one is custom, using port 22
-        verdi -p $TEST_AIIDA_BACKEND computer configure ssh torquessh --non-interactive --username=jenkins --port=22 --key-filename=~/.ssh/id_rsa --timeout=60 --compress --gss-host=localhost --load-system-host-keys --key-policy=RejectPolicy
+        verdi -p $TEST_AIIDA_BACKEND computer configure ssh torquessh --non-interactive --safe-interval=1 --username=jenkins --port=22 --key-filename=~/.ssh/id_rsa --timeout=60 --compress --gss-host=localhost --load-system-host-keys --key-policy=RejectPolicy
 
         # Configure the 'doubler' code inside torquessh
         verdi -p $TEST_AIIDA_BACKEND code setup -n -L doubler \

--- a/aiida/backends/tests/cmdline/commands/test_computer.py
+++ b/aiida/backends/tests/cmdline/commands/test_computer.py
@@ -368,16 +368,17 @@ class TestVerdiComputerConfigure(AiidaTestCase):
         comp = self.comp_builder.new()
         comp.store()
 
-        result = self.cli_runner.invoke(computer_configure, ['local', comp.label, '--non-interactive'],
-                                        catch_exceptions=False)
+        options = ['local', comp.label, '--non-interactive', '--safe-interval', '0']
+        result = self.cli_runner.invoke(computer_configure, options, catch_exceptions=False)
         self.assertTrue(comp.is_user_configured(self.user), msg=result.output)
 
         self.comp_builder.label = 'test_local_ni_empty_mismatch'
         self.comp_builder.transport = 'ssh'
         comp_mismatch = self.comp_builder.new()
         comp_mismatch.store()
-        result = self.cli_runner.invoke(computer_configure, ['local', comp_mismatch.label, '--non-interactive'],
-                                        catch_exceptions=False)
+
+        options = ['local', comp_mismatch.label, '--non-interactive']
+        result = self.cli_runner.invoke(computer_configure, options, catch_exceptions=False)
         self.assertIsNotNone(result.exception)
         self.assertIn('ssh', result.output)
         self.assertIn('local', result.output)
@@ -427,16 +428,17 @@ safe_interval: {interval}
         comp = self.comp_builder.new()
         comp.store()
 
-        result = self.cli_runner.invoke(computer_configure, ['ssh', comp.label, '--non-interactive'],
-                                        catch_exceptions=False)
+        options = ['ssh', comp.label, '--non-interactive', '--safe-interval',  '1']
+        result = self.cli_runner.invoke(computer_configure, options, catch_exceptions=False)
         self.assertTrue(comp.is_user_configured(self.user), msg=result.output)
 
         self.comp_builder.label = 'test_ssh_ni_empty_mismatch'
         self.comp_builder.transport = 'local'
         comp_mismatch = self.comp_builder.new()
         comp_mismatch.store()
-        result = self.cli_runner.invoke(computer_configure, ['ssh', comp_mismatch.label, '--non-interactive'],
-                                        catch_exceptions=False)
+
+        options = ['ssh', comp_mismatch.label, '--non-interactive']
+        result = self.cli_runner.invoke(computer_configure, options, catch_exceptions=False)
         self.assertIsNotNone(result.exception)
         self.assertIn('local', result.output)
         self.assertIn('ssh', result.output)
@@ -449,9 +451,8 @@ safe_interval: {interval}
         comp.store()
 
         username = 'TEST'
-        result = self.cli_runner.invoke(computer_configure,
-                                        ['ssh', comp.label, '--non-interactive', '--username={}'.format(username)],
-                                        catch_exceptions=False)
+        options = ['ssh', comp.label, '--non-interactive', '--username={}'.format(username), '--safe-interval', '1']
+        result = self.cli_runner.invoke(computer_configure, options, catch_exceptions=False)
         self.assertTrue(comp.is_user_configured(self.user), msg=result.output)
         self.assertEqual(orm.AuthInfo.objects.get(
             dbcomputer_id=comp.id, aiidauser_id=self.user.id).get_auth_params()['username'],

--- a/aiida/cmdline/params/options/interactive.py
+++ b/aiida/cmdline/params/options/interactive.py
@@ -191,10 +191,12 @@ class InteractiveOption(ConditionalOption):
         successful = False
         try:
             value = self.type.convert(value, param, ctx)
+            value = self.after_callback(ctx, param, value)
             successful = True
         except click.BadParameter as err:
             echo.echo_error(str(err))
             self.ctrl_help()
+
         return successful, value
 
     def simple_prompt_loop(self, ctx, param, value):

--- a/aiida/transports/transport.py
+++ b/aiida/transports/transport.py
@@ -36,9 +36,9 @@ def validate_positive_number(ctx, param, value):  # pylint: disable=unused-argum
     :param value: the value passed for the parameter
     :raises `click.BadParameter`: if the value is not a positive number
     """
-    if value is not None and value < 0:
+    if not isinstance(value, (int, float)) or value < 0:
         from click import BadParameter
-        raise BadParameter('value needs to be a positive number')
+        raise BadParameter('{} is not a valid positive number'.format(value))
 
 
 @six.add_metaclass(ABCMeta)
@@ -58,7 +58,6 @@ class Transport(object):
         'type': float,
         'prompt': 'Connection cooldown time (s)',
         'help': 'Minimum time interval in seconds between consecutive connection openings',
-        'non_interactive_default': True,
         'callback': validate_positive_number
     })]
 


### PR DESCRIPTION
Fixes #2987 

The option allows to specify a callback function to perform validation
in addition to the type. However, in the prompt loop, only the normal
type validation was called. This caused the validation in the callback
to be skipped if called more than once, allowing illegal values to be
accepted in interactive mode if simply passed more than once.

Additionally, the `non_interactive_default` setting for the
`safe_interval` option of `verdi computer configure` in combination with
the implementation of the callback function, which ignored `None`
values, allowed `None` values to be set in non-interactive mode. The
callback now properly checks for the correct type and raises an error if
`None` is passed.