### PR TITLE
Update dependency `paramiko==2.6.0`

### DIFF
--- a/docs/requirements_for_rtd.txt
+++ b/docs/requirements_for_rtd.txt
@@ -37,7 +37,7 @@ kiwipy[rmq]==0.5.1
 marshmallow-sqlalchemy==0.16.0
 mock==2.0.0
 numpy==1.16.1
-paramiko==2.4.2
+paramiko==2.6.0
 passlib==1.7.1
 pg8000<1.13.0
 pgtest==1.2.0

--- a/environment.yml
+++ b/environment.yml
@@ -29,7 +29,7 @@ dependencies:
 - ete3==3.1.1
 - uritools==2.2.0
 - psycopg2==2.8
-- paramiko==2.4.2
+- paramiko==2.6.0
 - ipython>=4.0,<6.0
 - plumpy==0.14.1
 - kiwipy[rmq]==0.5.1

--- a/setup.json
+++ b/setup.json
@@ -41,7 +41,7 @@
     "ete3==3.1.1",
     "uritools==2.2.0",
     "psycopg2-binary==2.8",
-    "paramiko==2.4.2",
+    "paramiko==2.6.0",
     "ipython>=4.0,<6.0",
     "plumpy==0.14.1",
     "kiwipy[rmq]==0.5.1",
@@ -58,7 +58,7 @@
   "extras_require": {
     "ssh_kerberos": [
       "pyasn1==0.4.2",
-      "python-gssapi==0.6.4"
+      "gssapi==1.4.1"
     ],
     "rest": [
       "Flask==1.0.2",


### PR DESCRIPTION
Fixes #2922 

The indirect dependency `cryptography` deprecated various methods that
were being used in `paramiko==2.4.2`, which have been addressed in the
new release. In addition, `paramiko==2.6.0` now provides the extra
`gssapi` which will install the requirements that we were installing
manually with our `ssh_kerberos` extra. This change automatically takes
care of replacing the unmaintained `python-gssapi==0.6.4` by the
package `gssapi` that supercedes it.