### PR TITLE
First restructuring of devel docs

### DIFF
--- a/docs/source/developer_guide/index.rst
+++ b/docs/source/developer_guide/index.rst
@@ -2,24 +2,6 @@ Practical information concerning how to set up your development environment and 
 to contribute to aiida core can be found on the 
 `AiiDA Wiki <https://github.com/aiidateam/aiida_core/wiki>`_.
 
-=============
-AiiDA plugins
-=============
-
-.. toctree::
-   :maxdepth: 1
-
-   plugins/index
-   devel_tutorial/code_plugin_float_sum
-   devel_tutorial/plugin_tests
-   devel_tutorial/cmdline_plugin
-   devel_tutorial/parser_warnings_policy
-   aiida_sphinxext
-
-==========
-AiiDA core
-==========
-
 .. toctree::
    :maxdepth: 1
 
@@ -31,13 +13,5 @@ AiiDA core
    core/caching
    core/plugin_system
    tools/sphinx_cheatsheet
-
-============
-AiiDA design
-============
-
-.. toctree::
-   :maxdepth: 1
-
    design/changes
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -65,7 +65,6 @@ The software is available at http://www.aiida.net.
     working/calculations
     working/workflows
 
-
 .. toctree::
     :maxdepth: 1
     :caption: Working with AiiDA
@@ -77,11 +76,10 @@ The software is available at http://www.aiida.net.
 
 .. toctree::
     :maxdepth: 1
-    :caption: Development
+    :caption: For AiiDA developers
     :hidden:
 
     developer_guide/index
-
 
 .. toctree::
     :maxdepth: 1
@@ -97,6 +95,19 @@ The software is available at http://www.aiida.net.
     :hidden:
 
     apidoc/aiida
+
+.. toctree::
+   :maxdepth: 1
+   :caption: aiida-plugins [Section to be moved]
+   :hidden:
+
+
+   developer_guide/plugins/index
+   developer_guide/devel_tutorial/code_plugin_float_sum
+   developer_guide/devel_tutorial/plugin_tests
+   developer_guide/devel_tutorial/cmdline_plugin
+   developer_guide/devel_tutorial/parser_warnings_policy
+   developer_guide/aiida_sphinxext
 
 
 ***********


### PR DESCRIPTION
This is preliminary to #3035 to move some docs out
of the main documentation or at least revised.

Moreover, also the main devel section has been
renamed from "Development" to "For AiiDA developers"
and the only page under "AiiDA design" has been moved 
inside the same section "for AiiDA developers".