### PR TITLE
Make construction of `AttributeDict` recursive

### DIFF
--- a/aiida/orm/nodes/process/calculation/calcjob.py
+++ b/aiida/orm/nodes/process/calculation/calcjob.py
@@ -149,10 +149,9 @@ class CalcJobNode(CalculationNode):
         except TypeError as exception:
             raise exceptions.ValidationError('invalid parser specified: {}'.format(exception))
 
-        computer = self.computer
-        scheduler = computer.get_scheduler()
         resources = self.get_option('resources')
-        def_cpus_machine = computer.get_default_mpiprocs_per_machine()
+        scheduler = self.computer.get_scheduler()  # pylint: disable=no-member
+        def_cpus_machine = self.computer.get_default_mpiprocs_per_machine()  # pylint: disable=no-member
 
         if def_cpus_machine is not None:
             resources['default_mpiprocs_per_machine'] = def_cpus_machine

--- a/docs/source/nitpick-exceptions
+++ b/docs/source/nitpick-exceptions
@@ -60,6 +60,7 @@ py:class  unittest.case.TestCase
 py:class  unittest.runner.TextTestRunner
 py:class  unittest2.case.TestCase
 py:meth   unittest.TestLoader.discover
+py:meth   copy.copy
 py:class  ABCMeta
 py:class  exceptions.Exception
 py:class  exceptions.ValueError


### PR DESCRIPTION
Fixes #2996 

This means that dictionaries nested in the dictionaries will also
recursively be turned into `AttributeDicts`. This has the benefit that
when constructing a nested dictionary like:

    dictionary = AttributeDict({'sub': {'name': 1}})

the nested keys can all be accessed as attributes, i.e.:

    dictionary.sub.name

whereas before one had to do:

    dictionary.sub['name']

which is not very intuitive.