### PR TITLE
Only print `retrieve_singlefile_list` deprecation when necessary

### DIFF
--- a/aiida/engine/processes/calcjobs/calcjob.py
+++ b/aiida/engine/processes/calcjobs/calcjob.py
@@ -294,7 +294,8 @@ class CalcJob(Process):
                 raise PluginInternalError(
                     "[presubmission of calc {}] retrieve_singlefile_list subclass problem: {} is "
                     "not subclass of SinglefileData".format(self.node.pk, file_sub_class.__name__))
-        self.node.set_retrieve_singlefile_list(retrieve_singlefile_list)
+        if retrieve_singlefile_list:
+            self.node.set_retrieve_singlefile_list(retrieve_singlefile_list)
 
         # Handle the retrieve_temporary_list
         retrieve_temporary_list = (calcinfo.retrieve_temporary_list

--- a/aiida/orm/nodes/process/calculation/calcjob.py
+++ b/aiida/orm/nodes/process/calculation/calcjob.py
@@ -373,7 +373,6 @@ class CalcJobNode(CalculationNode):
             Will be removed in `v2.0.0`, use
             :meth:`aiida.orm.nodes.process.calculation.calcjob.CalcJobNode.get_retrieve_temporary_list` instead.
         """
-        warnings.warn('method is deprecated, use `get_retrieve_temporary_list` instead', AiidaDeprecationWarning)  # pylint: disable=no-member
         return self.get_attribute(self.RETRIEVE_SINGLE_FILE_LIST_KEY, None)
 
     def set_job_id(self, job_id):


### PR DESCRIPTION
While the functionality still exists, the engine will keep calling the
`get_retrieve_singlefile_list` method and try to set them from the
calculation info object, so the warnings were printed even when the user
was not actually using it. Make sure that the relevant methods are only
called when the user explicitly sets the `retrieve_singlefile_list`.