### PR TITLE
Correct decorator implementation using the `wrapt` library

### DIFF
--- a/aiida/backends/tests/__init__.py
+++ b/aiida/backends/tests/__init__.py
@@ -74,6 +74,7 @@ DB_TEST_LIST = {
         'common.extendeddicts': ['aiida.backends.tests.common.test_extendeddicts'],
         'common.folders': ['aiida.backends.tests.common.test_folders'],
         'common.hashing': ['aiida.backends.tests.common.test_hashing'],
+        'common.lang': ['aiida.backends.tests.common.test_lang'],
         'common.links': ['aiida.backends.tests.common.test_links'],
         'common.logging': ['aiida.backends.tests.common.test_logging'],
         'common.serialize': ['aiida.backends.tests.common.test_serialize'],

--- a/aiida/backends/tests/common/test_lang.py
+++ b/aiida/backends/tests/common/test_lang.py
@@ -1,0 +1,107 @@
+# -*- coding: utf-8 -*-
+###########################################################################
+# Copyright (c), The AiiDA team. All rights reserved.                     #
+# This file is part of the AiiDA code.                                    #
+#                                                                         #
+# The code is hosted on GitHub at https://github.com/aiidateam/aiida_core #
+# For further information on the license, see the LICENSE.txt file        #
+# For further information please visit http://www.aiida.net               #
+###########################################################################
+"""Tests for the :py:mod:`~aiida.common.lang` module."""
+from __future__ import division
+from __future__ import print_function
+from __future__ import absolute_import
+
+from aiida.backends.testbase import AiidaTestCase
+from aiida.common import lang
+
+protected_checked = lang.protected_decorator(check=True)  # pylint: disable=invalid-name
+protected_unchecked = lang.protected_decorator(check=False)  # pylint: disable=invalid-name
+
+
+class Protected(object):
+    """Class to test the protected decorator."""
+
+    # pylint: disable=no-self-use,useless-object-inheritance
+
+    def member_internal(self):
+        """Class method that is allowed to call the protected methods."""
+        result = self.member_unprotected()
+        result &= self.member_protected_checked()
+        result &= self.member_protected_unchecked()
+        result &= self.property_correct_order
+        return result
+
+    def member_unprotected(self):
+        """Simple unproctected method."""
+        return True
+
+    @protected_unchecked
+    def member_protected_unchecked(self):
+        """Decorated method but without check - can be called outside scope."""
+        return True
+
+    @protected_checked
+    def member_protected_checked(self):
+        """Decorated method but without check - cannot be called outside scope."""
+        return True
+
+    @property
+    @protected_checked
+    def property_correct_order(self):
+        """Decorated property but without check - cannot be called outside scope."""
+        return True
+
+
+class TestProtectedDecorator(AiidaTestCase):
+    """Tests for the :py:func:`~aiida.common.lang.protected` decorator."""
+
+    # pylint: disable=unused-variable,useless-object-inheritance
+
+    def test_free_function(self):
+        """Decorating a free function should raise."""
+        with self.assertRaises(RuntimeError):
+
+            @protected_unchecked
+            def some_function():
+                pass
+
+    def test_property_incorrect_order(self):
+        """The protected decorator should raise if applied before the property decorator."""
+        with self.assertRaises(RuntimeError):
+
+            class InvalidProtected(object):
+                """Invalid use of protected decorator."""
+
+                @staticmethod
+                @protected_checked
+                @property
+                def property_incorrect_order():
+                    return True
+
+    def test_internal(self):
+        """Calling protected internally from a public class method should work."""
+        instance = Protected()
+        self.assertTrue(instance.member_internal())
+
+    def test_unprotected(self):
+        """Test that calling unprotected class method is allowed."""
+        instance = Protected()
+        self.assertTrue(instance.member_unprotected())
+
+    def test_protected_unchecked(self):
+        """Test that calling an unchecked protected class method is allowed."""
+        instance = Protected()
+        self.assertTrue(instance.member_protected_unchecked())
+
+    def test_protected_checked(self):
+        """Test that calling a checked protected class method raises."""
+        instance = Protected()
+        with self.assertRaises(RuntimeError):
+            self.assertTrue(instance.member_protected_checked())
+
+    def test_protected_property_correct_order(self):
+        """Test that calling a checked protected property raises."""
+        instance = Protected()
+        with self.assertRaises(RuntimeError):
+            self.assertEqual(instance.property_correct_order, True)

--- a/aiida/manage/caching.py
+++ b/aiida/manage/caching.py
@@ -16,11 +16,11 @@ import io
 import os
 import copy
 from enum import Enum
-from functools import wraps
 from contextlib import contextmanager
 
 import yaml
 import six
+from wrapt import decorator
 
 from aiida.common import exceptions
 from aiida.common.utils import get_object_from_string
@@ -101,16 +101,12 @@ def configure(config_file=None):
     _CONFIG.update(_get_config(config_file=config_file))
 
 
-def _with_config(func):
+@decorator
+def _with_config(wrapped, _, args, kwargs):
     """Function decorator to load the caching configuration for the scope of the wrapped function."""
-
-    @wraps(func)
-    def inner(*args, **kwargs):
-        if not _CONFIG:
-            configure()
-        return func(*args, **kwargs)
-
-    return inner
+    if not _CONFIG:
+        configure()
+    return wrapped(*args, **kwargs)
 
 
 @_with_config

--- a/docs/requirements_for_rtd.txt
+++ b/docs/requirements_for_rtd.txt
@@ -68,3 +68,4 @@ typing==3.6.6; python_version<'3.5'
 tzlocal==1.5.1
 unittest2==1.1.0; python_version<'3.5'
 uritools==2.2.0
+wrapt==1.11.1

--- a/environment.yml
+++ b/environment.yml
@@ -36,4 +36,5 @@ dependencies:
 - pika==1.0.0
 - circus==0.15.0
 - tornado<5.0
+- wrapt==1.11.1
 - simplejson==3.16.0

--- a/setup.json
+++ b/setup.json
@@ -48,6 +48,7 @@
     "pika==1.0.0",
     "circus==0.15.0",
     "tornado<5.0",
+    "wrapt==1.11.1",
     "pyblake2==1.1.2; python_version<'3.6'",
     "singledispatch>=3.4.0.3; python_version<'3.5'",
     "enum34==1.1.6; python_version<'3.5'",


### PR DESCRIPTION
Fixes #2446 

The naive implementation of a decorator will break some of the
functionality of the functions they wrap. For example, the original
docstring will be lost. The module `functools` provides the `wraps`
decorator to fix this problem, but this is not the only issue. In
addition to the docstring, other properties, such as the function
signature are also lost. This means that using the `inspect` module on
decorated functions is hopelessly broken. The `wrapt` library provides
the `decorator` decorator that simplifies writing decorators, while
ensuring that all the important properties of wrapped function are
maintained.