### PR TITLE
add order options to `verdi process list`

### DIFF
--- a/aiida/cmdline/commands/cmd_process.py
+++ b/aiida/cmdline/commands/cmd_process.py
@@ -33,6 +33,8 @@ def verdi_process():
 @verdi_process.command('list')
 @options.PROJECT(
     type=click.Choice(CalculationQueryBuilder.valid_projections), default=CalculationQueryBuilder.default_projections)
+@options.ORDER_BY()
+@options.ORDER_DIR()
 @options.GROUP(help='Only include entries that are a member of this group.')
 @options.ALL(help='Show all entries, regardless of their process state.')
 @options.PROCESS_STATE()
@@ -42,8 +44,10 @@ def verdi_process():
 @options.LIMIT()
 @options.RAW()
 @decorators.with_dbenv()
-def process_list(all_entries, group, process_state, exit_status, failed, past_days, limit, project, raw):
+def process_list(all_entries, group, process_state, exit_status, failed, past_days, limit, project, raw, order_by,
+                 order_dir):
     """Show a list of processes that are still running."""
+    # pylint: disable=too-many-locals
     from tabulate import tabulate
     from aiida.cmdline.utils.common import print_last_process_state_change, check_worker_load
 
@@ -54,7 +58,8 @@ def process_list(all_entries, group, process_state, exit_status, failed, past_da
 
     builder = CalculationQueryBuilder()
     filters = builder.get_filters(all_entries, process_state, exit_status, failed)
-    query_set = builder.get_query_set(relationships=relationships, filters=filters, past_days=past_days, limit=limit)
+    query_set = builder.get_query_set(
+        relationships=relationships, filters=filters, order_by={order_by: order_dir}, past_days=past_days, limit=limit)
     projected = builder.get_projected(query_set, projections=project)
 
     headers = projected.pop(0)

--- a/aiida/cmdline/params/options/__init__.py
+++ b/aiida/cmdline/params/options/__init__.py
@@ -280,6 +280,11 @@ ORDER_BY = OverridableOption(
     type=click.Choice(['id', 'ctime']), default='ctime', show_default=True,
     help='Order the entries by this attribute.')
 
+ORDER_DIR = OverridableOption(
+    '-D', '--order-dir', 'order_dir',
+    type=click.Choice(['asc', 'desc']), default='asc', show_default=True,
+    help='List the entries in ascending or descending order')
+
 PAST_DAYS = OverridableOption(
     '-p', '--past-days', 'past_days',
     type=click.INT, metavar='PAST_DAYS',

--- a/aiida/schedulers/plugins/pbsbaseclasses.py
+++ b/aiida/schedulers/plugins/pbsbaseclasses.py
@@ -380,7 +380,8 @@ class PbsBaseClass(Scheduler):
             _LOGGER.warning("Warning in _parse_joblist_output, non-empty "
                             "(filtered) stderr='{}'".format(filtered_stderr))
             if retval != 0:
-                raise SchedulerError("Error during qstat parsing (_parse_joblist_output function)")
+                raise SchedulerError("Error during qstat parsing, retval={}\n"
+                                    "stdout={}\nstderr={}".format(retval, stdout, stderr))
 
         jobdata_raw = []  # will contain raw data parsed from qstat output
         # Get raw data and split in lines


### PR DESCRIPTION
As it says on the tin! Particularly helpful if you want to list the last *x* processes, i.e. `verdi process list -D desc -l 10`