### PR TITLE
Add the `verdi process call-root` command

### DIFF
--- a/aiida/cmdline/commands/cmd_process.py
+++ b/aiida/cmdline/commands/cmd_process.py
@@ -94,6 +94,30 @@ def process_show(processes):
         echo.echo(get_node_info(process))
 
 
+@verdi_process.command('call-root')
+@arguments.PROCESSES()
+@decorators.with_dbenv()
+def process_call_root(processes):
+    """Show the root process of the call stack for the given processes."""
+    for process in processes:
+
+        caller = process.caller
+
+        if caller is None:
+            echo.echo('No callers found for Process<{}>'.format(process.pk))
+            continue
+
+        while True:
+            next_caller = caller.caller
+
+            if next_caller is None:
+                break
+
+            caller = next_caller
+
+        echo.echo('{}'.format(caller.pk))
+
+
 @verdi_process.command('report')
 @arguments.PROCESSES()
 @click.option('-i', '--indent-size', type=int, default=2, help='Set the number of spaces to indent each level by.')

--- a/aiida/orm/nodes/process/process.py
+++ b/aiida/orm/nodes/process/process.py
@@ -446,11 +446,12 @@ class ProcessNode(Sealable, Node):
 
         :returns: process node that called this process node instance or None
         """
-        caller = self.get_incoming(link_type=(LinkType.CALL_CALC, LinkType.CALL_WORK))
-        if caller:
-            return caller.first().node
-
-        return None
+        try:
+            caller = self.get_incoming(link_type=(LinkType.CALL_CALC, LinkType.CALL_WORK)).one().node
+        except ValueError:
+            return None
+        else:
+            return caller
 
     def validate_incoming(self, source, link_type, link_label):
         """Validate adding a link of the given type from a given node to ourself.
@@ -466,7 +467,6 @@ class ProcessNode(Sealable, Node):
         :raise ValueError: if the proposed link is invalid
         """
         super(ProcessNode, self).validate_incoming(source, link_type, link_label)
-        # if self.is_stored and link_type in [LinkType.INPUT_CALC, LinkType.INPUT_WORK]:
         if self.is_stored:
             raise ValueError('attempted to add an input link after the process node was already stored.')
 

--- a/docs/source/verdi/verdi_user_guide.rst
+++ b/docs/source/verdi/verdi_user_guide.rst
@@ -583,14 +583,15 @@ Below is a list with all available subcommands.
       --help  Show this message and exit.
 
     Commands:
-      kill    Kill running processes.
-      list    Show a list of processes that are still running.
-      pause   Pause running processes.
-      play    Play paused processes.
-      report  Show the log report for one or multiple processes.
-      show    Show a summary for one or multiple processes.
-      status  Print the status of the process.
-      watch   Watch the state transitions for a process.
+      call-root  Show the root process of the call stack for the given...
+      kill       Kill running processes.
+      list       Show a list of processes that are still running.
+      pause      Pause running processes.
+      play       Play paused processes.
+      report     Show the log report for one or multiple processes.
+      show       Show a summary for one or multiple processes.
+      status     Print the status of the process.
+      watch      Watch the state transitions for a process.
 
 
 .. _verdi_profile:


### PR DESCRIPTION
Fixes #1150 

This command will go up the call stack for a given process node and
return the root caller, if there is one.