### PR TITLE
Add aiida-core version to docs home page (0.12 branch)

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -3,6 +3,8 @@
    You can adapt this file completely to your liking, but it should at least
    contain the root `toctree` directive.
 
+**aiida-core version:** |release|
+
 .. figure:: images/AiiDA_transparent_logo.png
     :width: 250px
     :align: center


### PR DESCRIPTION
Addresses issue #2918 for the 0.12 branch.
Note that the home page will say "version 0.12.3" until `__version__` is updated in `aiida/__init__.py`.