### PR TITLE
Update documentation for version v3 of REST API

### DIFF
--- a/aiida/orm/groups.py
+++ b/aiida/orm/groups.py
@@ -330,7 +330,7 @@ class Group(entities.Entity):
         return {
             "description": {
                 "display_name": "Description",
-                "help_text": "short description of the Computer",
+                "help_text": "Short description of the group",
                 "is_foreign_key": False,
                 "type": "str"
             },
@@ -348,7 +348,7 @@ class Group(entities.Entity):
             },
             "type_string": {
                 "display_name": "Type_string",
-                "help_text": "Code type",
+                "help_text": "Type of the group",
                 "is_foreign_key": False,
                 "type": "str"
             },

--- a/aiida/restapi/run_api.py
+++ b/aiida/restapi/run_api.py
@@ -88,6 +88,7 @@ def run_api(flask_app, flask_api, **kwargs):
 
     # Check if the app has to be hooked-up or just returned
     if hookup:
+        print(" * REST API running on http://{}:{}{}".format(hostname, port, confs.PREFIX))
         api.app.run(debug=debug, host=hostname, port=int(port), threaded=True)
 
     else:

--- a/docs/source/developer_guide/core/extend_restapi.rst
+++ b/docs/source/developer_guide/core/extend_restapi.rst
@@ -267,7 +267,7 @@ To route a request to the API from a terminal you can employ ``curl``. Alternati
 
 .. code-block:: bash
 
-    curl http://127.0.0.2:6000/api/v2/new-endpoint/ -X GET
+    curl http://127.0.0.2:6000/api/v3/new-endpoint/ -X GET
 
 The form of the output (and only the form) should resemble
 
@@ -281,9 +281,9 @@ Now, let us create a node through the POST method, and check it again through GE
 
 .. code-block:: bash
 
-    curl http://127.0.0.2:6000/api/v2/new-endpoint/ -X POST
+    curl http://127.0.0.2:6000/api/v3/new-endpoint/ -X POST
     {"id": 410618}
-    curl http://127.0.0.2:6000/api/v2/new-endpoint/ -X GET
+    curl http://127.0.0.2:6000/api/v3/new-endpoint/ -X GET
     {"attributes": {"property1": "spam", "property2": "egg"}, "ctime": "2017-06-20T15:36:56.320180+00:00", "id": 410618}
 
 The POST request triggers the creation of a new Dict node, as confirmed by the response to the GET request.

--- a/docs/source/restapi/index.rst
+++ b/docs/source/restapi/index.rst
@@ -25,9 +25,8 @@ To start the REST server open a terminal and type
 
     verdi restapi
 
-This command will hook up a REST api with the default parameters, namely on port ``5000``
-of ``localhost``,
-connect to the default AiiDA profile and assuming the default folder for the REST configuration files, namely ``common``.
+This command will hook up a REST api with the default parameters, namely on port ``5000`` of ``localhost``, connecting
+to the default AiiDA profile and assuming the default folder for the REST configuration files, namely ``common``.
 
 For an overview of options accepted by ``verdi restapi`` you can type
 
@@ -40,10 +39,12 @@ Like all ``verdi`` commands, the AiiDA profile can be changed by putting ``-p PR
 
 The base url for your REST API is::
 
-        http://localhost:5000/api/v2
+        http://localhost:5000/api/v3
 
-where the last field identifies the version of the API (currently ``v2``).
+where the last field identifies the version of the API (currently ``v3``).
 Simply type this URL in your browser or use command-line tools such as ``curl`` or ``wget``.
+
+.. note:: Note that the ``v2`` version of the API was used for versions of AiiDA previous to 1.0.0b3.
 
 For the full list of configuration options, see ``aiida/restapi/config.py``.
 
@@ -55,40 +56,50 @@ A generic url to send requests to the REST API is formed by:
 
     1. the base url. It specifies the host and the version of the API. Example::
 
-        http://localhost:5000/api/v2
+        http://localhost:5000/api/v3
 
     2. the path. It defines the kind of resource requested by the client and the type of query.
-    3. the query string (not mandatory). It can be used for any further specification of the request, e.g. to introduce query filters, to give instructions for ordering, to set how results have to be paginated, etc.
+    3. the query string (not mandatory). It can be used for any further specification of the request, e.g. to introduce
+       query filters, to give instructions for ordering, to set how results have to be paginated, etc.
 
 The query string is introduced by the question mark character ``?``. Here are some examples::
 
-  http://localhost:5000/api/v2/users/
-  http://localhost:5000/api/v2/computers?scheduler_type="slurm"
-  http://localhost:5000/api/v2/nodes/?id>45&type=like="%data%"
+  http://localhost:5000/api/v3/users/
+  http://localhost:5000/api/v3/computers?scheduler_type="slurm"
+  http://localhost:5000/api/v3/nodes/?id>45&node_type=like="%data%"
 
 The trailing slash at the end of the path is not mandatory.
 
 How to set the number of results
 --------------------------------
 
-Before exploring in details the functionalities of the API it is important to know that the AiiDA RESTAPI provides two different ways to limit the number of results returned by the server: using pagination, or specifying explicitly *limit* and *offset*.
+Before exploring in details the functionalities of the API it is important to know that the AiiDA RESTAPI provides two
+different ways to limit the number of results returned by the server:
+using pagination, or specifying explicitly *limit* and *offset*.
 
 Pagination
 **********
 
-The complete set of results is divided in *pages* containing by default 20 results each. Individual pages are accessed by appending ``/page/(PAGE)`` to the end of the path, where ``(PAGE)`` has to be replaced by the number of the required page. The number of results contained in each page can be altered by specifying the ``perpage=(PERPAGE)`` field in the query string. However, ``(PERPAGE)`` values larger than 400 are not allowed. Examples::
+The complete set of results is divided in *pages* containing by default 20 results each.
+Individual pages are accessed by appending ``/page/(PAGE)`` to the end of the path, where ``(PAGE)`` has to be replaced
+by the number of the required page.
+The number of results contained in each page can be altered by specifying the ``perpage=(PERPAGE)`` field in the
+query string. However, ``(PERPAGE)`` values larger than 400 are not allowed. Examples::
 
-    http://localhost:5000/api/v2/computers/page/1?
-    http://localhost:5000/api/v2/computers/page/1?perpage=5
-    http://localhost:5000/api/v2/computers/page
+    http://localhost:5000/api/v3/computers/page/1?
+    http://localhost:5000/api/v3/computers/page/1?perpage=5
+    http://localhost:5000/api/v3/computers/page
 
-If no page number is specified, as in the last example, the system redirects the request to page 1. When pagination is used the header of the response contains two more non-empty fields:
+If no page number is specified, as in the last example, the system redirects the request to page 1.
+When pagination is used the header of the response contains two more non-empty fields:
 
-    - ``X-Total-Counts`` (custom field): the total number of results returned by the query, i.e.the sum of the results of all pages)
-    - ``Links``: links to the first, previous, next, and last page. Suppose you send a request whose results would fill 8 pages. Then the value of the ``Links`` field would look like::
+    - ``X-Total-Counts`` (custom field): the total number of results returned by the query, i.e.the sum of the results
+      of all pages)
+    - ``Links``: links to the first, previous, next, and last page. Suppose you send a request whose results would fill
+      8 pages. Then the value of the ``Links`` field would look like::
 
             <\http://localhost:5000/.../page/1?... >; rel=first,
-            <\http://localhost:5000/.../page/3?...     ;>; rel=prev,
+            <\http://localhost:5000/.../page/3?... >; rel=prev,
             <\http://localhost:5000/.../page/5?... >; rel=next,
             <\http://localhost:5000/.../page/8?... >; rel=last
 
@@ -97,12 +108,14 @@ Setting *limit* and *offset*
 
 You can specify two special fields in the query string:
 
-    - ``limit=(LIMIT)``: field that specifies the largest number of results that will be returned, ex: "limit=20". The default and highest allowed ``LIMIT`` is 400.
-    - ``offset=(OFFSET)``: field that specifies how many entries are skipped before returning results, ex: ``offset=20``. By default no offset applies.
+    - ``limit=(LIMIT)``: field that specifies the largest number of results that will be returned, ex: "limit=20".
+      The default and highest allowed ``LIMIT`` is 400.
+    - ``offset=(OFFSET)``: field that specifies how many entries are skipped before returning results, ex:
+      ``offset=20``. By default no offset applies.
 
 Example::
 
-    http://localhost:5000/api/v2/computers/?limit=3&offset=2
+    http://localhost:5000/api/v3/computers/?limit=3&offset=2
 
 
 How to build the path
@@ -111,82 +124,98 @@ How to build the path
 The first element of the path is the *Resource* corresponding to the
 AiiDA object(s) you want to request. The following resources are available:
 
-+--------------------------------------------------------------------------------------------+-------------------+
-| Class                                                                                      | Resource          |
-+============================================================================================+===================+
-| :py:class:`ProcessNode <aiida.orm.nodes.process.ProcessNode>`                              | ``/calculations`` |
-+--------------------------------------------------------------------------------------------+-------------------+
-| :py:class:`Computer <aiida.orm.Computer>`                                                  | ``/computers``    |
-+--------------------------------------------------------------------------------------------+-------------------+
-| :py:class:`Data <aiida.orm.nodes.data.data.Data>`                                          | ``/data``         |
-+--------------------------------------------------------------------------------------------+-------------------+
-| :py:class:`Group <aiida.orm.groups.Group>`                                                 | ``/groups``       |
-+--------------------------------------------------------------------------------------------+-------------------+
-| :py:class:`Node <aiida.orm.nodes.Node>`                                                    | ``/nodes``        |
-+--------------------------------------------------------------------------------------------+-------------------+
-| :py:class:`User <aiida.orm.User>`                                                          | ``/users``        |
-+--------------------------------------------------------------------------------------------+-------------------+
-| :py:class:`BandsData <aiida.orm.nodes.data.array.bands.BandsData>`                         | ``/bands``        |
-+--------------------------------------------------------------------------------------------+-------------------+
-| :py:class:`CifData <aiida.orm.nodes.data.cif.CifData>`                                     | ``/cifs``         |
-+--------------------------------------------------------------------------------------------+-------------------+
-| :py:class:`KpointsData <aiida.orm.nodes.data.array.kpoints.KpointsData>`                   | ``/kpoints``      |
-+--------------------------------------------------------------------------------------------+-------------------+
-| :py:class:`StructureData <aiida.orm.nodes.data.structure.StructureData>`                   | ``/structures``   |
-+--------------------------------------------------------------------------------------------+-------------------+
-| :py:class:`UpfData <aiida.orm.nodes.data.upf.UpfData>`                                     | ``/upfs``         |
-+--------------------------------------------------------------------------------------------+-------------------+
++-------------------------------------------------------------------------+-------------------+
+| Class                                                                   | Resource          |
++=========================================================================+===================+
+| :py:class:`ProcessNode <aiida.orm.nodes.process.ProcessNode>`           | ``/calculations`` |
++-------------------------------------------------------------------------+-------------------+
+| :py:class:`Computer <aiida.orm.Computer>`                               | ``/computers``    |
++-------------------------------------------------------------------------+-------------------+
+| :py:class:`Data <aiida.orm.nodes.data.data.Data>`                       | ``/data``         |
++-------------------------------------------------------------------------+-------------------+
+| :py:class:`Group <aiida.orm.groups.Group>`                              | ``/groups``       |
++-------------------------------------------------------------------------+-------------------+
+| :py:class:`Node <aiida.orm.nodes.Node>`                                 | ``/nodes``        |
++-------------------------------------------------------------------------+-------------------+
+| :py:class:`User <aiida.orm.User>`                                       | ``/users``        |
++-------------------------------------------------------------------------+-------------------+
+| :py:class:`Code <aiida.orm.nodes.data.code.Code>`                       | ``/codes``        |
++-------------------------------------------------------------------------+-------------------+
+| :py:class:`BandsData <aiida.orm.nodes.data.array.bands.BandsData>`      | ``/bands``        |
++-------------------------------------------------------------------------+-------------------+
+| :py:class:`CifData <aiida.orm.nodes.data.cif.CifData>`                  | ``/cifs``         |
++-------------------------------------------------------------------------+-------------------+
+| :py:class:`KpointsData <aiida.orm.nodes.data.array.kpoints.KpointsData>`| ``/kpoints``      |
++-------------------------------------------------------------------------+-------------------+
+| :py:class:`StructureData <aiida.orm.nodes.data.structure.StructureData>`| ``/structures``   |
++-------------------------------------------------------------------------+-------------------+
+| :py:class:`UpfData <aiida.orm.nodes.data.upf.UpfData>`                  | ``/upfs``         |
++-------------------------------------------------------------------------+-------------------+
 
 For a **full list** of available endpoints for each resource, simply query the base URL of the REST API.
 
 There are two types of paths: you may either request a list of objects
 or one specific object of a resource.
 
-If no specific endpoint is appended to the name of the resource, the Api
+If no specific endpoint is appended to the name of the resource, the API
 returns the full list of objects of that resource (default limits apply).
 
 Appending the endpoint ``schema`` to a
-resource will give the list of fields that are normally returned by the Api for
+resource will give the list of fields that are normally returned by the API for
 an object of a specific resource, whereas the endpoint ``statistics`` returns a
 list of statistical facts concerning a resource.
 Here are few examples of valid URIs::
 
-    http://localhost:5000/api/v2/nodes/statistics
-    http://localhost:5000/api/v2/users/
-    http://localhost:5000/api/v2/groups/schema
+    http://localhost:5000/api/v3/nodes/statistics
+    http://localhost:5000/api/v3/users/
+    http://localhost:5000/api/v3/groups/schema
 
 
 If you request informations of a specific object, in general you have to append its entire *uuid* or the starting pattern of its *uuid* to the path.
  Here are two examples that should return the same object::
 
-    http://localhost:5000/api/v2/nodes/338357f4-f236-4f9c-8fbe-cd550dc6b858
-    http://localhost:5000/api/v2/nodes/338357f4-f2
+    http://localhost:5000/api/v3/nodes/338357f4-f236-4f9c-8fbe-cd550dc6b858
+    http://localhost:5000/api/v3/nodes/338357f4-f2
 
-In the first URL, we have specified the full *uuid*, whereas in the second only a chunk of its first characters that is sufficiently long to match only one *uuid* in the database.
+In the first URL, we have specified the full *uuid*, whereas in the second only a chunk of its first characters that is
+sufficiently long to match only one *uuid* in the database.
 Il the *uuid* pattern is not long enough to identify a unique object, the API will raise an exception.
-The only exception to this rule is the resource *users* since the corresponding AiiDA``User`` class has no *uuid* attribute. In this case, you have to specify the *pk* (integer) of the object. Here is an example::
+The only exception to this rule is the resource *users* since the corresponding AiiDA``User`` class has no *uuid*
+attribute. In this case, you have to specify the *pk* (integer) of the object. Here is an example::
 
-    http://localhost:5000/api/v2/users/2
+    http://localhost:5000/api/v3/users/2
 
-When you ask for a single object (and only in that case) you can construct more complex requests, namely, you can ask for its inputs/outputs or for its attributes/extras. In the first case you have to append to the path the string ``/io/inputs`` or ``io/outputs`` depending on the desired relation between the nodes, whereas in the second case you have to append ``content/attributes`` or ``content/extras`` depending on the kind of content you want to access. Here are some examples::
+When you ask for a single object (and only in that case) you can construct more complex requests, namely, you can ask
+for its inputs/outputs or for its attributes/extras.
+In the first case you have to append to the path the string ``/io/inputs`` or ``io/outputs`` depending on the desired
+relation between the nodes, whereas in the second case you have to append ``content/attributes`` or ``content/extras``
+depending on the kind of content you want to access. Here are some examples::
 
-    http://localhost:5000/api/v2/calculations/338357f4-f2/io/inputs
-    http://localhost:5000/api/v2/nodes/338357f4-f2/io/inputs
-    http://localhost:5000/api/v2/data/338357f4-f2/content/attributes
-    http://localhost:5000/api/v2/nodes/338357f4-f2/content/extras
+    http://localhost:5000/api/v3/calculations/338357f4-f2/io/inputs
+    http://localhost:5000/api/v3/nodes/338357f4-f2/io/inputs
+    http://localhost:5000/api/v3/data/338357f4-f2/content/attributes
+    http://localhost:5000/api/v3/nodes/338357f4-f2/content/extras
 
-.. note:: As you can see from the last examples, a *Node* object can be accessed requesting either a generic ``nodes`` resource or requesting the resource corresponding to its specific type (``data``, ``codes``, ``calculations``, ``kpoints``, ... ). This is because in AiiDA  the classes *Data*, *Code*, and *Calculation* are derived from the class *Node*. In turn, *Data* is the baseclass of a number of built-in and custom classes, e.g. ``KpointsData``, ``StructureData``, ``BandsData``, ...
+.. note:: As you can see from the last examples, a *Node* object can be accessed requesting either a generic ``nodes``
+    resource or requesting the resource corresponding to its specific node type (``data``, ``codes``, ``calculations``,
+    ``kpoints``, ... ).
+    This is because in AiiDA the classes *Data* and *Calculation* are derived from the class *Node*.
+    In turn, *Data* is the baseclass of a number of built-in and custom classes, e.g. ``KpointsData``,
+    ``StructureData``, ``BandsData``, ``Code``, ...
 
 How to build the query string
 -----------------------------
 
 The query string is formed by one or more fields separated by the special character ``&``.
-Each field has the form (``key``)(``operator``)(``value``). The same constraints that apply to the names of python variables determine what are the valid keys, namely, only alphanumeric characters plus ``_`` are allowed and the first character cannot be a number.
+Each field has the form (``key``)(``operator``)(``value``).
+The same constraints that apply to the names of python variables determine what are the valid keys, namely,
+only alphanumeric characters plus ``_`` are allowed and the first character cannot be a number.
 
 Special keys
 ************
 
-There are several special keys that can be specified only once in a query string. All of them must be followed by the operator ``=``. Here is the complete list:
+There are several special keys that can be specified only once in a query string.
+All of them must be followed by the operator ``=``. Here is the complete list:
 
     :limit: This key only supports integer values.
 
@@ -194,109 +223,135 @@ There are several special keys that can be specified only once in a query string
 
     :perpage: Same format as ``limit``.
 
-    :orderby: This key is used to impose a specific ordering to the results. Two orderings are supported, ascending or descending. The value for the ``orderby`` key must be the name of the property with respect to which to order the results. Additionally, ``+`` or ``-`` can be pre-pended to the value in order to select, respectively, ascending or descending order. Specifying no leading character is equivalent to select ascending order. Ascending (descending) order for strings corresponds to alphabetical (reverse-alphabetical) order, whereas for datetime objects it corresponds to chronological (reverse-chronological order). Examples:
+    :orderby: This key is used to impose a specific ordering to the results. Two orderings are supported, ascending or
+        descending.
+        The value for the ``orderby`` key must be the name of the property with respect to which to order the results.
+        Additionally, ``+`` or ``-`` can be pre-pended to the value in order to select, respectively, ascending or
+        descending order.
+        Specifying no leading character is equivalent to select ascending order.
+        Ascending (descending) order for strings corresponds to alphabetical (reverse-alphabetical) order, whereas for
+        datetime objects it corresponds to chronological (reverse-chronological order). Examples:
 
         ::
 
-            http://localhost:5000/api/v2/c=+id
-            http://localhost:5000/api/v2/computers=+name
-            http://localhost:5000/api/v2/computers/orderby=-uuid
+            http://localhost:5000/api/v3/c=+id
+            http://localhost:5000/api/v3/computers=+name
+            http://localhost:5000/api/v3/computers/orderby=-uuid
 
 
-    :alist: This key is used to specify which attributes of a specific object have to be returned. The desired attributes have to be provided as a comma-separated list of values. It requires that the path contains the endpoint ``/content/attributes``. Example:
+    :alist: This key is used to specify which attributes of a specific object have to be returned.
+        The desired attributes have to be provided as a comma-separated list of values.
+        It requires that the path contains the endpoint ``/content/attributes``. Example:
 
         ::
 
-            http://localhost:5000/api/v2/codes/4fb10ef1-1a/content/attributes?
+            http://localhost:5000/api/v3/codes/4fb10ef1-1a/content/attributes?
                                         alist=append_text,prepend_text
 
 
-    :nalist: (incompatible with ``alist``) This key is used to specify which attributes of a specific object should not be returned. The syntax is identical to ``alist``. The system returns all the attributes except those specified in the list of values.
+    :nalist: (incompatible with ``alist``) This key is used to specify which attributes of a specific object should not
+        be returned. The syntax is identical to ``alist``.
+        The system returns all the attributes except those specified in the list of values.
 
     :elist: Similar to ``alist`` but for extras. It requires that the path contains the endpoint ``/content/extras``.
 
-    :nelist: (incompatible with ``elist``) Similar to ``nalist`` but for extras. It requires that the path contains the endpoint ``/content/extras``.
+    :nelist: (incompatible with ``elist``) Similar to ``nalist`` but for extras.
+        It requires that the path contains the endpoint ``/content/extras``.
 
 Filters
 *******
 
-All the other fields composing a query string are filters, that is, conditions that have to be fulfilled by the retrieved objects. When a query string contains multiple filters, those are applied as if they were related by the AND logical clause, that is, the results have to fulfill all the conditions set by the filters (and not any of them). Each filter key is associated to a unique value type. The possible types are:
+All the other fields composing a query string are filters, that is, conditions that have to be fulfilled by the
+retrieved objects. When a query string contains multiple filters, those are applied as if they were related by the AND
+logical clause, that is, the results have to fulfill all the conditions set by the filters (and not any of them).
+Each filter key is associated to a unique value type. The possible types are:
 
-    :string: Text enclosed in double quotes. If the string contains double quotes those have to be escaped as ``""`` (two double quotes). Note that in the unlikely occurrence of a sequence of double quotes you will have to escape it by writing twice as many double quotes.
+    :string: Text enclosed in double quotes.
+        If the string contains double quotes those have to be escaped as ``""`` (two double quotes).
+        Note that in the unlikely occurrence of a sequence of double quotes you will have to escape it by writing twice
+        as many double quotes.
 
     :integer: Positive integer numbers.
 
-    :datetime: Datetime objects expressed in the format ``(DATE)T(TIME)(SHIFT)`` where ``(SHIFT)`` is the time difference with respect to the UTC time. This is required to avoid any problem arising from comparing datetime values expressed in different time zones. The formats of each field are:
+    :datetime: Datetime objects expressed in the format ``(DATE)T(TIME)(SHIFT)`` where ``(SHIFT)`` is the time
+        difference with respect to the UTC time.
+        This is required to avoid any problem arising from comparing datetime values expressed in different time zones.
+        The formats of each field are:
 
         1. ``YYYY-MM-DD`` for ``(DATE)`` (mandatory).
         2. ``HH:MM:SS`` for ``(TIME)`` (optional). The formats ``HH`` and ``HH:MM`` are supported too.
-        3. ``+/-HH:MM`` for ``(SHIFT)`` (optional, if present requires ``(TIME)`` to be specified). The format ``+/-HH`` is allowed too. If no shift is specified UTC time is assumed. The shift format follows the general convention that eastern (western) shifts are positive (negative). The API is unaware of daylight saving times so the user is required to adjust the shift to take them into account.
+        3. ``+/-HH:MM`` for ``(SHIFT)`` (optional, if present requires ``(TIME)`` to be specified). The format
+           ``+/-HH`` is allowed too. If no shift is specified UTC time is assumed.
+           The shift format follows the general convention that eastern (western) shifts are positive (negative).
+           The API is unaware of daylight saving times so the user is required to adjust the shift to take them into
+           account.
 
-        This format is ``ISO-8601`` compliant. Note that date and time fields have to be separated by the character ``T``. Examples:
+        This format is ``ISO-8601`` compliant. Note that date and time fields have to be separated by the character
+        ``T``. Examples:
 
         ::
 
-            ctime>2016-04-23T05:45+03:45
-            ctime<2016-04-23T05:45
-            mtime>=2016-04-23
+            ctime>2019-04-23T05:45+03:45
+            ctime<2019-04-23T05:45
+            mtime>=2019-04-23
 
 
     :bool: It can be either true or false (lower case).
 
 The following table reports what is the value type and the supported resources associated to each key.
+
 .. note:: In the following *id* is a synonym for *pk* (often used in other sections of the documentation).
 
-.. note:: If a key is present in the resource *data*, it will be also in the derived resources: *kpoints*, *structures*, *bands*
+.. note:: If a key is present in the resource *data*, it will be also in the derived resources: *structures*, *kpoints*,
+    *bands*, ...
 
-+----------------+----------+----------------------------------------------------------+
-|key             |value type|resources                                                 |
-+================+==========+==========================================================+
-|id              |integer   |users, computers, groups, nodes, calculations, codes, data|
-+----------------+----------+----------------------------------------------------------+
-|user_id         |integer   |groups                                                    |
-+----------------+----------+----------------------------------------------------------+
-|uuid            |string    |computers, groups, nodes, calculations, codes, data       |
-+----------------+----------+----------------------------------------------------------+
-|name            |string    |computers, groups                                         |
-+----------------+----------+----------------------------------------------------------+
-|first_name      |string    |users                                                     |
-+----------------+----------+----------------------------------------------------------+
-|last_name       |string    |users                                                     |
-+----------------+----------+----------------------------------------------------------+
-|institution     |string    |users                                                     |
-+----------------+----------+----------------------------------------------------------+
-|email *         |string    |users                                                     |
-+----------------+----------+----------------------------------------------------------+
-|label           |string    |nodes, calculations, codes, data                          |
-+----------------+----------+----------------------------------------------------------+
-|description     |string    |computers, groups                                         |
-+----------------+----------+----------------------------------------------------------+
-|transport_type  |string    |computers                                                 |
-+----------------+----------+----------------------------------------------------------+
-|transport_params|string    |computers                                                 |
-+----------------+----------+----------------------------------------------------------+
-|scheduler_type  |string    |computers                                                 |
-+----------------+----------+----------------------------------------------------------+
-|is_active *     |bool      |users                                                     |
-+----------------+----------+----------------------------------------------------------+
-|ctime           |datetime  |nodes, calculations, codes, data                          |
-+----------------+----------+----------------------------------------------------------+
-|mtime           |datetime  |nodes, calculations, codes, data                          |
-+----------------+----------+----------------------------------------------------------+
-|last_login *    |datetime  |users                                                     |
-+----------------+----------+----------------------------------------------------------+
-|date_joined     |datetime  |users                                                     |
-+----------------+----------+----------------------------------------------------------+
-|type            |string    |groups, nodes, calculations, codes, data                  |
-+----------------+----------+----------------------------------------------------------+
-|state           |string    |nodes, calculations, codes, data                          |
-+----------------+----------+----------------------------------------------------------+
-|hostname        |string    |computers                                                 |
-+----------------+----------+----------------------------------------------------------+
++--------------+----------+---------------------------------------------------+
+|key           |value type|resources                                          |
++==============+==========+===================================================+
+|id            |integer   |users, computers, groups, nodes, calculations, data|
++--------------+----------+---------------------------------------------------+
+|user_id       |integer   |groups                                             |
++--------------+----------+---------------------------------------------------+
+|uuid          |string    |computers, groups, nodes, calculations, data       |
++--------------+----------+---------------------------------------------------+
+|name          |string    |computers                                          |
++--------------+----------+---------------------------------------------------+
+|first_name    |string    |users                                              |
++--------------+----------+---------------------------------------------------+
+|last_name     |string    |users                                              |
++--------------+----------+---------------------------------------------------+
+|institution   |string    |users                                              |
++--------------+----------+---------------------------------------------------+
+|email *       |string    |users                                              |
++--------------+----------+---------------------------------------------------+
+|label         |string    |groups, nodes, calculations, data                  |
++--------------+----------+---------------------------------------------------+
+|description   |string    |computers, groups                                  |
++--------------+----------+---------------------------------------------------+
+|transport_type|string    |computers                                          |
++--------------+----------+---------------------------------------------------+
+|scheduler_type|string    |computers                                          |
++--------------+----------+---------------------------------------------------+
+|attributes    |string    |nodes, calculations, data                          |
++--------------+----------+---------------------------------------------------+
+|ctime         |datetime  |nodes, calculations, data                          |
++--------------+----------+---------------------------------------------------+
+|mtime         |datetime  |nodes, calculations, data                          |
++--------------+----------+---------------------------------------------------+
+|user_email    |string    |groups, nodes, calculations, data                  |
++--------------+----------+---------------------------------------------------+
+|node_type     |string    |nodes, calculations, data                          |
++--------------+----------+---------------------------------------------------+
+|type_string   |string    |groups                                             |
++--------------+----------+---------------------------------------------------+
+|hostname      |string    |computers                                          |
++--------------+----------+---------------------------------------------------+
 
 \* Key not available via the ``/users/`` endpoint for reasons of privacy.
 
-The operators supported by a specific key are uniquely determined by the value type associated to that key. For example, a key that requires a boolean value admits only the identity operator ``=``, whereas an integer value enables the usage of the relational operators ``=``, ``<``, ``<=``, ``>``, ``>=`` plus the membership operator ``=in=``.
+The operators supported by a specific key are uniquely determined by the value type associated to that key.
+For example, a key that requires a boolean value admits only the identity operator ``=``, whereas an integer value
+enables the usage of the relational operators ``=``, ``<``, ``<=``, ``>``, ``>=`` plus the membership operator ``=in=``.
 Please refer to the following table for a comprehensive list.
 
 +-----------+------------------------+---------------------------------+
@@ -318,10 +373,11 @@ Please refer to the following table for a comprehensive list.
 |           |pattern matching        |                                 |
 +-----------+------------------------+---------------------------------+
 |``=in=``   |identity with one       |integers, strings, datetime      |
-|           |    element of a list   |                                 |
+|           |element of a list       |                                 |
 +-----------+------------------------+---------------------------------+
 
-The pattern matching operators ``=like=`` and ``=ilike=`` must be followed by the pattern definition, namely, a string where two characters assume special meaning:
+The pattern matching operators ``=like=`` and ``=ilike=`` must be followed by the pattern definition, namely, a string
+where two characters assume special meaning:
 
     1. ``%`` is used to replace an arbitrary sequence of characters, including no characters.
     2. ``_`` is used to replace one or zero characters.
@@ -332,54 +388,56 @@ To prevent interpreting special characters as wildcards, these have to be escape
 
 Examples:
 
-+-------------------------------+----------------------+-------------------+
-| Filter                        | Matched string       | Non-matched string|
-+===============================+======================+===================+
-| ``name=like="a%d_"``          |       "aiida"        |      "AiiDA"      |
-+-------------------------------+----------------------+-------------------+
-| ``name=ilike="a%d_"``         |   "aiida", "AiiDA"   |                   |
-+-------------------------------+----------------------+-------------------+
-| ``name=like="a_d_"``          |                      |      "aiida"      |
-+-------------------------------+----------------------+-------------------+
-| ``name=like="aii%d_a"``       |        "aiida"       |                   |
-+-------------------------------+----------------------+-------------------+
-| ``uuid=like="cdfd48%"``       | "cdfd48f9-7ed2-4969  |                   |
-|                               |  -ba06-09c752b83d2"  |                   |
-+-------------------------------+----------------------+-------------------+
-| ``description=like="This``    | "This calculation is |                   |
-| ``calculation is %\% useful"``|  100% useful"        |                   |
-+-------------------------------+----------------------+-------------------+
++-----------------------------------------------------+-------------------------------------+------------------+
+| Filter                                              | Matched string                      |Non-matched string|
++=====================================================+=====================================+==================+
+| ``name=like="a%d_"``                                |       "aiida"                       |     "AiiDA"      |
++-----------------------------------------------------+-------------------------------------+------------------+
+| ``name=ilike="a%d_"``                               |   "aiida", "AiiDA"                  |                  |
++-----------------------------------------------------+-------------------------------------+------------------+
+| ``name=like="a_d_"``                                |                                     |     "aiida"      |
++-----------------------------------------------------+-------------------------------------+------------------+
+| ``name=like="aii%d_a"``                             |        "aiida"                      |                  |
++-----------------------------------------------------+-------------------------------------+------------------+
+| ``uuid=like="cdfd48%"``                             |"cdfd48f9-7ed2-4969-ba06-09c752b83d2"|                  |
++-----------------------------------------------------+-------------------------------------+------------------+
+|``description=like="This calculation is %\% useful"``|"This calculation is 100% useful"    |                  |
++-----------------------------------------------------+-------------------------------------+------------------+
 
-The membership operator ``=in=`` has to be followed by a comma-separated list of values of the same type. The condition is fulfilled if the column value of an object is an element of the list.
+The membership operator ``=in=`` has to be followed by a comma-separated list of values of the same type.
+The condition is fulfilled if the column value of an object is an element of the list.
 
 Examples::
 
-    http://localhost:5000/api/v2/nodes?id=in=45,56,78
-    http://localhost:5000/api/v2/computers/?
-    scheduler_type=in="slurm","pbs"&state="FINISHED"
+    http://localhost:5000/api/v3/nodes?id=in=45,56,78
+    http://localhost:5000/api/v3/computers/?scheduler_type=in="slurm","pbs"
 
-The relational operators '<', '>', '<=', '>=' assume natural ordering for integers, (case-insensitive) alphabetical ordering for strings, and chronological ordering for datetime values.
+The relational operators '<', '>', '<=', '>=' assume natural ordering for integers, (case-insensitive) alphabetical
+ordering for strings, and chronological ordering for datetime values.
 
 Examples:
 
-    - ``http://localhost:5000/api/v2/nodes?id>578`` selects the nodes having an id larger than 578.
-    - ``http://localhost:5000/api/v2/users/?last_login>2014-04-07`` selects only the user that logged in for the last time after April 7th, 2014.
-    - ``http://localhost:5000/api/v2/users/?last_name<="m"`` selects only the users whose last name begins with a character in the range [a-m].
+    - ``http://localhost:5000/api/v3/nodes?id>578`` selects the nodes having an id larger than 578.
+    - ``http://localhost:5000/api/v3/users/?last_name<="m"`` selects only the users whose last name begins with a
+      character in the range [a-m].
 
 
-.. note:: Object types have to be specified by a string that defines their position in the AiiDA source tree ending with a dot. Examples:
+.. note:: Node types have to be specified by a string that defines their position in the AiiDA source tree ending
+    with a dot. Examples:
 
-    - ``type="data.Data."`` selects only objects of *Data* type
-    - ``type="data.remote.RemoteData."`` selects only objects of *RemoteData* type
+    - ``node_type="data.code.Code."`` selects only objects of *Code* type
+    - ``node_type="data.remote.RemoteData."`` selects only objects of *RemoteData* type
 
-.. note:: If you use in your request the endpoint *io/input* (*io/outputs*) together with one or more filters, the latter are applied to the input (output) nodes of the selected *pk*. For example, the request:
+.. note:: If you use in your request the endpoint *io/input* (*io/outputs*) together with one or more filters, the
+    latter are applied to the input (output) nodes of the selected *pk*. For example, the request:
 
         ::
 
-            http://localhost:5000/api/v2/nodes/a67fba41-8a/io/outputs/?
-                              type="data.folder.FolderData."
+            http://localhost:5000/api/v3/nodes/a67fba41-8a/io/outputs/?
+                              node_type="data.folder.FolderData."
 
-    would first search for the outputs of the node with *uuid* starting with "a67fba41-8a" and then select only those objects of type *FolderData*.
+    would first search for the outputs of the node with *uuid* starting with "a67fba41-8a" and then select only those
+    nodes of type *FolderData*.
 
 
 
@@ -391,43 +449,82 @@ The HTTP response of the REST API consists in a JSON object, a header, and a sta
     1. 200 for successful requests.
     2. 400 for bad requests. In this case, the JSON object contains only an error message describing the problem.
     3. 500 for a generic internal server error. The JSON object contains only a generic error message.
-    4. 404 for invalid url. Differently from the 400 status, it is returned when the REST API does not succeed in directing the request to a specific resource. This typically happens when the path does not match any of the supported format. No JSON is returned.
+    4. 404 for invalid url.
+       Differently from the 400 status, it is returned when the REST API does not succeed in directing the request
+       to a specific resource.
+       This typically happens when the path does not match any of the supported format. No JSON is returned.
 
-The header is a standard HTTP response header with the additional custom field ``X-Total-Counts`` and, only if paginated results are required, a non-empty ``Link`` field, as described in the Pagination section.
+The header is a standard HTTP response header with the additional custom field ``X-Total-Counts`` and, only if
+paginated results are required, a non-empty ``Link`` field, as described in the Pagination section.
 
-The JSON object mainly contains the list of the results returned by the API. This list is assigned to the key ``data``. Additionally, the JSON object contains several informations about the request (keys ``method``, ``url``, ``url_root``, ``path``, ``query_string``, ``resource_type``, and ``pk``).
+The JSON object mainly contains the list of the results returned by the API.
+This list is assigned to the key ``data``.
+Additionally, the JSON object contains several informations about the request (keys ``method``, ``url``, ``url_root``,
+``path``, ``query_string``, and ``resource_type``).
 
 
 .. _restapi_apache:
 
 How to run the REST API through Apache
 ++++++++++++++++++++++++++++++++++++++
-By default ``verdi restapi`` hooks up the REST API through the HTTP server (Werkzeug) that is  usually bundled with Python distributions. However, to deploy real web applications the server of choice is in most cases `Apache <https://httpd.apache.org/>`_. in fact, you can instruct Apache to run Python applications by employing the `WSGI <modwsgi.readthedocs.io/>`_ module and the AiiDA REST API is inherently structured so that you can easily realize the pipeline ``AiiDA->WSGI->Apache``.
-Moreover, one single Apache service can support multiple apps so that you can, for instance, hook up multiple APIs using as many different sets of configurations. For example, one might have several apps connecting to different AiiDA profiles. We'll go through an example to explain how to achieve this result.
+By default ``verdi restapi`` hooks up the REST API through the HTTP server (Werkzeug) that is  usually bundled with
+Python distributions.
+However, to deploy real web applications the server of choice is in most cases `Apache <https://httpd.apache.org/>`_.
+In fact, you can instruct Apache to run Python applications by employing the `WSGI <modwsgi.readthedocs.io/>`_ module
+and the AiiDA REST API is inherently structured so that you can easily realize the pipeline ``AiiDA-> WSGI-> Apache``.
+Moreover, one single Apache service can support multiple apps so that you can, for instance, hook up multiple APIs
+using as many different sets of configurations.
+For example, one might have several apps connecting to different AiiDA profiles.
+We'll go through an example to explain how to achieve this result.
 
 We assume you have a working installation of Apache that includes ``mod_wsgi``.
 
-The goal of the example is to hookup the APIs ``django`` and ``sqlalchemy`` pointing to two AiiDA profiles, called for simplicity ``django`` and ``sqlalchemy``.
+The goal of the example is to hookup the APIs ``django`` and ``sqlalchemy`` pointing to two AiiDA profiles, called for
+simplicity ``django`` and ``sqlalchemy``.
 
-All the relevant files are enclosed under the path ``<aiida.source.code.path>/docs/wsgi/``. In each of the folders ``app1/`` and ``app2/``, there is a file named ``rest.wsgi`` containing a Pytyhon script that instantiates and configures a python web app called ``application``, according to the rules of ``mod_wsgi``. For how the script is written, the object ``application`` is configured through the file ``config.py`` contained in the same folder. Indeed, in ``app1/config.py`` the variable ``aiida-profile`` is set to ``"django"``, whereas in ``app2/config.py`` its value is ``"sqlalchemy"``.
+All the relevant files are enclosed under the path ``<aiida.source.code.path>/docs/wsgi/``.
+In each of the folders ``app1/`` and ``app2/``, there is a file named ``rest.wsgi`` containing a python script that
+instantiates and configures a python web app called ``application``, according to the rules of ``mod_wsgi``.
+For how the script is written, the object ``application`` is configured through the file ``config.py`` contained in the
+same folder. Indeed, in ``app1/config.py`` the variable ``aiida-profile`` is set to ``"django"``, whereas in
+``app2/config.py`` its value is ``"sqlalchemy"``.
 
-Anyway, the path where you put the ``.wsgi`` file as well as its name are irrelevant as long as they are correctly referred to in the Apache configuration file, as shown later on. Similarly, you can place ``config.py`` in a custom path, provided you change the variable ``config_file_path`` in the ``wsgi file`` accordingly.
+Anyway, the path where you put the ``.wsgi`` file as well as its name are irrelevant as long as they are correctly
+referred to in the Apache configuration file, as shown later on.
+Similarly, you can place ``config.py`` in a custom path, provided you change the variable ``config_file_path`` in
+the ``wsgi file`` accordingly.
 
-In ``rest.wsgi`` probably the only options you might want to change is ``catch_internal_server``. When set to ``True``, it lets the exceptions thrown during the execution of the app propagate all the way through until they reach the logger of Apache. Especially when the app is not entirely stable yet, one would like to read the full python error traceback in the Apache error log.
+In ``rest.wsgi`` probably the only options you might want to change is ``catch_internal_server``.
+When set to ``True``, it lets the exceptions thrown during the execution of the app propagate all the way through until
+they reach the logger of Apache.
+Especially when the app is not entirely stable yet, one would like to read the full python error traceback in the
+Apache error log.
 
-Finally, you need to setup the Apache site through a proper configuration file. We provide two template files: ``one.conf`` or ``many.conf``. The first file tells Apache to bundle both apps in a unique Apache daemon process. Apache usually creates multiple process dynamically and with this configuration each process will handle both apps.
+Finally, you need to setup the Apache site through a proper configuration file.
+We provide two template files: ``one.conf`` or ``many.conf``.
+The first file tells Apache to bundle both apps in a unique Apache daemon process.
+Apache usually creates multiple process dynamically and with this configuration each process will handle both apps.
 
-The script ``many.conf``, instead, defines two different process groups, one for each app. So the processes created dynamically by Apache will always be handling one app each. The minimal number of Apache daemon processes equals the number of apps, contrarily to the first architecture, where one process is enough to handle two or even a larger number of apps.
+The script ``many.conf``, instead, defines two different process groups, one for each app.
+So the processes created dynamically by Apache will always be handling one app each.
+The minimal number of Apache daemon processes equals the number of apps, contrarily to the first architecture, where
+one process is enough to handle two or even a larger number of apps.
 
-Let us call the two apps for this example ``django`` and ``sqlalchemy``. In both ``one.conf`` and ``many.conf``, the important directives that should be updated if one changes the paths or names of the apps are:
+Let us call the two apps for this example ``django`` and ``sqlalchemy``.
+In both ``one.conf`` and ``many.conf``, the important directives that should be updated if one changes the paths or
+names of the apps are:
 
-    - ``WSGIProcessGroup`` to define the process groups for later reference. In ``one.conf`` this directive appears only once to define the generic group ``profiles``, as there is only one kind of process handling both apps. In ``many.conf`` this directive appears once per app and is embedded into a "Location" tag, e.g.::
+    - ``WSGIProcessGroup`` to define the process groups for later reference.
+      In ``one.conf`` this directive appears only once to define the generic group ``profiles``, as there is only one
+      kind of process handling both apps.
+      In ``many.conf`` this directive appears once per app and is embedded into a "Location" tag, e.g.::
 
         <Location /django>
             WSGIProcessGroup sqlalchemy
         <Location/>
 
-    - ``WSGIDaemonProcess`` to define the path to the AiiDA virtual environment. This appears once per app in both configurations.
+    - ``WSGIDaemonProcess`` to define the path to the AiiDA virtual environment.
+      This appears once per app in both configurations.
 
     - ``WSGIScriptAlias`` to define the absolute path of the ``.wsgi`` file of each app.
 
@@ -437,23 +534,33 @@ Let us call the two apps for this example ``django`` and ``sqlalchemy``. In both
                 Require all granted
         </Directory>
 
-The latest step is to move either ``one.conf`` or ``many.conf`` into the Apache configuration folder and restart the Apache server. In Ubuntu, this is usually done with the commands:
+The latest step is to move either ``one.conf`` or ``many.conf`` into the Apache configuration folder and restart
+the Apache server. In Ubuntu, this is usually done with the commands:
 
 .. code-block:: bash
 
     cp <conf_file>.conf /etc/apache2/sites-enabled/000-default.conf
     sudo service apache2 restart
 
-We believe the two basic architectures we have just explained can be successfully applied in many different deployment scenarios. Nevertheless, we suggest users who need finer tuning of the deployment setup to look into to the official documentation of `Apache <https://httpd.apache.org/>`_ and, more importantly,  `WSGI <modwsgi.readthedocs.io/>`_.
+We believe the two basic architectures we have just explained can be successfully applied in many different deployment
+scenarios.
+Nevertheless, we suggest users who need finer tuning of the deployment setup to look into to the official documentation
+of `Apache <https://httpd.apache.org/>`_ and, more importantly, `WSGI <modwsgi.readthedocs.io/>`_.
 
-The URLs of the requests handled by Apache must start with one of the paths specified in the directives ``WSGIScriptAlias``. These paths identify uniquely each app and allow Apache to route the requests to their correct apps. Examples of well-formed URLs are:
+The URLs of the requests handled by Apache must start with one of the paths specified in the directives
+``WSGIScriptAlias``.
+These paths identify uniquely each app and allow Apache to route the requests to their correct apps.
+Examples of well-formed URLs are:
 
 .. code-block:: bash
 
-    curl http://localhost/django/api/v2/computers -X GET
-    curl http://localhost/sqlalchemy/api/v2/computers -X GET
+    curl http://localhost/django/api/v3/computers -X GET
+    curl http://localhost/sqlalchemy/api/v3/computers -X GET
 
-The first (second)request will be handled by the app ``django`` (``sqlalchemy``), namely will serve results fetched from the profile ``django`` (``sqlalchemy``). Notice that we haven't specified any port in the URLs since Apache listens conventionally to port 80, where any request lacking the port is automatically redirected.
+The first (second) request will be handled by the app ``django`` (``sqlalchemy``), namely will serve results fetched
+from the profile ``django`` (``sqlalchemy``).
+Notice that we haven't specified any port in the URLs since Apache listens conventionally to port 80, where any request
+lacking the port is automatically redirected.
 
 Examples
 ++++++++
@@ -466,7 +573,7 @@ Computers
 
     REST url::
 
-        http://localhost:5000/api/v2/computers?limit=3&offset=2&orderby=id
+        http://localhost:5000/api/v3/computers?limit=3&offset=2&orderby=id
 
     Description:
 
@@ -485,7 +592,6 @@ Computers
                 "id": 3,
                 "name": "Alpha",
                 "scheduler_type": "slurm",
-                "transport_params": "{}",
                 "transport_type": "ssh",
                 "uuid": "9b5c84bb-4575-4fbe-b18c-b23fc30ec55e"
               },
@@ -495,7 +601,6 @@ Computers
                 "id": 4,
                 "name": "Beta",
                 "scheduler_type": "slurm",
-                "transport_params": "{}",
                 "transport_type": "ssh",
                 "uuid": "5d490d77-638d-4d4b-8288-722f930783c8"
               },
@@ -505,18 +610,16 @@ Computers
                 "id": 5,
                 "name": "Gamma",
                 "scheduler_type": "slurm",
-                "transport_params": "{}",
                 "transport_type": "ssh",
                 "uuid": "7a0c3ff9-1caf-405c-8e89-2369cf91b634"
               }
             ]
           },
           "method": "GET",
-          "path": "/api/v2/computers",
-          "pk": null,
+          "path": "/api/v3/computers",
           "query_string": "limit=3&offset=2&orderby=id",
           "resource_type": "computers",
-          "url": "http://localhost:5000/api/v2/computers?limit=3&offset=2&orderby=id",
+          "url": "http://localhost:5000/api/v3/computers?limit=3&offset=2&orderby=id",
           "url_root": "http://localhost:5000/"
         }
 
@@ -526,7 +629,7 @@ Computers
 
     REST url::
 
-        http://localhost:5000/api/v2/computers/5d490d77-638d
+        http://localhost:5000/api/v3/computers/5d490d77-638d
 
     Description:
 
@@ -543,18 +646,16 @@ Computers
                 "id": 4,
                 "name": "Beta",
                 "scheduler_type": "slurm",
-                "transport_params": "{}",
                 "transport_type": "ssh",
                 "uuid": "5d490d77-638d-4d4b-8288-722f930783c8"
               }
             ]
           },
           "method": "GET",
-          "path": "/api/v2/computers/5d490d77-638d",
-          "pk": 4,
+          "path": "/api/v3/computers/5d490d77-638d",
           "query_string": "",
           "resource_type": "computers",
-          "url": "http://localhost:5000/api/v2/computers/5d490d77-638d",
+          "url": "http://localhost:5000/api/v3/computers/5d490d77-638d",
           "url_root": "http://localhost:5000/"
         }
 
@@ -566,7 +667,7 @@ Nodes
 
     REST url::
 
-        http://localhost:5000/api/v2/nodes?limit=2&offset=8&orderby=-id
+        http://localhost:5000/api/v3/nodes?limit=2&offset=8&orderby=-id
 
     Description:
 
@@ -580,31 +681,36 @@ Nodes
           "data": {
             "nodes  ": [
               {
-                "ctime": "Fri, 29 Apr 2016 19:24:12 GMT",
+                "attributes": {...},
+                "ctime": "Fri, 29 Apr 2019 19:24:12 GMT",
+                "extras": {},
                 "id": 386913,
                 "label": "",
-                "mtime": "Fri, 29 Apr 2016 19:24:13 GMT",
-                "state": null,
-                "type": "node.process.calculation.CalcFunctionNode.",
+                "mtime": "Fri, 29 Apr 2019 19:24:13 GMT",
+                "node_type": "process.calculation.calcfunction.CalcFunctionNode.",
+                "user_email": "aiida@theossrv5.epfl.ch",
+                "user_id": 3,
                 "uuid": "68d2ed6c-6f51-4546-8d10-7fe063525ab8"
               },
               {
-                "ctime": "Fri, 29 Apr 2016 19:24:00 GMT",
+                "attributes": {...},
+                "ctime": "Fri, 29 Apr 2019 19:24:00 GMT",
+                "extras": {},
                 "id": 386912,
                 "label": "",
-                "mtime": "Fri, 29 Apr 2016 19:24:00 GMT",
-                "state": null,
-                "type": "data.dict.Dict.",
+                "mtime": "Fri, 29 Apr 2019 19:24:00 GMT",
+                "node_type": "data.dict.Dict.",
+                "user_email": "aiida@theossrv5.epfl.ch",
+                "user_id": 3,
                 "uuid": "a39dc158-fedd-4ea1-888d-d90ec6f86f35"
               }
             ]
           },
           "method": "GET",
-          "path": "/api/v2/nodes",
-          "pk": null,
+          "path": "/api/v3/nodes",
           "query_string": "limit=2&offset=8&orderby=-id",
           "resource_type": "nodes",
-          "url": "http://localhost:5000/api/v2/nodes?limit=2&offset=8&orderby=-id",
+          "url": "http://localhost:5000/api/v3/nodes?limit=2&offset=8&orderby=-id",
           "url_root": "http://localhost:5000/"
         }
 
@@ -612,7 +718,7 @@ Nodes
 
     REST url::
 
-        http://localhost:5000/api/v2/nodes/e30da7cc
+        http://localhost:5000/api/v3/nodes/e30da7cc
 
     Description:
 
@@ -624,22 +730,24 @@ Nodes
           "data": {
             "nodes  ": [
               {
-                "ctime": "Fri, 14 Aug 2015 13:18:04 GMT",
+                "attributes": {...},
+                "ctime": "Fri, 14 Aug 2018 13:18:04 GMT",
+                "extras": {},
                 "id": 1,
                 "label": "",
-                "mtime": "Mon, 25 Jan 2016 14:34:59 GMT",
-                "state": "IMPORTED",
-                "type": "data.dict.Dict.",
+                "mtime": "Mon, 25 Jan 2019 14:34:59 GMT",
+                "node_type": "data.dict.Dict.",
+                "user_email": "aiida@theossrv5.epfl.ch",
+                "user_id": 3,
                 "uuid": "e30da7cc-af50-40ca-a940-2ac8d89b2e0d"
               }
             ]
           },
           "method": "GET",
-          "path": "/api/v2/nodes/e30da7cc",
-          "pk": 1,
+          "path": "/api/v3/nodes/e30da7cc",
           "query_string": "",
           "resource_type": "nodes",
-          "url": "http://localhost:5000/api/v2/nodes/e30da7cc",
+          "url": "http://localhost:5000/api/v3/nodes/e30da7cc",
           "url_root": "http://localhost:5000/"
         }
 
@@ -647,7 +755,7 @@ Nodes
 
     REST url::
 
-        http://localhost:5000/api/v2/nodes/de83b1/io/inputs?limit=2
+        http://localhost:5000/api/v3/nodes/de83b1/io/inputs?limit=2
 
     Description:
 
@@ -659,40 +767,45 @@ Nodes
           "data": {
             "inputs": [
               {
-                "ctime": "Fri, 24 Jul 2015 18:49:23 GMT",
+                "attributes": {...},
+                "ctime": "Fri, 24 Jul 2018 18:49:23 GMT",
+                "extras": {},
                 "id": 10605,
                 "label": "",
-                "mtime": "Mon, 25 Jan 2016 14:35:00 GMT",
-                "state": "IMPORTED",
-                "type": "data.remote.RemoteData.",
+                "mtime": "Mon, 25 Jan 2019 14:35:00 GMT",
+                "node_type": "data.remote.RemoteData.",
+                "user_email": "aiida@theossrv5.epfl.ch",
+                "user_id": 6,
                 "uuid": "16b93b23-8629-4d83-9259-de2a947b43ed"
               },
               {
-                "ctime": "Fri, 24 Jul 2015 14:33:04 GMT",
+                "attributes": {...},
+                "ctime": "Fri, 24 Jul 2018 14:33:04 GMT",
+                "extras": {},
                 "id": 9215,
                 "label": "",
-                "mtime": "Mon, 25 Jan 2016 14:35:00 GMT",
-                "state": "IMPORTED",
-                "type": "data.array.kpoints.KpointsData.",
+                "mtime": "Mon, 25 Jan 2019 14:35:00 GMT",
+                "node_type": "data.array.kpoints.KpointsData.",
+                "user_email": "aiida@theossrv5.epfl.ch",
+                "user_id": 6,
                 "uuid": "1b4d22ec-9f29-4e0d-9d68-84ddd18ad8e7"
               }
             ]
           },
           "method": "GET",
-          "path": "/api/v2/nodes/de83b1/io/inputs",
-          "pk": 6,
+          "path": "/api/v3/nodes/de83b1/io/inputs",
           "query_string": "limit=2",
           "resource_type": "nodes",
-          "url": "http://localhost:5000/api/v2/nodes/de83b1/io/inputs?limit=2",
+          "url": "http://localhost:5000/api/v3/nodes/de83b1/io/inputs?limit=2",
           "url_root": "http://localhost:5000/"
         }
 
 
-4. Filter the inputs/outputs of a node by their type.
+4. Filter the inputs/outputs of a node by their node type.
 
     REST url::
 
-        http://localhost:5000/api/v2/nodes/de83b1/io/inputs?type="data.array.kpoints.KpointsData."
+        http://localhost:5000/api/v3/nodes/de83b1/io/inputs?node_type="data.array.kpoints.KpointsData."
 
     Description:
 
@@ -705,28 +818,30 @@ Nodes
           "data": {
             "inputs": [
               {
-                "ctime": "Fri, 24 Jul 2015 14:33:04 GMT",
+                "attributes": {...},
+                "ctime": "Fri, 24 Jul 2018 14:33:04 GMT",
+                "extras": {},
                 "id": 9215,
                 "label": "",
-                "mtime": "Mon, 25 Jan 2016 14:35:00 GMT",
-                "state": "IMPORTED",
-                "type": "data.array.kpoints.KpointsData.",
+                "mtime": "Mon, 25 Jan 2019 14:35:00 GMT",
+                "node_type": "data.array.kpoints.KpointsData.",
+                "user_email": "aiida@theossrv5.epfl.ch",
+                "user_id": 6,
                 "uuid": "1b4d22ec-9f29-4e0d-9d68-84ddd18ad8e7"
               }
             ]
           },
           "method": "GET",
-          "path": "/api/v2/nodes/de83b1/io/inputs",
-          "pk": 6,
-          "query_string": "type=\"data.array.kpoints.KpointsData.\"",
+          "path": "/api/v3/nodes/de83b1/io/inputs",
+          "query_string": "node_type=\"data.array.kpoints.KpointsData.\"",
           "resource_type": "nodes",
-          "url": "http://localhost:5000/api/v2/nodes/de83b1/io/inputs?type=\"data.array.kpoints.KpointsData.\"",
+          "url": "http://localhost:5000/api/v3/nodes/de83b1/io/inputs?node_type=\"data.array.kpoints.KpointsData.\"",
           "url_root": "http://localhost:5000/"
         }
 
     REST url::
 
-        http://localhost:5000/api/v2/nodes/de83b1/io/outputs?type="data.remote.RemoteData."
+        http://localhost:5000/api/v3/nodes/de83b1/io/outputs?node_type="data.remote.RemoteData."
 
     Description:
 
@@ -738,22 +853,24 @@ Nodes
           "data": {
             "outputs": [
               {
-                "ctime": "Fri, 24 Jul 2015 20:35:02 GMT",
+                "attributes": {...},
+                "ctime": "Fri, 24 Jul 2018 20:35:02 GMT",
+                "extras": {},
                 "id": 2811,
                 "label": "",
-                "mtime": "Mon, 25 Jan 2016 14:34:59 GMT",
-                "state": "IMPORTED",
-                "type": "data.remote.RemoteData.",
+                "mtime": "Mon, 25 Jan 2019 14:34:59 GMT",
+                "node_type": "data.remote.RemoteData.",
+                "user_email": "aiida@theossrv5.epfl.ch",
+                "user_id": 6,
                 "uuid": "bd48e333-da8a-4b6f-8e1e-6aaa316852eb"
               }
             ]
           },
           "method": "GET",
-          "path": "/api/v2/nodes/de83b1/io/outputs",
-          "pk": 6,
-          "query_string": "type=\"data.remote.RemoteData.\"",
+          "path": "/api/v3/nodes/de83b1/io/outputs",
+          "query_string": "node_type=\"data.remote.RemoteData.\"",
           "resource_type": "nodes",
-          "url": "http://localhost:5000/api/v2/nodes/de83b1/io/outputs?type=\"data.remote.RemoteData.\"",
+          "url": "http://localhost:5000/api/v3/nodes/de83b1/io/outputs?node_type=\"data.remote.RemoteData.\"",
           "url_root": "http://localhost:5000/"
         }
 
@@ -763,7 +880,7 @@ Nodes
 
     REST url::
 
-        http://localhost:5000/api/v2/nodes/ffe11/content/attributes
+        http://localhost:5000/api/v3/nodes/ffe11/content/attributes
 
     Description:
 
@@ -782,11 +899,10 @@ Nodes
             }
           },
           "method": "GET",
-          "path": "/api/v2/nodes/ffe11/content/attributes",
-          "pk": 1822,
+          "path": "/api/v3/nodes/ffe11/content/attributes",
           "query_string": "",
           "resource_type": "nodes",
-          "url": "http://localhost:5000/api/v2/nodes/ffe11/content/attributes",
+          "url": "http://localhost:5000/api/v3/nodes/ffe11/content/attributes",
           "url_root": "http://localhost:5000/"
         }
 
@@ -794,7 +910,7 @@ Nodes
 
     REST url::
 
-        http://localhost:5000/api/v2/nodes/ffe11/content/extras
+        http://localhost:5000/api/v3/nodes/ffe11/content/extras
 
     Description:
 
@@ -812,11 +928,10 @@ Nodes
             }
           },
           "method": "GET",
-          "path": "/api/v2/codes/ffe11/content/extras",
-          "pk": 1822,
+          "path": "/api/v3/nodes/ffe11/content/extras",
           "query_string": "",
-          "resource_type": "codes",
-          "url": "http://localhost:5000/api/v2/codes/ffe11/content/extras",
+          "resource_type": "nodes",
+          "url": "http://localhost:5000/api/v3/nodes/ffe11/content/extras",
           "url_root": "http://localhost:5000/"
         }
 
@@ -825,7 +940,7 @@ Nodes
 
     REST url::
 
-         http://localhost:5000/api/v2/codes/ffe11/content/attributes?alist=append_text,is_local
+         http://localhost:5000/api/v3/codes/ffe11/content/attributes?alist=append_text,is_local
 
     Description:
 
@@ -841,11 +956,10 @@ Nodes
             }
           },
           "method": "GET",
-          "path": "/api/v2/codes/ffe11/content/attributes",
-          "pk": 1822,
+          "path": "/api/v3/codes/ffe11/content/attributes",
           "query_string": "alist=append_text,is_local",
           "resource_type": "codes",
-          "url": "http://localhost:5000/api/v2/codes/ffe11/content/attributes?alist=append_text,is_local",
+          "url": "http://localhost:5000/api/v3/codes/ffe11/content/attributes?alist=append_text,is_local",
           "url_root": "http://localhost:5000/"
         }
 
@@ -853,7 +967,7 @@ Nodes
 
     REST url::
 
-        http://localhost:5000/api/v2/codes/ffe11/content/extras?elist=trialBool,trialInt
+        http://localhost:5000/api/v3/codes/ffe11/content/extras?elist=trialBool,trialInt
 
     Description:
 
@@ -869,11 +983,10 @@ Nodes
             }
           },
           "method": "GET",
-          "path": "/api/v2/codes/ffe11/content/extras",
-          "pk": 1822,
+          "path": "/api/v3/codes/ffe11/content/extras",
           "query_string": "elist=trialBool,trialInt",
           "resource_type": "codes",
-          "url": "http://localhost:5000/api/v2/codes/ffe11/content/extras?elist=trialBool,trialInt",
+          "url": "http://localhost:5000/api/v3/codes/ffe11/content/extras?elist=trialBool,trialInt",
           "url_root": "http://localhost:5000/"
         }
 
@@ -882,7 +995,7 @@ Nodes
 
     REST url::
 
-        http://localhost:5000/api/v2/codes/ffe11/content/attributes?nalist=append_text,is_local
+        http://localhost:5000/api/v3/codes/ffe11/content/attributes?nalist=append_text,is_local
 
     Description:
 
@@ -899,18 +1012,17 @@ Nodes
             }
           },
           "method": "GET",
-          "path": "/api/v2/codes/ffe11/content/attributes",
-          "pk": 1822,
+          "path": "/api/v3/codes/ffe11/content/attributes",
           "query_string": "nalist=append_text,is_local",
           "resource_type": "codes",
-          "url": "http://localhost:5000/api/v2/codes/ffe11/content/attributes?nalist=append_text,is_local",
+          "url": "http://localhost:5000/api/v3/codes/ffe11/content/attributes?nalist=append_text,is_local",
           "url_root": "http://localhost:5000/"
         }
 
 
     REST url::
 
-        http://localhost:5000/api/v2/codes/ffe11/content/extras?nelist=trialBool,trialInt
+        http://localhost:5000/api/v3/codes/ffe11/content/extras?nelist=trialBool,trialInt
 
     Description:
 
@@ -926,16 +1038,16 @@ Nodes
             }
           },
           "method": "GET",
-          "path": "/api/v2/codes/ffe11/content/extras",
-          "pk": 1822,
+          "path": "/api/v3/codes/ffe11/content/extras",
           "query_string": "nelist=trialBool,trialInt",
           "resource_type": "codes",
-          "url": "http://localhost:5000/api/v2/codes/ffe11/content/extras?nelist=trialBool,trialInt",
+          "url": "http://localhost:5000/api/v3/codes/ffe11/content/extras?nelist=trialBool,trialInt",
           "url_root": "http://localhost:5000/"
         }
 
 
-.. note:: The same REST urls supported for the resource ``nodes`` are also available with the derived resources, namely,  ``calculations``, ``data``, and ``codes``, just changing the resource field in the path.
+.. note:: The same REST urls supported for the resource ``nodes`` are also available with the derived resources, namely,
+    ``calculations`` and ``data``, just changing the resource field in the path.
 
 
 Users
@@ -945,7 +1057,7 @@ Users
 
     REST url::
 
-        http://localhost:5000/api/v2/users/
+        http://localhost:5000/api/v3/users/
 
     Description:
 
@@ -957,14 +1069,12 @@ Users
           "data": {
             "users": [
               {
-                "date_joined": "Mon, 25 Jan 2016 14:31:17 GMT",
                 "first_name": "AiiDA",
                 "id": 1,
                 "institution": "",
                 "last_name": "Daemon"
               },
               {
-                "date_joined": "Thu, 11 Aug 2016 12:35:32 GMT",
                 "first_name": "Gengis",
                 "id": 2,
                 "institution": "",
@@ -973,11 +1083,10 @@ Users
             ]
           },
           "method": "GET",
-          "path": "/api/v2/users/",
-          "pk": null,
+          "path": "/api/v3/users/",
           "query_string": "",
           "resource_type": "users",
-          "url": "http://localhost:5000/api/v2/users/",
+          "url": "http://localhost:5000/api/v3/users/",
           "url_root": "http://localhost:5000/"
         }
 
@@ -985,7 +1094,7 @@ Users
 
     REST url::
 
-        http://localhost:5000/api/v2/users/?first_name=ilike="aii%"
+        http://localhost:5000/api/v3/users/?first_name=ilike="aii%"
 
     Description:
 
@@ -997,7 +1106,6 @@ Users
           "data": {
             "users": [
               {
-                "date_joined": "Mon, 25 Jan 2016 14:31:17 GMT",
                 "first_name": "AiiDA",
                 "id": 1,
                 "institution": "",
@@ -1006,11 +1114,10 @@ Users
             ]
           },
           "method": "GET",
-          "path": "/api/v2/users/",
-          "pk": null,
+          "path": "/api/v3/users/",
           "query_string": "first_name=ilike=%22aii%%22",
           "resource_type": "users",
-          "url": "http://localhost:5000/api/v2/users/?first_name=ilike=\"aii%\"",
+          "url": "http://localhost:5000/api/v3/users/?first_name=ilike=\"aii%\"",
           "url_root": "http://localhost:5000/"
         }
 
@@ -1022,7 +1129,7 @@ Groups
 
     REST url::
 
-        http://localhost:5000/api/v2/groups/?limit=10&orderby=-user_id
+        http://localhost:5000/api/v3/groups/?limit=10&orderby=-user_id
 
     Description:
 
@@ -1038,16 +1145,18 @@ Groups
               {
                 "description": "",
                 "id": 104,
-                "name": "SSSP_new_phonons_0p002",
-                "type": "",
+                "label": "SSSP_new_phonons_0p002",
+                "type_string": "",
+                "user_email": "aiida@theossrv5.epfl.ch",
                 "user_id": 2,
                 "uuid": "7c0e0744-8549-4eea-b1b8-e7207c18de32"
               },
               {
                 "description": "",
                 "id": 102,
-                "name": "SSSP_cubic_old_phonons_0p025",
-                "type": "",
+                "label": "SSSP_cubic_old_phonons_0p025",
+                "type_string": "",
+                "user_email": "aiida@localhost",
                 "user_id": 1,
                 "uuid": "c4e22134-495d-4779-9259-6192fcaec510"
               },
@@ -1056,11 +1165,10 @@ Groups
             ]
           },
           "method": "GET",
-          "path": "/api/v2/groups/",
-          "pk": null,
+          "path": "/api/v3/groups/",
           "query_string": "limit=10&orderby=-user_id",
           "resource_type": "groups",
-          "url": "http://localhost:5000/api/v2/groups/?limit=10&orderby=-user_id",
+          "url": "http://localhost:5000/api/v3/groups/?limit=10&orderby=-user_id",
           "url_root": "http://localhost:5000/"
         }
 
@@ -1068,7 +1176,7 @@ Groups
 
     REST url::
 
-        http://localhost:5000/api/v2/groups/a6e5b
+        http://localhost:5000/api/v3/groups/a6e5b
 
     Description:
 
@@ -1082,18 +1190,18 @@ Groups
               {
                 "description": "GBRV US pseudos, version 1.2",
                 "id": 23,
-                "name": "GBRV_1.2",
-                "type": "data.upf.family",
+                "label": "GBRV_1.2",
+                "type_string": "data.upf.family",
+                "user_email": "aiida@theossrv5.epfl.ch",
                 "user_id": 2,
                 "uuid": "a6e5b6c6-9d47-445b-bfea-024cf8333c55"
               }
             ]
           },
           "method": "GET",
-          "path": "/api/v2/groups/a6e5b",
-          "pk": 23,
+          "path": "/api/v3/groups/a6e5b",
           "query_string": "",
           "resource_type": "groups",
-          "url": "http://localhost:5000/api/v2/groups/a6e5b",
+          "url": "http://localhost:5000/api/v3/groups/a6e5b",
           "url_root": "http://localhost:5000/"
         }

--- a/docs/wsgi/app1/config.py
+++ b/docs/wsgi/app1/config.py
@@ -18,7 +18,7 @@ LIMIT_DEFAULT = 400
 PERPAGE_DEFAULT = 20
 
 ##Version prefix for all the URLs
-PREFIX="/api/v2"
+PREFIX="/api/v3"
 
 
 """

--- a/docs/wsgi/app2/config.py
+++ b/docs/wsgi/app2/config.py
@@ -16,7 +16,7 @@ PERPAGE_DEFAULT = 20
 
 ##Version prefix for all the URLs (in most cases, you need to omit trailing
 # slash)
-PREFIX="/api/v2"
+PREFIX="/api/v3"
 
 
 """


### PR DESCRIPTION
Fix ~~#3048~~ #2964.

Changed v2 to v3 in the base url, and updated documentation and examples to reflect the changes in the ORM. 
Added full base url (including /api/v* suffix) to the message printed by ``verdi restapi`` command, so the user can click on the link and directly access the API. 
As soon as the functionality of passing the REST endpoint as a variable in the URL of Materials Cloud Explore is implemented in production, this should print also the proper link to [https://www.materialscloud.org/explore/connect](https://www.materialscloud.org/explore/connect), so it can directly connect to the explore interface of a database.

Fixed help text in rest api schema for Groups.