### PR TITLE
Move import in `aiida.cmdline.commands` to speed up `verdi`

### DIFF
--- a/aiida/cmdline/commands/cmd_export.py
+++ b/aiida/cmdline/commands/cmd_export.py
@@ -24,7 +24,6 @@ from aiida.cmdline.params import arguments
 from aiida.cmdline.params import options
 from aiida.cmdline.utils import decorators
 from aiida.cmdline.utils import echo
-from aiida.cmdline.utils import migration
 
 
 @verdi.group('export')
@@ -168,6 +167,7 @@ def migrate(input_file, output_file, force, silent, archive_format):
     from aiida.common import json
     from aiida.common.folders import SandboxFolder
     from aiida.common.archive import extract_zip, extract_tar
+    from aiida.cmdline.utils import migration
 
     if os.path.exists(output_file) and not force:
         echo.echo_critical('the output file already exists')

--- a/aiida/manage/configuration/__init__.py
+++ b/aiida/manage/configuration/__init__.py
@@ -87,11 +87,11 @@ def load_config(create=False):
     from .config import Config
     from .migrations import check_and_migrate_config
     from .settings import AIIDA_CONFIG_FOLDER, DEFAULT_CONFIG_FILE_NAME
-    from aiida.manage.external.postgres import DEFAULT_DBINFO
 
     if IN_RT_DOC_MODE:
         # The following is a dummy config.json configuration that it is used for the
         # proper compilation of the documentation on readthedocs.
+        from aiida.manage.external.postgres import DEFAULT_DBINFO
         return ({
             'default_profile': 'default',
             'profiles': {


### PR DESCRIPTION
The `aiida.cmdline.utils.migration` is importing quite some modules that
were slowing the usual loading time of 200 ms to near 350 ms.