### PR TITLE
Properly overload function module and name to `FunctionProcess`

### DIFF
--- a/aiida/backends/tests/engine/test_process_function.py
+++ b/aiida/backends/tests/engine/test_process_function.py
@@ -131,6 +131,12 @@ class TestProcessFunction(AiidaTestCase):
         self.assertEqual(node.is_finished_ok, True)
         self.assertEqual(node.is_failed, False)
 
+    def test_process_type(self):
+        """Test that the process type correctly contains the module and name of original decorated function."""
+        _, node = self.function_defaults.run_get_node()
+        process_type = '{}.{}'.format(self.function_defaults.__module__, self.function_defaults.__name__)
+        self.assertEqual(node.process_type, process_type)
+
     def test_exit_status(self):
         """A FINISHED process function has to have an exit status of 0"""
         _, node = self.function_args_with_default.run_get_node()

--- a/aiida/engine/processes/functions.py
+++ b/aiida/engine/processes/functions.py
@@ -295,6 +295,8 @@ class FunctionProcess(Process):
 
         return type(
             func.__name__, (FunctionProcess,), {
+                '__module__': func.__module__,
+                '__name__': func.__name__,
                 '_func': staticmethod(func),
                 Process.define.__name__: classmethod(_define),
                 '_func_args': args,


### PR DESCRIPTION
Fixes #3115 

The `FunctionProcess` class that is dynamically built based on the
function that is decorated with the `calcfunction` or `workfunction`
decorator was not overloading the `__module__` and `__name__` attributes
of the wrapped function. Since the `process_type` attribute of the
process node is defined by those attributes, an incorrect basic value
was being stored of the form `abc.name_of_wrapped_function`.