### PR TITLE
Remove process function docstring as default for node description

### DIFF
--- a/aiida/backends/tests/engine/test_process_function.py
+++ b/aiida/backends/tests/engine/test_process_function.py
@@ -87,8 +87,7 @@ class TestProcessFunction(AiidaTestCase):
             return data_a
 
         @workfunction
-        def function_default_from_docs():
-            """Description taken from the docs."""
+        def function_default_label():
             return
 
         @workfunction
@@ -112,7 +111,7 @@ class TestProcessFunction(AiidaTestCase):
         self.function_args_and_kwargs = function_args_and_kwargs
         self.function_args_and_default = function_args_and_default
         self.function_defaults = function_defaults
-        self.function_default_from_docs = function_default_from_docs
+        self.function_default_label = function_default_label
         self.function_exit_code = function_exit_code
         self.function_excepts = function_excepts
         self.function_out_unstored = function_out_unstored
@@ -306,15 +305,15 @@ class TestProcessFunction(AiidaTestCase):
         self.assertEqual(node.label, CUSTOM_LABEL)
         self.assertEqual(node.description, CUSTOM_DESCRIPTION)
 
-    def test_function_default_label_description(self):
-        """Verify unless specified label and description are taken from function name and docstring respectively."""
+    def test_function_default_label(self):
+        """Verify unless specified label is taken from function name."""
         metadata = {'label': CUSTOM_LABEL, 'description': CUSTOM_DESCRIPTION}
 
-        _, node = self.function_default_from_docs.run_get_node()
-        self.assertEqual(node.label, 'function_default_from_docs')
-        self.assertEqual(node.description, 'Description taken from the docs.')
+        _, node = self.function_default_label.run_get_node()
+        self.assertEqual(node.label, 'function_default_label')
+        self.assertEqual(node.description, '')
 
-        _, node = self.function_default_from_docs.run_get_node(metadata=metadata)
+        _, node = self.function_default_label.run_get_node(metadata=metadata)
         self.assertEqual(node.label, CUSTOM_LABEL)
         self.assertEqual(node.description, CUSTOM_DESCRIPTION)
 

--- a/aiida/engine/processes/functions.py
+++ b/aiida/engine/processes/functions.py
@@ -273,13 +273,9 @@ class FunctionProcess(Process):
 
             # Set defaults for label and description based on function name and docstring, if not explicitly defined
             port_label = spec.inputs['metadata']['label']
-            port_description = spec.inputs['metadata']['description']
 
             if not port_label.has_default():
                 port_label.default = func.__name__
-
-            if not port_description.has_default() and func.__doc__:
-                port_description.default = func.__doc__
 
             # If the function support kwargs then allow dynamic inputs, otherwise disallow
             spec.inputs.dynamic = keywords is not None


### PR DESCRIPTION
Fixes #3069 

The idea was nice, but if one writes a decently sized docstring, this
content will be stored each time the function is run. Besides this is
already stored in the repository, which is a better place for it as it
does not need to be queryable.