### PR TITLE
Allow to ignore default values in `InteractiveOption`

### DIFF
--- a/aiida/cmdline/params/options/test_interactive.py
+++ b/aiida/cmdline/params/options/test_interactive.py
@@ -93,10 +93,10 @@ class InteractiveOptionTest(unittest.TestCase):
         expected_4 = '1.0'
         self.assertIsNone(result.exception)
         lines = result.output.split('\n')
-        self.assertIn(expected_1, lines[2])
-        self.assertIn(expected_2, lines[5])
-        self.assertIn(expected_3, lines[8])
-        self.assertIn(expected_4, lines[11])
+        self.assertIn(expected_1, lines[3])
+        self.assertIn(expected_2, lines[6])
+        self.assertIn(expected_3, lines[9])
+        self.assertIn(expected_4, lines[12])
 
     def test_prompt_str(self):
         """
@@ -223,6 +223,26 @@ class InteractiveOptionTest(unittest.TestCase):
         expected = '\n'
         self.assertIsNone(result.exception)
         self.assertEqual(result.output, expected)
+
+    def test_default_value_ignore_character(self):
+        """
+        scenario: InteractiveOption with default value, invoke with ignore default character `!`
+        behaviour: return `None` for the value
+        """
+        cmd = self.simple_command(default='default')
+        runner = CliRunner()
+
+        # Check the interactive mode, by not specifying the input on the command line and then enter `!` at the prompt
+        result = runner.invoke(cmd, [], input='!\n')
+        expected = 'None'
+        self.assertIsNone(result.exception)
+        self.assertIn(expected, result.output.split('\n')[3])  # Fourth line should be parsed value printed to stdout
+
+        # In the non-interactive mode the special character `!` should have no special meaning and be accepted as is
+        result = runner.invoke(cmd, ['--opt=!'])
+        expected = '!\n'
+        self.assertIsNone(result.exception)
+        self.assertIn(expected, result.output)
 
     def test_opt_given_valid(self):
         """


### PR DESCRIPTION
Fixes #2905 

The `InteractiveOption` in interactive mode, will populate the value
with a default, if defined. If no value is specified by the user, this
is interpreted as the user wanting to use the default. However, since
the defaults are often contextual and are determined by existing data,
the situation can occur where one wants to set no specific value, even
though a default has been defined through pre-existing data. To fix this
situation, a special character `!` is introduced that when passed in
interactive mode is interpreted as passing `None`. Note that this only
works in interactive mode. When `!` is used non-interactively, the value
is interpreted as is.