### PR TITLE
Return `None` for invalid state in `CalcJobNode.get_state`

### DIFF
--- a/aiida/backends/tests/orm/node/test_calcjob.py
+++ b/aiida/backends/tests/orm/node/test_calcjob.py
@@ -15,12 +15,27 @@ from __future__ import absolute_import
 import tempfile
 
 from aiida.backends.testbase import AiidaTestCase
-from aiida.common import LinkType
+from aiida.common import LinkType, CalcJobState
 from aiida.orm import CalcJobNode, FolderData
 
 
 class TestCalcJobNode(AiidaTestCase):
     """Tests for the `CalcJobNode` node sub class."""
+
+    def test_get_set_state(self):
+        """Test the `get_state` and `set_state` method."""
+        node = CalcJobNode(computer=self.computer,)
+        self.assertEqual(node.get_state(), None)
+
+        with self.assertRaises(ValueError):
+            node.set_state('INVALID')
+
+        node.set_state(CalcJobState.UPLOADING)
+        self.assertEqual(node.get_state(), CalcJobState.UPLOADING)
+
+        # Setting an illegal calculation job state, the `get_state` should not fail but return `None`
+        node.set_attribute(node.CALC_JOB_STATE_KEY, 'INVALID')
+        self.assertEqual(node.get_state(), None)
 
     def test_get_scheduler_stdout(self):
         """Verify that the repository sandbox folder is cleaned after the node instance is garbage collected."""

--- a/aiida/engine/processes/process.py
+++ b/aiida/engine/processes/process.py
@@ -76,8 +76,10 @@ class Process(plumpy.Process):
             help='Label to set on the process node.')
         spec.input('{}.call_link_label'.format(spec.metadata_key), valid_type=six.string_types[0], default='CALL',
             help='The label to use for the `CALL` link if the process is called by another process.')
-        spec.exit_code(10, 'ERROR_INVALID_OUTPUT', message='the process returned an invalid output')
-        spec.exit_code(11, 'ERROR_MISSING_OUTPUT', message='the process did not register a required output')
+        spec.exit_code(1, 'ERROR_UNSPECIFIED', message='The process has failed with an unspecified error.')
+        spec.exit_code(2, 'ERROR_LEGACY_FAILURE', message='The process failed with legacy failure mode.')
+        spec.exit_code(10, 'ERROR_INVALID_OUTPUT', message='The process returned an invalid output.')
+        spec.exit_code(11, 'ERROR_MISSING_OUTPUT', message='The process did not register a required output.')
 
     @classmethod
     def get_builder(cls):

--- a/aiida/orm/nodes/process/calculation/calcjob.py
+++ b/aiida/orm/nodes/process/calculation/calcjob.py
@@ -136,9 +136,6 @@ class CalcJobNode(CalculationNode):
         if self.computer is None:
             raise exceptions.ValidationError('no computer was specified')
 
-        if self.get_state() and self.get_state() not in CalcJobState:
-            raise exceptions.ValidationError('invalid calculation state `{}`'.format(self.get_state()))
-
         try:
             parser_class = self.get_parser_class()
         except exceptions.EntryPointError as exception:
@@ -225,20 +222,26 @@ class CalcJobNode(CalculationNode):
             self.set_option(name, value)
 
     def get_state(self):
-        """Return the state of the calculation job.
+        """Return the calculation job active sub state.
 
-        :return: the calculation job state
+        The calculation job state serves to give more granular state information to `CalcJobs`, in addition to the
+        generic process state, while the calculation job is active. The state can take values from the enumeration
+        defined in `aiida.common.datastructures.CalcJobState` and can be used to query for calculation jobs in specific
+        active states.
+
+        :return: instance of `aiida.common.datastructures.CalcJobState` or `None` if invalid value, or not set
         """
         state = self.get_attribute(self.CALC_JOB_STATE_KEY, None)
 
-        if state:
-            return CalcJobState(state)
+        try:
+            state = CalcJobState(state)
+        except ValueError:
+            state = None
 
-        return None
+        return state
 
     def set_state(self, state):
-        """
-        Set the state of the calculation job.
+        """Set the calculation active job state.
 
         :param state: a string with the state from ``aiida.common.datastructures.CalcJobState``.
         :raise: ValueError if state is invalid


### PR DESCRIPTION
Fixes #2894 

The `state` attribute of a calculation job node is an active sub state
specific only to `CalcJobs` to give more granularity to the general
process state. This attribute is only set during the lifetime of the
calculation job and is removed afterwards. The docstring now makes this
clear to prevent confusion when it returns `None`. The method now also
returns `None` if the attribute contains an invalid value, instead of
excepting, which should only happen due to incorrectly migrated legacy
data. We do not want this to except the application.