### PR TITLE
Update dependency requirement `plumpy==0.14.1`

### DIFF
--- a/docs/requirements_for_rtd.txt
+++ b/docs/requirements_for_rtd.txt
@@ -41,7 +41,7 @@ passlib==1.7.1
 pg8000<1.13.0
 pgtest==1.2.0
 pika==1.0.0
-plumpy==0.14.0
+plumpy==0.14.1
 psutil==5.5.1
 pyblake2==1.1.2; python_version<'3.6'
 pymatgen<=2018.12.12

--- a/environment.yml
+++ b/environment.yml
@@ -31,7 +31,7 @@ dependencies:
 - psycopg2==2.8
 - paramiko==2.4.2
 - ipython>=4.0,<6.0
-- plumpy==0.14.0
+- plumpy==0.14.1
 - kiwipy[rmq]==0.5.1
 - pika==1.0.0
 - circus==0.15.0

--- a/setup.json
+++ b/setup.json
@@ -43,7 +43,7 @@
     "psycopg2-binary==2.8",
     "paramiko==2.4.2",
     "ipython>=4.0,<6.0",
-    "plumpy==0.14.0",
+    "plumpy==0.14.1",
     "kiwipy[rmq]==0.5.1",
     "pika==1.0.0",
     "circus==0.15.0",


### PR DESCRIPTION
Fixes #2891 and fixes #3037 

This patch release of `plumpy` tackles two problems:

 * When the engine encountered an exception while running a process, it
   was not setting the traceback on the future, with the result that the
   actual printed traceback did not contain any useful information.
 * The `exclude` and `include` rules of `ProcessSpec.expose_inputs` now
   support nested rules whereas before only top-level ports could be
   targeted, despite the absorbing of nested ports being supported.