### PR TITLE
Add `errors_handled` updatable attribute to `WorkChainNode`

### DIFF
--- a/aiida/backends/tests/__init__.py
+++ b/aiida/backends/tests/__init__.py
@@ -126,6 +126,7 @@ DB_TEST_LIST = {
         'orm.logs': ['aiida.backends.tests.orm.test_logs'],
         'orm.mixins': ['aiida.backends.tests.orm.test_mixins'],
         'orm.node.calcjob': ['aiida.backends.tests.orm.node.test_calcjob'],
+        'orm.node.workchain': ['aiida.backends.tests.orm.node.test_workchain'],
         'orm.node.node': ['aiida.backends.tests.orm.node.test_node'],
         'orm.querybuilder': ['aiida.backends.tests.orm.test_querybuilder'],
         'orm.utils.calcjob': ['aiida.backends.tests.orm.utils.test_calcjob'],

--- a/aiida/backends/tests/orm/node/test_workchain.py
+++ b/aiida/backends/tests/orm/node/test_workchain.py
@@ -1,0 +1,42 @@
+# -*- coding: utf-8 -*-
+###########################################################################
+# Copyright (c), The AiiDA team. All rights reserved.                     #
+# This file is part of the AiiDA code.                                    #
+#                                                                         #
+# The code is hosted on GitHub at https://github.com/aiidateam/aiida_core #
+# For further information on the license, see the LICENSE.txt file        #
+# For further information please visit http://www.aiida.net               #
+###########################################################################
+"""Tests for the `WorkChainNode` node sub class."""
+from __future__ import division
+from __future__ import print_function
+from __future__ import absolute_import
+
+from aiida.backends.testbase import AiidaTestCase
+from aiida.common import exceptions
+from aiida.orm import WorkChainNode
+
+
+class TestWorkChainNode(AiidaTestCase):
+    """Tests for the `WorkChainNode` node sub class."""
+
+    def test_errors_handled(self):
+        """Test the property `errors_handled` and the attribute `add_error_handler`."""
+        errors = ['handle_unconverged', 'handle_out_of_walltime']
+        node = WorkChainNode().store()
+
+        # If the attribute does not exist, the property should
+        self.assertEqual(node.errors_handled, None)
+
+        node.add_error_handled(errors[0])
+        self.assertEqual(node.errors_handled, [errors[0]])
+
+        node.add_error_handled(errors[1])
+        self.assertEqual(node.errors_handled, errors)
+
+        # After sealing, retrieving should still work, but `add_error_handler` should raise
+        node.seal()
+        self.assertEqual(node.errors_handled, errors)
+
+        with self.assertRaises(exceptions.ModificationNotAllowed):
+            node.add_error_handled(errors[1])

--- a/aiida/orm/nodes/process/workflow/workchain.py
+++ b/aiida/orm/nodes/process/workflow/workchain.py
@@ -25,25 +25,43 @@ class WorkChainNode(WorkflowNode):
     _cachable = False
 
     STEPPER_STATE_INFO_KEY = 'stepper_state_info'
+    ERRORS_HANDLED_KEY = 'errors_handled'
 
     @classproperty
     def _updatable_attributes(cls):
         # pylint: disable=no-self-argument
-        return super(WorkChainNode, cls)._updatable_attributes + (cls.STEPPER_STATE_INFO_KEY,)
+        return super(WorkChainNode, cls)._updatable_attributes + (cls.STEPPER_STATE_INFO_KEY, cls.ERRORS_HANDLED_KEY)
 
     @property
     def stepper_state_info(self):
-        """
-        Return the stepper state info
+        """Return the stepper state info
 
         :returns: string representation of the stepper state info
         """
         return self.get_attribute(self.STEPPER_STATE_INFO_KEY, None)
 
     def set_stepper_state_info(self, stepper_state_info):
-        """
-        Set the stepper state info
+        """Set the stepper state info
 
         :param state: string representation of the stepper state info
         """
         return self.set_attribute(self.STEPPER_STATE_INFO_KEY, stepper_state_info)
+
+    @property
+    def errors_handled(self):
+        """Return the errors handled during execution of this work chain.
+
+        When an error is handled through an error handler, it can be added through `add_error_handled`.
+
+        :return: a list of error handler method names
+        """
+        return self.get_attribute(self.ERRORS_HANDLED_KEY, None)
+
+    def add_error_handled(self, error_handled):
+        """Return the names of the error handlers that were triggered during execution
+
+        :param state: string representation of the stepper state info
+        """
+        errors_handled = self.errors_handled or []
+        errors_handled.append(error_handled)
+        return self.set_attribute(self.ERRORS_HANDLED_KEY, errors_handled)


### PR DESCRIPTION
Fixes #2992 

This new updatable attribute for the `WorkChainNode` class will be
useful once the `BaseRestartWorkChain` and `register_error_handler`
concepts will be added to `aiida-core`. These utilities provide a basic
framework to quickly write powerful work chains around `CalcJob`
implementations. Through the `register_error_handler` methods can be
attached to the `BaseRestartWorkChain` implementation to extend the
error handling capability in the case of a failed calculation. To make
it possible to query for work chains that had certain error handlers
triggered during their execution, their method names need to be added to
some list in the attributes. This is the intended purpose for the new
`errors_handled` attribute.